### PR TITLE
Phase 7.6: DaVinci Metadata CSV Export

### DIFF
--- a/CODEX_RESULT_phase7-6.md
+++ b/CODEX_RESULT_phase7-6.md
@@ -1,0 +1,43 @@
+# CODEX_RESULT
+
+## Phase 7.6 Summary
+
+| Subtask | Commit | Status | Evidence |
+| --- | --- | --- | --- |
+| 7.6b | e07f90e | PASS | `python -c "import server; print('import ok')"`; in-process route probe returned `attachment; filename=arkiv_metadata.csv` and CSV header `Filename,Keywords,Comments,Description,Scene,ContentType,Atmosphere` |
+| 7.6c | 2003a59 | PASS | Toolbar button added to `index.html`; `doExportMetadataCsv()` fetches `/api/export/metadata-csv` and downloads `arkiv_metadata.csv` |
+| 7.6d | ac06851 | PASS | Resolve plugin now prints and updates the UI with the next-step prompt after import completes |
+| 7.6e | 77ec06d | PASS | `python -c "import server; print('import ok')"`; direct handler probe returned CSV header + sample row; direct `curl`/loopback HTTP was refused in this sandbox, so verification used the in-process route probe |
+
+## Vision Schema Found
+
+`vision.py` exposes these fields:
+
+- `description`
+- `tags`
+- `content_type`
+- `focus_score`
+- `exposure`
+- `stability`
+- `audio_quality`
+- `atmosphere`
+- `energy`
+- `edit_position`
+- `edit_reason`
+
+## CSV Mapping Used
+
+- `Filename` -> clip filename
+- `Keywords` -> semicolon-joined tag names
+- `Comments` -> `content_type`
+- `Description` -> representative frame `description`
+- `Scene` -> representative frame `description`
+- `ContentType` -> `content_type`
+- `Atmosphere` -> `atmosphere`
+
+`Scene` duplicates the representative description because this schema does not define a separate `scene` field.
+
+## Notes
+
+- The current `media.db` snapshot has `description` data but no non-empty `content_type` or `atmosphere` values, so the sample row in verification is structurally correct but blank in those columns.
+- The Resolve plugin message uses `ShowMessage` when available and otherwise falls back to console output plus the status label.

--- a/index.html
+++ b/index.html
@@ -194,6 +194,11 @@ window.onunhandledrejection = function(e) {
     EDL 匯出
   </button>
 
+  <button class="export-btn ml-1.5 shrink-0" title="Export DaVinci Metadata CSV" onclick="doExportMetadataCsv()">
+    <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M7 3h10a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Zm0 4h10M7 11h10M7 15h6"/></svg>
+    Metadata CSV
+  </button>
+
   <button class="theme-toggle ml-1.5 shrink-0" onclick="toggleTheme()" title="切換主題" id="theme-btn">
     <svg class="w-3.5 h-3.5 dark-icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
     <svg class="w-3.5 h-3.5 light-icon" style="display:none" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
@@ -954,6 +959,18 @@ async function doExportGoodEdl() {
   const goodItems = state.items.filter(r => r.rating === 'good');
   if (goodItems.length === 0) { await tauriMessage('沒有 GOOD 評級的素材'); return; }
   await doExport(goodItems[0].id, 'edl');
+}
+
+async function doExportMetadataCsv() {
+  try {
+    const resp = await fetch('/api/export/metadata-csv');
+    if (!resp.ok) { await tauriMessage('CSV export failed: HTTP ' + resp.status); return; }
+    const blob = await resp.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a'); a.href = url; a.download = 'arkiv_metadata.csv';
+    document.body.appendChild(a); a.click(); document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  } catch(e) { await tauriMessage('CSV export error: ' + e.message); }
 }
 
 async function doOpenFile(id) {

--- a/resolve_plugin/arkiv_resolve.py
+++ b/resolve_plugin/arkiv_resolve.py
@@ -469,6 +469,17 @@ def create_ui(resolve):
         except Exception as e:
             win.Find("StatusLabel").Text = f"載入失敗：{e}"
 
+    def _announce_import_complete():
+        message = "Clips imported. Next step: File \u2192 Import Metadata from CSV \u2192 select arkiv_metadata.csv"
+        print(f"[arkiv] {message}")
+        win.Find("StatusLabel").Text = message
+        show_message = getattr(resolve, "ShowMessage", None)
+        if callable(show_message):
+            try:
+                show_message(message)
+            except Exception:
+                pass
+
     def on_import(ev):
         selected = tree.SelectedItems()
         if not selected:
@@ -493,7 +504,7 @@ def create_ui(resolve):
             if paths:
                 success = import_to_resolve(resolve, paths, ratings, tags)
                 if success:
-                    win.Find("StatusLabel").Text = f"已匯入 {len(paths)} 個片段"
+                    _announce_import_complete()
                 else:
                     win.Find("StatusLabel").Text = "匯入失敗 — 請檢查媒體庫"
             else:

--- a/server.py
+++ b/server.py
@@ -8,6 +8,8 @@ Usage:
 from __future__ import annotations
 
 import asyncio
+import csv
+import io
 import json
 import os
 import urllib.request
@@ -16,7 +18,7 @@ from typing import Optional, Set
 
 from fastapi import BackgroundTasks, FastAPI, HTTPException, Query, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, HTMLResponse, Response
+from fastapi.responses import FileResponse, HTMLResponse, Response, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
@@ -703,6 +705,102 @@ def clear_cache(target: str = Query("app", description="app|thumbnails|chromadb|
             cleared.append("chromadb")
     return {"ok": True, "cleared": cleared}
 
+
+def _parse_clip_ids(clip_ids: Optional[str]):
+    if not clip_ids:
+        return None
+    parsed = []
+    seen = set()
+    for part in clip_ids.split(','):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            clip_id = int(part)
+        except ValueError:
+            raise HTTPException(400, f'??? clip_id?{part}')
+        if clip_id in seen:
+            continue
+        seen.add(clip_id)
+        parsed.append(clip_id)
+    return parsed
+
+
+def _pick_vision_frame(frames):
+    if not frames:
+        return {}
+    center = len(frames) // 2
+    ordered = [frames[center]] + [frame for idx, frame in enumerate(frames) if idx != center]
+    for frame in ordered:
+        if frame.get('description') or frame.get('content_type') or frame.get('atmosphere'):
+            return frame
+    return frames[0]
+
+
+def _metadata_csv_rows(clip_ids: Optional[str]):
+    selected_ids = _parse_clip_ids(clip_ids)
+    if selected_ids is None:
+        with db.get_conn() as conn:
+            rows = conn.execute('SELECT id FROM media ORDER BY filename, id').fetchall()
+        media_ids = [row['id'] for row in rows]
+    else:
+        placeholders = ','.join('?' for _ in selected_ids)
+        with db.get_conn() as conn:
+            rows = conn.execute(
+                f'SELECT id FROM media WHERE id IN ({placeholders}) ORDER BY filename, id',
+                selected_ids,
+            ).fetchall()
+        existing = [row['id'] for row in rows]
+        order_map = {mid: idx for idx, mid in enumerate(selected_ids)}
+        media_ids = sorted(existing, key=lambda mid: order_map.get(mid, len(selected_ids)))
+
+    for media_id in media_ids:
+        rec = db.get_record_by_id(media_id)
+        if not rec:
+            continue
+        tags = db.get_tags(media_id)
+        frames = db.get_frames(media_id)
+        vision_frame = _pick_vision_frame(frames)
+        description = vision_frame.get('description') or ''
+        content_type = vision_frame.get('content_type') or rec.get('content_type') or ''
+        atmosphere = vision_frame.get('atmosphere') or rec.get('atmosphere') or ''
+        yield {
+            'Filename': rec.get('filename', ''),
+            'Keywords': ';'.join(tag.get('name', '') for tag in tags if tag.get('name')),
+            'Comments': content_type,
+            'Description': description,
+            'Scene': description,
+            'ContentType': content_type,
+            'Atmosphere': atmosphere,
+        }
+
+
+@app.get('/api/export/metadata-csv')
+def export_metadata_csv(clip_ids: Optional[str] = Query(None)):
+    """Export clip metadata in a DaVinci-friendly CSV."""
+    def _stream():
+        buffer = io.StringIO()
+        writer = csv.DictWriter(
+            buffer,
+            fieldnames=['Filename', 'Keywords', 'Comments', 'Description', 'Scene', 'ContentType', 'Atmosphere'],
+            lineterminator='\n',
+        )
+        writer.writeheader()
+        yield buffer.getvalue().encode('utf-8')
+        buffer.seek(0)
+        buffer.truncate(0)
+
+        for row in _metadata_csv_rows(clip_ids):
+            writer.writerow(row)
+            yield buffer.getvalue().encode('utf-8')
+            buffer.seek(0)
+            buffer.truncate(0)
+
+    return StreamingResponse(
+        _stream(),
+        media_type='text/csv; charset=utf-8',
+        headers={'Content-Disposition': 'attachment; filename=arkiv_metadata.csv'},
+    )
 
 # ── Export ────────────────────────────────────────────────────────────────────
 

--- a/server.py
+++ b/server.py
@@ -718,7 +718,7 @@ def _parse_clip_ids(clip_ids: Optional[str]):
         try:
             clip_id = int(part)
         except ValueError:
-            raise HTTPException(400, f'??? clip_id?{part}')
+            raise HTTPException(400, f'invalid clip_id: {part}')
         if clip_id in seen:
             continue
         seen.add(clip_id)

--- a/server.py
+++ b/server.py
@@ -776,7 +776,7 @@ def _metadata_csv_rows(clip_ids: Optional[str]):
 
 
 @app.get('/api/export/metadata-csv')
-def export_metadata_csv(clip_ids: Optional[str] = Query(None)):
+def export_metadata_csv(clip_ids: Optional[str] = None):
     """Export clip metadata in a DaVinci-friendly CSV."""
     def _stream():
         buffer = io.StringIO()


### PR DESCRIPTION
## Summary

Implements arkiv roadmap **Phase 7.6** — DaVinci Resolve metadata integration via **CSV import** (the original SetMetadata scripting-API approach in 7.6a was confirmed dead in 04-09 testing — Metadata panel stayed blank — so this ships the CSV-based replacement that DaVinci has built-in: `File → Import Metadata from CSV`).

The endpoint exports per-clip vision-derived metadata (tags, content type, atmosphere, scene description) keyed by `Filename`, so users can run the existing arkiv Resolve plugin to import clips, then a single CSV import inside DaVinci to populate Metadata panel and unlock Smart Bin filters.

## Commits (6, atomic)

| Hash | Subtask | Notes |
|---|---|---|
| `d0d19f0` | 7.6b — `/api/export/metadata-csv` endpoint in `server.py` | columns: `Filename, Keywords, Comments, Description, Scene, ContentType, Atmosphere`; `Comments`/`ContentType` mirror so Smart Bins (e.g. `Comments contains 'b-roll'`) work, `Scene` mirrors `Description` (no separate scene field in vision schema) |
| `905fc32` | 7.6c — Toolbar button in `index.html` | triggers browser download of the CSV |
| `981241c` | 7.6d — Post-import prompt in `resolve_plugin/arkiv_resolve.py` | reminds user to run `File → Import Metadata from CSV` after the plugin finishes importing |
| `7bf72fc` | follow-up — make CSV route safe for direct (non-HTTP) calls | avoids `Query` default object leaking when called in-process |
| `74ae009` | 7.6e — verification evidence in `CODEX_RESULT_phase7-6.md` | renamed from `CODEX_RESULT.md` to avoid clobbering the existing audit report on `main` |
| `02a1bb1` | encoding scrub | the cherry-picked patch carried mojibake in a 400 error string (`'??? clip_id?{part}'`); replaced with plain ASCII |

## Vision schema mapping

`vision.py` exposes per-frame: `description, tags, content_type, focus_score, exposure, stability, audio_quality, atmosphere, energy, edit_position, edit_reason`. The CSV picks a representative frame (center, falling back to first non-empty) per media row:

- `Keywords` ← per-media tags (joined with `;`)
- `Comments` ← `frames.content_type` (or `media.content_type` fallback)
- `Description` ← representative frame `description`
- `Scene` ← duplicates `Description` (no dedicated scene field)
- `ContentType` ← same source as `Comments`
- `Atmosphere` ← `frames.atmosphere` (or `media.atmosphere` fallback)

## Test plan

- [x] `python -c \"import server\"` smoke (passed locally)
- [x] CSV response probe returns `attachment; filename=arkiv_metadata.csv` and the seven-column header (verified in-process)
- [x] `python -m py_compile resolve_plugin/arkiv_resolve.py` clean
- [ ] **Mac end-to-end** (where the populated vision data lives — 205/210 frames have descriptions, 168 frames have atmosphere): start uvicorn, `curl /api/export/metadata-csv`, confirm `Description` / `Atmosphere` columns are non-empty, then `File → Import Metadata from CSV` in Resolve and verify Metadata panel + Smart Bin filter
- [ ] PC verification will read blanks in vision columns because the PC `media.db` has zero `frames.content_type` / `frames.atmosphere` rows — that's data state, not code (Mac is the source of truth here)

## Why a feature branch instead of pushing to `main`

The PC clone where Codex ran was on the pre-04-24-purge history, so the original direct push to `main` was rejected (212 commits diverged after `purge-history.sh` rewrote the entire history with new hashes). Cherry-picking onto fresh `origin/main` is the clean route — none of the 5 sub-commits depend on the stale ancestry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)