### PR TITLE
docs(zh-TW): mirror EN W1.3 repositioning + W1.2 install split

### DIFF
--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -4,11 +4,13 @@
 [![Python 3.9+](https://img.shields.io/badge/Python-3.9%2B-3776AB.svg)](https://python.org)
 [![Tauri](https://img.shields.io/badge/Tauri-Desktop_App-FFC131.svg)](https://tauri.app)
 
-**本地優先的媒體素材管理器，支援語義搜尋。**
-
-使用 AI 轉錄與向量搜尋，瀏覽、搜尋、評級、標記你的影音素材。DaVinci Resolve 風格的深色介面。
+**DIT 工作流的開源 AI 素材標註層 — Resolve 原生、CJK 優先。**
 
 > 🌐 [English](README.md) | **繁體中文**
+
+arkiv 介於素材硬碟與 DaVinci Resolve 之間：自動 ingest footage、附上 AI 標註（逐字稿、視覺標籤、氛圍、能量、剪輯位置），並用任何語言（中文、日文、英文）的語義搜尋找回 clip。Resolve plugin 讓你搜尋、帶 clip color 匯入、加 frame marker，不用離開 NLE。
+
+為 solo DIT 與小團隊設計，資料自己持有：本地優先、自架、MIT license、零雲端依賴。
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -66,34 +66,67 @@ arkiv 介於素材硬碟與 DaVinci Resolve 之間：自動 ingest footage、附
 ## 快速開始
 
 ### 前置需求
-- Python 3.9+
-- FFmpeg 6.0+
-- Ollama 搭配 `nomic-embed-text` 模型
-- **DaVinci Resolve Plugin 額外需求**：需安裝 [Python 3.10 Framework 版本](https://www.python.org/downloads/release/python-31011/)（macOS 64-bit universal2 installer .pkg）。Homebrew / 系統內建 Python 不被 DaVinci 識別。安裝後重啟 DaVinci，Console 左下角出現 Py3 選項即代表成功。
 
-### 安裝
+| 依賴 | macOS (brew) | Linux (apt) | Windows |
+|---|---|---|---|
+| Python 3.9+ | `brew install python` | `sudo apt install python3 python3-venv` | [python.org](https://python.org) |
+| FFmpeg 6.0+ | `brew install ffmpeg` | `sudo apt install ffmpeg` | [ffmpeg.org](https://ffmpeg.org/download.html) |
+| Ollama | `brew install ollama` | [ollama.com/download](https://ollama.com/download) | [ollama.com/download](https://ollama.com/download) |
+
+> **DaVinci Resolve Plugin 額外需求 (macOS)**：Resolve 需要 [python.org 官方 Python 3.10 Framework 安裝檔 (.pkg)](https://www.python.org/downloads/release/python-31011/) — Homebrew Python 不被識別。安裝路徑：`/Library/Frameworks/Python.framework/Versions/3.10/`。安裝後重啟 Resolve，Console 左下角應顯示 Py3，scripts 透過 Workspace > Scripts 載入。
+
+### 安裝 — macOS (brew + pip)
+
+```bash
+brew install python ffmpeg ollama
+git clone https://github.com/vulture-s/arkiv.git
+cd arkiv
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+pip install mlx-whisper          # Apple Silicon (Metal GPU)
+ollama pull nomic-embed-text && ollama pull qwen3-vl:8b && ollama pull qwen2.5:14b
+python health.py
+```
+
+### 安裝 — Linux (pip)
+
+```bash
+sudo apt install python3 python3-venv ffmpeg
+git clone https://github.com/vulture-s/arkiv.git
+cd arkiv
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+pip install faster-whisper torch  # NVIDIA CUDA GPU
+# pip install faster-whisper      # CPU 後備
+ollama pull nomic-embed-text && ollama pull qwen3-vl:8b && ollama pull qwen2.5:14b
+python health.py
+```
+
+### 安裝 — Windows (pip, PowerShell)
+
+```powershell
+# 先手動安裝 Python 3.9+、FFmpeg、Ollama，然後：
+git clone https://github.com/vulture-s/arkiv.git
+cd arkiv
+python -m venv .venv
+.\.venv\Scripts\activate
+pip install -r requirements.txt
+pip install faster-whisper torch  # NVIDIA CUDA GPU
+# pip install faster-whisper      # CPU 後備
+ollama pull nomic-embed-text; ollama pull qwen3-vl:8b; ollama pull qwen2.5:14b
+$env:PYTHONUTF8=1; python health.py
+```
+
+### 安裝 — Docker (跨平台)
 
 ```bash
 git clone https://github.com/vulture-s/arkiv.git
 cd arkiv
-python -m venv .venv
-source .venv/bin/activate        # macOS / Linux
-# .venv\Scripts\activate         # Windows (PowerShell)
-pip install -r requirements.txt
-
-# 安裝 Whisper 後端（擇一）：
-pip install mlx-whisper          # macOS Apple Silicon
-pip install faster-whisper torch  # NVIDIA GPU
-pip install faster-whisper        # 純 CPU
-
-# 下載 Ollama 模型
-ollama pull nomic-embed-text
-ollama pull qwen3-vl:8b    # 視覺幀描述
-ollama pull qwen2.5:14b    # LLM 轉錄潤稿
-
-# 檢查環境
-python health.py
+docker compose up -d
+# 開啟 http://localhost:8501
 ```
+
+> 模型會在 Ollama container 首次啟動時自動下載（可能需要幾分鐘）。
 
 ### 方式 A：Web UI — 在瀏覽器中瀏覽、搜尋、評級、標記
 
@@ -148,13 +181,6 @@ Invoke-RestMethod "http://localhost:8501/api/media?q=關鍵字&limit=5"
 ```
 
 </details>
-
-### Docker
-
-```bash
-docker compose up -d
-# 開啟 http://localhost:8501
-```
 
 ## 設定
 


### PR DESCRIPTION
## Summary

zh-TW 對稱 W1.3 (positioning) + W1.2 (install block 4-platform split) — 兩條跨機 docs 對齊，把 Mac overnight C1/C2 (3db35cb / 8b4afe4) 沒帶到中文版的部分補齊。

## Commits

1. `0b95cbf` — **W1.3 zh-TW hero**: tagline + 段落 + solo DIT positioning 從「本地優先的媒體素材管理器，支援語義搜尋」改為「DIT 工作流的開源 AI 素材標註層 — Resolve 原生、CJK 優先」+ 對齊 EN 段落順序
2. `9e1d897` — **W1.2 zh-TW install split**: 前置需求改 table、單塊 install 拆 4 段（macOS / Linux / Windows / Docker），跟 EN 結構鏡像

## Why

`r/selfhosted` 主帖（W2 ship）+ vulture.s Threads 中文圈讀者會落 zh-TW（lang fallback）。原版 zh-TW positioning 還是「本地優先的媒體素材管理器」generic frame、install 是單塊讓讀者自過濾平台 — 對 W2 主帖 funnel 收斂力弱於 EN 版。本 PR 把 zh-TW 拉到跟 EN 對稱，避免「中文讀者看到舊定位 + 平台 readability 差」的二層折扣。

## Test plan

- [x] zh-TW 結構 grep 對齊 EN（前置需求 table / 4 個 install H3 / Docker 段移正位）
- [x] 沒影響 EN README（diff 只動 zh-TW）
- [ ] Hevin 中文母語 review tagline + hero 段是否要微調用詞

## Spec source

- W1.3 positioning: `hevin-ai-os/references/plans/arkiv/2026-04-29-positioning-and-moat.md` §1
- W1.2 install structure: 對齊過夜 commit `8b4afe4` (8.0b README install block Linux/Win/Mac + Docker)