### PR TITLE
fix(b10b): ExifTool sidecar + Keys group — 解 0/427 populated 根因

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -156,6 +156,7 @@ def exiftool_extract(path: str) -> dict:
         "-FNumber", "-ApertureValue",
         "-FocalLength",
         "-CreateDate", "-DateTimeOriginal",
+        "-Keys:CreationDate",
         "-n",  # numeric output for GPS
         path,
     ]
@@ -194,7 +195,7 @@ def exiftool_extract(path: str) -> dict:
             pass
 
     # Creation date — prefer CreateDate, fallback DateTimeOriginal
-    cdate = d.get("CreateDate") or d.get("DateTimeOriginal")
+    cdate = d.get("CreateDate") or d.get("DateTimeOriginal") or d.get("CreationDate")
     cdate_str = str(cdate) if cdate else None
 
     return {
@@ -210,6 +211,36 @@ def exiftool_extract(path: str) -> dict:
         "focal_length": fl,
         "creation_date": cdate_str,
         "reel_name": d.get("ReelName") or d.get("CameraReelName") or d.get("Reel#") or d.get("ReelNumber"),
+    }
+
+
+def parse_xavc_sidecar(mp4_path: str) -> dict:
+    from pathlib import Path
+    import xml.etree.ElementTree as ET
+
+    p = Path(mp4_path)
+    sidecar = p.with_name(p.stem + "M01.XML")
+    if not sidecar.exists():
+        return {}
+    try:
+        tree = ET.parse(sidecar)
+        root = tree.getroot()
+        ns = {"x": root.tag.split("}")[0].lstrip("{")} if "}" in root.tag else {}
+    except (ET.ParseError, OSError):
+        return {}
+
+    def find_attr(xpath_with_x, xpath_plain, attr):
+        if ns:
+            el = root.find(xpath_with_x, ns)
+        else:
+            el = root.find(xpath_plain)
+        return el.get(attr) if el is not None else None
+
+    return {
+        "camera_make": find_attr(".//x:Device", ".//Device", "manufacturer"),
+        "camera_model": find_attr(".//x:Device", ".//Device", "modelName"),
+        "lens_model": find_attr(".//x:Lens", ".//Lens", "modelName"),
+        "creation_date": find_attr(".//x:CreationDate", ".//CreationDate", "value"),
     }
 
 
@@ -309,6 +340,10 @@ def process_file(path: Path, skip_vision: bool, existing: Optional[Dict] = None)
         return {}
 
     exif = exiftool_extract(str(path))
+    sidecar = parse_xavc_sidecar(str(path))
+    for k, v in sidecar.items():
+        if v and not exif.get(k):
+            exif[k] = v
 
     record = {
         "path": db.to_relative(str(path)),

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,38 @@
+def test_parse_xavc_sidecar_with_namespace(tmp_path):
+    mp4 = tmp_path / 'FX30.5378.MP4'
+    mp4.write_bytes(b'fake mp4')
+    sidecar = tmp_path / 'FX30.5378M01.XML'
+    sidecar.write_text('''<?xml version="1.0" encoding="UTF-8"?>
+<NonRealTimeMeta xmlns="urn:schemas-professionalDisc:nonRealTimeMeta:ver.2.20">
+    <Device manufacturer="Sony" modelName="ILME-FX30" serialNo="05000452"/>
+    <Lens modelName="E 17-70mm F2.8 B070"/>
+    <CreationDate value="2026-01-28T10:50:45+08:00"/>
+</NonRealTimeMeta>''', encoding='utf-8')
+    import sys, os
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    import ingest
+    result = ingest.parse_xavc_sidecar(str(mp4))
+    assert result['camera_make'] == 'Sony'
+    assert result['camera_model'] == 'ILME-FX30'
+    assert result['lens_model'] == 'E 17-70mm F2.8 B070'
+    assert result['creation_date'] == '2026-01-28T10:50:45+08:00'
+
+
+def test_parse_xavc_sidecar_missing(tmp_path):
+    mp4 = tmp_path / 'lone.MP4'
+    mp4.write_bytes(b'fake')
+    import sys, os
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    import ingest
+    assert ingest.parse_xavc_sidecar(str(mp4)) == {}
+
+
+def test_parse_xavc_sidecar_malformed(tmp_path):
+    mp4 = tmp_path / 'broken.MP4'
+    mp4.write_bytes(b'fake')
+    sidecar = tmp_path / 'brokenM01.XML'
+    sidecar.write_text('<not valid xml', encoding='utf-8')
+    import sys, os
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    import ingest
+    assert ingest.parse_xavc_sidecar(str(mp4)) == {}


### PR DESCRIPTION
## Summary

B10 PR #5 merge 後實機 probe 發現 arkiv `exiftool_extract()` 對 Hevin 主力相機**幾乎全空**。本 PR 補兩條路徑：

1. **Sony XAVC sidecar parser** — 新 `parse_xavc_sidecar()` 讀 `<stem>M01.XML`，抓 `<Device manufacturer/modelName>` + `<Lens modelName>` + `<CreationDate value>`，namespace-aware XPath，malformed/missing 安全 fallback `{}`
2. **iPhone `[Keys]` group CreationDate** — `exiftool_extract()` cmd 加 `-Keys:CreationDate`，return parse 對 `d.get("CreationDate")` 做 fallback（Blackmagic Cam app 把 CreationDate 寫在 Keys group，原有 `-CreateDate`/`-DateTimeOriginal` 短語法抓不到）
3. **`process_file()` 合併**：sidecar 補 ExifTool 沒填到的 field（不覆蓋已有值）

## Why

dev-log 2026-05-05 提的「DB cols 在恬馨庫 0/427 populated（ExifTool migration 沒跑）」根因 = **不是 migration 沒跑，是抓不到**：
- FX30 XAVC：相機資訊全在 sidecar `.XML`，arkiv 沒讀
- iPhone Blackmagic Cam：CreationDate 在 Keys group，短語法漏抓

## E2E probe（PC，本機跑 ExifTool 13.58）

```
FX30.5378.MP4
  make/model/lens = 'Sony' / 'ILME-FX30' / 'E 17-70mm F2.8 B070'   ← sidecar 補
  creation_date = '2026:01:28 02:50:45'                             ← ExifTool 自帶
  reel_name = None                                                   ← XAVC sidecar 沒寫 (B10 已知 caveat)

A001_03111050_C469.mov (iPhone Blackmagic Cam)
  make/model/lens = None / 'Apple iPhone 16 Pro 48mm' / None         ← model via Keys
  creation_date = '2026:03:11 02:50:18'                              ← B10b -Keys:CreationDate 補
  reel_name = None                                                   ← AppleProappsReel=1 常數無用
```

FX30 4/4 fields populated = B10b 主要目標達成。iPhone Lens 在非標 tag `Blackmagic-design Camera Lens Type`，留 B10b2（per-app schema parser）。

## Test plan

- [x] `pytest tests/test_ingest.py -v -k sidecar` → 3/3 PASS (namespace XML / missing / malformed)
- [x] 全 test suite: 92 → **95 passed**（+3 sidecar 新 test），16 pre-existing Windows path fail（同 main，非 B10b regression）
- [x] E2E probe FX30 + iPhone 兩支實機素材（見上方）
- [ ] **Hevin 端**：對恬馨庫 427 row `python ingest.py --refresh` 後 `sqlite3 .arkiv/media.db "SELECT COUNT(*) FROM media WHERE camera_make IS NOT NULL"` 應 > 0（驗 0/427 → N/427 改善）

## 配套修正（不在本 PR）

`references/plans/arkiv/arkiv-roadmap.md` 的 B10 RED 驗證 SOP 寫錯 env var 名稱（`EXIFTOOL_PATH` → 應為 `ARKIV_EXIFTOOL_PATH`），CC 在 hevin-ai-os repo 修。

🤖 Generated with [Claude Code](https://claude.com/claude-code)