### PR TITLE
fix(b10c): ExifTool 路徑 auto-detect — 解 fresh PC clone silent skip 根因

### DIFF
--- a/config.py
+++ b/config.py
@@ -106,11 +106,13 @@ def _detect_exiftool() -> str:
         Path("C:/Program Files/exiftool/exiftool.exe"),
         Path("C:/ProgramData/chocolatey/bin/exiftool.exe"),
         Path(os.environ.get("USERPROFILE", "")) / "scoop" / "shims" / "exiftool.exe",
+        Path("C:/Strawberry/perl/bin/exiftool.bat"),  # Strawberry Perl install
         # macOS
         Path("/opt/homebrew/bin/exiftool"),
-        Path("/usr/local/bin/exiftool"),
+        Path("/usr/local/bin/exiftool"),  # Intel brew / Linux manual / Arch / NixOS
         # Linux
-        Path("/usr/bin/exiftool"),
+        Path("/usr/bin/exiftool"),  # apt default
+        Path.home() / ".local" / "bin" / "exiftool",  # pipx / user install
     ]
     for c in candidates:
         try:

--- a/config.py
+++ b/config.py
@@ -79,7 +79,50 @@ OLLAMA_URL = _validate_http_url(
 EMBED_MODEL = os.getenv("ARKIV_EMBED_MODEL", "nomic-embed-text")
 VISION_MODEL = os.getenv("ARKIV_VISION_MODEL", "qwen3-vl:8b")
 
-EXIFTOOL_PATH = os.getenv("ARKIV_EXIFTOOL_PATH", "exiftool")
+def _detect_exiftool() -> str:
+    """Resolve ExifTool binary path via fallback chain.
+
+    Priority: ARKIV_EXIFTOOL_PATH env > shutil.which('exiftool') > common
+    per-platform install paths. Returns "exiftool" literal as last resort
+    so subprocess fails loudly (WinError 2 / FileNotFoundError).
+
+    Background: winget/scoop/chocolatey on Windows don't add ExifTool to
+    PATH by default. Before this, fresh PC install would silent-skip every
+    exiftool_extract() call.
+    """
+    import shutil as _shutil
+
+    env_val = os.getenv("ARKIV_EXIFTOOL_PATH")
+    if env_val:
+        return env_val
+
+    which = _shutil.which("exiftool")
+    if which:
+        return which
+
+    candidates = [
+        # Windows
+        Path(os.environ.get("LOCALAPPDATA", "")) / "Programs" / "ExifTool" / "exiftool.exe",
+        Path("C:/Program Files/exiftool/exiftool.exe"),
+        Path("C:/ProgramData/chocolatey/bin/exiftool.exe"),
+        Path(os.environ.get("USERPROFILE", "")) / "scoop" / "shims" / "exiftool.exe",
+        # macOS
+        Path("/opt/homebrew/bin/exiftool"),
+        Path("/usr/local/bin/exiftool"),
+        # Linux
+        Path("/usr/bin/exiftool"),
+    ]
+    for c in candidates:
+        try:
+            if c.exists():
+                return str(c)
+        except OSError:
+            continue
+
+    return "exiftool"
+
+
+EXIFTOOL_PATH = _detect_exiftool()
 
 import platform as _plat
 

--- a/health.py
+++ b/health.py
@@ -106,13 +106,21 @@ def main():
 
     # ── ExifTool ────────────────────────────────────────────────────────
     print("\n-- ExifTool --")
-    exiftool = shutil.which("exiftool")
-    if plat == "docker":
-        check("exiftool", exiftool is not None, "(optional in Docker)", required=False)
+    import config as _config
+    exiftool_resolved = _config.EXIFTOOL_PATH
+    # config.EXIFTOOL_PATH may be absolute path (auto-detected) or literal "exiftool" (PATH lookup)
+    if os.sep in exiftool_resolved or "/" in exiftool_resolved:
+        exiftool_ok = Path(exiftool_resolved).exists()
     else:
-        check("exiftool", exiftool is not None,
-              f"({exiftool})" if exiftool else "(not found — install for rich metadata extraction)",
-              required=False)
+        exiftool_ok = shutil.which(exiftool_resolved) is not None
+    detail = (
+        f"({exiftool_resolved})" if exiftool_ok
+        else f"(not found — set ARKIV_EXIFTOOL_PATH or add to PATH; resolved: {exiftool_resolved!r})"
+    )
+    if plat == "docker":
+        check("exiftool", exiftool_ok, "(optional in Docker)", required=False)
+    else:
+        check("exiftool", exiftool_ok, detail, required=False)
 
     # ── Whisper ─────────────────────────────────────────────────────────
     print("\n-- Whisper --")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -130,10 +130,41 @@ def test_detect_exiftool_all_miss_returns_literal(monkeypatch, tmp_path):
     # Point all env-var-based candidates at empty tmp_path so none exist
     monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "empty1"))
     monkeypatch.setenv("USERPROFILE", str(tmp_path / "empty2"))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "empty_home"))
     # Hard-coded /usr/local/bin/exiftool etc. may exist on Mac CI — skip if so
-    import shutil as _real_shutil
     if any(Path(p).exists() for p in ["/usr/local/bin/exiftool", "/opt/homebrew/bin/exiftool",
                                        "/usr/bin/exiftool", "C:/Program Files/exiftool/exiftool.exe",
-                                       "C:/ProgramData/chocolatey/bin/exiftool.exe"]):
+                                       "C:/ProgramData/chocolatey/bin/exiftool.exe",
+                                       "C:/Strawberry/perl/bin/exiftool.bat"]):
         pytest.skip("hardcoded common path exists on host — can't isolate")
     assert config._detect_exiftool() == "exiftool"
+
+
+def test_detect_exiftool_empty_env_falls_through(monkeypatch):
+    """ARKIV_EXIFTOOL_PATH='' (empty string, e.g. user explicitly cleared) →
+    treated same as unset, falls through to shutil.which (not returned as empty)."""
+    sys.path.insert(0, str(ARKIV_ROOT))
+    import config
+    monkeypatch.setenv("ARKIV_EXIFTOOL_PATH", "")
+    monkeypatch.setattr("shutil.which", lambda name: "/from/which/exiftool" if name == "exiftool" else None)
+    assert config._detect_exiftool() == "/from/which/exiftool"
+
+
+def test_detect_exiftool_user_local_bin(tmp_path, monkeypatch):
+    """Linux pipx / user install: ~/.local/bin/exiftool detected via Path.home() candidate."""
+    sys.path.insert(0, str(ARKIV_ROOT))
+    import config
+    fake_home = tmp_path / "fakehome"
+    fake_exif = fake_home / ".local" / "bin" / "exiftool"
+    fake_exif.parent.mkdir(parents=True)
+    fake_exif.write_text("fake")
+    monkeypatch.delenv("ARKIV_EXIFTOOL_PATH", raising=False)
+    monkeypatch.setattr("shutil.which", lambda _: None)
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "empty"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "empty"))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    # Skip if hardcoded paths exist on host (Mac/Linux CI)
+    if any(Path(p).exists() for p in ["/usr/local/bin/exiftool", "/opt/homebrew/bin/exiftool",
+                                       "/usr/bin/exiftool"]):
+        pytest.skip("hardcoded common path exists on host — can't isolate")
+    assert config._detect_exiftool() == str(fake_exif)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -87,3 +87,53 @@ def test_config_accepts_localhost_and_tailscale_ollama():
     # Tailscale CGNAT (Ollama on NAS)
     code, stderr = _check_config_loads({"ARKIV_OLLAMA_URL": "http://100.64.154.6:11434"})
     assert code == 0, f"unexpected failure: {stderr}"
+
+
+# ── B10c: ExifTool auto-detect fallback chain ────────────────────────────────
+
+def test_detect_exiftool_env_var_wins(monkeypatch):
+    """ARKIV_EXIFTOOL_PATH env > everything else (trusts user override blindly)"""
+    sys.path.insert(0, str(ARKIV_ROOT))
+    import config
+    monkeypatch.setenv("ARKIV_EXIFTOOL_PATH", "/custom/path/exiftool")
+    assert config._detect_exiftool() == "/custom/path/exiftool"
+
+
+def test_detect_exiftool_falls_back_to_shutil_which(monkeypatch):
+    """No env → shutil.which lookup"""
+    sys.path.insert(0, str(ARKIV_ROOT))
+    import config
+    monkeypatch.delenv("ARKIV_EXIFTOOL_PATH", raising=False)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/local/bin/exiftool" if name == "exiftool" else None)
+    assert config._detect_exiftool() == "/usr/local/bin/exiftool"
+
+
+def test_detect_exiftool_falls_back_to_common_paths(tmp_path, monkeypatch):
+    """No env + which miss → scan common install paths (Windows winget LOCALAPPDATA pattern)"""
+    sys.path.insert(0, str(ARKIV_ROOT))
+    import config
+    fake_exif = tmp_path / "Programs" / "ExifTool" / "exiftool.exe"
+    fake_exif.parent.mkdir(parents=True)
+    fake_exif.write_text("fake")
+    monkeypatch.delenv("ARKIV_EXIFTOOL_PATH", raising=False)
+    monkeypatch.setattr("shutil.which", lambda _: None)
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+    assert config._detect_exiftool() == str(fake_exif)
+
+
+def test_detect_exiftool_all_miss_returns_literal(monkeypatch, tmp_path):
+    """All fallbacks miss → returns 'exiftool' literal (subprocess fails loud later)"""
+    sys.path.insert(0, str(ARKIV_ROOT))
+    import config
+    monkeypatch.delenv("ARKIV_EXIFTOOL_PATH", raising=False)
+    monkeypatch.setattr("shutil.which", lambda _: None)
+    # Point all env-var-based candidates at empty tmp_path so none exist
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "empty1"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "empty2"))
+    # Hard-coded /usr/local/bin/exiftool etc. may exist on Mac CI — skip if so
+    import shutil as _real_shutil
+    if any(Path(p).exists() for p in ["/usr/local/bin/exiftool", "/opt/homebrew/bin/exiftool",
+                                       "/usr/bin/exiftool", "C:/Program Files/exiftool/exiftool.exe",
+                                       "C:/ProgramData/chocolatey/bin/exiftool.exe"]):
+        pytest.skip("hardcoded common path exists on host — can't isolate")
+    assert config._detect_exiftool() == "exiftool"


### PR DESCRIPTION
## Summary

`config.py` ExifTool 路徑解析從「env var > 字面 'exiftool'」升級為三段 fallback chain：

```
ARKIV_EXIFTOOL_PATH env  >  shutil.which('exiftool')  >  常見 install paths
```

常見路徑覆蓋：
- **Windows**: winget (`LOCALAPPDATA\Programs\ExifTool\exiftool.exe`) / Program Files / chocolatey (`ProgramData\chocolatey\bin`) / scoop shims (`USERPROFILE\scoop\shims`)
- **macOS**: homebrew (`/opt/homebrew/bin` Apple Silicon / `/usr/local/bin` Intel)
- **Linux**: `/usr/bin/exiftool` (apt 默認)

`health.py` 改用 `config.EXIFTOOL_PATH`（不再獨立 `shutil.which`），印出哪條 fallback 命中或教 user 設 env var。

## Why

`exiftool_extract()` silent skip 的真正根因：winget/scoop/chocolatey 在 Windows **都不進 PATH**。arkiv 之前 default `"exiftool"` 字面 → `subprocess.run` `[WinError 2] 系統找不到指定檔案` → exception 被 `try/except` 吞掉 → 回 `{}` → DB ExifTool 欄全 NULL。

Mac brew 默認進 PATH 所以 2026-04-19 Mac smoke test PASS（`IMG_8780.MOV → Apple / iPhone 15 Pro / lens / creation_date 全寫入`）誤導以為「PC 也通」。**PC 端從未真正驗到 ExifTool 整合**，到今天（2026-05-18）B10/B10b 才實機撞到。

## E2E（PC 本機驗證）

```python
import os
os.environ.pop('ARKIV_EXIFTOOL_PATH', None)  # 故意 unset env
import config
print(config.EXIFTOOL_PATH)
# → 'C:\Users\user\AppData\Local\Programs\ExifTool\exiftool.exe'
```

```bash
$ python health.py
-- ExifTool --
  [PASS] exiftool (C:\Users\user\AppData\Local\Programs\ExifTool\exiftool.exe)
```

無需手動設 env var，winget 默認位置自動命中。

## Test plan

- [x] `pytest tests/test_config.py -v -k detect_exiftool` → **4/4 PASS**
  - `test_detect_exiftool_env_var_wins` — env override 永遠贏（trust user blindly）
  - `test_detect_exiftool_falls_back_to_shutil_which` — env 缺 → which 接手
  - `test_detect_exiftool_falls_back_to_common_paths` — env + which 缺 → 掃常見路徑（LOCALAPPDATA winget pattern）
  - `test_detect_exiftool_all_miss_returns_literal` — 全 miss 回 `"exiftool"` 字面，subprocess 之後 fail loud
- [x] 全 test suite: 92 → **96 passed**（+4 B10c），16 pre-existing Windows path fail（同主線，非 B10c regression）
- [x] E2E unset env → auto-detect winget 路徑 + health.py PASS

## 與 B10b 關係

獨立 PR — B10c 動 `config.py + health.py + tests/test_config.py`，B10b 動 `ingest.py + tests/test_ingest.py`。無 file 衝突，順序無關。但**兩者搭配**才完整解 0/427 populated：
- B10b → ExifTool 抓得到（XAVC sidecar + Keys group）
- B10c → arkiv 找得到 ExifTool

🤖 Generated with [Claude Code](https://claude.com/claude-code)