### PR TITLE
fix(b10-hotfix): EDL reel name 控制字元注入 + whitespace fallback (Codex audit)

### DIFF
--- a/server.py
+++ b/server.py
@@ -1031,7 +1031,14 @@ def clear_cache(target: str = Query("app", description="app|thumbnails|chromadb|
 # ── Export ────────────────────────────────────────────────────────────────────
 
 def _edl_reel(rec, stem):
-    value = rec.get("reel_name") or stem
+    # CMX3600 reel: ASCII only, 8 chars, no control chars (would inject EDL lines).
+    # Treat blank/whitespace-only reel_name as missing → stem fallback.
+    raw = rec.get("reel_name")
+    value = raw.strip() if isinstance(raw, str) and raw.strip() else stem
+    # Strip ASCII control chars (0x00-0x1F + 0x7F) BEFORE ASCII conversion —
+    # encode("ascii", "replace") would happily pass \r\n through, letting a
+    # poisoned reel_name like "A001\r\nFCM: NONAME" inject EDL header lines.
+    value = "".join(c for c in value if 0x20 <= ord(c) < 0x7F or ord(c) >= 0x80)
     value = value.encode("ascii", "replace").decode("ascii")
     return value[:8].ljust(8)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -263,6 +263,57 @@ def test_edl_reel_strips_non_ascii(fastapi_client, sample_record):
     assert reel_field.isascii()
 
 
+def test_edl_reel_strips_control_chars_no_injection(fastapi_client, sample_record):
+    """CRITICAL: poisoned reel_name with \\r\\n must NOT inject EDL lines."""
+    db = importlib.import_module("db")
+    db.upsert(sample_record(
+        path="/tmp/inject.mp4",
+        filename="inject.mp4",
+        reel_name="A001\r\nFCM: NONAME\r\n002  EVIL",
+    ))
+
+    resp = fastapi_client.get("/api/media/1/export/edl")
+    assert resp.status_code == 200
+    # Should still have exactly ONE event line (starting with "001  ")
+    event_lines = [l for l in resp.text.splitlines() if l.lstrip().startswith(("001", "002"))]
+    assert len(event_lines) == 1, f"Expected 1 event line, got: {event_lines}"
+    # Reel field stays inside 8-char window — no embedded newline
+    reel_field = event_lines[0][5:13]
+    assert "\n" not in reel_field
+    assert "\r" not in reel_field
+    assert len(reel_field) == 8
+
+
+def test_edl_reel_whitespace_only_falls_back_to_stem(fastapi_client, sample_record):
+    """Whitespace-only reel_name (e.g. "   ") must fall back to filename stem."""
+    db = importlib.import_module("db")
+    db.upsert(sample_record(
+        path="/tmp/whitespace_clip.mp4",
+        filename="FX30_C002.MP4",
+        reel_name="   ",
+    ))
+
+    resp = fastapi_client.get("/api/media/1/export/edl")
+    assert resp.status_code == 200
+    line = next(line for line in resp.text.splitlines() if line.startswith("001  "))
+    assert line[5:13] == "FX30_C00"
+
+
+def test_edl_reel_empty_string_falls_back_to_stem(fastapi_client, sample_record):
+    """Empty-string reel_name (vs NULL) must also fall back to stem."""
+    db = importlib.import_module("db")
+    db.upsert(sample_record(
+        path="/tmp/empty_clip.mp4",
+        filename="FX30_C003.MP4",
+        reel_name="",
+    ))
+
+    resp = fastapi_client.get("/api/media/1/export/edl")
+    assert resp.status_code == 200
+    line = next(line for line in resp.text.splitlines() if line.startswith("001  "))
+    assert line[5:13] == "FX30_C00"
+
+
 def test_fcpxml_export_keeps_asset_full_but_clip_uses_trim(fastapi_client, sample_record):
     _insert_media_with_segments(sample_record)
 


### PR DESCRIPTION
## Summary

Codex audit (2026-05-18) 對 PR #5 B10 merge 後抓到的 fix。

### CRITICAL — control char injection
`_edl_reel()` 對 ASCII control chars (\r \n) 直通 `encode('ascii', 'replace')` 階段，攻擊者控制 reel_name (e.g. via API, DB UPDATE) 可注 EDL 行：

```
reel_name = "A001\r\nFCM: NONAME\r\n002  EVIL"
→ EDL 輸出多兩行：FCM: NONAME / 002 EVIL
→ 破壞 conform / 偽造 source clip / 替換 reel
```

Fix: encode 前剔除 0x00-0x1F + 0x7F 控制字元（保留 ASCII printable + Latin-1+ 留給後面的 replace step）。

### SHOULD-FIX — whitespace-only reel_name
\"   \" (全空白) 不 fallback 到 stem，輸出全空格 reel field。Fix: `rec.get('reel_name')` 後 `.strip()`，blank/empty 視為缺失走 stem。

## Test plan

- [x] 3 既有 reel test 全 PASS（B10 PR #5）
- [x] 3 新 regression test PASS：
  - control char injection → 輸出只 1 event line，reel field 無 \n/\r
  - whitespace-only \"   \" → 走 stem (FX30_C00)
  - empty string \"\" → 走 stem (FX30_C00)
- [x] 全 suite: 92 → **95 passed**（+3 hotfix），16 pre-existing Windows path fail 同主線

## Audit context

完整 audit report 見 Codex output（CC session 2026-05-18）。
- PR #6 (B10b) 自驗 clean
- PR #7 (B10c) 另有 1 SHOULD-FIX（缺 Linux/Strawberry Perl 路徑）→ amend PR #7 separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)