### PR TITLE
fix(b10b2): Blackmagic Cam app lens fallback for iPhone

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -157,6 +157,11 @@ def exiftool_extract(path: str) -> dict:
         "-FocalLength",
         "-CreateDate", "-DateTimeOriginal",
         "-Keys:CreationDate",
+        # Blackmagic Cam app (iOS) writes per-vendor schema in [Keys] group.
+        # Lens info goes to "Blackmagic-design Camera Lens Type" (short form
+        # collapses spaces). Other BMD fields (ISO/Aperture/ShutterAngle/WB)
+        # not consumed yet — see todo B10b3.
+        "-Blackmagic-designCameraLensType",
         "-n",  # numeric output for GPS
         path,
     ]
@@ -201,7 +206,7 @@ def exiftool_extract(path: str) -> dict:
     return {
         "camera_make": d.get("Make"),
         "camera_model": d.get("Model"),
-        "lens_model": d.get("LensModel"),
+        "lens_model": d.get("LensModel") or d.get("Blackmagic-designCameraLensType"),
         "gps_lat": d.get("GPSLatitude"),
         "gps_lon": d.get("GPSLongitude"),
         "color_space": str(d.get("ColorSpace")) if d.get("ColorSpace") else None,

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -36,3 +36,54 @@ def test_parse_xavc_sidecar_malformed(tmp_path):
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     import ingest
     assert ingest.parse_xavc_sidecar(str(mp4)) == {}
+
+
+# B10b2: Blackmagic Cam app (iOS) per-vendor lens tag
+
+def test_exiftool_lens_falls_back_to_bmd_camera_lens_type(monkeypatch):
+    """Blackmagic Cam app writes lens in non-standard `Blackmagic-design Camera
+    Lens Type` (Keys group). When standard `-LensModel` returns empty, fall
+    back to BMD tag so iPhone clips recorded via BMD Cam still populate lens."""
+    import sys, os, json
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    import ingest
+
+    fake_stdout = json.dumps([{
+        "SourceFile": "iphone.mov",
+        "Model": "Apple iPhone 16 Pro 48mm",
+        "Blackmagic-designCameraLensType": "iPhone 16 Pro 48mm",
+        # LensModel intentionally absent (BMD Cam doesn't write it)
+    }])
+
+    class _FakeProc:
+        returncode = 0
+        stdout = fake_stdout
+        stderr = ""
+
+    monkeypatch.setattr(ingest.subprocess, "run", lambda *a, **kw: _FakeProc())
+    result = ingest.exiftool_extract("iphone.mov")
+    assert result["lens_model"] == "iPhone 16 Pro 48mm"
+    assert result["camera_model"] == "Apple iPhone 16 Pro 48mm"
+
+
+def test_exiftool_lens_prefers_standard_lensmodel_over_bmd(monkeypatch):
+    """If both standard LensModel and BMD tag present, standard wins (e.g.
+    BMD app on a Sony body that already writes LensModel)."""
+    import sys, os, json
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    import ingest
+
+    fake_stdout = json.dumps([{
+        "SourceFile": "edge.mov",
+        "LensModel": "Standard 24-70mm f/2.8",
+        "Blackmagic-designCameraLensType": "Generic BMD lens",
+    }])
+
+    class _FakeProc:
+        returncode = 0
+        stdout = fake_stdout
+        stderr = ""
+
+    monkeypatch.setattr(ingest.subprocess, "run", lambda *a, **kw: _FakeProc())
+    result = ingest.exiftool_extract("edge.mov")
+    assert result["lens_model"] == "Standard 24-70mm f/2.8"


### PR DESCRIPTION
## Summary

iPhone clips recorded via Blackmagic Cam (iOS) 把 lens 寫在非標 `[Keys]` tag `Blackmagic-design Camera Lens Type`（ExifTool 短語法 collapse 為 `Blackmagic-designCameraLensType`）。BMD Cam 不寫標準 `LensModel`，所以 arkiv 之前 lens_model 全 NULL。

- `ingest.exiftool_extract()` cmd 加 `-Blackmagic-designCameraLensType`
- lens_model fallback chain: `LensModel` → `Blackmagic-designCameraLensType`（standard 優先，BMD 作 vendor fallback）
- 2 regression test (BMD-only / standard-wins-when-both-present)

## Why

B10b PR #6 e2e probe 抓到 iPhone Blackmagic Cam clip lens 全 NULL（dev-log 5/18 §5）— `Model` 在 Keys group 短語法已能 fallback，但 `LensModel` 沒被寫，arkiv 從沒 query BMD 私有 tag。

## E2E

PC 本機 ExifTool 13.58 對 `H:\Project_V1-LAN\_影片素材\iphone 16pro\A001_03111050_C469.mov`：

```
BEFORE B10b2: lens_model = None
AFTER B10b2:  lens_model = 'iPhone 16 Pro 48mm'
```

## Test plan

- [x] `pytest tests/test_ingest.py -v` → 5/5 PASS（3 既有 sidecar + 2 新 BMD lens）
- [x] 全 suite: 95 → **97 passed**（+2 B10b2），16 pre-existing Windows path fail（同主線，無 regression）
- [x] E2E iPhone clip lens_model 確實寫入

## Base branch

**Off `fix-b10b-exiftool-sidecar`** (PR #6) — B10b 跟 B10b2 都改 `exiftool_extract()` cmd list + return dict，off PR #6 branch 避 conflict。merge 順序：PR #6 先 merge → 本 PR 改 base 為 main → merge。

## Out of scope (留 B10b3)

BMD Cam 還寫 ISO（int）/ Aperture（`f1.8` str）/ ShutterAngle（`180°`，**非** ShutterSpeed，需 angle/360/fps 換算才能填 shutter_speed）/ WhiteBalance Kelvin。lens 屬最簡單 case，先 ship；其他需 parse 換算 + scope 大留 follow-up。

🤖 Generated with [Claude Code](https://claude.com/claude-code)