### PR TITLE
docs(release): v0.3.0 — DIT Companion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## v0.3.0 (2026-05-22) — DIT Companion
+
+### New Features
+- **DaVinci Resolve metadata CSV export** — `/api/export/metadata-csv` endpoint + toolbar button + plugin auto-prompt. Drop-in for Resolve's `File → Import Metadata from CSV` workflow (Phase 7.6b/c/d/e)
+- **ExifTool full integration** — Sony XAVC sidecar `.XML` parsing, iPhone Keys group fallback, Blackmagic Cam app per-vendor lens tags (`Blackmagic-designCameraLensType`). LensModel chain: ExifTool LensModel → BMD vendor tag
+- **ExifTool auto-detect** — `config._detect_exiftool()` fallback chain (env var → `shutil.which` → Windows winget LOCALAPPDATA / Program Files / chocolatey / scoop / macOS homebrew / Linux apt + `~/.local/bin` + Strawberry Perl). Solves silent skip on fresh Windows clone
+- **HEVC/ProRes browser proxy** — `/api/proxy/build/{id}` POST endpoint + 409 surface in frontend + "build proxy" button (Phase 7.7g)
+- **Tauri panic hook** — surfaces Rust crashes to stderr (Windows dialog crash diagnosis)
+
+### Bug Fixes
+- **EDL reel name (B10)** — was `stem[:8]` unconditionally. Now uses ExifTool ReelName when present, falls back to filename stem; sanitizes control chars; pads/truncates to 8-char CMX3600 spec
+- **EDL reel injection hotfix (B10-hotfix)** — control char (`\r\n` etc.) stripped before encode; whitespace-only reel falls back to stem (Codex audit)
+- **Tauri dialog crash (Windows)** — `rfd` folder picker crash workaround: drop `title` arg
+- **Vision Ollama timeout** — bump 120s → 300s for large prompts
+- **mlx-whisper backend** — drop unsupported `beam_size` kwarg
+
+### Security
+- Codex Round 1+2 audit: 5 SSRF / path-bound hardenings (Batch J), export-to dest allowlist (blocks `~/.ssh` / LaunchAgents RCE), CSV formula injection prevention, XSS hardening, vectordb `build_doc_text` production schema alignment
+
+### Internals
+- Cross-platform `detect_gpu()` for `bench_ingest.json`
+- `arkiv_resolve.py` honors `ARKIV_API` / `ARKIV_HOST` / `ARKIV_PORT` env
+- 6+ new tests (ExifTool fallback chain + reel name regressions + CSV scope + BMD lens + ExifTool sidecar)
+
+### Known Issues
+- Resolve conform pathname pattern `*/%R/%D` mis-parses paths like `iphone 16pro` as reel — workaround: set conform pattern to filename-based, or use FCPXML import (B10c-resolve, open)
+
+---
+
 ## v0.2.1 (2026-04-12)
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ Designed for solo DITs and small crews who own their data: local-first, self-hos
 - **Tag system** — auto (AI) + manual tags with autocomplete
 - **DaVinci Resolve UI** — dark theme, 3-panel layout, filmstrip, waveform
 - **Export** — SRT, VTT, TXT, EDL (drop-frame TC), FCPXML 1.8 (FCPX + DaVinci compatible)
-- **Tauri native app** — desktop app with native file/folder dialogs
+- **DaVinci Resolve metadata CSV** — `/api/export/metadata-csv` endpoint exports clip metadata (Camera/Lens/ISO/Shutter/Aperture/GPS/CreateDate) ready for Resolve's `File → Import Metadata from CSV`. Plugin auto-prompts after import
+- **ExifTool integration** — auto-extracts 12 fields per clip (Make/Model/LensModel/GPS/ColorSpace/ISO/Shutter/Aperture/FocalLength/CreateDate). Sidecar-aware for Sony XAVC `.XML`, iPhone Keys group, Blackmagic Cam app per-vendor lens tags. Auto-detects exiftool binary on Windows (winget/scoop/chocolatey/Program Files)
+- **EDL reel name** — uses ExifTool ReelName with safe fallback to filename stem (8-char CMX3600 compat, control-char sanitized)
+- **HEVC/ProRes browser proxy** — auto-builds H.264 proxy on demand for browser playback (Phase 7.7g)
+- **Tauri native app** — desktop app with native file/folder dialogs (Windows panic hook surfaces Rust crashes to stderr)
 - **DaVinci Resolve plugin** — search, import with clip color, add frame markers
 
 ## Quick Start
@@ -214,6 +218,7 @@ Copy `.env.example` to `.env` and customize:
 | LLM Polish | Ollama qwen2.5:14b (punctuation + typo correction) |
 | Vision | Ollama qwen3-vl:8b (brand/object recognition) |
 | Media | FFmpeg (probe, thumbnails, frame extraction) |
+| Metadata | ExifTool (12 fields, sidecar-aware, cross-platform auto-detect) |
 | Export | SRT, VTT, TXT, EDL (DF/NDF), FCPXML 1.8 |
 | Desktop | Tauri (native app wrapper) |
 | NLE Plugin | DaVinci Resolve (import + clip color + markers) |
@@ -271,13 +276,13 @@ SKIP items are **optional dependencies** — they do not affect functionality. A
 | Apple Silicon | — | Required | — | |
 | fastapi + uvicorn | Required | Required | Required | |
 
-### Latest Results (v0.1.0)
+### Latest Results (v0.3.0)
 
 | Platform | Health Check | Smoke Test | Date |
 |----------|-------------|------------|------|
-| macOS M2 Max | 18/19 PASS, 0 FAIL, 1 SKIP | 9/9 PASS | 2026-04-03 |
-| Windows 11 (RTX 4070) | 17/18 PASS, 0 FAIL, 1 SKIP | 9/9 PASS | 2026-04-02 |
-| Linux (Docker) | 14/17 PASS, 0 FAIL, 3 SKIP | 9/9 PASS | 2026-04-01 |
+| macOS M2 Max | TBD | TBD | 2026-05-22 |
+| Windows 11 (RTX 4070) | TBD | TBD | 2026-05-22 |
+| Linux (Docker) | TBD | TBD | 2026-05-22 |
 
 ## License
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -60,7 +60,11 @@ arkiv 介於素材硬碟與 DaVinci Resolve 之間：自動 ingest footage、附
 - **標籤系統** — 自動（AI）+ 手動標籤，附自動補全
 - **DaVinci Resolve 風格 UI** — 深色主題、三欄式佈局、膠卷條、波形圖
 - **匯出** — SRT、VTT、TXT、EDL（DF/NDF 時間碼）、FCPXML 1.8（FCPX + DaVinci 相容）
-- **Tauri 原生應用** — 桌面應用程式，支援原生檔案/資料夾對話框
+- **DaVinci Resolve 詮釋資料 CSV 匯出** — `/api/export/metadata-csv` 端點輸出片段詮釋資料（Camera／Lens／ISO／Shutter／Aperture／GPS／CreateDate），可直接餵 Resolve 的「檔案 → 從 CSV 匯入詮釋資料」。外掛匯入後自動提示
+- **ExifTool 整合** — 每支片段自動擷取 12 個欄位（Make／Model／LensModel／GPS／ColorSpace／ISO／Shutter／Aperture／FocalLength／CreateDate）。支援 sidecar：Sony XAVC `.XML`、iPhone Keys group、Blackmagic Cam app 廠商專屬鏡頭標籤。Windows 自動偵測 exiftool 二進位位置（winget／scoop／chocolatey／Program Files）
+- **EDL reel 名** — 採 ExifTool ReelName，缺失時 fallback 到檔名 stem（8 字元 CMX3600 規格相容、控制字元已過濾）
+- **HEVC／ProRes 瀏覽器代理** — 瀏覽器播放時依需求自動產生 H.264 代理（Phase 7.7g）
+- **Tauri 原生應用** — 桌面應用程式，支援原生檔案/資料夾對話框（Windows panic hook 將 Rust crash 寫到 stderr）
 - **DaVinci Resolve 外掛** — 搜尋、匯入（含片段顏色）、新增幀標記
 
 ## 快速開始
@@ -212,6 +216,7 @@ Invoke-RestMethod "http://localhost:8501/api/media?q=關鍵字&limit=5"
 | LLM 潤稿 | Ollama qwen2.5:14b（標點 + 錯字校正） |
 | 視覺 | Ollama qwen3-vl:8b（品牌/物件辨識） |
 | 媒體 | FFmpeg（探測、縮圖、幀擷取） |
+| 詮釋資料 | ExifTool（12 欄位、sidecar-aware、跨平台自動偵測） |
 | 匯出 | SRT、VTT、TXT、EDL（DF/NDF）、FCPXML 1.8 |
 | 桌面 | Tauri（原生應用程式包裝） |
 | NLE 外掛 | DaVinci Resolve（匯入 + 片段上色 + 標記） |
@@ -269,13 +274,13 @@ SKIP 項目是**選用的相依套件** — 不影響功能。通過的結果是
 | Apple Silicon | — | 必要 | — | |
 | fastapi + uvicorn | 必要 | 必要 | 必要 | |
 
-### 最新結果 (v0.2.0)
+### 最新結果 (v0.3.0)
 
 | 平台 | 環境健檢 | 冒煙測試 | 日期 |
 |------|----------|----------|------|
-| macOS M2 Max | 18/19 PASS, 0 FAIL, 1 SKIP | 9/9 PASS | 2026-04-03 |
-| Windows 11 (RTX 4070) | 17/18 PASS, 0 FAIL, 1 SKIP | 9/9 PASS | 2026-04-02 |
-| Linux (Docker) | 14/17 PASS, 0 FAIL, 3 SKIP | 9/9 PASS | 2026-04-01 |
+| macOS M2 Max | TBD | TBD | 2026-05-22 |
+| Windows 11 (RTX 4070) | TBD | TBD | 2026-05-22 |
+| Linux (Docker) | TBD | TBD | 2026-05-22 |
 
 ## 授權
 


### PR DESCRIPTION
## Summary

v0.3.0 release docs prep — README (EN + zh-TW) + CHANGELOG bumped to reflect work landed via PR #5/#6/#7/#8/#9 since v0.2.1.

Driven by W3.4 r/DaVinciResolve post prerequisite — readers landing on the repo from Reddit cannot see a stale v0.2.1 page.

## Changes

- **README.md / README.zh-TW.md**: +4 Features bullets (CSV export / ExifTool integration / EDL reel name / HEVC browser proxy) + Tauri panic hook note + Tech Stack adds Metadata row + Latest Results table reset to v0.3.0 (smoke test numbers TBD)
- **CHANGELOG.md**: prepend v0.3.0 entry — New Features (5) / Bug Fixes (5 incl. B10-hotfix) / Security (Codex Round 1+2) / Internals / Known Issues (B10c-resolve)

## Test plan

- [ ] Hevin runs `health.py` + smoke test on macOS M2 Max, Windows 11 (RTX 4070), Linux Docker → fills in Latest Results table on main post-merge
- [ ] Tag `v0.3.0` after merge
- [ ] Demo gif #1 (Resolve plugin Chinese search → clip color import) recorded for Reddit post

🤖 Generated with [Claude Code](https://claude.com/claude-code)