### PR TITLE
fix(b10b3): BMD per-vendor metadata — ISO/Aperture/ShutterAngle→Speed/WhiteBalance

### DIFF
--- a/db.py
+++ b/db.py
@@ -81,6 +81,7 @@ def init_db():
                 lang           TEXT,
                 frame_tags     TEXT,
                 reel_name      TEXT,
+                white_balance  TEXT,
                 thumbnail_path TEXT,
                 processed_at   TEXT
             )
@@ -126,6 +127,7 @@ def init_db():
             ("focal_length", "REAL"),
             ("creation_date", "TEXT"),
             ("reel_name", "TEXT"),
+            ("white_balance", "TEXT"),
             ("content_type", "TEXT"),
             ("start_tc", "TEXT"),
             # Phase 9.4: Whisper segment timestamps for precise SRT/VTT
@@ -215,7 +217,7 @@ _ALLOWED_COLS = {
     "fps", "has_audio", "transcript", "lang", "frame_tags", "thumbnail_path",
     "processed_at", "rating", "rating_note", "camera_make", "camera_model",
     "lens_model", "gps_lat", "gps_lon", "color_space", "iso", "shutter_speed",
-    "aperture", "focal_length", "creation_date", "content_type",
+    "aperture", "focal_length", "creation_date", "white_balance", "content_type",
     "reel_name",
     "start_tc",
     "segments_json",

--- a/ingest.py
+++ b/ingest.py
@@ -7,6 +7,7 @@ Usage:
 from __future__ import annotations
 import argparse
 import json
+import logging
 import shutil
 import subprocess
 import sys
@@ -26,6 +27,7 @@ SUPPORTED = {".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts", ".mp3", ".
 VIDEO_EXT = {".mp4", ".mov", ".m4v", ".mts"}
 # Codecs needing browser-playable proxy — single source of truth in codec.py.
 PROXY_CODECS = codec.PROXY_CODECS
+logger = logging.getLogger(__name__)
 
 
 def _warm_up_vision_model():
@@ -65,6 +67,55 @@ def _unload_ollama_model(model: str):
         print(f"  Unloaded {model} from VRAM")
     except Exception as e:
         print(f"  Warning: could not unload {model}: {e}")
+
+
+def _normalize_bmd_tag(value):
+    if value is None:
+        return None
+    tag = str(value).strip().lower()
+    return tag or None
+
+
+def _shutter_angle_to_speed(angle, fps, path=None):
+    try:
+        angle_value = float(angle)
+        fps_value = float(fps)
+        if angle_value <= 0 or fps_value <= 0:
+            raise ValueError
+    except (TypeError, ValueError):
+        logger.warning(
+            "Blackmagic-designCameraShutterAngle parse failed for %s: angle=%r fps=%r",
+            path or "media",
+            angle,
+            fps,
+        )
+        return None
+
+    denominator = round((360.0 * fps_value) / angle_value)
+    if denominator <= 0:
+        logger.warning(
+            "Blackmagic-designCameraShutterAngle parse failed for %s: angle=%r fps=%r",
+            path or "media",
+            angle,
+            fps,
+        )
+        return None
+    return "1/{0}".format(denominator)
+
+
+def _white_balance_string(kelvin, tint, path=None):
+    try:
+        kelvin_value = float(kelvin)
+        tint_value = float(tint)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Blackmagic-designCameraWhiteBalance parse failed for %s: kelvin=%r tint=%r",
+            path or "media",
+            kelvin,
+            tint,
+        )
+        return None
+    return "{0}K T{1}".format(int(round(kelvin_value)), int(round(tint_value)))
 
 
 def probe(path: str) -> Optional[Dict]:
@@ -143,7 +194,7 @@ def probe(path: str) -> Optional[Dict]:
     }
 
 
-def exiftool_extract(path: str) -> dict:
+def exiftool_extract(path: str, fps: Optional[float] = None) -> dict:
     """Extract EXIF metadata via exiftool -json. Returns dict of 12 fields."""
     cmd = [
         config.EXIFTOOL_PATH, "-json",
@@ -162,6 +213,13 @@ def exiftool_extract(path: str) -> dict:
         # collapses spaces). Other BMD fields (ISO/Aperture/ShutterAngle/WB)
         # not consumed yet — see todo B10b3.
         "-Blackmagic-designCameraLensType",
+        "-Blackmagic-designCameraIso",
+        "-Blackmagic-designCameraAperture",
+        "-Blackmagic-designCameraShutterAngle",
+        "-Blackmagic-designCameraWhiteBalanceKelvin",
+        "-Blackmagic-designCameraWhiteBalanceTint",
+        "-Blackmagic-designCameraEnvironment",
+        "-Blackmagic-designCameraDayNight",
         "-n",  # numeric output for GPS
         path,
     ]
@@ -189,6 +247,8 @@ def exiftool_extract(path: str) -> dict:
     # Parse shutter speed — prefer ExposureTime as string
     ss = d.get("ShutterSpeed") or d.get("ExposureTime")
     ss_str = str(ss) if ss else None
+    if not ss_str and d.get("Blackmagic-designCameraShutterAngle") is not None:
+        ss_str = _shutter_angle_to_speed(d.get("Blackmagic-designCameraShutterAngle"), fps, path=path)
 
     # Parse aperture — prefer FNumber
     ap_raw = d.get("FNumber") or d.get("ApertureValue")
@@ -197,9 +257,28 @@ def exiftool_extract(path: str) -> dict:
         try:
             ap = float(ap_raw)
         except (ValueError, TypeError):
-            pass
+            logger.warning("Aperture parse failed for %s: value=%r", path, ap_raw)
+    elif d.get("Blackmagic-designCameraAperture") is not None:
+        ap = d.get("Blackmagic-designCameraAperture")
 
     # Creation date — prefer CreateDate, fallback DateTimeOriginal
+    white_balance = None
+    if d.get("Blackmagic-designCameraWhiteBalanceKelvin") is not None or d.get("Blackmagic-designCameraWhiteBalanceTint") is not None:
+        white_balance = _white_balance_string(
+            d.get("Blackmagic-designCameraWhiteBalanceKelvin"),
+            d.get("Blackmagic-designCameraWhiteBalanceTint"),
+            path=path,
+        )
+
+    auto_tags = []
+    for tag_value in (
+        d.get("Blackmagic-designCameraEnvironment"),
+        d.get("Blackmagic-designCameraDayNight"),
+    ):
+        tag_name = _normalize_bmd_tag(tag_value)
+        if tag_name and tag_name not in auto_tags:
+            auto_tags.append(tag_name)
+
     cdate = d.get("CreateDate") or d.get("DateTimeOriginal") or d.get("CreationDate")
     cdate_str = str(cdate) if cdate else None
 
@@ -210,12 +289,14 @@ def exiftool_extract(path: str) -> dict:
         "gps_lat": d.get("GPSLatitude"),
         "gps_lon": d.get("GPSLongitude"),
         "color_space": str(d.get("ColorSpace")) if d.get("ColorSpace") else None,
-        "iso": d.get("ISO"),
+        "iso": d.get("ISO") if d.get("ISO") is not None else d.get("Blackmagic-designCameraIso"),
         "shutter_speed": ss_str,
         "aperture": ap,
         "focal_length": fl,
         "creation_date": cdate_str,
         "reel_name": d.get("ReelName") or d.get("CameraReelName") or d.get("Reel#") or d.get("ReelNumber"),
+        "white_balance": white_balance,
+        "_auto_tags": auto_tags,
     }
 
 
@@ -344,7 +425,7 @@ def process_file(path: Path, skip_vision: bool, existing: Optional[Dict] = None)
         print(" [ffprobe failed]")
         return {}
 
-    exif = exiftool_extract(str(path))
+    exif = exiftool_extract(str(path), fps=meta.get("fps") or (existing.get("fps") if existing else None))
     sidecar = parse_xavc_sidecar(str(path))
     for k, v in sidecar.items():
         if v and not exif.get(k):
@@ -838,6 +919,13 @@ def main():
             if record:
                 frames = record.pop("_frames", [])
                 db.upsert(record)
+                auto_tags = record.get("_auto_tags") or []
+                if auto_tags:
+                    mid = _get_media_id_for_path(f)
+                    if mid:
+                        with db.get_conn() as conn:
+                            for tag_name in auto_tags:
+                                db.add_tag(mid, tag_name, source="auto", _conn=conn)
                 # Store frame records (without vision descriptions yet)
                 if frames:
                     with db.get_conn() as conn:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -87,3 +87,95 @@ def test_exiftool_lens_prefers_standard_lensmodel_over_bmd(monkeypatch):
     monkeypatch.setattr(ingest.subprocess, "run", lambda *a, **kw: _FakeProc())
     result = ingest.exiftool_extract("edge.mov")
     assert result["lens_model"] == "Standard 24-70mm f/2.8"
+
+
+def test_bmd_metadata_parsing_and_shutter_angle_conversion(monkeypatch):
+    import sys, os, json
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    import ingest
+
+    fake_stdout = json.dumps([{
+        "SourceFile": "bmd.mov",
+        "Blackmagic-designCameraIso": 640,
+        "Blackmagic-designCameraAperture": 2.8,
+        "Blackmagic-designCameraShutterAngle": 172.8,
+        "Blackmagic-designCameraWhiteBalanceKelvin": 5600,
+        "Blackmagic-designCameraWhiteBalanceTint": 10,
+        "Blackmagic-designCameraEnvironment": "Indoor",
+        "Blackmagic-designCameraDayNight": "Night",
+    }])
+
+    class _FakeProc:
+        returncode = 0
+        stdout = fake_stdout
+        stderr = ""
+
+    monkeypatch.setattr(ingest.subprocess, "run", lambda *a, **kw: _FakeProc())
+    result = ingest.exiftool_extract("bmd.mov", fps=24)
+    assert result["iso"] == 640
+    assert result["aperture"] == 2.8
+    assert result["shutter_speed"] == "1/50"
+    assert result["white_balance"] == "5600K T10"
+    assert result["_auto_tags"] == ["indoor", "night"]
+
+
+def test_bmd_shutter_angle_conversion_examples():
+    import sys, os
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    import ingest
+
+    cases = [
+        (172.8, 24, "1/50"),
+        (360.0, 24, "1/24"),
+        (90.0, 24, "1/96"),
+        (180.0, 25, "1/50"),
+    ]
+    for angle, fps, expected in cases:
+        assert ingest._shutter_angle_to_speed(angle, fps) == expected
+
+
+def test_bmd_shutter_angle_parse_fail_logs_warning(monkeypatch, caplog):
+    import sys, os, json
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    import ingest
+
+    fake_stdout = json.dumps([{
+        "SourceFile": "broken.mov",
+        "Blackmagic-designCameraShutterAngle": "not-a-number",
+    }])
+
+    class _FakeProc:
+        returncode = 0
+        stdout = fake_stdout
+        stderr = ""
+
+    monkeypatch.setattr(ingest.subprocess, "run", lambda *a, **kw: _FakeProc())
+    with caplog.at_level("WARNING"):
+        result = ingest.exiftool_extract("broken.mov", fps=24)
+    assert result["shutter_speed"] is None
+    assert any("Blackmagic-designCameraShutterAngle parse failed" in record.message for record in caplog.records)
+
+
+def test_bmd_metadata_roundtrips_white_balance_column(tmp_db, sample_record):
+    import importlib
+
+    db = importlib.import_module("db")
+    db.upsert(
+        sample_record(
+            path="/tmp/bmd.mov",
+            filename="bmd.mov",
+            iso=800,
+            aperture=2.8,
+            shutter_speed="1/50",
+            white_balance="5600K T0",
+        )
+    )
+    with db.get_conn() as conn:
+        row = conn.execute(
+            "SELECT iso, aperture, shutter_speed, white_balance FROM media WHERE path = ?",
+            ("/tmp/bmd.mov",),
+        ).fetchone()
+    assert row["iso"] == 800
+    assert row["aperture"] == 2.8
+    assert row["shutter_speed"] == "1/50"
+    assert row["white_balance"] == "5600K T0"


### PR DESCRIPTION
## Summary

B10b2 衍生 — Blackmagic Cam app 寫的 mov/mp4 含 vendor-specific ExifTool tags（B10b2 已 ship lens parser，PR #9 merged 2026-05-18）。本 PR 補完其他 4 條 metadata：

- **`Blackmagic-designCameraIso`** → DB `iso` column（純 parse）
- **`Blackmagic-designCameraAperture`** → DB `aperture` column
- **`Blackmagic-designCameraShutterAngle`** → 配 fps 換算 → DB `shutter_speed` 寫 `1/N` format
  - **關鍵 formula**：`exposure_time_seconds = (shutter_angle_degrees / 360) / fps`
  - 172.8°@24fps → `1/50`；360°@24fps → `1/24`
  - fps 來源優先 ffprobe stream `r_frame_rate`
- **`Blackmagic-designCameraWhiteBalanceKelvin` + `Tint`** → 新 DB column `white_balance`（schema ALTER 加 1 col）
- **`Blackmagic-designCameraEnvironment` + `DayNight`** → auto tag 進既有 tag system

## Test plan

- [x] `pytest tests/test_ingest.py -v` → **9/9 PASS** (0.26s)
  - 既有 5 case regression 全綠（XAVC sidecar / lens fallback）
  - 4 new BMD case：parsing + ShutterAngle 換算 examples + parse_fail warning log + white_balance roundtrip
- [ ] PC real-data smoke：對 BMD Cam app 拍的 `.mov` / `.mp4` 跑 `python ingest.py --refresh` 後驗 `SELECT iso, aperture, shutter_speed, white_balance FROM media WHERE camera_make='Blackmagic'` 4 col 全填
- [ ] Non-BMD regression：對 FX30 XAVC + iPhone Keys group 跑 ingest 確認既有 metadata 路徑不破

## Files changed (3, +187 / -5)

- `ingest.py` (+96)：`exiftool_extract()` 加 BMD tag normalization helpers + ShutterAngle 換算 + Environment/DayNight tag emit
- `db.py` (+4)：migration loop 加 `white_balance TEXT` ALTER
- `tests/test_ingest.py` (+92)：BMD parsing + ShutterAngle 換算範例 + warning log + WB roundtrip case

Codex impl, CC commit (per `[reference_codex_sandbox_no_git_index_write]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)