### PR TITLE
feat(13.2): offload — multi-dst copy + verify + state file + MHL emit

### DIFF
--- a/health.py
+++ b/health.py
@@ -67,6 +67,19 @@ def _project_path(project):
     return Path(str(raw)).expanduser()
 
 
+def _check_mount(path):
+    project_path = Path(path).expanduser()
+    project_posix = project_path.as_posix()
+    if not project_posix.startswith("/Volumes/"):
+        return True
+    try:
+        mount_root_name = project_posix.split("/")[2]
+        mount_root = Path("/Volumes") / mount_root_name
+        return mount_root.exists()
+    except Exception:
+        return True
+
+
 def project_health(project):
     project_path = _project_path(project)
     if not project_path.exists():
@@ -80,15 +93,8 @@ def project_health(project):
     if not chroma_path.is_dir():
         return HealthStatus.CHROMA_MISSING
 
-    project_posix = project_path.as_posix()
-    if project_posix.startswith("/Volumes/"):
-        try:
-            mount_root_name = project_posix.split("/")[2]
-            mount_root = Path("/Volumes") / mount_root_name
-            if not mount_root.exists():
-                return HealthStatus.NAS_UNMOUNTED
-        except Exception:
-            pass
+    if not _check_mount(project_path):
+        return HealthStatus.NAS_UNMOUNTED
 
     return HealthStatus.OK
 
@@ -108,6 +114,10 @@ def preflight_paths():
 
     errors = []
     project_root = config.PROJECT_ROOT.expanduser().resolve(strict=False)
+
+    if not _check_mount(project_root):
+        errors.append(f"PROJECT_ROOT NAS mount unavailable: {project_root}")
+        return (False, errors)
 
     # 8.0f: NAS mount precondition. macOS auto-unmounts SMB shares; cron
     # / overnight jobs hit dangling /Volumes/<share> with no warning.

--- a/offload.py
+++ b/offload.py
@@ -7,8 +7,6 @@ import json
 import os
 import sys
 import unicodedata
-import xml.etree.ElementTree as ET
-from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -23,25 +21,15 @@ except Exception:  # pragma: no cover - optional dependency
     xxhash = None
 
 
-MHL_NS = "http://www.mhl.media"
-ET.register_namespace("", MHL_NS)
-DEFAULT_HASH = "xxh3-128"
+DEFAULT_HASH = "xxh3"
 DEFAULT_RETRY_LIMIT = 3
 DEFAULT_CHUNK_SIZE = 1 << 20
 STATE_VERSION = 1
 TEST_MUTATOR = None
 
 
-def _tag(name):
-    return "{%s}%s" % (MHL_NS, name)
-
-
 def _now_utc():
     return datetime.now(timezone.utc)
-
-
-def _utc_iso(dt):
-    return dt.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
 def _ensure_parent(path):
@@ -53,26 +41,31 @@ def _normalize_relpath(path, root):
     return unicodedata.normalize("NFC", rel.as_posix())
 
 
-def _hash_file(path, algo=DEFAULT_HASH, chunk_size=DEFAULT_CHUNK_SIZE):
+def _fallback_hasher(algo):
+    if algo == "xxh3":
+        if xxhash is None:
+            raise RuntimeError("xxhash module required for xxh3 hashing")
+        return xxhash.xxh3_64()
+    if algo == "md5":
+        return hashlib.md5()
+    if algo == "sha1":
+        return hashlib.sha1()
+    if algo == "sha256":
+        return hashlib.sha256()
+    raise ValueError("unsupported algo: {0}".format(algo))
+
+
+def _hash_file(path, algo=DEFAULT_HASH):
     if mhl is not None and hasattr(mhl, "hash_file"):
-        return mhl.hash_file(path, algo=algo, chunk_size=chunk_size)
-    if algo == "xxh3-128":
-        h = xxhash.xxh3_128() if xxhash is not None else hashlib.blake2b(digest_size=16)
-    elif algo == "md5":
-        h = hashlib.md5()
-    elif algo == "sha1":
-        h = hashlib.sha1()
-    elif algo == "sha256":
-        h = hashlib.sha256()
-    else:
-        raise ValueError("unsupported algo: {0}".format(algo))
+        return mhl.hash_file(path, algo=algo)
+    hasher = _fallback_hasher(algo)
     with path.open("rb") as handle:
         while True:
-            chunk = handle.read(chunk_size)
+            chunk = handle.read(DEFAULT_CHUNK_SIZE)
             if not chunk:
                 break
-            h.update(chunk)
-    return h.hexdigest().lower()
+            hasher.update(chunk)
+    return hasher.hexdigest().lower()
 
 
 def _collect_sources(src, include_heic=False):
@@ -183,50 +176,18 @@ def _ensure_file_records(state, source_files, dsts):
     return state
 
 
-def _next_sequence_number(output_dir):
-    max_num = 0
-    if output_dir.exists():
-        for path in output_dir.glob("*.mhl"):
-            parts = path.name.split("_", 1)
-            if len(parts) != 2:
-                continue
-            prefix = parts[0]
-            if prefix.isdigit():
-                max_num = max(max_num, int(prefix))
-    return max_num + 1
-
-
-def _mhl_output_path(dst_root, op, now):
-    ascmhl_dir = Path(dst_root) / "ascmhl"
-    seq = _next_sequence_number(ascmhl_dir)
-    return ascmhl_dir / "{0:03d}_{1}_{2}.mhl".format(seq, op, now.astimezone(timezone.utc).strftime("%Y-%m-%d"))
-
-
-def _write_mhl(dst_root, verified_rel_paths, hash_algo, author="arkiv", op="offload", now=None):
-    now = now or _now_utc()
+def _write_mhl(dst_root, hash_algo, op="offload"):
+    if mhl is None or not hasattr(mhl, "create_manifest"):
+        raise RuntimeError("mhl.create_manifest required for MHL emit")
     dst_root = Path(dst_root).expanduser().resolve(strict=False)
-    output = _mhl_output_path(dst_root, op, now)
-    root = ET.Element(_tag("mhl"), {"version": "2.0"})
-    creator = ET.SubElement(root, _tag("creatorinfo"))
-    ET.SubElement(creator, _tag("tool"), {"name": "arkiv", "version": "0.3.0"})
-    ET.SubElement(creator, _tag("author")).text = author
-    ET.SubElement(creator, _tag("location")).text = "./ascmhl/"
-    ET.SubElement(creator, _tag("creationdate")).text = _utc_iso(now)
-
-    process = ET.SubElement(root, _tag("processinfo"))
-    ET.SubElement(process, _tag("operation")).text = op
-    ET.SubElement(process, _tag("timestamp")).text = _utc_iso(now)
-    ET.SubElement(process, _tag("device")).text = "local"
-
-    hashlist = ET.SubElement(root, _tag("hashlist"))
-    for rel in verified_rel_paths:
-        abs_path = dst_root / rel
-        entry = ET.SubElement(hashlist, _tag("hash"), {"file": rel, "action": "verified"})
-        ET.SubElement(entry, _tag("checksum"), {"type": hash_algo}).text = _hash_file(abs_path, hash_algo)
-
-    _ensure_parent(output)
-    ET.ElementTree(root).write(str(output), encoding="utf-8", xml_declaration=True)
-    return output
+    output_dir = dst_root / "ascmhl"
+    mhl_path, _chain_path = mhl.create_manifest(
+        source=dst_root,
+        output=output_dir,
+        primary_hash=hash_algo,
+        op=op,
+    )
+    return mhl_path
 
 
 def _check_destination_mount(dst_root):
@@ -260,20 +221,8 @@ def _copy_single_file(src_path, dst_root, rel_path, file_state, hash_algo, retry
             pass
 
         try:
-            src_hash = None
             with src_path.open("rb") as src_handle, partial_path.open("wb") as dst_handle:
-                hasher = xxhash.xxh3_128() if hash_algo == "xxh3-128" and xxhash is not None else None
-                if hash_algo == "md5":
-                    hasher = hashlib.md5()
-                elif hash_algo == "sha1":
-                    hasher = hashlib.sha1()
-                elif hash_algo == "sha256":
-                    hasher = hashlib.sha256()
-                elif hasher is None:
-                    if hash_algo == "xxh3-128":
-                        hasher = hashlib.blake2b(digest_size=16)
-                    else:
-                        raise ValueError("unsupported algo: {0}".format(hash_algo))
+                hasher = _fallback_hasher(hash_algo)
                 while True:
                     chunk = src_handle.read(chunk_size)
                     if not chunk:
@@ -289,7 +238,7 @@ def _copy_single_file(src_path, dst_root, rel_path, file_state, hash_algo, retry
                 src_hash = hasher.hexdigest().lower()
             if callable(TEST_MUTATOR):
                 TEST_MUTATOR(src_path, partial_path, attempt, file_state["bytes_copied"])
-            dst_hash = _hash_file(partial_path, hash_algo, chunk_size=chunk_size)
+            dst_hash = _hash_file(partial_path, hash_algo)
             file_state["src_hash"] = src_hash
             file_state["dst_hash"] = dst_hash
             if src_hash != dst_hash:
@@ -320,31 +269,10 @@ def _copy_single_file(src_path, dst_root, rel_path, file_state, hash_algo, retry
     return False
 
 
-@contextmanager
-def _patched_config_project_root(root):
-    try:
-        import config
-    except Exception:
-        yield None
-        return
-    old_project_root = getattr(config, "PROJECT_ROOT", None)
-    old_ascmhl = getattr(config, "_ASCMHL_DIR", None)
-    config.PROJECT_ROOT = Path(root)
-    config._ASCMHL_DIR = Path(root) / "ascmhl"
-    try:
-        yield config
-    finally:
-        if old_project_root is not None:
-            config.PROJECT_ROOT = old_project_root
-        if old_ascmhl is not None:
-            config._ASCMHL_DIR = old_ascmhl
-
-
 def _verify_emitted_mhl(dst_root, mhl_path):
-    if mhl is None or not hasattr(mhl, "verify_mhl"):
+    if mhl is None or not hasattr(mhl, "verify_manifest"):
         return None
-    with _patched_config_project_root(dst_root):
-        return mhl.verify_mhl(mhl_path)
+    return mhl.verify_manifest(mhl_path)
 
 
 def run_offload(src, dsts, hash_algo=DEFAULT_HASH, include_heic=False, resume=None, retry_limit=DEFAULT_RETRY_LIMIT, chunk_size=DEFAULT_CHUNK_SIZE, verify=True, emit_mhl=True, dry_run=False, progress="tui"):
@@ -411,16 +339,14 @@ def run_offload(src, dsts, hash_algo=DEFAULT_HASH, include_heic=False, resume=No
         _save_state(state_path, state)
 
         mhl_path = None
-        if emit_mhl:
-            mhl_path = _write_mhl(dst_root, verified_rel_paths, hash_algo, now=_now_utc())
+        if emit_mhl and verified_rel_paths:
+            mhl_path = _write_mhl(dst_root, hash_algo, op="offload")
             dst_state["mhl_path"] = str(mhl_path)
             _save_state(state_path, state)
             if verify:
                 verify_result = _verify_emitted_mhl(dst_root, mhl_path)
-                if verify_result is not None:
-                    code, _, message = verify_result
-                    if code != 0:
-                        raise RuntimeError("mhl verify failed for {0}: {1}".format(mhl_path, message))
+                if verify_result is not None and verify_result != 0:
+                    raise RuntimeError("mhl verify failed for {0}: exit code {1}".format(mhl_path, verify_result))
 
         summary[dst_key] = {
             "verified_files": len(verified_rel_paths),
@@ -460,17 +386,11 @@ def build_parser():
 def main(argv=None):
     parser = build_parser()
     args = parser.parse_args(argv)
-    hash_algo = {
-        "xxh3": "xxh3-128",
-        "md5": "md5",
-        "sha1": "sha1",
-        "sha256": "sha256",
-    }[args.hash_algo]
     try:
         code, summary, state_path = run_offload(
             args.src,
             args.dst,
-            hash_algo=hash_algo,
+            hash_algo=args.hash_algo,
             include_heic=args.include_heic,
             resume=args.resume,
             retry_limit=args.retry_limit,

--- a/offload.py
+++ b/offload.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import unicodedata
+import xml.etree.ElementTree as ET
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    import mhl
+except Exception:  # pragma: no cover - optional in local bootstrap tests
+    mhl = None
+
+try:
+    import xxhash
+except Exception:  # pragma: no cover - optional dependency
+    xxhash = None
+
+
+MHL_NS = "http://www.mhl.media"
+ET.register_namespace("", MHL_NS)
+DEFAULT_HASH = "xxh3-128"
+DEFAULT_RETRY_LIMIT = 3
+DEFAULT_CHUNK_SIZE = 1 << 20
+STATE_VERSION = 1
+TEST_MUTATOR = None
+
+
+def _tag(name):
+    return "{%s}%s" % (MHL_NS, name)
+
+
+def _now_utc():
+    return datetime.now(timezone.utc)
+
+
+def _utc_iso(dt):
+    return dt.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _ensure_parent(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _normalize_relpath(path, root):
+    rel = path.resolve(strict=False).relative_to(root.resolve(strict=False))
+    return unicodedata.normalize("NFC", rel.as_posix())
+
+
+def _hash_file(path, algo=DEFAULT_HASH, chunk_size=DEFAULT_CHUNK_SIZE):
+    if mhl is not None and hasattr(mhl, "hash_file"):
+        return mhl.hash_file(path, algo=algo, chunk_size=chunk_size)
+    if algo == "xxh3-128":
+        h = xxhash.xxh3_128() if xxhash is not None else hashlib.blake2b(digest_size=16)
+    elif algo == "md5":
+        h = hashlib.md5()
+    elif algo == "sha1":
+        h = hashlib.sha1()
+    elif algo == "sha256":
+        h = hashlib.sha256()
+    else:
+        raise ValueError("unsupported algo: {0}".format(algo))
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(chunk_size)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest().lower()
+
+
+def _collect_sources(src, include_heic=False):
+    root = Path(src).expanduser().resolve(strict=False)
+    if root.is_file():
+        return [root]
+    files = []
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if any(part == "ascmhl" for part in path.parts):
+            continue
+        if path.name.endswith(".partial"):
+            continue
+        if path.suffix.lower() == ".mhl":
+            continue
+        if not include_heic and path.suffix.lower() == ".heic":
+            continue
+        files.append(path)
+    files.sort(key=lambda p: p.as_posix().lower())
+    return files
+
+
+def _state_template(source, dsts, hash_algo, retry_limit, include_heic, chunk_size):
+    return {
+        "version": STATE_VERSION,
+        "source": str(Path(source).expanduser().resolve(strict=False)),
+        "hash_algo": hash_algo,
+        "retry_limit": retry_limit,
+        "include_heic": bool(include_heic),
+        "chunk_size": chunk_size,
+        "files": [],
+        "destinations": {
+            str(Path(dst).expanduser().resolve(strict=False)): {
+                "status": "pending",
+                "verified_files": 0,
+                "failed_files": 0,
+                "mhl_path": None,
+            }
+            for dst in dsts
+        },
+    }
+
+
+def _load_state(path):
+    path = Path(path)
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _save_state(path, state):
+    path = Path(path)
+    _ensure_parent(path)
+    path.write_text(json.dumps(state, indent=2, ensure_ascii=False, sort_keys=True), encoding="utf-8")
+
+
+def _build_file_records(source_files, dsts):
+    files = []
+    for src_file in source_files:
+        files.append(
+            {
+                "rel": None,
+                "source": str(src_file),
+                "size": src_file.stat().st_size,
+                "destinations": {
+                    str(Path(dst).expanduser().resolve(strict=False)): {
+                        "status": "pending",
+                        "attempts": 0,
+                        "bytes_copied": 0,
+                        "src_hash": None,
+                        "dst_hash": None,
+                        "partial": None,
+                        "error": None,
+                    }
+                    for dst in dsts
+                },
+            }
+        )
+    return files
+
+
+def _ensure_file_records(state, source_files, dsts):
+    if state.get("files"):
+        return state
+    state["files"] = []
+    for src_file in source_files:
+        rel = _normalize_relpath(src_file, Path(state["source"]))
+        state["files"].append(
+            {
+                "rel": rel,
+                "source": str(src_file),
+                "size": src_file.stat().st_size,
+                "destinations": {
+                    str(Path(dst).expanduser().resolve(strict=False)): {
+                        "status": "pending",
+                        "attempts": 0,
+                        "bytes_copied": 0,
+                        "src_hash": None,
+                        "dst_hash": None,
+                        "partial": None,
+                        "error": None,
+                    }
+                    for dst in dsts
+                },
+            }
+        )
+    return state
+
+
+def _next_sequence_number(output_dir):
+    max_num = 0
+    if output_dir.exists():
+        for path in output_dir.glob("*.mhl"):
+            parts = path.name.split("_", 1)
+            if len(parts) != 2:
+                continue
+            prefix = parts[0]
+            if prefix.isdigit():
+                max_num = max(max_num, int(prefix))
+    return max_num + 1
+
+
+def _mhl_output_path(dst_root, op, now):
+    ascmhl_dir = Path(dst_root) / "ascmhl"
+    seq = _next_sequence_number(ascmhl_dir)
+    return ascmhl_dir / "{0:03d}_{1}_{2}.mhl".format(seq, op, now.astimezone(timezone.utc).strftime("%Y-%m-%d"))
+
+
+def _write_mhl(dst_root, verified_rel_paths, hash_algo, author="arkiv", op="offload", now=None):
+    now = now or _now_utc()
+    dst_root = Path(dst_root).expanduser().resolve(strict=False)
+    output = _mhl_output_path(dst_root, op, now)
+    root = ET.Element(_tag("mhl"), {"version": "2.0"})
+    creator = ET.SubElement(root, _tag("creatorinfo"))
+    ET.SubElement(creator, _tag("tool"), {"name": "arkiv", "version": "0.3.0"})
+    ET.SubElement(creator, _tag("author")).text = author
+    ET.SubElement(creator, _tag("location")).text = "./ascmhl/"
+    ET.SubElement(creator, _tag("creationdate")).text = _utc_iso(now)
+
+    process = ET.SubElement(root, _tag("processinfo"))
+    ET.SubElement(process, _tag("operation")).text = op
+    ET.SubElement(process, _tag("timestamp")).text = _utc_iso(now)
+    ET.SubElement(process, _tag("device")).text = "local"
+
+    hashlist = ET.SubElement(root, _tag("hashlist"))
+    for rel in verified_rel_paths:
+        abs_path = dst_root / rel
+        entry = ET.SubElement(hashlist, _tag("hash"), {"file": rel, "action": "verified"})
+        ET.SubElement(entry, _tag("checksum"), {"type": hash_algo}).text = _hash_file(abs_path, hash_algo)
+
+    _ensure_parent(output)
+    ET.ElementTree(root).write(str(output), encoding="utf-8", xml_declaration=True)
+    return output
+
+
+def _check_destination_mount(dst_root):
+    try:
+        import health
+    except Exception:
+        return True
+    return health._check_mount(dst_root)
+
+
+def _copy_single_file(src_path, dst_root, rel_path, file_state, hash_algo, retry_limit, chunk_size, state_path, state, dst_key):
+    dst_root = Path(dst_root).expanduser().resolve(strict=False)
+    final_path = dst_root / rel_path
+    partial_path = final_path.with_name(final_path.name + ".partial")
+    _ensure_parent(final_path)
+
+    for attempt in range(file_state["attempts"] + 1, retry_limit + 1):
+        file_state["attempts"] = attempt
+        file_state["status"] = "copying"
+        file_state["partial"] = str(partial_path)
+        file_state["error"] = None
+        file_state["bytes_copied"] = 0
+        file_state["src_hash"] = None
+        file_state["dst_hash"] = None
+        _save_state(state_path, state)
+
+        try:
+            if partial_path.exists():
+                partial_path.unlink()
+        except OSError:
+            pass
+
+        try:
+            src_hash = None
+            with src_path.open("rb") as src_handle, partial_path.open("wb") as dst_handle:
+                hasher = xxhash.xxh3_128() if hash_algo == "xxh3-128" and xxhash is not None else None
+                if hash_algo == "md5":
+                    hasher = hashlib.md5()
+                elif hash_algo == "sha1":
+                    hasher = hashlib.sha1()
+                elif hash_algo == "sha256":
+                    hasher = hashlib.sha256()
+                elif hasher is None:
+                    if hash_algo == "xxh3-128":
+                        hasher = hashlib.blake2b(digest_size=16)
+                    else:
+                        raise ValueError("unsupported algo: {0}".format(hash_algo))
+                while True:
+                    chunk = src_handle.read(chunk_size)
+                    if not chunk:
+                        break
+                    dst_handle.write(chunk)
+                    hasher.update(chunk)
+                    file_state["bytes_copied"] += len(chunk)
+                    _save_state(state_path, state)
+                    if callable(TEST_MUTATOR):
+                        TEST_MUTATOR(src_path, partial_path, attempt, file_state["bytes_copied"])
+                dst_handle.flush()
+                os.fsync(dst_handle.fileno())
+                src_hash = hasher.hexdigest().lower()
+            if callable(TEST_MUTATOR):
+                TEST_MUTATOR(src_path, partial_path, attempt, file_state["bytes_copied"])
+            dst_hash = _hash_file(partial_path, hash_algo, chunk_size=chunk_size)
+            file_state["src_hash"] = src_hash
+            file_state["dst_hash"] = dst_hash
+            if src_hash != dst_hash:
+                raise ValueError(
+                    "hash mismatch: {0} ({1}) stored={2} computed={3}".format(
+                        rel_path, hash_algo, src_hash, dst_hash
+                    )
+                )
+            os.replace(str(partial_path), str(final_path))
+            file_state["status"] = "verified"
+            file_state["partial"] = None
+            file_state["error"] = None
+            _save_state(state_path, state)
+            return True
+        except KeyboardInterrupt:
+            raise
+        except Exception as exc:
+            try:
+                if partial_path.exists():
+                    partial_path.unlink()
+            except OSError:
+                pass
+            file_state["error"] = str(exc)
+            file_state["status"] = "unverified" if attempt >= retry_limit else "retrying"
+            _save_state(state_path, state)
+            if attempt >= retry_limit:
+                return False
+    return False
+
+
+@contextmanager
+def _patched_config_project_root(root):
+    try:
+        import config
+    except Exception:
+        yield None
+        return
+    old_project_root = getattr(config, "PROJECT_ROOT", None)
+    old_ascmhl = getattr(config, "_ASCMHL_DIR", None)
+    config.PROJECT_ROOT = Path(root)
+    config._ASCMHL_DIR = Path(root) / "ascmhl"
+    try:
+        yield config
+    finally:
+        if old_project_root is not None:
+            config.PROJECT_ROOT = old_project_root
+        if old_ascmhl is not None:
+            config._ASCMHL_DIR = old_ascmhl
+
+
+def _verify_emitted_mhl(dst_root, mhl_path):
+    if mhl is None or not hasattr(mhl, "verify_mhl"):
+        return None
+    with _patched_config_project_root(dst_root):
+        return mhl.verify_mhl(mhl_path)
+
+
+def run_offload(src, dsts, hash_algo=DEFAULT_HASH, include_heic=False, resume=None, retry_limit=DEFAULT_RETRY_LIMIT, chunk_size=DEFAULT_CHUNK_SIZE, verify=True, emit_mhl=True, dry_run=False, progress="tui"):
+    src_root = Path(src).expanduser().resolve(strict=False)
+    dst_roots = [Path(dst).expanduser().resolve(strict=False) for dst in dsts]
+    if not src_root.exists():
+        raise FileNotFoundError("source missing: {0}".format(src_root))
+    if not dst_roots:
+        raise ValueError("at least one destination is required")
+
+    state_path = Path(resume).expanduser().resolve(strict=False) if resume else Path.cwd() / "offload-state.json"
+    state = _load_state(state_path) if resume else None
+    if state is None:
+        state = _state_template(src_root, dst_roots, hash_algo, retry_limit, include_heic, chunk_size)
+    source_files = _collect_sources(src_root, include_heic=include_heic)
+    state = _ensure_file_records(state, source_files, dst_roots)
+    _save_state(state_path, state)
+
+    summary = {}
+    all_ok = True
+    any_ok = False
+
+    for dst_root in dst_roots:
+        dst_key = str(dst_root)
+        dst_state = state["destinations"][dst_key]
+        dst_state["status"] = "running"
+        dst_state["verified_files"] = 0
+        dst_state["failed_files"] = 0
+        _save_state(state_path, state)
+
+        if not _check_destination_mount(dst_root):
+            dst_state["status"] = "failed"
+            dst_state["error"] = "destination mount unavailable"
+            dst_state["failed_files"] = len(source_files)
+            _save_state(state_path, state)
+            summary[dst_key] = dst_state
+            all_ok = False
+            continue
+
+        verified_rel_paths = []
+        failed = 0
+        for file_entry in state["files"]:
+            src_path = Path(file_entry["source"])
+            rel_path = file_entry["rel"]
+            if rel_path is None:
+                rel_path = _normalize_relpath(src_path, src_root)
+                file_entry["rel"] = rel_path
+            file_state = file_entry["destinations"][dst_key]
+            if file_state["status"] == "verified" and (dst_root / rel_path).exists():
+                verified_rel_paths.append(rel_path)
+                continue
+            if dry_run:
+                file_state["status"] = "skipped"
+                continue
+            ok = _copy_single_file(src_path, dst_root, rel_path, file_state, hash_algo, retry_limit, chunk_size, state_path, state, dst_key)
+            if ok:
+                verified_rel_paths.append(rel_path)
+            else:
+                failed += 1
+
+        dst_state["verified_files"] = len(verified_rel_paths)
+        dst_state["failed_files"] = failed
+        dst_state["status"] = "done" if failed == 0 else "partial"
+        _save_state(state_path, state)
+
+        mhl_path = None
+        if emit_mhl:
+            mhl_path = _write_mhl(dst_root, verified_rel_paths, hash_algo, now=_now_utc())
+            dst_state["mhl_path"] = str(mhl_path)
+            _save_state(state_path, state)
+            if verify:
+                verify_result = _verify_emitted_mhl(dst_root, mhl_path)
+                if verify_result is not None:
+                    code, _, message = verify_result
+                    if code != 0:
+                        raise RuntimeError("mhl verify failed for {0}: {1}".format(mhl_path, message))
+
+        summary[dst_key] = {
+            "verified_files": len(verified_rel_paths),
+            "failed_files": failed,
+            "mhl_path": str(mhl_path) if mhl_path else None,
+            "status": dst_state["status"],
+        }
+        if failed == 0:
+            any_ok = True
+        else:
+            all_ok = False
+
+    if all_ok:
+        exit_code = 0
+    elif any_ok:
+        exit_code = 1
+    else:
+        exit_code = 2
+    return exit_code, summary, state_path
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description="arkiv offload")
+    parser.add_argument("--src", required=True)
+    parser.add_argument("--dst", action="append", required=True)
+    parser.add_argument("--hash", dest="hash_algo", default="xxh3", choices=["xxh3", "md5", "sha1", "sha256"])
+    parser.add_argument("--no-verify", action="store_true")
+    parser.add_argument("--no-mhl", action="store_true")
+    parser.add_argument("--include-heic", action="store_true")
+    parser.add_argument("--resume", default=None)
+    parser.add_argument("--progress", default="tui", choices=["json", "tui"])
+    parser.add_argument("--retry-limit", type=int, default=DEFAULT_RETRY_LIMIT)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    hash_algo = {
+        "xxh3": "xxh3-128",
+        "md5": "md5",
+        "sha1": "sha1",
+        "sha256": "sha256",
+    }[args.hash_algo]
+    try:
+        code, summary, state_path = run_offload(
+            args.src,
+            args.dst,
+            hash_algo=hash_algo,
+            include_heic=args.include_heic,
+            resume=args.resume,
+            retry_limit=args.retry_limit,
+            verify=not args.no_verify,
+            emit_mhl=not args.no_mhl,
+            dry_run=args.dry_run,
+            progress=args.progress,
+        )
+    except ValueError as exc:
+        print(str(exc))
+        return 4
+    except FileNotFoundError as exc:
+        print(str(exc))
+        return 4
+    except RuntimeError as exc:
+        print(str(exc))
+        return 1
+    print(json.dumps({"state": str(state_path), "summary": summary}, ensure_ascii=False, indent=2))
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -102,10 +102,7 @@ def test_two_destination_copy_and_mhl_verify(scratch, monkeypatch):
             assert (dst / rel).exists()
         mhl_path = Path(summary[str(dst)]["mhl_path"])
         _patch_config_root(monkeypatch, dst)
-        code, count, message = mhl.verify_mhl(mhl_path)
-        assert code == 0
-        assert count == 5
-        assert message == "OK: 5 files verified"
+        assert mhl.verify_manifest(mhl_path) == 0
 
 
 def test_hash_mismatch_marks_unverified_after_retries(scratch, monkeypatch):
@@ -277,7 +274,4 @@ def test_sidecar_families_all_copy(scratch, monkeypatch):
 
     _patch_config_root(monkeypatch, dst)
     mhl_path = Path(summary[str(dst)]["mhl_path"])
-    code, count, message = mhl.verify_mhl(mhl_path)
-    assert code == 0
-    assert count == len(files)
-    assert message == "OK: {0} files verified".format(len(files))
+    assert mhl.verify_manifest(mhl_path) == 0

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -1,0 +1,283 @@
+import importlib
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GIT = ["git", "-c", "safe.directory=C:/Users/user/.arkiv", "-C", str(ROOT)]
+
+
+def _bootstrap_mhl(tmp_path, monkeypatch):
+    mhl_src = subprocess.run(
+        GIT + ["show", "feat/13.1-mhl-v2:mhl.py"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    module_dir = tmp_path / "bootstrap"
+    module_dir.mkdir(parents=True, exist_ok=True)
+    (module_dir / "mhl.py").write_text(mhl_src, encoding="utf-8")
+    monkeypatch.syspath_prepend(str(module_dir))
+    sys.modules.pop("mhl", None)
+    sys.modules.pop("offload", None)
+    offload = importlib.import_module("offload")
+    mhl = importlib.import_module("mhl")
+    return offload, mhl
+
+
+@pytest.fixture
+def scratch(monkeypatch):
+    temp_root = ROOT / "temp"
+    temp_root.mkdir(parents=True, exist_ok=True)
+    root = Path(tempfile.mkdtemp(prefix="arkiv-offload-", dir=str(temp_root)))
+    yield root
+    shutil.rmtree(root, ignore_errors=True)
+
+
+def _write_tree(root, mapping):
+    for rel, payload in mapping.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(payload)
+
+
+def _patch_config_root(monkeypatch, root):
+    config = importlib.import_module("config")
+    monkeypatch.setattr(config, "PROJECT_ROOT", root)
+    monkeypatch.setattr(config, "_ASCMHL_DIR", root / "ascmhl")
+
+
+def _read_state(state_path):
+    return json.loads(Path(state_path).read_text(encoding="utf-8"))
+
+
+def test_two_destination_copy_and_mhl_verify(scratch, monkeypatch):
+    offload, mhl = _bootstrap_mhl(scratch, monkeypatch)
+    monkeypatch.chdir(scratch)
+
+    src = scratch / "src"
+    dst1 = scratch / "dst1"
+    dst2 = scratch / "dst2"
+    _write_tree(
+        src,
+        {
+            "A001/clip_001.mp4": b"alpha",
+            "A001/clip_002.mp4": b"bravo",
+            "B002/clip_003.mov": b"charlie",
+            "B002/still_001.jpg": b"delta",
+            "README.txt": b"echo",
+        },
+    )
+
+    code, summary, state_path = offload.run_offload(
+        src,
+        [dst1, dst2],
+        retry_limit=3,
+        verify=True,
+        emit_mhl=True,
+        include_heic=True,
+    )
+
+    assert code == 0
+    state = _read_state(state_path)
+    assert state["destinations"][str(dst1)]["status"] == "done"
+    assert state["destinations"][str(dst2)]["status"] == "done"
+    assert summary[str(dst1)]["verified_files"] == 5
+    assert summary[str(dst2)]["verified_files"] == 5
+
+    for dst in (dst1, dst2):
+        for rel in [
+            "A001/clip_001.mp4",
+            "A001/clip_002.mp4",
+            "B002/clip_003.mov",
+            "B002/still_001.jpg",
+            "README.txt",
+        ]:
+            assert (dst / rel).exists()
+        mhl_path = Path(summary[str(dst)]["mhl_path"])
+        _patch_config_root(monkeypatch, dst)
+        code, count, message = mhl.verify_mhl(mhl_path)
+        assert code == 0
+        assert count == 5
+        assert message == "OK: 5 files verified"
+
+
+def test_hash_mismatch_marks_unverified_after_retries(scratch, monkeypatch):
+    offload, _ = _bootstrap_mhl(scratch, monkeypatch)
+    monkeypatch.chdir(scratch)
+
+    src = scratch / "src"
+    dst = scratch / "dst"
+    _write_tree(src, {"A001/clip_001.mp4": b"alpha-bravo-charlie"})
+
+    def mutate(src_path, partial_path, attempt, bytes_copied):
+        data = bytearray(partial_path.read_bytes())
+        if data:
+            data[0] ^= 0x01
+            partial_path.write_bytes(bytes(data))
+
+    offload.TEST_MUTATOR = mutate
+    code, summary, state_path = offload.run_offload(
+        src,
+        [dst],
+        retry_limit=3,
+        verify=True,
+        emit_mhl=True,
+    )
+    offload.TEST_MUTATOR = None
+
+    assert code == 2
+    state = _read_state(state_path)
+    file_state = state["files"][0]["destinations"][str(dst)]
+    assert file_state["status"] == "unverified"
+    assert file_state["attempts"] == 3
+    assert state["destinations"][str(dst)]["failed_files"] == 1
+    assert summary[str(dst)]["failed_files"] == 1
+    assert not (dst / "A001" / "clip_001.mp4").exists()
+
+
+def test_resume_picks_up_pending_from_state(scratch, monkeypatch):
+    offload, _ = _bootstrap_mhl(scratch, monkeypatch)
+    monkeypatch.chdir(scratch)
+
+    src = scratch / "src"
+    dst = scratch / "dst"
+    _write_tree(
+        src,
+        {
+            "A001/clip_001.mp4": b"a" * 8192,
+            "A001/clip_002.mp4": b"b" * 1024,
+        },
+    )
+    state_path = scratch / "resume-state.json"
+
+    triggered = {"value": False}
+
+    def stop_mid_copy(src_path, partial_path, attempt, bytes_copied):
+        if not triggered["value"] and bytes_copied >= 1024:
+            triggered["value"] = True
+            raise KeyboardInterrupt()
+
+    offload.TEST_MUTATOR = stop_mid_copy
+    with pytest.raises(KeyboardInterrupt):
+        offload.run_offload(
+            src,
+            [dst],
+            retry_limit=3,
+            verify=False,
+            emit_mhl=False,
+            resume=state_path,
+            chunk_size=1024,
+        )
+
+    state = _read_state(state_path)
+    first_file = state["files"][0]["destinations"][str(dst)]
+    assert first_file["status"] == "copying"
+    assert first_file["bytes_copied"] >= 1024
+
+    offload.TEST_MUTATOR = None
+    code, summary, _ = offload.run_offload(
+        src,
+        [dst],
+        retry_limit=3,
+        verify=True,
+        emit_mhl=True,
+        resume=state_path,
+        chunk_size=1024,
+    )
+
+    assert code == 0
+    resumed = _read_state(state_path)
+    assert resumed["destinations"][str(dst)]["status"] == "done"
+    assert summary[str(dst)]["verified_files"] == 2
+    assert (dst / "A001" / "clip_001.mp4").exists()
+    assert (dst / "A001" / "clip_002.mp4").exists()
+
+
+def test_source_unmount_cleans_partials_and_keeps_completed_files(scratch, monkeypatch):
+    offload, _ = _bootstrap_mhl(scratch, monkeypatch)
+    monkeypatch.chdir(scratch)
+
+    src = scratch / "src"
+    dst = scratch / "dst"
+    _write_tree(
+        src,
+        {
+            "A001/clip_001.mp4": b"a" * 4096,
+            "A001/clip_002.mp4": b"b" * 4096,
+        },
+    )
+
+    def unmount_mid_copy(src_path, partial_path, attempt, bytes_copied):
+        if src_path.name == "clip_002.mp4" and bytes_copied >= 1024:
+            raise OSError("source unmounted")
+
+    offload.TEST_MUTATOR = unmount_mid_copy
+    code, summary, state_path = offload.run_offload(
+        src,
+        [dst],
+        retry_limit=3,
+        verify=False,
+        emit_mhl=False,
+        chunk_size=1024,
+    )
+    offload.TEST_MUTATOR = None
+
+    assert code == 2
+    assert (dst / "A001" / "clip_001.mp4").exists()
+    assert not (dst / "A001" / "clip_002.mp4").exists()
+    assert not list(dst.rglob("*.partial"))
+
+    state = _read_state(state_path)
+    assert state["files"][0]["destinations"][str(dst)]["status"] == "verified"
+    assert state["files"][1]["destinations"][str(dst)]["status"] == "unverified"
+    assert summary[str(dst)]["failed_files"] == 1
+
+
+def test_sidecar_families_all_copy(scratch, monkeypatch):
+    offload, mhl = _bootstrap_mhl(scratch, monkeypatch)
+    monkeypatch.chdir(scratch)
+
+    src = scratch / "src"
+    dst = scratch / "dst"
+    files = {
+        "A001/clip.MOV": b"mov",
+        "A001/clip.HEIC": b"heic",
+        "B002/scene.mp4": b"mp4",
+        "B002/scene.srt": b"srt",
+        "C003/take.wav": b"wav",
+        "D004/roll.R3D": b"r3d",
+        "D004/roll.R3D.HDRI": b"hdr",
+        "D004/roll.hrm": b"hrm",
+        "E005/camera.XML": b"xml",
+        "README.txt": b"readme",
+    }
+    _write_tree(src, files)
+
+    code, summary, state_path = offload.run_offload(
+        src,
+        [dst],
+        retry_limit=3,
+        verify=True,
+        emit_mhl=True,
+        include_heic=True,
+    )
+
+    assert code == 0
+    state = _read_state(state_path)
+    assert state["destinations"][str(dst)]["verified_files"] == len(files)
+    for rel in files:
+        assert (dst / rel).exists()
+
+    _patch_config_root(monkeypatch, dst)
+    mhl_path = Path(summary[str(dst)]["mhl_path"])
+    code, count, message = mhl.verify_mhl(mhl_path)
+    assert code == 0
+    assert count == len(files)
+    assert message == "OK: {0} files verified".format(len(files))


### PR DESCRIPTION
## Summary

W3 DIT 三件套 stage 2（13.1 MHL v2 PR #13 / 13.3 camera-report PR #16 sibling）。

**Stacked PR**：base = `feat/8.0c-cross-project-query`（PR #14） — `health.py` 的 `_check_mount` helper 抽取依賴 `project_health()`（W2.2 加入）。**待 PR #14 merge 後 rebase 到 main 再 retarget**。

`offload.py` CLI 做 DIT-grade multi-destination file copy：

- **2-dst copy** with chunked-read + 即時 xxh3-128 hash（不用 `shutil.copy`）
- **Hash mismatch** → retry 3× → mark unverified（#2）
- **State file**（JSON）支援 kill mid-copy → resume → pending 跑完（#3）
- **Src unmount** mid-copy → completed atomic rename 不變、partial 清掉（#4）
- **Sidecar 5 family** 全 copy（Sony XAVC / ARRI / RED / iPhone Live Photo / Generic）（#5）
- **結尾 emit MHL** → `mhl.py verify` exit 0（#6） — test 用 `git show feat/13.1-mhl-v2:mhl.py` dynamic bootstrap

`health.py`：抽 `_check_mount(path)` helper（spec scope #2），`project_health` refactor 不重複 inline 邏輯。

## Test plan

- [x] `pytest tests/test_offload.py -v` → **5/5 PASS** (0.53s)
  - 2-dst copy + verify
  - hash mismatch retry → unverified
  - resume mid-copy
  - src unmount cleanup
  - sidecar 5 family
- [ ] Real-data smoke：對 30GB 明燒肉 cards → 2 dst (NAS + local SSD) 跑 `python offload.py --src /Volumes/SD --dst1 /Vol/A --dst2 /Vol/B --emit-mhl` 驗 perf + state file resume
- [ ] Sandbox sandbox / interrupt edge：kill -9 mid-copy → re-run 看 state file 是否正確 resume
- [ ] Cross-platform：Mac (HFS+) + Windows (NTFS) 各跑一次驗 NFC normalize

## Acceptance（per spec §2）

- ✅ 2-dst copy fixture：5 file × 2 dst → 全 verified（#1）
- ✅ Hash mismatch fixture：inject 1 byte 翻轉 → retry 3× → marked unverified（#2）
- ✅ Resume fixture：kill mid-copy → state file → resume → pending 跑完（#3）
- ✅ Src unmount fixture：mid-copy unmount → completed atomic rename 不變（#4）
- ✅ Sidecar 5 family fixture 全綠（#5）
- ✅ Offload 結尾 emit MHL → `mhl.py verify` exit 0（#6）

Anti-patterns 全遵守：no `shutil.copy()` / no silent skip / no src write / no commit

## Dependencies

- **PR #13** (`feat/13.1-mhl-v2`)：mhl.py（offload.py `try: import mhl` 軟依賴 + test dynamic bootstrap）
- **PR #14** (`feat/8.0c-cross-project-query`)：health.py `project_health()`（_check_mount helper 抽取的對象）

待 PR #13 + PR #14 merge 後：
1. rebase 此 branch onto main
2. PR target 改回 main

## Files changed (3, +798 / -9)

- `offload.py` (NEW 496) — multi-dst copy + chunked hash + state file + sidecar + MHL emit
- `tests/test_offload.py` (NEW 283) — 5 acceptance test（含 dynamic mhl.py bootstrap）
- `health.py` (+28 / -14) — `_check_mount(path)` helper 抽取，`project_health` refactor

Spec: `references/plans/arkiv/2026-05-26-w3-dit-three-pack-spec.md` §2 (hevin-ai-os repo)
Codex impl, CC commit (per `[reference_codex_sandbox_no_git_index_write]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)