### PR TITLE
feat(fe): Svelte 4 + Vite frontend rebuild (9/9 screens, mock-data) — visual/brand review pending

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,10 @@ venv/
 *.db-journal
 pages/
 src-tauri/target/
+
+# Frontend (Svelte 4 + Vite) — deps + build + local audit artifacts
+frontend/node_modules/
+frontend/.audit/
+
+# Local overnight work-order (ephemeral, mini-only)
+OVERNIGHT_UI_BUILD.md

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:," />
+    <title>arkiv</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,2426 @@
+{
+  "name": "arkiv-frontend",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "arkiv-frontend",
+      "version": "0.0.0",
+      "dependencies": {
+        "@fontsource/archivo-black": "^5.2.0",
+        "@fontsource/inter": "^5.2.0",
+        "@fontsource/jetbrains-mono": "^5.2.0",
+        "@fontsource/noto-sans-tc": "^5.2.0",
+        "svelte-spa-router": "^4.0.2"
+      },
+      "devDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^3.1.2",
+        "puppeteer-core": "^23.0.0",
+        "svelte": "^4.2.20",
+        "vite": "^5.4.21"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@fontsource/archivo-black": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/archivo-black/-/archivo-black-5.2.8.tgz",
+      "integrity": "sha512-3zNj/o9LzWyDl/UEpY5IOHpAQyUtFr3hQaFS7NSKwCLLkXOfH/CMCt1L2b2Z+OF25OURtOYenCadgAebALz7/A==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/noto-sans-tc": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans-tc/-/noto-sans-tc-5.2.9.tgz",
+      "integrity": "sha512-Z+pXTvXYrip79lPV9X1lCYO3UTys55P25VqcifDStIzdZ86I4R6t8dz+NhGd09YdbvHWvOCB5Icw1m7glKHPNQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.6.1.tgz",
+      "integrity": "sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.6.3",
+        "tar-fs": "^3.0.6",
+        "unbzip2-stream": "^1.4.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-3.1.2.tgz",
+      "integrity": "sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte-inspector": "^2.1.0",
+        "debug": "^4.3.4",
+        "deepmerge": "^4.3.1",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.10",
+        "svelte-hmr": "^0.16.0",
+        "vitefu": "^0.2.5"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "vite": "^5.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-2.1.0.tgz",
+      "integrity": "sha512-9QX28IymvBlSCqsCll5t0kQVxipsfhFFL+L2t3nTWfXnddYwxBuAEtTtlaVQpRz9c37BhJjltSeY4AJSC03SSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20"
+      },
+      "peerDependencies": {
+        "@sveltejs/vite-plugin-svelte": "^3.0.0",
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "vite": "^5.0.0"
+      }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.11.0.tgz",
+      "integrity": "sha512-6CJWHkNRoyZyjV9Rwv2lYONZf1Xm0IuDyNq97nwSsxxP3wf5Bwy15K5rOvVKMtJ127jJBmxFUanSAOjgFRxgrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "3.0.1",
+        "zod": "3.23.8"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/code-red": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
+      "integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@types/estree": "^1.0.1",
+        "acorn": "^8.10.0",
+        "estree-walker": "^3.0.3",
+        "periscopic": "^3.1.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1367902",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
+      "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/periscopic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
+      "integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^3.0.0",
+        "is-reference": "^3.0.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "23.11.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.11.1.tgz",
+      "integrity": "sha512-3HZ2/7hdDKZvZQ7dhhITOUg4/wOrDRjyK2ZBllRB0ZCOi9u0cwq1ACHDjBB+nX+7+kltHjQvBRdeY7+W0T+7Gg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.6.1",
+        "chromium-bidi": "0.11.0",
+        "debug": "^4.4.0",
+        "devtools-protocol": "0.0.1367902",
+        "typed-query-selector": "^2.12.0",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.26.0.tgz",
+      "integrity": "sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.20.tgz",
+      "integrity": "sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/estree": "^1.0.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
+        "axobject-query": "^4.0.0",
+        "code-red": "^1.0.3",
+        "css-tree": "^2.3.1",
+        "estree-walker": "^3.0.3",
+        "is-reference": "^3.0.1",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.4",
+        "periscopic": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/svelte-hmr": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.16.0.tgz",
+      "integrity": "sha512-Gyc7cOS3VJzLlfj7wKS0ZnzDVdv3Pn2IuVeJPk9m2skfhcu5bq3wtIZyQGggr7/Iim5rH5cncyQft/kRLupcnA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.20 || ^14.13.1 || >= 16"
+      },
+      "peerDependencies": {
+        "svelte": "^3.19.0 || ^4.0.0"
+      }
+    },
+    "node_modules/svelte-spa-router": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/svelte-spa-router/-/svelte-spa-router-4.0.2.tgz",
+      "integrity": "sha512-T1WYYk+ymwCr5m5U+n91k4dRAT6cw5HgmoPaI/TpKgAmuugymFoSBlfzkcKIK83QH4H8gUMn4tdQ0B9enFBM6g==",
+      "license": "MIT",
+      "dependencies": {
+        "regexparam": "2.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ItalyPaleAle"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.5.tgz",
+      "integrity": "sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "arkiv-frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^3.1.2",
+    "puppeteer-core": "^23.0.0",
+    "svelte": "^4.2.20",
+    "vite": "^5.4.21"
+  },
+  "dependencies": {
+    "@fontsource/archivo-black": "^5.2.0",
+    "@fontsource/inter": "^5.2.0",
+    "@fontsource/jetbrains-mono": "^5.2.0",
+    "@fontsource/noto-sans-tc": "^5.2.0",
+    "svelte-spa-router": "^4.0.2"
+  }
+}

--- a/frontend/scripts/audit/forbidden-css.mjs
+++ b/frontend/scripts/audit/forbidden-css.mjs
@@ -1,0 +1,57 @@
+// Forbidden-CSS / brand-integrity scanner — Tier-A hard gate.
+// Forbids: backdrop-filter, color-mix(, oklch( (WebView2+WKWebView compat).
+// ALLOWS: mix-blend-mode (the design's own grain overlay + Thumb use it).
+// Also: no icon-library imports; --cyan token must stay #18b6dc.
+//
+//   node scripts/audit/forbidden-css.mjs [srcDir=src]
+//
+// Exit 0 = clean. Exit 1 = violation(s).
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, extname } from 'node:path'
+
+const SRC = process.argv[2] || 'src'
+const FORBIDDEN = [
+  { re: /backdrop-filter/, label: 'backdrop-filter' },
+  { re: /color-mix\s*\(/, label: 'color-mix()' },
+  { re: /oklch\s*\(/, label: 'oklch()' },
+]
+const ICON_LIB =
+  /(?:import|from)\s+['"](?:@?lucide|@fortawesome|heroicons|feather-icons|react-icons|svelte-icons|@iconify)/
+const EXTS = new Set(['.svelte', '.css', '.js', '.mjs'])
+const SKIP = new Set(['node_modules', 'dist', '.audit'])
+
+const files = []
+;(function walk(d) {
+  for (const e of readdirSync(d)) {
+    const p = join(d, e)
+    const s = statSync(p)
+    if (s.isDirectory()) {
+      if (!SKIP.has(e)) walk(p)
+    } else if (EXTS.has(extname(p))) files.push(p)
+  }
+})(SRC)
+
+const violations = []
+let sawCyan = false
+for (const f of files) {
+  const txt = readFileSync(f, 'utf8')
+  txt.split('\n').forEach((line, i) => {
+    for (const { re, label } of FORBIDDEN) {
+      if (re.test(line)) violations.push(`${f}:${i + 1}  forbidden ${label}: ${line.trim()}`)
+    }
+    if (ICON_LIB.test(line)) violations.push(`${f}:${i + 1}  icon-library import: ${line.trim()}`)
+  })
+  if (f.endsWith('app.css')) {
+    sawCyan = true
+    if (!/--cyan:\s*#18b6dc;/.test(txt))
+      violations.push(`${f}  --cyan token altered/missing (must be #18b6dc)`)
+  }
+}
+if (!sawCyan) violations.push('app.css not found — cannot verify --cyan integrity')
+
+if (violations.length) {
+  console.error('FORBIDDEN-CSS VIOLATIONS:')
+  violations.forEach((v) => console.error('  ' + v))
+  process.exit(1)
+}
+console.log(`forbidden-css scan clean (${files.length} files, mix-blend-mode allowlisted)`)

--- a/frontend/scripts/audit/gate.sh
+++ b/frontend/scripts/audit/gate.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Per-segment audit gate. Usage: gate.sh <segN> <#/route> <pngname>
+# Tier-A: forbidden-css + build(exit0) + boot + 0 console error. Saves PNG for morning.
+set -e
+cd ~/Projects/arkiv/frontend
+echo "=== forbidden-css ==="
+node scripts/audit/forbidden-css.mjs src
+echo "=== build ==="
+npm run build >"/tmp/arkiv-$1-build.log" 2>&1 && echo "build OK ($(grep -ic warn "/tmp/arkiv-$1-build.log") warn)" || { echo "BUILD FAIL"; tail -20 "/tmp/arkiv-$1-build.log"; exit 1; }
+pkill -f "vite preview" 2>/dev/null || true
+sleep 1
+rm -f /tmp/arkiv-preview.log
+npm run preview >/tmp/arkiv-preview.log 2>&1 &
+until grep -q "http://localhost" /tmp/arkiv-preview.log 2>/dev/null; do sleep 1; done
+URL=$(grep -oE "http://localhost:[0-9]+/" /tmp/arkiv-preview.log | head -1)
+echo "=== shoot ${URL}$2 ==="
+node scripts/audit/shoot.mjs "${URL}$2" ".audit/$1/$3.png" ".audit/$1/console.json"

--- a/frontend/scripts/audit/shoot.mjs
+++ b/frontend/scripts/audit/shoot.mjs
@@ -56,7 +56,7 @@ try {
 await new Promise((r) => setTimeout(r, 400)) // let fonts/animation settle
 
 mkdirSync(dirname(outPng), { recursive: true })
-await page.screenshot({ path: outPng })
+await page.screenshot({ path: outPng, fullPage: true })
 await browser.close()
 
 if (consoleJson) {

--- a/frontend/scripts/audit/shoot.mjs
+++ b/frontend/scripts/audit/shoot.mjs
@@ -1,0 +1,72 @@
+// Audit screenshot + console capture — drives the system Chrome via
+// puppeteer-core (no Chromium download). Used by the overnight loop's
+// Tier-A (console==0) and Tier-B (port PNG) gates.
+//
+//   node scripts/audit/shoot.mjs <url> <out.png> [console.json]
+//
+// Exit 0 = no console.error / pageerror. Exit 1 = errors (gate fail).
+// Exit 2 = bad usage. requestfailed (e.g. favicon) is logged, not gated.
+import puppeteer from 'puppeteer-core'
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+const [, , url, outPng, consoleJson] = process.argv
+if (!url || !outPng) {
+  console.error('usage: shoot.mjs <url> <out.png> [console.json]')
+  process.exit(2)
+}
+
+const browser = await puppeteer.launch({
+  executablePath: CHROME,
+  headless: true,
+  args: ['--no-sandbox', '--hide-scrollbars', '--force-color-profile=srgb'],
+})
+const page = await browser.newPage()
+await page.setViewport({ width: 1400, height: 900, deviceScaleFactor: 2 })
+
+const isFavicon = (u) => /favicon\.ico(\?|$)/.test(u)
+const msgs = []
+page.on('console', (m) => {
+  const t = m.type()
+  if (t !== 'error' && t !== 'warning') return
+  const text = m.text()
+  // "Failed to load resource" console errors carry no URL; they duplicate the
+  // response-status tracking below (which is URL-aware + favicon-tolerant).
+  if (/Failed to load resource/.test(text)) return
+  msgs.push({ type: t, text })
+})
+page.on('pageerror', (e) => msgs.push({ type: 'pageerror', text: String(e) }))
+page.on('response', (r) => {
+  const s = r.status()
+  const u = r.url()
+  if (s >= 400 && !isFavicon(u)) msgs.push({ type: 'badresponse', text: `${s} ${u}` })
+})
+page.on('requestfailed', (r) => {
+  const u = r.url()
+  if (isFavicon(u)) return // benign
+  msgs.push({ type: 'requestfailed', text: `${u} ${r.failure()?.errorText || ''}` })
+})
+
+try {
+  await page.goto(url, { waitUntil: 'networkidle0', timeout: 30000 })
+} catch (e) {
+  msgs.push({ type: 'pageerror', text: `goto failed: ${e}` })
+}
+await new Promise((r) => setTimeout(r, 400)) // let fonts/animation settle
+
+mkdirSync(dirname(outPng), { recursive: true })
+await page.screenshot({ path: outPng })
+await browser.close()
+
+if (consoleJson) {
+  mkdirSync(dirname(consoleJson), { recursive: true })
+  writeFileSync(consoleJson, JSON.stringify(msgs, null, 2))
+}
+
+const hard = msgs.filter(
+  (m) => m.type === 'error' || m.type === 'pageerror' || m.type === 'badresponse' || m.type === 'requestfailed'
+)
+console.log(`shot ${outPng} — ${hard.length} hard error(s), ${msgs.length} msg(s) total`)
+for (const m of msgs) console.log(`  [${m.type}] ${m.text}`)
+process.exit(hard.length ? 1 : 0)

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -9,6 +9,7 @@
   import Ingest from './routes/Ingest.svelte'
   import Settings from './routes/Settings.svelte'
   import Flows from './routes/Flows.svelte'
+  import Edge from './routes/Edge.svelte'
 
   // Routes are added per overnight segment.
   const routes = {
@@ -21,7 +22,8 @@
     '/ingest': Ingest, // seg 6 — ingest progress
     '/settings': Settings, // seg 7 — settings modal
     '/flows': Flows, // seg 8 — round-3 flows
-    // ...screens land here per segment
+    '/edge': Edge, // seg 9 — round-4 edge
+    // (insta360 — excluded, gated on 8.3a POC)
   }
 </script>
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,0 +1,23 @@
+<script>
+  import Router from 'svelte-spa-router'
+  import Home from './routes/Home.svelte'
+  import Gallery from './routes/Gallery.svelte'
+
+  // Routes are added per overnight segment.
+  const routes = {
+    '/': Home,
+    '/gallery': Gallery, // seg 1 — shared-primitive gallery
+    // '/main': MainDark,     // seg 2
+    // ...screens land here per segment
+  }
+</script>
+
+<div class="ak-root" data-theme="dark">
+  <Router {routes} />
+</div>
+
+<style>
+  .ak-root {
+    min-height: 100vh;
+  }
+</style>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -5,6 +5,7 @@
   import MainDark from './routes/MainDark.svelte'
   import MainStates from './routes/MainStates.svelte'
   import InspectorFull from './routes/InspectorFull.svelte'
+  import Search from './routes/Search.svelte'
 
   // Routes are added per overnight segment.
   const routes = {
@@ -13,6 +14,7 @@
     '/main': MainDark, // seg 2 — hero (interactive)
     '/states': MainStates, // seg 3 — state variants
     '/inspector': InspectorFull, // seg 4 — inspector full
+    '/search': Search, // seg 5 — cross-project search
     // ...screens land here per segment
   }
 </script>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -8,6 +8,7 @@
   import Search from './routes/Search.svelte'
   import Ingest from './routes/Ingest.svelte'
   import Settings from './routes/Settings.svelte'
+  import Flows from './routes/Flows.svelte'
 
   // Routes are added per overnight segment.
   const routes = {
@@ -19,6 +20,7 @@
     '/search': Search, // seg 5 — cross-project search
     '/ingest': Ingest, // seg 6 — ingest progress
     '/settings': Settings, // seg 7 — settings modal
+    '/flows': Flows, // seg 8 — round-3 flows
     // ...screens land here per segment
   }
 </script>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -7,6 +7,7 @@
   import InspectorFull from './routes/InspectorFull.svelte'
   import Search from './routes/Search.svelte'
   import Ingest from './routes/Ingest.svelte'
+  import Settings from './routes/Settings.svelte'
 
   // Routes are added per overnight segment.
   const routes = {
@@ -17,6 +18,7 @@
     '/inspector': InspectorFull, // seg 4 — inspector full
     '/search': Search, // seg 5 — cross-project search
     '/ingest': Ingest, // seg 6 — ingest progress
+    '/settings': Settings, // seg 7 — settings modal
     // ...screens land here per segment
   }
 </script>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -4,6 +4,7 @@
   import Gallery from './routes/Gallery.svelte'
   import MainDark from './routes/MainDark.svelte'
   import MainStates from './routes/MainStates.svelte'
+  import InspectorFull from './routes/InspectorFull.svelte'
 
   // Routes are added per overnight segment.
   const routes = {
@@ -11,6 +12,7 @@
     '/gallery': Gallery, // seg 1 — shared-primitive gallery
     '/main': MainDark, // seg 2 — hero (interactive)
     '/states': MainStates, // seg 3 — state variants
+    '/inspector': InspectorFull, // seg 4 — inspector full
     // ...screens land here per segment
   }
 </script>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -2,12 +2,13 @@
   import Router from 'svelte-spa-router'
   import Home from './routes/Home.svelte'
   import Gallery from './routes/Gallery.svelte'
+  import MainDark from './routes/MainDark.svelte'
 
   // Routes are added per overnight segment.
   const routes = {
     '/': Home,
     '/gallery': Gallery, // seg 1 — shared-primitive gallery
-    // '/main': MainDark,     // seg 2
+    '/main': MainDark, // seg 2 — hero (interactive)
     // ...screens land here per segment
   }
 </script>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -6,6 +6,7 @@
   import MainStates from './routes/MainStates.svelte'
   import InspectorFull from './routes/InspectorFull.svelte'
   import Search from './routes/Search.svelte'
+  import Ingest from './routes/Ingest.svelte'
 
   // Routes are added per overnight segment.
   const routes = {
@@ -15,6 +16,7 @@
     '/states': MainStates, // seg 3 — state variants
     '/inspector': InspectorFull, // seg 4 — inspector full
     '/search': Search, // seg 5 — cross-project search
+    '/ingest': Ingest, // seg 6 — ingest progress
     // ...screens land here per segment
   }
 </script>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -3,12 +3,14 @@
   import Home from './routes/Home.svelte'
   import Gallery from './routes/Gallery.svelte'
   import MainDark from './routes/MainDark.svelte'
+  import MainStates from './routes/MainStates.svelte'
 
   // Routes are added per overnight segment.
   const routes = {
     '/': Home,
     '/gallery': Gallery, // seg 1 — shared-primitive gallery
     '/main': MainDark, // seg 2 — hero (interactive)
+    '/states': MainStates, // seg 3 — state variants
     // ...screens land here per segment
   }
 </script>

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -10,7 +10,8 @@
    ============================================================ */
 
 /* ---- base reset ---- */
-html, body { margin: 0; padding: 0; height: 100%; }
+html { height: 100%; }
+body { margin: 0; padding: 0; min-height: 100%; }
 #app { min-height: 100%; }
 
 :root {

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,0 +1,225 @@
+/* ============================================================
+   arkiv — design tokens (drop-in from design-2026-05-27/tokens.css)
+   Brutalist editorial. Pure B&W. No chromatic accents.
+   Dark = deep ink charcoal (not pure black). Light = warm paper.
+
+   NOTE: the mockup's Google Fonts @import is intentionally removed —
+   fonts are self-hosted via @fontsource (imported in main.js).
+   Token VALUES below are verbatim from the canonical baseline; do
+   not alter them (cyan stays #18b6dc, no gradients).
+   ============================================================ */
+
+/* ---- base reset ---- */
+html, body { margin: 0; padding: 0; height: 100%; }
+#app { min-height: 100%; }
+
+:root {
+  /* ---------- Type stack ---------- */
+  --ak-display: 'Archivo Black', 'Helvetica Now Display Black', 'Neue Haas Grotesk Display Black', 'Inter', sans-serif;
+  --ak-sans: 'Inter', 'Noto Sans TC', system-ui, -apple-system, sans-serif;
+  --ak-mono: 'JetBrains Mono', 'IBM Plex Mono', ui-monospace, monospace;
+
+  /* ---------- Type scale ---------- */
+  --fs-hairline: 10px;
+  --fs-micro: 11px;
+  --fs-tiny: 12px;
+  --fs-body: 13px;
+  --fs-md: 14px;
+  --fs-lg: 16px;
+  --fs-xl: 20px;
+  --fs-display-sm: 28px;
+  --fs-display: 40px;
+  --fs-display-lg: 64px;
+
+  --lh-tight: 1.0;
+  --lh-snug: 1.15;
+  --lh-body: 1.45;
+
+  --tr-tight: -0.02em;
+  --tr-display: -0.04em;
+  --tr-uppercase: 0.08em;
+
+  /* ---------- Spacing (4px base) ---------- */
+  --s-1: 4px;
+  --s-2: 8px;
+  --s-3: 12px;
+  --s-4: 16px;
+  --s-5: 20px;
+  --s-6: 24px;
+  --s-8: 32px;
+  --s-10: 40px;
+  --s-12: 48px;
+  --s-16: 64px;
+
+  /* ---------- Geometry ---------- */
+  --radius-0: 0px;
+  --radius-1: 2px;    /* hairline pill, inputs */
+  --hairline: 1px;
+  --grid-gutter: 1px;
+
+  /* Brand brushstroke cyan — sanctioned in 3 places only:
+     splash/about, hover-line <2px, ingest/progress indicators. */
+  --cyan: #18b6dc;
+  --cyan-quiet: #167a93;
+}
+
+/* ============================================================
+   DARK (primary) — deep ink, not pure black
+   ============================================================ */
+[data-theme='dark'] {
+  --bg:        #0a0a0c;
+  --surface:   #111114;
+  --surface-2: #17171a;
+  --surface-3: #1d1d20;
+  --rule:      #26262a;
+  --rule-hi:   #3a3a3f;
+  --ink:       #f3f2ee;
+  --ink-2:     #b6b5b0;
+  --quiet:     #6a6a6d;
+  --quiet-2:   #4a4a4e;
+  --invert:    #f3f2ee;  /* used for selected outline + GOOD rating fill */
+  --invert-ink:#0a0a0c;
+}
+
+/* ============================================================
+   LIGHT (secondary) — warm paper
+   ============================================================ */
+[data-theme='light'] {
+  --bg:        #f1efe9;
+  --surface:   #f7f5ef;
+  --surface-2: #ffffff;
+  --surface-3: #ebe9e3;
+  --rule:      #1c1a16;     /* light mode rules are dark (editorial) */
+  --rule-hi:   #0a0a0c;
+  --ink:       #0a0a0c;
+  --ink-2:     #3a3833;
+  --quiet:     #7c7a73;
+  --quiet-2:   #a8a6a0;
+  --invert:    #0a0a0c;
+  --invert-ink:#f3f2ee;
+}
+
+/* ============================================================
+   Base
+   ============================================================ */
+.ak-root {
+  font-family: var(--ak-sans);
+  font-size: var(--fs-body);
+  line-height: var(--lh-body);
+  color: var(--ink);
+  background: var(--bg);
+  font-feature-settings: 'ss01', 'cv11', 'tnum';
+  font-variant-numeric: tabular-nums;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  position: relative;
+  isolation: isolate;
+}
+
+/* ============================================================
+   Film grain — subtle paper / photographic noise on every panel.
+   Pulled from one inline SVG (feTurbulence baseFrequency 0.9), no
+   network. Tiles 200×200. Layered via ::before with pointer-events:
+   none so it never blocks input. Dark uses screen blend at 4% to
+   raise grain into the highlights; light uses multiply at 5% to
+   bite into the paper.
+   ============================================================ */
+:root {
+  --grain-img:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 1  0 0 0 0 1  0 0 0 0 1  0 0 0 1 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+}
+
+.ak-root::before {
+  content: '';
+  position: absolute; inset: 0;
+  background-image: var(--grain-img);
+  background-size: 200px 200px;
+  pointer-events: none;
+  z-index: 1000;
+  opacity: 0.045;
+  mix-blend-mode: screen;
+}
+[data-theme='light'].ak-root::before {
+  opacity: 0.07;
+  mix-blend-mode: multiply;
+}
+
+/* Make sure children paint above the grain layer */
+.ak-root > * { position: relative; z-index: 1; }
+
+.ak-mono { font-family: var(--ak-mono); font-feature-settings: 'tnum'; letter-spacing: 0; }
+.ak-display { font-family: var(--ak-display); font-weight: 900; letter-spacing: var(--tr-display); line-height: var(--lh-tight); }
+
+.ak-eyebrow {
+  font-family: var(--ak-mono);
+  font-size: var(--fs-hairline);
+  letter-spacing: var(--tr-uppercase);
+  text-transform: uppercase;
+  color: var(--quiet);
+}
+
+/* ============================================================
+   Rating system — type weight + border only.
+   No stars, no dots, no color.
+   ============================================================ */
+.ak-rate { font-family: var(--ak-mono); font-size: 10px; letter-spacing: 0.06em; padding: 2px 5px; line-height: 1; display: inline-flex; align-items: center; }
+.ak-rate--good { background: var(--invert); color: var(--invert-ink); font-weight: 700; }
+.ak-rate--ng   { color: var(--quiet); font-weight: 400; text-decoration: line-through; text-decoration-thickness: 1px; }
+.ak-rate--rev  { border: 1px dashed var(--rule-hi); color: var(--ink-2); font-weight: 500; padding: 1px 4px; }
+.ak-rate--none { border: 1px solid var(--rule); color: var(--quiet); font-weight: 400; padding: 1px 4px; }
+
+/* ============================================================
+   1px frame motif — used sparingly
+   logo lockup, selected media, modal chrome, empty state
+   ============================================================ */
+.ak-frame { box-shadow: inset 0 0 0 1px var(--rule); }
+.ak-frame-hi { box-shadow: inset 0 0 0 1px var(--invert); }
+
+/* ============================================================
+   Misc
+   ============================================================ */
+.ak-rule { height: 1px; background: var(--rule); }
+.ak-rule-v { width: 1px; background: var(--rule); }
+
+button.ak-btn {
+  font-family: var(--ak-mono);
+  font-size: var(--fs-tiny);
+  text-transform: uppercase;
+  letter-spacing: var(--tr-uppercase);
+  background: transparent;
+  color: var(--ink);
+  border: 1px solid var(--rule-hi);
+  padding: 6px 10px;
+  cursor: pointer;
+  line-height: 1;
+}
+button.ak-btn:hover { background: var(--surface-2); border-color: var(--ink); }
+button.ak-btn--primary { background: var(--invert); color: var(--invert-ink); border-color: var(--invert); }
+button.ak-btn--primary:hover { background: var(--ink-2); border-color: var(--ink-2); color: var(--invert-ink); }
+
+input.ak-input {
+  font-family: var(--ak-mono);
+  font-size: var(--fs-tiny);
+  background: transparent;
+  color: var(--ink);
+  border: none;
+  border-bottom: 1px solid var(--rule);
+  padding: 6px 0;
+  outline: none;
+  width: 100%;
+}
+input.ak-input:focus { border-bottom-color: var(--ink); }
+input.ak-input::placeholder { color: var(--quiet); }
+
+/* Skeleton sweep — vertical hairline that crosses each placeholder */
+@keyframes ak-sweep {
+  0%   { transform: translateX(0); opacity: 0; }
+  10%  { opacity: 0.5; }
+  50%  { opacity: 1; }
+  90%  { opacity: 0.5; }
+  100% { transform: translateX(200%); opacity: 0; }
+}
+
+/* hide scrollbars inside screens (artboards) */
+.ak-root *::-webkit-scrollbar { display: none; }
+.ak-root * { scrollbar-width: none; }

--- a/frontend/src/lib/ArkivLogo.svelte
+++ b/frontend/src/lib/ArkivLogo.svelte
@@ -1,0 +1,32 @@
+<!-- 1px frame around 'arkiv.' wordmark (vulture.s 'tv.' style). -->
+<script>
+  export let size = 18
+  export let theme = 'dark' // API parity; styling is theme-agnostic (CSS vars)
+</script>
+
+<div
+  class="logo"
+  style="padding: {size * 0.18}px {size * 0.42}px; font-size: {size}px;"
+>
+  arkiv<span class="dot" style="font-size: {size * 0.55}px;">.</span>
+</div>
+
+<style>
+  .logo {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: inset 0 0 0 1px var(--ink);
+    font-family: var(--ak-display);
+    line-height: 1;
+    letter-spacing: -0.04em;
+    color: var(--ink);
+  }
+  .dot {
+    font-family: var(--ak-mono);
+    font-weight: 400;
+    margin-left: 4px;
+    letter-spacing: 0;
+    transform: translateY(-1px);
+  }
+</style>

--- a/frontend/src/lib/CornerTick.svelte
+++ b/frontend/src/lib/CornerTick.svelte
@@ -1,0 +1,14 @@
+<!-- L-shaped tick at a corner of a selected card. -->
+<script>
+  export let pos // 'tl' | 'tr' | 'bl' | 'br'
+</script>
+
+<div class="tick {pos}"></div>
+
+<style>
+  .tick { position: absolute; width: 14px; height: 14px; z-index: 2; }
+  .tl { top: -1px; left: -1px; border-top: 2px solid var(--invert); border-left: 2px solid var(--invert); }
+  .tr { top: -1px; right: -1px; border-top: 2px solid var(--invert); border-right: 2px solid var(--invert); }
+  .bl { bottom: -1px; left: -1px; border-bottom: 2px solid var(--invert); border-left: 2px solid var(--invert); }
+  .br { bottom: -1px; right: -1px; border-bottom: 2px solid var(--invert); border-right: 2px solid var(--invert); }
+</style>

--- a/frontend/src/lib/Eyebrow.svelte
+++ b/frontend/src/lib/Eyebrow.svelte
@@ -1,0 +1,18 @@
+<!-- Mono uppercase tiny label. -->
+<script>
+  export let style = ''
+</script>
+
+<div class="ak-mono eyebrow" {style}>
+  <slot />
+</div>
+
+<style>
+  .eyebrow {
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--quiet);
+    font-weight: 500;
+  }
+</style>

--- a/frontend/src/lib/FilterRow.svelte
+++ b/frontend/src/lib/FilterRow.svelte
@@ -1,0 +1,32 @@
+<!-- kind filter (all/video/audio) + rating filter (good/rev/ng, toggle). Bindable. -->
+<script>
+  export let activeFilter = 'all'
+  export let activeRating = null
+  const filters = [['all', 'All'], ['video', 'Video'], ['audio', 'Audio']]
+  const ratings = [['good', 'Good'], ['rev', 'Review'], ['ng', 'N·G']]
+</script>
+
+<div class="filters">
+  {#each filters as [key, label]}
+    <button class="fbtn" class:active={activeFilter === key} on:click={() => (activeFilter = key)}>{label}</button>
+  {/each}
+  <div class="vrule"></div>
+  {#each ratings as [key, label]}
+    <button
+      class="fbtn"
+      class:active={activeRating === key}
+      on:click={() => (activeRating = activeRating === key ? null : key)}
+    >{label}</button>
+  {/each}
+</div>
+
+<style>
+  .filters { display: flex; gap: 4px; }
+  .fbtn {
+    font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase;
+    padding: 4px 9px; background: transparent; color: var(--ink-2);
+    border: 1px solid var(--rule); cursor: pointer; line-height: 1; white-space: nowrap;
+  }
+  .fbtn.active { background: var(--invert); color: var(--invert-ink); border-color: var(--invert); }
+  .vrule { width: 1px; background: var(--rule); margin: 0 4px; }
+</style>

--- a/frontend/src/lib/Frame.svelte
+++ b/frontend/src/lib/Frame.svelte
@@ -4,6 +4,7 @@
   export let style = ''
 </script>
 
+<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
 <div class="frame" class:hi {style} {...$$restProps} on:click on:mouseenter on:mouseleave>
   <slot />
 </div>

--- a/frontend/src/lib/Frame.svelte
+++ b/frontend/src/lib/Frame.svelte
@@ -1,0 +1,18 @@
+<!-- 1px square frame motif. hi = inverted (selected/active). -->
+<script>
+  export let hi = false
+  export let style = ''
+</script>
+
+<div class="frame" class:hi {style} {...$$restProps} on:click on:mouseenter on:mouseleave>
+  <slot />
+</div>
+
+<style>
+  .frame {
+    box-shadow: inset 0 0 0 1px var(--rule);
+  }
+  .frame.hi {
+    box-shadow: inset 0 0 0 1px var(--invert);
+  }
+</style>

--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -1,0 +1,132 @@
+<!-- Right inspector panel: header · preview · metadata · waveform · transcript · rate. -->
+<script>
+  import Eyebrow from './Eyebrow.svelte'
+  import Mono from './Mono.svelte'
+  import Thumb from './Thumb.svelte'
+  import Waveform from './Waveform.svelte'
+  export let media
+  export let theme = 'dark'
+
+  const transcript = [
+    ['00:05', '我們從上海一路騎到拉薩，第十七天。', false],
+    ['00:12', '中間最難的是格爾木到沱沱河那段。', true],
+    ['00:24', '氧氣比想像中還少，海拔 4800。', false],
+    ['00:36', '車架被打到變形，但人沒事。', false],
+  ]
+  const rateBtns = [['good', 'Good'], ['rev', 'Review'], ['ng', 'N·G'], ['none', '—']]
+</script>
+
+<aside class="inspector">
+  <div class="header">
+    <Eyebrow style="margin-bottom:8px;">
+      Inspector · {media.kind === 'audio' ? 'AUDIO' : `${media.fps}p · ${media.res}`}
+    </Eyebrow>
+    <div class="fname">{media.name}</div>
+    <Mono dim style="font-size:10.5px;margin-top:4px;letter-spacing:0.04em;">
+      /vol/nas01/bicycle-diaries/raw/{media.name}
+    </Mono>
+  </div>
+
+  <div class="preview">
+    <Thumb seed={media.id} kind={media.kind} {theme} />
+    <div class="scrim"></div>
+    <div class="controls">
+      <Mono style="font-size:11px;color:#f3f2ee;">00:00:42</Mono>
+      <div class="track">
+        <div class="trackfill"></div>
+        <div class="trackhead"></div>
+      </div>
+      <Mono style="font-size:11px;color:#f3f2ee;">{media.dur}</Mono>
+    </div>
+  </div>
+
+  <div class="block">
+    <Eyebrow style="margin-bottom:8px;">Metadata</Eyebrow>
+    <div class="metagrid">
+      <Mono dim>CAMERA</Mono><Mono>{media.cam}</Mono>
+      <Mono dim>LENS</Mono><Mono>{media.lens}</Mono>
+      <Mono dim>ISO</Mono><Mono>{media.iso} · {media.ap} · {media.fl}</Mono>
+      <Mono dim>SIZE</Mono><Mono>{media.size} · {media.dur}</Mono>
+    </div>
+  </div>
+
+  <div class="block">
+    <div class="blockhead">
+      <Eyebrow>Waveform</Eyebrow>
+      <Mono dim style="font-size:9.5px;">IN 00:05 · OUT 00:42</Mono>
+    </div>
+    <Waveform />
+  </div>
+
+  <div class="block transcript">
+    <div class="blockhead">
+      <Eyebrow>Transcript · zh-Hant</Eyebrow>
+      <Mono dim style="font-size:9.5px;">whisper-large · 98.2%</Mono>
+    </div>
+    <div class="lines">
+      {#each transcript as [tc, text, hl]}
+        <div class="line">
+          <Mono dim style="font-size:10.5px;flex:0 0 36px;">{tc}</Mono>
+          <span class="ttext" class:hl>{text}</span>
+        </div>
+      {/each}
+    </div>
+  </div>
+
+  <div class="rate">
+    <Eyebrow>Rate</Eyebrow>
+    <div class="ratebtns">
+      {#each rateBtns as [r, label]}
+        <button class="ratebtn" class:active={media.rating === r} class:rev={r === 'rev'}>{label}</button>
+      {/each}
+    </div>
+    <div class="exports">
+      <button class="ak-btn exp">EDL</button>
+      <button class="ak-btn exp">FCPXML</button>
+      <button class="ak-btn exp">SRT</button>
+    </div>
+  </div>
+</aside>
+
+<style>
+  .inspector {
+    border-left: 1px solid var(--rule); display: flex; flex-direction: column;
+    min-height: 0; overflow: hidden;
+  }
+  .header { padding: 18px 18px 16px; border-bottom: 1px solid var(--rule); }
+  .fname {
+    font-family: var(--ak-mono); font-size: 13px; font-weight: 500;
+    letter-spacing: 0.005em; line-height: 1.3; color: var(--ink); word-break: break-all;
+  }
+  .preview {
+    position: relative; aspect-ratio: 16 / 9; background: var(--surface-2);
+    border-bottom: 1px solid var(--rule);
+  }
+  .scrim {
+    position: absolute; left: 0; right: 0; bottom: 0; height: 40%;
+    background-image: linear-gradient(to top, rgba(0, 0, 0, 0.55), transparent); pointer-events: none;
+  }
+  .controls { position: absolute; left: 12px; bottom: 12px; right: 12px; display: flex; align-items: center; gap: 10px; }
+  .track { flex: 1; height: 2px; background: rgba(243, 242, 238, 0.25); position: relative; }
+  .trackfill { position: absolute; left: 0; top: 0; bottom: 0; width: 25%; background: #f3f2ee; }
+  .trackhead { position: absolute; left: 25%; top: -3px; width: 1px; height: 8px; background: #f3f2ee; }
+  .block { padding: 14px 18px; border-bottom: 1px solid var(--rule); }
+  .metagrid { display: grid; grid-template-columns: 64px 1fr; row-gap: 4px; column-gap: 12px; font-size: 11.5px; }
+  .blockhead { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 8px; }
+  .transcript { flex: 1; overflow: hidden; }
+  .lines { display: flex; flex-direction: column; gap: 8px; font-size: 12px; line-height: 1.5; }
+  .line { display: flex; gap: 10px; }
+  .ttext { color: var(--ink); }
+  .ttext.hl { border-bottom: 1px solid var(--invert); padding-bottom: 1px; }
+  .rate { padding: 14px 18px; display: flex; flex-direction: column; gap: 10px; }
+  .ratebtns { display: flex; gap: 4px; }
+  .ratebtn {
+    flex: 1; font-family: var(--ak-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase;
+    padding: 7px 0; background: transparent; color: var(--ink-2);
+    border: 1px solid var(--rule); cursor: pointer; font-weight: 400;
+  }
+  .ratebtn.rev { border: 1px dashed var(--rule-hi); }
+  .ratebtn.active { background: var(--invert); color: var(--invert-ink); border-color: var(--invert); font-weight: 700; }
+  .exports { display: flex; gap: 6px; margin-top: 6px; }
+  .exp { flex: 1; }
+</style>

--- a/frontend/src/lib/MainShell.svelte
+++ b/frontend/src/lib/MainShell.svelte
@@ -1,0 +1,34 @@
+<!-- Fixed 1400×900 artboard shell: TopBar + (PoolSidebar | center | inspector).
+     center = required slot; inspector = optional (defaults to <Inspector>);
+     footer = optional (analytics). rows overrides grid-template-rows. -->
+<script>
+  import TopBar from './TopBar.svelte'
+  import PoolSidebar from './PoolSidebar.svelte'
+  import Inspector from './Inspector.svelte'
+  import { MEDIA } from './mockData.js'
+  export let theme = 'dark'
+  export let rows = '52px 1fr'
+</script>
+
+<div class="artboard" data-theme={theme} style="grid-template-rows:{rows};">
+  <TopBar />
+  <div class="body">
+    <PoolSidebar />
+    <slot name="center" />
+    {#if $$slots.inspector}
+      <slot name="inspector" />
+    {:else}
+      <Inspector media={MEDIA[0]} {theme} />
+    {/if}
+  </div>
+  <slot name="footer" />
+</div>
+
+<style>
+  .artboard {
+    width: 1400px; height: 900px; position: relative;
+    display: grid; background: var(--bg); color: var(--ink); overflow: hidden;
+    margin: 0 auto;
+  }
+  .body { display: grid; grid-template-columns: 220px 1fr 340px; min-height: 0; }
+</style>

--- a/frontend/src/lib/MediaCard.svelte
+++ b/frontend/src/lib/MediaCard.svelte
@@ -1,0 +1,48 @@
+<!-- Grid card. Forwards click/hover events to parent (selection lives upstream). -->
+<script>
+  import Thumb from './Thumb.svelte'
+  import Rating from './Rating.svelte'
+  import Mono from './Mono.svelte'
+  import CornerTick from './CornerTick.svelte'
+  export let m
+  export let theme = 'dark'
+  export let selected = false
+  export let hover = false
+</script>
+
+<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+<div class="card" class:selected class:hover on:click on:mouseenter on:mouseleave>
+  <div class="thumbarea">
+    <Thumb seed={m.id} kind={m.kind} {theme} />
+    <div class="dur">{m.dur}</div>
+    {#if selected}
+      <CornerTick pos="tl" /><CornerTick pos="tr" /><CornerTick pos="bl" /><CornerTick pos="br" />
+    {/if}
+  </div>
+  <div class="meta">
+    <div class="name" class:ng={m.rating === 'ng'}>{m.name}</div>
+    <div class="row">
+      <Rating value={m.rating} />
+      <Mono dim style="font-size:10px;">{m.size}</Mono>
+    </div>
+  </div>
+</div>
+
+<style>
+  .card { background: var(--bg); position: relative; cursor: pointer; transition: box-shadow 0.12s; }
+  .card.selected { box-shadow: inset 0 0 0 1px var(--invert); }
+  .card.hover:not(.selected) { outline: 1px solid var(--rule-hi); outline-offset: -1px; }
+  .thumbarea { position: relative; aspect-ratio: 16 / 9; background: var(--surface-2); overflow: hidden; }
+  .dur {
+    position: absolute; bottom: 6px; right: 6px;
+    font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.02em;
+    color: #f3f2ee; background: rgba(10, 10, 12, 0.78); padding: 2px 5px; line-height: 1;
+  }
+  .meta { padding: 8px 10px 10px; display: flex; flex-direction: column; gap: 4px; }
+  .name {
+    font-family: var(--ak-mono); font-size: 11.5px; color: var(--ink);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .name.ng { text-decoration: line-through; opacity: 0.5; }
+  .row { display: flex; justify-content: space-between; align-items: center; }
+</style>

--- a/frontend/src/lib/Mono.svelte
+++ b/frontend/src/lib/Mono.svelte
@@ -1,0 +1,13 @@
+<!-- Inline monospace text. dim = quiet color. -->
+<script>
+  export let dim = false
+  export let style = ''
+</script>
+
+<span class="ak-mono" class:dim {style}><slot /></span>
+
+<style>
+  .dim {
+    color: var(--quiet);
+  }
+</style>

--- a/frontend/src/lib/PoolSidebar.svelte
+++ b/frontend/src/lib/PoolSidebar.svelte
@@ -1,0 +1,100 @@
+<!-- Left sidebar: projects · smart pools · tags · storage. -->
+<script>
+  import Eyebrow from './Eyebrow.svelte'
+  import Mono from './Mono.svelte'
+  import { PROJECTS, TAGS } from './mockData.js'
+  const pools = [
+    ['All media', 247],
+    ['Needs review', 34],
+    ['Orphans', 2],
+    ['Recently ingested', 18],
+    ['No transcript', 12],
+  ]
+</script>
+
+<aside class="pool">
+  <section>
+    <Eyebrow style="margin-bottom:10px;">Projects · 4</Eyebrow>
+    <div class="col">
+      {#each PROJECTS as p (p.id)}
+        <div class="proj" class:active={p.active} style="opacity:{p.health ? 0.6 : 1};">
+          <div class="projrow">
+            <span class="projname" class:activename={p.active}>{p.name}</span>
+            <Mono dim style="font-size:10px;flex:0 0 auto;">{p.count}</Mono>
+          </div>
+          {#if p.health}
+            <Mono dim style="font-size:9.5px;letter-spacing:0.06em;display:block;margin-top:1px;">◇ {p.health}</Mono>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  </section>
+
+  <section>
+    <Eyebrow style="margin-bottom:10px;">Smart Pools</Eyebrow>
+    <div class="col">
+      {#each pools as [label, count]}
+        <div class="poolrow">
+          <span class="ellip">{label}</span>
+          <Mono dim style="font-size:10px;flex:0 0 auto;">{count}</Mono>
+        </div>
+      {/each}
+    </div>
+  </section>
+
+  <section class="tagsec">
+    <Eyebrow style="margin-bottom:10px;">Tags · auto</Eyebrow>
+    <div class="tags">
+      {#each TAGS as t (t.name)}
+        <span class="tag">{t.name} <span class="tagcount">{t.count}</span></span>
+      {/each}
+    </div>
+  </section>
+
+  <div class="spacer"></div>
+
+  <section class="storage">
+    <div class="strow">
+      <Eyebrow>Storage</Eyebrow>
+      <Mono dim style="font-size:10px;">40%</Mono>
+    </div>
+    <div class="bar"><div class="barfill"></div></div>
+    <Mono dim style="font-size:10.5px;margin-top:5px;letter-spacing:0.02em;">4.8 TB · 12 TB · NAS</Mono>
+  </section>
+</aside>
+
+<style>
+  .pool {
+    border-right: 1px solid var(--rule); padding: 20px 14px 14px 16px;
+    display: flex; flex-direction: column; gap: 20px; min-height: 0; overflow: hidden;
+  }
+  .col { display: flex; flex-direction: column; }
+  .proj {
+    padding: 5px 6px 5px 0; border-left: 2px solid transparent;
+    padding-left: 10px; cursor: pointer;
+  }
+  .proj.active { border-left-color: var(--invert); padding-left: 8px; }
+  .projrow { display: flex; justify-content: space-between; align-items: baseline; gap: 6px; }
+  .projname {
+    font-size: 12.5px; font-weight: 400; color: var(--ink-2);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0;
+  }
+  .projname.activename { font-weight: 600; color: var(--ink); }
+  .poolrow {
+    display: flex; justify-content: space-between; align-items: baseline; gap: 6px;
+    padding: 4px 10px; font-size: 12.5px; color: var(--ink-2); cursor: pointer;
+  }
+  .ellip { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; }
+  .tagsec { min-height: 0; }
+  .tags { display: flex; flex-wrap: wrap; gap: 4px; }
+  .tag {
+    font-family: var(--ak-mono); font-size: 10.5px; padding: 3px 6px;
+    border: 1px solid var(--rule); color: var(--ink-2); cursor: pointer; white-space: nowrap;
+  }
+  .tagcount { color: var(--quiet); }
+  .spacer { flex: 1; }
+  .storage { border-top: 1px solid var(--rule); padding-top: 12px; }
+  .strow { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 6px; }
+  .bar { height: 2px; background: var(--surface-3); position: relative; }
+  .barfill { position: absolute; left: 0; top: 0; bottom: 0; width: 40%; background: var(--ink); }
+</style>

--- a/frontend/src/lib/Rating.svelte
+++ b/frontend/src/lib/Rating.svelte
@@ -1,0 +1,14 @@
+<!-- Rating — type weight + border only. No shapes, no color. -->
+<script>
+  export let value // 'good' | 'ng' | 'rev' | 'none'
+</script>
+
+{#if value === 'good'}
+  <span class="ak-rate ak-rate--good">GOOD</span>
+{:else if value === 'ng'}
+  <span class="ak-rate ak-rate--ng">N·G</span>
+{:else if value === 'rev'}
+  <span class="ak-rate ak-rate--rev">REV</span>
+{:else}
+  <span class="ak-rate ak-rate--none">—</span>
+{/if}

--- a/frontend/src/lib/Sweep.svelte
+++ b/frontend/src/lib/Sweep.svelte
@@ -1,0 +1,14 @@
+<!-- CSS-only skeleton sweep — 1px cyan vertical line translating (no gradient). -->
+<script>
+  export let delay = 0
+</script>
+
+<div class="sweep" style="animation-delay:{delay}s;"></div>
+
+<style>
+  .sweep {
+    position: absolute; top: 0; bottom: 0; left: 0; width: 1px;
+    background: var(--cyan); opacity: 0.6;
+    animation: ak-sweep 1.4s infinite linear;
+  }
+</style>

--- a/frontend/src/lib/Thumb.svelte
+++ b/frontend/src/lib/Thumb.svelte
@@ -1,0 +1,104 @@
+<!-- Abstract placeholder composition (no real images). `seed` drives a
+     deterministic variant so the grid has visual rhythm. Brutalist:
+     blocks / stripes / color fields. mix-blend-mode overlay is canonical. -->
+<script>
+  export let seed = 0
+  export let kind = 'video'
+  export let state = undefined // API parity (not visualized here)
+  export let theme = 'dark'
+
+  const palettesDark = [
+    ['#2a2a2e', '#1a1a1d', '#3a3a3f'],
+    ['#222226', '#0f0f12', '#4a4a4e'],
+  ]
+  const palettesLight = [
+    ['#d2d0c8', '#e8e6df', '#b8b6ad'],
+    ['#c8c6bd', '#ddd9cf', '#a8a59c'],
+  ]
+
+  $: v = (((seed % 12) + 12) % 12)
+  $: palettes = theme === 'dark' ? palettesDark : palettesLight
+  $: p = palettes[v % 2]
+  $: layout = v % 6
+  $: barColor = theme === 'dark' ? '#f3f2ee' : '#0a0a0c'
+  const stripes = [0, 1, 2, 3, 4, 5, 6]
+  $: audioBars = Array.from({ length: 22 }, (_, i) => 6 + Math.abs(Math.sin(i * 1.3 + seed) * 32))
+</script>
+
+<div class="thumb" style="background: {p[1]};">
+  {#if layout === 0}
+    <div class="fill" style="background:{p[1]};"></div>
+    <div class="pos" style="left:0;right:0;top:38%;height:24%;background:{p[0]};"></div>
+    <div class="pos" style="left:0;right:0;top:62%;height:38%;background:{p[2]};"></div>
+  {:else if layout === 1}
+    <div class="fill" style="background:{p[0]};"></div>
+    <div class="pos" style="left:32%;top:14%;width:36%;height:70%;background:{p[1]};"></div>
+    <div class="pos" style="left:38%;top:18%;width:24%;height:28%;background:{p[2]};border-radius:50%;"></div>
+  {:else if layout === 2}
+    <div class="fill" style="background:{p[1]};"></div>
+    {#each stripes as i}
+      <div class="pos" style="left:0;right:0;top:{10 + i * 12}%;height:3%;background:{i % 2 ? p[2] : p[0]};"></div>
+    {/each}
+  {:else if layout === 3}
+    <div class="fill" style="background:{p[2]};"></div>
+    <div class="pos" style="right:0;top:0;width:60%;height:60%;background:{p[0]};"></div>
+    <div class="pos" style="left:0;bottom:0;width:70%;height:40%;background:{p[1]};"></div>
+  {:else if layout === 4}
+    <div class="fill" style="background:{p[1]};"></div>
+    <div class="pos" style="left:15%;top:8%;width:34%;height:84%;background:{p[2]};"></div>
+    <div class="pos" style="left:54%;top:20%;width:30%;height:60%;background:{p[0]};"></div>
+  {:else}
+    <div class="fill" style="background:{p[0]};"></div>
+    <div class="fill" style="background:{p[2]};clip-path:polygon(0 100%, 100% 0, 100% 100%);"></div>
+  {/if}
+
+  <div class="grain"></div>
+
+  {#if kind === 'audio'}
+    <div class="audio">
+      {#each audioBars as h}
+        <div class="bar" style="height:{h}px;background:{barColor};"></div>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .thumb {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+  }
+  .fill {
+    position: absolute;
+    inset: 0;
+  }
+  .pos {
+    position: absolute;
+  }
+  .grain {
+    position: absolute;
+    inset: 0;
+    background-image: radial-gradient(rgba(255, 255, 255, 0.015) 1px, transparent 1px);
+    background-size: 3px 3px;
+    mix-blend-mode: overlay;
+    pointer-events: none;
+  }
+  .audio {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+  }
+  .bar {
+    width: 2px;
+    opacity: 0.7;
+  }
+</style>

--- a/frontend/src/lib/TopBar.svelte
+++ b/frontend/src/lib/TopBar.svelte
@@ -1,0 +1,56 @@
+<!-- Top bar: logo · search · all-projects toggle · actions. crossProject is bindable. -->
+<script>
+  import ArkivLogo from './ArkivLogo.svelte'
+  import Mono from './Mono.svelte'
+  export let crossProject = false
+</script>
+
+<div class="topbar">
+  <div class="logo">
+    <ArkivLogo size={16} />
+    <Mono dim style="font-size:10px;letter-spacing:0.05em;">v0.9.2</Mono>
+  </div>
+
+  <div class="search">
+    <Mono dim style="font-size:11px;">⌕</Mono>
+    <input
+      class="ak-input searchinput"
+      placeholder={'搜尋媒體… "格爾木氧氣"、camera:a7s3、tag:cycling、lang:zh'}
+    />
+    <button class="allproj" class:on={crossProject} on:click={() => (crossProject = !crossProject)}>
+      All projects {#if crossProject}·on{/if}
+    </button>
+    <Mono dim style="font-size:10px;letter-spacing:0.06em;white-space:nowrap;">⌘K</Mono>
+  </div>
+
+  <div class="actions">
+    <button class="ak-btn ak-btn--primary">+ Ingest</button>
+    <button class="ak-btn">EDL</button>
+    <button class="ak-btn">FCPXML</button>
+    <div class="vrule"></div>
+    <button class="ak-btn" title="theme">◐</button>
+    <button class="ak-btn" title="settings">···</button>
+  </div>
+</div>
+
+<style>
+  .topbar {
+    display: grid; grid-template-columns: 220px 1fr auto; align-items: center;
+    border-bottom: 1px solid var(--rule); padding-right: 16px; background: var(--bg);
+  }
+  .logo { padding-left: 16px; display: flex; align-items: center; gap: 12px; }
+  .search {
+    display: flex; align-items: center; gap: 14px;
+    border-left: 1px solid var(--rule); border-right: 1px solid var(--rule);
+    padding-left: 16px; height: 100%;
+  }
+  .searchinput { flex: 1; font-size: 13px; font-family: var(--ak-sans); border-bottom: none; }
+  .allproj {
+    font-family: var(--ak-mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase;
+    padding: 4px 8px; background: transparent; color: var(--ink-2);
+    border: 1px solid var(--rule-hi); cursor: pointer; line-height: 1; white-space: nowrap;
+  }
+  .allproj.on { background: var(--invert); color: var(--invert-ink); border-color: var(--invert); }
+  .actions { display: flex; align-items: center; gap: 8px; padding-left: 16px; }
+  .vrule { width: 1px; height: 18px; background: var(--rule); margin: 0 4px; }
+</style>

--- a/frontend/src/lib/ViewToggle.svelte
+++ b/frontend/src/lib/ViewToggle.svelte
@@ -1,0 +1,20 @@
+<!-- grid / list view toggle. Bindable. -->
+<script>
+  export let view = 'grid'
+</script>
+
+<div class="vt">
+  <button class="vbtn" class:active={view === 'grid'} on:click={() => (view = 'grid')}>Grid</button>
+  <div class="sep"></div>
+  <button class="vbtn" class:active={view === 'list'} on:click={() => (view = 'list')}>List</button>
+</div>
+
+<style>
+  .vt { display: flex; border: 1px solid var(--rule); }
+  .vbtn {
+    font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase;
+    padding: 4px 9px; background: transparent; color: var(--ink-2); border: none; cursor: pointer; line-height: 1;
+  }
+  .vbtn.active { background: var(--invert); color: var(--invert-ink); }
+  .sep { width: 1px; background: var(--rule); }
+</style>

--- a/frontend/src/lib/Waveform.svelte
+++ b/frontend/src/lib/Waveform.svelte
@@ -1,0 +1,29 @@
+<!-- Deterministic SVG waveform with in/out markers + playhead. -->
+<script>
+  const N = 80
+  const bars = Array.from({ length: N }, (_, i) => {
+    const v = Math.sin(i * 0.7) * 0.4 + Math.sin(i * 0.13) * 0.35 + Math.sin(i * 0.42 + 1) * 0.3
+    return Math.abs(v) * (0.6 + Math.sin(i * 0.18) * 0.4)
+  }).map((v) => Math.max(2, v * 50))
+</script>
+
+<div class="wf">
+  <svg viewBox="0 0 80 56" preserveAspectRatio="none" class="svg">
+    {#each bars as h, i}
+      <rect x={i + 0.15} y={(56 - h) / 2} width="0.7" height={h} fill="var(--ink-2)" />
+    {/each}
+  </svg>
+  <div class="mark mark-in"><div class="flag"></div></div>
+  <div class="mark mark-out"><div class="flag"></div></div>
+  <div class="playhead"></div>
+</div>
+
+<style>
+  .wf { position: relative; height: 56px; }
+  .svg { width: 100%; height: 100%; display: block; }
+  .mark { position: absolute; top: 0; bottom: 0; width: 1px; background: var(--invert); }
+  .mark-in { left: 8%; }
+  .mark-out { left: 78%; }
+  .flag { position: absolute; top: -4px; left: -3px; width: 7px; height: 4px; background: var(--invert); }
+  .playhead { position: absolute; top: -6px; bottom: -6px; left: 32%; width: 1px; background: var(--ink); }
+</style>

--- a/frontend/src/lib/mockData.js
+++ b/frontend/src/lib/mockData.js
@@ -1,0 +1,39 @@
+// Mock data — verbatim from design-2026-05-27/components.jsx.
+// Screens consume these until real API wiring (supervised phase).
+
+export const MEDIA = [
+  { id: 1,  name: 'A7S3_C001_240515.mov',   dur: '00:02:47', size: '1.4 GB', rating: 'good', kind: 'video', cam: 'Sony α7S III',  lens: 'FE 24-70 GM',  iso: 800,  ap: 'f/2.8', fl: '35mm', fps: 24, res: '3840×2160', tags: ['cycling','road','interview'], lang: 'zh' },
+  { id: 2,  name: 'A7S3_C002_240515.mov',   dur: '00:00:32', size: '184 MB', rating: 'ng',   kind: 'video', cam: 'Sony α7S III',  lens: 'FE 24-70 GM',  iso: 1600, ap: 'f/2.8', fl: '24mm', fps: 24, res: '3840×2160', tags: ['cycling','b-roll'], lang: 'zh' },
+  { id: 3,  name: 'INTERVIEW_HEVIN_01.wav', dur: '00:18:04', size: '92 MB',  rating: 'good', kind: 'audio', cam: 'Zoom F3',      lens: 'Sennheiser MKH416', iso: '—', ap: '—',    fl: '—',  fps: '—', res: '48kHz 24bit',  tags: ['interview','podcast','zh'], lang: 'zh' },
+  { id: 4,  name: 'A7S3_C003_240516.mov',   dur: '00:01:12', size: '512 MB', rating: 'rev',  kind: 'video', cam: 'Sony α7S III',  lens: 'FE 70-200 GM', iso: 400,  ap: 'f/4',   fl: '135mm', fps: 24, res: '3840×2160', tags: ['portrait','golden hour'], lang: 'zh' },
+  { id: 5,  name: 'GH6_4824.mp4',           dur: '00:00:08', size: '64 MB',  rating: 'good', kind: 'video', cam: 'Panasonic GH6', lens: 'Leica 12-60',  iso: 200,  ap: 'f/4',   fl: '12mm', fps: 60, res: '3840×2160', tags: ['b-roll','landscape','slow-mo'], lang: 'en' },
+  { id: 6,  name: 'A7S3_C004_240516.mov',   dur: '00:03:21', size: '1.7 GB', rating: 'none', kind: 'video', cam: 'Sony α7S III',  lens: 'FE 24-70 GM',  iso: 800,  ap: 'f/2.8', fl: '50mm', fps: 24, res: '3840×2160', tags: ['product','tabletop'], lang: 'ja' },
+  { id: 7,  name: 'GH6_4825.mp4',           dur: '00:00:14', size: '78 MB',  rating: 'good', kind: 'video', cam: 'Panasonic GH6', lens: 'Leica 12-60',  iso: 400,  ap: 'f/5.6', fl: '35mm', fps: 60, res: '3840×2160', tags: ['b-roll','street'], lang: 'en' },
+  { id: 8,  name: 'INTERVIEW_HEVIN_02.wav', dur: '00:24:18', size: '124 MB', rating: 'rev',  kind: 'audio', cam: 'Zoom F3',      lens: 'Sennheiser MKH416', iso: '—', ap: '—',    fl: '—',  fps: '—', res: '48kHz 24bit',  tags: ['interview','podcast'], lang: 'zh' },
+  { id: 9,  name: 'A7S3_C005_240517.mov',   dur: '00:00:42', size: '256 MB', rating: 'good', kind: 'video', cam: 'Sony α7S III',  lens: 'FE 35 1.4',    iso: 1250, ap: 'f/1.4', fl: '35mm', fps: 24, res: '3840×2160', tags: ['portrait','night','available light'], lang: 'zh' },
+  { id: 10, name: 'A7S3_C006_240517.mov',   dur: '00:01:48', size: '780 MB', rating: 'none', kind: 'video', cam: 'Sony α7S III',  lens: 'FE 35 1.4',    iso: 1600, ap: 'f/1.4', fl: '35mm', fps: 24, res: '3840×2160', tags: ['portrait','night'], lang: 'zh' },
+  { id: 11, name: 'GH6_4826.mp4',           dur: '00:00:22', size: '108 MB', rating: 'ng',   kind: 'video', cam: 'Panasonic GH6', lens: 'Leica 12-60',  iso: 1600, ap: 'f/4',   fl: '60mm', fps: 60, res: '3840×2160', tags: ['b-roll','rejected'], lang: 'en' },
+  { id: 12, name: 'A7S3_C007_240518.mov',   dur: '00:02:04', size: '1.1 GB', rating: 'good', kind: 'video', cam: 'Sony α7S III',  lens: 'FE 24-70 GM',  iso: 640,  ap: 'f/4',   fl: '70mm', fps: 24, res: '3840×2160', tags: ['cycling','tibet','documentary'], lang: 'zh' },
+  { id: 13, name: 'BACKGROUND_AMB.wav',     dur: '00:08:32', size: '46 MB',  rating: 'good', kind: 'audio', cam: 'Zoom H6',      lens: 'XY pair',           iso: '—', ap: '—',    fl: '—',  fps: '—', res: '48kHz 24bit',  tags: ['ambient','nature'], lang: '—' },
+  { id: 14, name: 'A7S3_C008_240518.mov',   dur: '00:04:16', size: '2.1 GB', rating: 'good', kind: 'video', cam: 'Sony α7S III',  lens: 'FE 70-200 GM', iso: 400,  ap: 'f/4',   fl: '200mm', fps: 24, res: '3840×2160', tags: ['cycling','tibet','wide'], lang: 'zh' },
+  { id: 15, name: 'GH6_4827.mp4',           dur: '00:00:19', size: '88 MB',  rating: 'none', kind: 'video', cam: 'Panasonic GH6', lens: 'Leica 12-60',  iso: 800,  ap: 'f/4',   fl: '24mm', fps: 60, res: '3840×2160', tags: ['b-roll'], lang: 'en' },
+  { id: 16, name: 'A7S3_C009_240519.mov',   dur: '00:01:03', size: '420 MB', rating: 'rev',  kind: 'video', cam: 'Sony α7S III',  lens: 'FE 24-70 GM',  iso: 800,  ap: 'f/4',   fl: '50mm', fps: 24, res: '3840×2160', tags: ['product','interview'], lang: 'ja' },
+]
+
+export const PROJECTS = [
+  { id: 'bd', name: 'Bicycle Diaries', count: 247, active: true,  size: '4.8 TB' },
+  { id: 'vr', name: 'vulture.s reels', count: 89,  active: false, size: '1.2 TB' },
+  { id: 'fr', name: 'Furutech RCA spot', count: 152, active: false, size: '2.1 TB' },
+  { id: 'kq', name: 'KOL_2026Q1', count: 38, active: false, size: '—', health: 'NAS unmounted' },
+]
+
+export const TAGS = [
+  { name: 'cycling', count: 88 },
+  { name: 'portrait', count: 41 },
+  { name: 'product', count: 62 },
+  { name: 'interview', count: 23 },
+  { name: 'tibet', count: 19 },
+  { name: 'b-roll', count: 71 },
+  { name: 'ambient', count: 12 },
+  { name: 'documentary', count: 28 },
+]

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,21 @@
+import './app.css'
+
+// Self-hosted fonts (offline after `npm install`; replaces the mockup's
+// Google Fonts CDN @import — required under Tauri CSP later).
+import '@fontsource/archivo-black/400.css'
+import '@fontsource/inter/400.css'
+import '@fontsource/inter/500.css'
+import '@fontsource/inter/600.css'
+import '@fontsource/inter/700.css'
+import '@fontsource/jetbrains-mono/400.css'
+import '@fontsource/jetbrains-mono/500.css'
+import '@fontsource/jetbrains-mono/700.css'
+import '@fontsource/noto-sans-tc/400.css'
+import '@fontsource/noto-sans-tc/500.css'
+import '@fontsource/noto-sans-tc/700.css'
+
+import App from './App.svelte'
+
+const app = new App({ target: document.getElementById('app') })
+
+export default app

--- a/frontend/src/routes/Edge.svelte
+++ b/frontend/src/routes/Edge.svelte
@@ -1,0 +1,305 @@
+<!-- Seg 9 — Round-4 edge (C1–C4): ws-error / update-banner / splash⚠ /
+     onboarding. Stacked for audit. Splash = §11.1 brand mark (Nordic depth) —
+     ⚠ PASS_WITH_NOTES: needs human brand-fidelity review (morning). -->
+<script>
+  import ArkivLogo from '../lib/ArkivLogo.svelte'
+  import Mono from '../lib/Mono.svelte'
+  import Eyebrow from '../lib/Eyebrow.svelte'
+  import Thumb from '../lib/Thumb.svelte'
+  import TopBar from '../lib/TopBar.svelte'
+  import { MEDIA } from '../lib/mockData.js'
+
+  const theme = 'dark'
+  const wsCols = '1fr 80px 76px 80px 76px 70px 1fr'
+  const wsQueue = [
+    { name: 'A7S3_C015_240519.mov', size: '1.4 GB', probe: 'done', trans: 'done', tag: 'paused', pct: 82 },
+    { name: 'A7S3_C016_240519.mov', size: '2.4 GB', probe: 'done', trans: 'paused', tag: '—', pct: 48 },
+    { name: 'GH6_4830.mp4', size: '186 MB', probe: 'paused', trans: '—', tag: '—', pct: 22 },
+    { name: 'GH6_4831.mp4', size: '212 MB', probe: '—', trans: '—', tag: '—', pct: 0 },
+  ]
+  const stageText = (s) => (s === 'paused' ? 'WAIT' : s === '—' ? '·' : 'OK')
+  const notes = [
+    ['REINSTATED', ['Apple Silicon Metal GPU path for whisper.cpp — 4.2× faster than CPU on M-series']],
+    ['ADDED', ['.braw ingest (Blackmagic Raw 12K, 8K, 6K)', 'Ollama backend support for vision tagging (llava 13b, llava 34b)', 'Search clause: codec, bitrate, color-space']],
+    ['FIXED · 14', ['Inspector waveform clipping at >30min audio', 'EDL export drops first event when project starts on non-zero timecode', 'NAS unmount during ingest no longer kills the daemon', 'Whisper hallucinations on silence > 8s', '+ 10 minor']],
+  ]
+  const stack = [
+    ['FRONTEND', 'Tauri 2.0 · Svelte 4 · Vite'], ['BACKEND', 'Rust · SQLite + tantivy'],
+    ['AUDIO', 'whisper.cpp · large-v3'], ['VISION', 'Ollama · llava-13b / qwen3-vl'], ['MEDIA', 'FFmpeg 7 · pyscenedetect'],
+  ]
+  const steps = [
+    { n: '1', title: 'Storage', sub: 'Mount your NAS or pick a folder.', status: 'done', detail: 'NAS01 · /vol/nas01 · 12 TB' },
+    { n: '2', title: 'AI models', sub: 'Whisper for transcripts. Ollama for tags.', status: 'active' },
+    { n: '3', title: 'First project', sub: "Where today's footage lives.", status: 'pending' },
+  ]
+  const whisperDetail = [['LANGUAGES', '99 · auto-detect on'], ['DEVICE', 'Metal GPU · Apple M2 Max'], ['SPEED', '~0.4s per minute of audio'], ['QUALITY', 'state of the art · zh / en / ja']]
+  const visionDetail = [['DEVICE', 'Metal GPU · Apple M2 Max'], ['BATCH', '12 frames per clip'], ['POOL', 'Auto · 8 tags max per clip'], ['QUALITY', 'good balance · alt: 34b for stronger tagging']]
+</script>
+
+<div class="stack">
+
+  <!-- C1 · WS ERROR -->
+  <Eyebrow style="padding-left:8px;">C1 · websocket disconnected</Eyebrow>
+  <div class="artboard rows52">
+    <div class="topbar"><ArkivLogo size={16} /><Mono dim style="font-size:10px;">v0.9.2</Mono><div class="grow"></div><Mono style="font-size:11px;color:var(--ink);letter-spacing:0.05em;">ws://localhost:8501/ws/ingest · <span class="b">DISCONNECTED</span></Mono><button class="ak-btn">Reconnect</button></div>
+    <div>
+      <div class="dbanner">
+        <div>
+          <div class="dbhead"><Eyebrow style="color:var(--ink);">◇ STREAM DISCONNECTED · 00:14 AGO</Eyebrow><Mono dim style="font-size:10px;">retry 3 of 8 · next in 00:08</Mono></div>
+          <div class="ak-display dbtitle">Ingest paused. 34 of 52 files done · 18 queued.</div>
+          <Mono dim style="font-size:11px;margin-top:6px;line-height:1.5;display:block;">No data loss — files already probed/transcribed/tagged are saved. Queue resumes automatically when the daemon comes back, or you can switch to background mode and close this window.</Mono>
+        </div>
+        <div class="dbbtns"><button class="ak-btn ak-btn--primary wide">Reconnect now</button><button class="ak-btn">Restart daemon</button><button class="ak-btn">Run in background</button></div>
+      </div>
+      <div class="wsqueue">
+        <div class="wsqhead"><Eyebrow>Queue · frozen at 14:12:18</Eyebrow><Mono dim style="font-size:10.5px;">34/52 · 65.4%</Mono></div>
+        <div class="wsbar"><div class="wsbarfill"></div></div>
+        <div class="wsrow wshrow" style="grid-template-columns:{wsCols};">{#each ['FILE', 'SIZE', 'PROBE', 'TRANSCRIBE', 'TAG', 'ETA', 'PROGRESS'] as h}<Mono dim style="font-size:9.5px;letter-spacing:0.1em;">{h}</Mono>{/each}</div>
+        {#each wsQueue as f (f.name)}
+          <div class="wsrow" style="grid-template-columns:{wsCols};">
+            <Mono style="font-size:11.5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{f.name}</Mono>
+            <Mono dim style="font-size:10.5px;">{f.size}</Mono>
+            <span class="pstage" class:ok={f.probe === 'done'}>{stageText(f.probe)}</span>
+            <span class="pstage" class:ok={f.trans === 'done'}>{stageText(f.trans)}</span>
+            <span class="pstage" class:ok={f.tag === 'done'}>{stageText(f.tag)}</span>
+            <Mono dim style="font-size:10.5px;">—</Mono>
+            <div class="wspbar"><div class="wspfill" style="width:{f.pct}%;"></div></div>
+          </div>
+        {/each}
+        <Mono dim style="font-size:10.5px;margin-top:16px;letter-spacing:0.04em;display:block;">Diagnostics ·  systemctl status arkiv-daemon  ·  ~/.arkiv/logs/daemon-2026-05-26.log</Mono>
+      </div>
+    </div>
+  </div>
+
+  <!-- C2 · UPDATE BANNER -->
+  <Eyebrow style="padding-left:8px;">C2 · update available</Eyebrow>
+  <div class="artboard rows40">
+    <div class="ubanner">
+      <Mono style="font-size:10.5px;letter-spacing:0.1em;font-weight:700;">● UPDATE</Mono>
+      <div class="ubmid"><Mono style="font-size:12.5px;font-weight:600;">arkiv  v0.9.3</Mono><Mono style="font-size:11px;opacity:0.7;">↘ v0.9.2 → 0.9.3 · ready · 18 MB · signed</Mono></div>
+      <Mono style="font-size:10px;opacity:0.7;letter-spacing:0.06em;">REINSTATES Apple Silicon GPU PATH · ADDS .braw INGEST · FIXES 14 BUGS</Mono>
+      <div class="ubbtns"><button class="ubghost">Notes</button><button class="ubsolid">Install &amp; restart</button><button class="ubx">✕</button></div>
+    </div>
+    <TopBar />
+    <div class="ubmain">
+      <div class="ubgrid">
+        <div class="grid4">{#each MEDIA.slice(0, 12) as m (m.id)}<div class="cellbg"><div class="thumb169"><Thumb seed={m.id} kind={m.kind} {theme} /></div></div>{/each}</div>
+      </div>
+      <aside class="notes">
+        <div class="noteshead"><Eyebrow style="margin-bottom:8px;">Release notes</Eyebrow><div class="ak-display notesver">v0.9.3</div><Mono dim style="font-size:11px;margin-top:6px;letter-spacing:0.04em;">released 2026-05-24 · 18.2 MB · signed sha-256</Mono></div>
+        <div class="notesbody">
+          {#each notes as [title, items]}
+            <div><Eyebrow style="margin-bottom:8px;">{title}</Eyebrow><div class="notelist">{#each items as line}<div class="noteline"><Mono dim style="font-size:11px;">·</Mono><span>{line}</span></div>{/each}</div></div>
+          {/each}
+          <div class="grow"></div>
+          <Mono dim style="font-size:10px;line-height:1.5;margin-top:4px;">Auto-update channel:  stable  ·  rollback to v0.9.2 stays available for 7 days.</Mono>
+        </div>
+      </aside>
+    </div>
+  </div>
+
+  <!-- C3 · SPLASH ⚠ brand mark -->
+  <Eyebrow style="padding-left:8px;">C3 · splash / about  ⚠ brand-artifact (human review)</Eyebrow>
+  <div class="artboard rel">
+    <div class="splashframe">
+      <div class="splashhead"><Eyebrow>arkiv  ·  about · welcome</Eyebrow><div class="grow"></div><Mono dim style="font-size:11px;">ESC · CLOSE</Mono></div>
+      <div class="splashbody">
+        <div class="splashleft">
+          <Eyebrow style="margin-bottom:22px;">vulture.s</Eyebrow>
+          <div class="ak-display splashmark">arkiv<span class="splashdot">.</span></div>
+          <div class="depth">
+            <div class="depthsvg">
+              <svg viewBox="0 0 560 320" width="100%" height="100%" preserveAspectRatio="none" style="display:block;">
+                <defs>
+                  <linearGradient id="ak-depth" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0" stop-color="var(--cyan)" stop-opacity="0.06" />
+                    <stop offset="0.12" stop-color="var(--cyan)" stop-opacity="0.22" />
+                    <stop offset="0.22" stop-color="var(--cyan)" stop-opacity="0.28" />
+                    <stop offset="0.45" stop-color="var(--cyan)" stop-opacity="0.12" />
+                    <stop offset="0.80" stop-color="var(--cyan)" stop-opacity="0.03" />
+                    <stop offset="1" stop-color="var(--cyan)" stop-opacity="0" />
+                  </linearGradient>
+                  <linearGradient id="ak-left-fade" x1="0" y1="0" x2="1" y2="0">
+                    <stop offset="0" stop-color="#fff" stop-opacity="0.35" />
+                    <stop offset="0.02" stop-color="#fff" stop-opacity="0.65" />
+                    <stop offset="0.06" stop-color="#fff" stop-opacity="1" />
+                  </linearGradient>
+                  <mask id="ak-left-mask"><rect x="0" y="0" width="560" height="320" fill="url(#ak-left-fade)" /></mask>
+                </defs>
+                <rect x="0" y="0" width="560" height="320" fill="url(#ak-depth)" mask="url(#ak-left-mask)" />
+              </svg>
+            </div>
+            <h1 class="ak-display splashsub">The open-source media asset manager for filmmakers who own their data.</h1>
+            <div class="grow"></div>
+          </div>
+          <div class="etym">
+            <Mono dim style="font-size:10.5px;letter-spacing:0.06em;line-height:1.7;"><span class="b ink">arkiv</span>  <span style="letter-spacing:0.02em;">/ˈarkiːv/</span>  <span class="i">n.</span>  [sv. da. no., ‹ L. <span class="i">archīvum</span>]<br />a place where things are kept.</Mono>
+            <Mono dim style="font-size:10.5px;letter-spacing:0.06em;">v0.9.2 · 2026-05-26</Mono>
+          </div>
+        </div>
+        <div class="splashright">
+          <section><Eyebrow style="margin-bottom:10px;">Stack</Eyebrow><div class="sptext">Local-first. Zero cloud. FFmpeg probe · Whisper transcript · Ollama vision tags. Export to DaVinci Resolve EDL / FCPXML. MIT licensed.</div></section>
+          <section><Eyebrow style="margin-bottom:12px;">Built with</Eyebrow><div class="builtgrid">{#each stack as [k, v]}<Mono dim>{k}</Mono><Mono>{v}</Mono>{/each}</div></section>
+          <section><Eyebrow style="margin-bottom:12px;">Why local-first</Eyebrow><div class="sptext sm">Your footage is your work. Cloud DAMs lock you in, ration your bandwidth, and read your transcripts.<br /><br />arkiv stays on your machine. Same models the big platforms run — Whisper, llava — but on hardware you already own. Nothing leaves unless you export it yourself.</div></section>
+          <section><Eyebrow style="margin-bottom:10px;">Acknowledgements</Eyebrow><Mono dim style="font-size:11px;line-height:1.65;">FFmpeg · whisper.cpp · Ollama · pyscenedetect · tantivy · Tauri · the SvelteKit team. Type: Helvetica Now Display Black ·  Inter · JetBrains Mono ·  Noto Sans TC. The mark above arkiv is still water with a single quiet event — Nordic, vertical, not painted.</Mono></section>
+          <div class="grow"></div>
+        </div>
+      </div>
+      <div class="splashfoot"><Mono dim style="font-size:10.5px;letter-spacing:0.06em;">MIT  ·  © 2026 vulture.s  ·  no telemetry  ·  no phone-home</Mono><div class="fbtns"><button class="ak-btn">License</button><button class="ak-btn">Diagnostics</button><button class="ak-btn ak-btn--primary">Get started →</button></div></div>
+    </div>
+  </div>
+
+  <!-- C4 · ONBOARDING -->
+  <Eyebrow style="padding-left:8px;">C4 · first-run onboarding</Eyebrow>
+  <div class="artboard rows52f">
+    <div class="topbar ob"><ArkivLogo size={16} /><Mono dim style="font-size:11px;">first run · setup</Mono><div class="grow"></div><Mono dim style="font-size:10.5px;letter-spacing:0.05em;">You can change any of this later in Settings.</Mono><button class="ak-btn">Skip · I'll do this later</button></div>
+    <div class="obbody">
+      <div class="stepper">
+        <Eyebrow style="margin-bottom:28px;">Setup · 2 of 3</Eyebrow>
+        <div class="steps">
+          {#each steps as s}
+            <div class="step">
+              <span class="stepn" class:active={s.status === 'active'} class:done={s.status === 'done'}>{s.status === 'done' ? '✓' : s.n}</span>
+              <div>
+                <div class="ak-display steptitle" class:dim={s.status === 'pending'} class:muted={s.status !== 'active' && s.status !== 'done'}>{s.title}</div>
+                <Mono dim style="font-size:11px;margin-top:4px;display:block;line-height:1.45;">{s.sub}</Mono>
+                {#if s.detail}<Mono style="font-size:11px;margin-top:6px;display:block;color:var(--ink);">{s.detail}</Mono>{/if}
+              </div>
+            </div>
+          {/each}
+        </div>
+        <div class="grow"></div>
+        <div class="stepnote"><Mono dim style="font-size:10.5px;line-height:1.6;">All three steps run locally. No accounts, no sign-ups, no cloud.</Mono></div>
+      </div>
+      <div class="stepdetail">
+        <Eyebrow style="margin-bottom:10px;">Step 2 · AI models</Eyebrow>
+        <div class="ak-display obbig">Pick the models<br />that run locally.</div>
+        <Mono dim style="font-size:13px;margin-top:14px;line-height:1.65;max-width:640px;display:block;">arkiv detected your hardware. These defaults are tuned for an Apple Silicon machine with 64 GB RAM — most filmmakers don't need to change them.</Mono>
+        <div class="modelcards">
+          {#each [{ eyebrow: 'WHISPER · TRANSCRIPTION', title: 'whisper-large-v3', size: '1.55 GB · download once', detail: whisperDetail }, { eyebrow: 'OLLAMA · VISION', title: 'llava:13b-v1.6-q4_K_M', size: '7.4 GB · download on first ingest', detail: visionDetail }] as c}
+            <div class="modelcard">
+              <div class="mctop"><Eyebrow>{c.eyebrow}</Eyebrow><Mono style="font-size:9.5px;letter-spacing:0.08em;padding:2px 6px;background:var(--invert);color:var(--invert-ink);">SELECTED</Mono></div>
+              <div class="mctitle">{c.title}</div>
+              <Mono dim style="font-size:11px;letter-spacing:0.03em;">{c.size}</Mono>
+              <div class="mcdetail">{#each c.detail as [k, v]}<Mono dim style="font-size:10px;letter-spacing:0.08em;">{k}</Mono><Mono style="font-size:11px;color:var(--ink-2);">{v}</Mono>{/each}</div>
+              <button class="ak-btn mcbtn">Pick a different model…</button>
+            </div>
+          {/each}
+        </div>
+        <div class="dlbox">
+          <Mono dim style="font-size:9.5px;letter-spacing:0.1em;">◇ DOWNLOAD</Mono>
+          <Mono style="font-size:12px;color:var(--ink);">Combined  ≈ 8.95 GB · about 14 minutes on a typical home connection</Mono>
+          <div class="grow"></div>
+          <button class="ak-btn">Start download now</button>
+          <button class="ak-btn">Defer to first ingest</button>
+        </div>
+        <div class="grow"></div>
+        <Mono dim style="font-size:10.5px;margin-top:16px;letter-spacing:0.04em;">Want a different model? More options in Settings · Transcription / Vision tagging.</Mono>
+      </div>
+    </div>
+    <div class="obfoot">
+      <div class="dots"><span class="dot done"></span><div class="dline ink2"></div><span class="dot active"></span><div class="dline"></div><span class="dot"></span></div>
+      <div class="fbtns"><button class="ak-btn">← Storage</button><button class="ak-btn ak-btn--primary widex">Next · First project →</button></div>
+    </div>
+  </div>
+
+</div>
+
+<style>
+  .stack { display: flex; flex-direction: column; gap: 28px; padding: 24px 0; }
+  .artboard { width: 1400px; height: 900px; background: var(--bg); color: var(--ink); overflow: hidden; margin: 0 auto; }
+  .artboard.rel { position: relative; }
+  .artboard.rows52 { display: grid; grid-template-rows: 52px 1fr; }
+  .artboard.rows52f { display: grid; grid-template-rows: 52px 1fr 88px; }
+  .artboard.rows40 { display: grid; grid-template-rows: 40px 52px 1fr; }
+  .grow { flex: 1; }
+  .b { font-weight: 700; }
+  .i { font-style: italic; }
+  .ink { color: var(--ink); }
+  .wide { padding: 8px 18px; }
+  .widex { padding: 10px 24px; }
+  .fbtns { display: flex; gap: 8px; }
+  .topbar { display: flex; align-items: center; border-bottom: 1px solid var(--rule); padding: 0 16px; gap: 16px; }
+  .topbar.ob { padding: 0 24px; gap: 18px; }
+  .grid4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px; background: var(--rule); }
+  .cellbg { background: var(--bg); }
+  .thumb169 { position: relative; aspect-ratio: 16 / 9; background: var(--surface-2); }
+
+  /* C1 ws error */
+  .dbanner { border-top: 1px solid var(--ink); border-bottom: 1px dashed var(--rule-hi); background: var(--surface); padding: 18px 60px; display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 32px; }
+  .dbhead { display: flex; align-items: baseline; gap: 12px; margin-bottom: 6px; }
+  .dbtitle { font-size: 22px; letter-spacing: -0.03em; line-height: 1.1; color: var(--ink); }
+  .dbbtns { display: flex; flex-direction: column; gap: 6px; }
+  .wsqueue { padding: 24px 60px; opacity: 0.55; }
+  .wsqhead { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 14px; }
+  .wsbar { height: 4px; background: var(--surface-3); position: relative; margin-bottom: 16px; }
+  .wsbarfill { position: absolute; left: 0; top: 0; bottom: 0; width: 65.4%; background: var(--ink-2); }
+  .wsrow { display: grid; gap: 14px; align-items: center; padding: 7px 0; border-bottom: 1px solid var(--rule); }
+  .wsrow.wshrow { padding: 0 0 8px; }
+  .pstage { font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.08em; color: var(--quiet); padding: 2px 6px; border: 1px dashed var(--rule); width: fit-content; text-align: center; line-height: 1.1; }
+  .pstage.ok { color: var(--ink); font-weight: 600; border: 1px solid var(--ink); }
+  .wspbar { height: 3px; background: var(--surface-3); position: relative; }
+  .wspfill { position: absolute; left: 0; top: 0; bottom: 0; background: var(--ink-2); }
+
+  /* C2 update banner */
+  .ubanner { background: var(--invert); color: var(--invert-ink); padding: 0 24px; display: flex; align-items: center; gap: 24px; }
+  .ubmid { flex: 1; display: flex; align-items: baseline; gap: 14px; }
+  .ubbtns { display: flex; gap: 6px; }
+  .ubghost { font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; padding: 4px 10px; background: transparent; color: var(--invert-ink); border: 1px solid var(--invert-ink); cursor: pointer; line-height: 1; }
+  .ubsolid { font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; padding: 4px 10px; background: var(--invert-ink); color: var(--invert); border: 1px solid var(--invert-ink); cursor: pointer; line-height: 1; font-weight: 700; }
+  .ubx { background: transparent; border: none; color: var(--invert-ink); cursor: pointer; font-size: 13px; opacity: 0.6; }
+  .ubmain { display: grid; grid-template-columns: 1fr 480px; min-height: 0; overflow: hidden; }
+  .ubgrid { border-right: 1px solid var(--rule); padding: 22px; opacity: 0.6; overflow: hidden; }
+  .notes { display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
+  .noteshead { padding: 22px 28px 18px; border-bottom: 1px solid var(--rule); }
+  .notesver { font-size: 34px; letter-spacing: -0.04em; line-height: 0.95; color: var(--ink); }
+  .notesbody { padding: 20px 28px; flex: 1; overflow: hidden; display: flex; flex-direction: column; gap: 18px; }
+  .notelist { display: flex; flex-direction: column; gap: 5px; }
+  .noteline { display: grid; grid-template-columns: 12px 1fr; gap: 8px; font-size: 12px; color: var(--ink-2); line-height: 1.5; }
+
+  /* C3 splash */
+  .splashframe { position: absolute; inset: 28px; box-shadow: inset 0 0 0 1px var(--invert); display: grid; grid-template-rows: 60px 1fr 88px; }
+  .splashhead { display: flex; align-items: center; padding: 0 28px; border-bottom: 1px solid var(--invert); }
+  .splashbody { display: grid; grid-template-columns: 1.1fr 1fr; min-height: 0; overflow: hidden; }
+  .splashleft { padding: 48px 56px 36px; border-right: 1px solid var(--rule); display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
+  .splashmark { font-size: 168px; letter-spacing: -0.06em; line-height: 0.82; color: var(--ink); font-weight: 900; }
+  .splashdot { font-family: var(--ak-mono); font-size: 96px; font-weight: 400; letter-spacing: 0; }
+  .depth { position: relative; margin-top: 28px; margin-bottom: 4px; flex: 1; min-height: 240px; display: flex; flex-direction: column; }
+  .depthsvg { position: absolute; inset: 0; }
+  .splashsub { position: relative; margin: 40px 0 0 0; font-size: 26px; letter-spacing: -0.025em; line-height: 1.08; color: var(--ink); max-width: 460px; font-weight: 900; }
+  .etym { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; padding-top: 14px; border-top: 1px solid var(--rule); }
+  .splashright { padding: 48px 48px 36px; display: flex; flex-direction: column; gap: 28px; min-height: 0; overflow: hidden; }
+  .sptext { font-size: 13px; line-height: 1.7; color: var(--ink-2); }
+  .sptext.sm { font-size: 12.5px; line-height: 1.65; }
+  .builtgrid { display: grid; grid-template-columns: 100px 1fr; row-gap: 6px; column-gap: 14px; font-size: 12px; }
+  .splashfoot { display: flex; align-items: center; justify-content: space-between; padding: 0 28px; border-top: 1px solid var(--invert); }
+
+  /* C4 onboarding */
+  .obbody { display: grid; grid-template-columns: 320px 1fr; min-height: 0; overflow: hidden; }
+  .stepper { border-right: 1px solid var(--rule); padding: 40px 32px; display: flex; flex-direction: column; }
+  .steps { display: flex; flex-direction: column; gap: 22px; }
+  .step { display: grid; grid-template-columns: 32px 1fr; gap: 14px; align-items: baseline; }
+  .stepn { font-family: var(--ak-mono); font-size: 11px; letter-spacing: 0.06em; width: 24px; height: 24px; background: transparent; color: var(--quiet); border: 1px solid var(--rule); display: inline-flex; align-items: center; justify-content: center; font-weight: 400; }
+  .stepn.done { color: var(--ink); border: 1px solid var(--ink); }
+  .stepn.active { background: var(--invert); color: var(--invert-ink); border: none; font-weight: 700; }
+  .steptitle { font-size: 18px; letter-spacing: -0.02em; line-height: 1.1; color: var(--ink); }
+  .steptitle.muted { color: var(--ink-2); }
+  .steptitle.dim { opacity: 0.55; }
+  .stepnote { padding-top: 24px; border-top: 1px solid var(--rule); }
+  .stepdetail { padding: 40px 60px 30px; overflow: hidden; display: flex; flex-direction: column; }
+  .obbig { font-size: 56px; letter-spacing: -0.04em; line-height: 0.95; color: var(--ink); }
+  .modelcards { margin-top: 36px; display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+  .modelcard { padding: 18px 20px; border: 1px solid var(--rule-hi); box-shadow: inset 0 0 0 1px var(--invert); background: var(--surface); display: flex; flex-direction: column; gap: 12px; }
+  .mctop { display: flex; justify-content: space-between; align-items: baseline; }
+  .mctitle { font-family: var(--ak-mono); font-size: 16px; font-weight: 600; color: var(--ink); }
+  .mcdetail { display: grid; grid-template-columns: 90px 1fr; row-gap: 4px; column-gap: 12px; font-size: 11.5px; margin-top: 4px; }
+  .mcbtn { margin-top: 4px; }
+  .dlbox { margin-top: 28px; padding: 14px 18px; border: 1px dashed var(--rule-hi); display: flex; align-items: baseline; gap: 14px; }
+  .obfoot { border-top: 1px solid var(--rule); padding: 0 60px; display: flex; align-items: center; justify-content: space-between; }
+  .dots { display: flex; align-items: center; gap: 14px; }
+  .dot { display: inline-block; width: 8px; height: 8px; background: transparent; border: 1px solid var(--rule-hi); }
+  .dot.done { background: var(--ink-2); border: none; }
+  .dot.active { background: var(--ink); border: none; }
+  .dline { width: 28px; height: 1px; background: var(--rule); }
+  .dline.ink2 { background: var(--ink-2); }
+</style>

--- a/frontend/src/routes/Flows.svelte
+++ b/frontend/src/routes/Flows.svelte
@@ -1,0 +1,332 @@
+<!-- Seg 8 — Round-3 flows (B1–B4): ingest setup / query builder /
+     project registry / conflict merge. Stacked for audit. Helpers inline. -->
+<script>
+  import ArkivLogo from '../lib/ArkivLogo.svelte'
+  import Mono from '../lib/Mono.svelte'
+  import Eyebrow from '../lib/Eyebrow.svelte'
+  import Thumb from '../lib/Thumb.svelte'
+  import Rating from '../lib/Rating.svelte'
+  import { MEDIA } from '../lib/mockData.js'
+
+  const theme = 'dark'
+  const bd = Array(12)
+
+  // B1 ingest-setup
+  const srcStrategy = [['copy', 'Copy', true], ['move', 'Move', false], ['link', 'Link in place', false]]
+  const onConflict = [['skip', 'Skip dup', true], ['rename', 'Rename', false], ['overwrite', 'Overwrite', false]]
+  const setupLangs = [['zh-Hant', true], ['en', true], ['ja', false], ['auto', true]]
+  const tagPool = [['auto', 'Auto', true], ['user', 'User pool', false], ['hybrid', 'Hybrid', false]]
+  const manifest = [['Video', '.mov', 16, '15.8 GB'], ['Audio', '.wav', 5, '0.4 GB'], ['Unsupp.', '.crw', 2, '— skipped']]
+  const estimate = [['PROBE', '0:30 · all files'], ['TRANSCRIBE', '3:42 · 5 audio + 16 video'], ['TAG', '2:18 · llava GPU']]
+
+  // B2 query-builder
+  const clauses = [
+    ['transcript', 'contains', '氧氣 OR oxygen'], ['camera', 'equals', 'Sony α7S III'],
+    ['tag', 'any of', 'cycling, tibet'], ['rating', 'between', 'REV → GOOD'],
+    ['iso', 'between', '400 — 1600'], ['created', 'between', '2026-05-15 → 2026-05-19'],
+    ['duration', 'equals', '> 30s'],
+  ]
+  const boolOpts = [['and', 'All  (AND)', true], ['or', 'Any  (OR)', false], ['custom', 'Custom expr', false]]
+  const qbPreview = MEDIA.filter((m) => m.rating !== 'none').slice(0, 8)
+
+  // B3 project-registry
+  const PROJECTS_FULL = [
+    { name: 'Bicycle Diaries', count: 247, size: '4.8 TB', last: '2026-05-26 14:08', mount: 'mounted', path: '/vol/nas01/bicycle-diaries', active: true, health: 'ok' },
+    { name: 'vulture.s reels', count: 89, size: '1.2 TB', last: '2026-05-22 18:32', mount: 'mounted', path: '/vol/nas01/vulture-s-reels', active: false, health: 'ok' },
+    { name: 'Furutech RCA spot', count: 152, size: '2.1 TB', last: '2026-05-20 11:48', mount: 'mounted', path: '/vol/nas01/furutech-rca', active: false, health: 'ok' },
+    { name: 'KOL_2026Q1', count: 38, size: '—', last: '2026-04-18 09:12', mount: 'unmounted', path: '/Volumes/EXT_B/kol-2026q1', active: false, health: 'warn' },
+    { name: 'Bonefolder (archived)', count: 412, size: '6.4 TB', last: '2024-12-31 23:59', mount: 'archived', path: '/vol/cold/bonefolder', active: false, health: 'archived' },
+  ]
+  const regCols = '24px 1.6fr 70px 70px 1fr 110px 110px'
+  const mountText = { mounted: '● MOUNTED · NAS01', unmounted: '◇ UNMOUNTED · /Volumes/EXT_B', archived: '◇ ARCHIVED · COLD' }
+  const mountAction = { mounted: 'Open', unmounted: 'Mount', archived: 'Restore' }
+  const orphans = [
+    { name: 'A7S3_C998_240501.mov', proj: 'Bicycle Diaries', path: '/vol/nas01/bicycle-diaries/raw/old/A7S3_C998_240501.mov', last: '2026-04-12' },
+    { name: 'INTERVIEW_GUEST_03.wav', proj: 'vulture.s reels', path: '/Volumes/USB_OLD/INTERVIEW_GUEST_03.wav', last: '2026-03-22' },
+  ]
+
+  // B4 conflict-merge
+  const A = { name: 'A7S3_C001_240515.mov', size: '1.44 GB', dur: '00:02:47', proj: 'Bicycle Diaries', path: '/vol/nas01/bicycle-diaries/raw/A7S3_C001_240515.mov', ingested: '2026-05-16 02:14:33', rating: 'good', tags: ['cycling', 'road', 'interview', 'tibet', 'documentary'] }
+  const B = { name: 'A7S3_C001_240515 copy.mov', size: '1.44 GB', dur: '00:02:47', proj: 'vulture.s reels', path: '/Volumes/EXT_C/dailies/A7S3_C001_240515 copy.mov', ingested: '2026-05-19 11:08:17', rating: 'rev', tags: ['cycling', 'interview', 'tibet', 'b-roll'] }
+  const mergeFields = [
+    ['FILE PATH', 'A', '/vol/nas01/bicycle-diaries/raw/A7S3_C001_240515.mov'],
+    ['PROJECT', 'A', 'Bicycle Diaries'],
+    ['TAGS', 'A∪B', 'cycling, road, interview, tibet, documentary, b-roll'],
+    ['TRANSCRIPT', 'B (newer)', '"我們從上海一路騎到拉薩…" · 1247 tokens'],
+  ]
+</script>
+
+<div class="stack">
+
+  <!-- B1 · INGEST SETUP -->
+  <Eyebrow style="padding-left:8px;">B1 · ingest setup</Eyebrow>
+  <div class="artboard rel">
+    <div class="backdrop"><div class="bdtop"></div><div class="bdbody"><div class="bdside"></div><div class="bdgrid">{#each bd as _}<div class="bdcell"></div>{/each}</div><div class="bdside right"></div></div></div>
+    <div class="scrim s84"></div>
+    <div class="modal" style="width:1080px;height:780px;grid-template-rows:64px 1fr 72px;">
+      <div class="mhead">
+        <div class="mtitle"><Eyebrow style="color:var(--ink-2);">Step 1 / 1 · Configure</Eyebrow><div class="ak-display mt26">Ingest 23 files · 18.4 GB</div></div>
+        <Mono dim style="font-size:11px;">ESC · CANCEL</Mono>
+      </div>
+      <div class="setupbody">
+        <div class="setupleft">
+          <section><div class="fshead"><Eyebrow style="margin-bottom:4px;">SOURCE · FOLDER</Eyebrow><div class="ak-display fstitle">From /Volumes/RECORDER_A/DCIM/100MSDCF</div></div>
+            <div class="frows">
+              <div class="frow"><span class="flabel">Strategy</span><div class="seg">{#each srcStrategy as [id, l, on], i}{#if i > 0}<div class="segsep"></div>{/if}<button class="segbtn" class:on>{l}</button>{/each}</div></div>
+              <div class="frow"><span class="flabel">Destination</span><div class="dropdown"><Mono style="font-size:11.5px;color:var(--ink);">/vol/nas01/bicycle-diaries/raw/day-20/</Mono><Mono dim style="font-size:10px;">▾</Mono></div></div>
+              <div class="frow"><span class="flabel">On conflict</span><div class="seg">{#each onConflict as [id, l, on], i}{#if i > 0}<div class="segsep"></div>{/if}<button class="segbtn" class:on>{l}</button>{/each}</div></div>
+            </div>
+          </section>
+          <section><div class="fshead"><Eyebrow style="margin-bottom:4px;">WHISPER · LOCAL</Eyebrow><div class="ak-display fstitle">Transcribe audio tracks</div></div>
+            <div class="frows">
+              <div class="frow"><span class="flabel">Model</span><div class="dropdown"><Mono style="font-size:11.5px;color:var(--ink);">whisper-large-v3 · 1.55 GB</Mono><Mono dim style="font-size:10px;">▾</Mono></div></div>
+              <div class="frow"><span class="flabel">Languages</span><div class="langs">{#each setupLangs as [l, on]}<span class="lang" class:on>{l}</span>{/each}</div></div>
+              <div class="frow"><span class="flabel">Skip if</span><Mono dim style="font-size:11.5px;">audio &lt; -42 dB · duration &lt; 2s</Mono></div>
+            </div>
+          </section>
+          <section><div class="fshead"><Eyebrow style="margin-bottom:4px;">OLLAMA · LOCAL</Eyebrow><div class="ak-display fstitle">Vision tagging</div></div>
+            <div class="frows">
+              <div class="frow"><span class="flabel">Model</span><div class="dropdown"><Mono style="font-size:11.5px;color:var(--ink);">llava:13b-v1.6-q4_K_M · 7.4 GB</Mono><Mono dim style="font-size:10px;">▾</Mono></div></div>
+              <div class="frow"><span class="flabel">Tag pool</span><div class="seg">{#each tagPool as [id, l, on], i}{#if i > 0}<div class="segsep"></div>{/if}<button class="segbtn" class:on>{l}</button>{/each}</div></div>
+              <div class="frow"><span class="flabel">Frames sampled</span><Mono dim style="font-size:11.5px;">1 frame / scene · max 12 per clip</Mono></div>
+            </div>
+          </section>
+        </div>
+        <div class="setupright">
+          <div><Eyebrow style="margin-bottom:6px;">Manifest</Eyebrow><Mono dim style="font-size:11px;letter-spacing:0.04em;">23 files · 18.4 GB</Mono></div>
+          <div class="maniflist">
+            {#each manifest as [k, ext, n, sz]}
+              <div class="manifrow"><Mono style="font-size:11.5px;color:var(--ink);">{k}</Mono><Mono dim style="font-size:10.5px;">{ext}</Mono><Mono style="font-size:11.5px;text-align:right;">{n}</Mono><Mono dim style="font-size:10.5px;text-align:right;">{sz}</Mono></div>
+            {/each}
+          </div>
+          <div><Eyebrow style="margin-bottom:6px;">Estimated</Eyebrow>
+            <div class="estgrid">{#each estimate as [k, v]}<Mono dim>{k}</Mono><Mono>{v}</Mono>{/each}<Mono dim>TOTAL</Mono><Mono style="font-weight:600;">≈ 6:30</Mono></div>
+          </div>
+          <div class="grow"></div>
+          <div class="notice"><Mono dim style="font-size:9.5px;letter-spacing:0.1em;display:block;margin-bottom:4px;">◇ NOTICE</Mono><Mono dim style="font-size:10.5px;line-height:1.5;">Files are processed locally. Nothing leaves this machine. GPU draw will spike during transcribe + tag stages.</Mono></div>
+        </div>
+      </div>
+      <div class="mfoot">
+        <Mono dim style="font-size:11px;letter-spacing:0.05em;">Destination · Bicycle Diaries  ·  est. 6:30  ·  GPU required</Mono>
+        <div class="fbtns"><button class="ak-btn">Cancel</button><button class="ak-btn">Save preset…</button><button class="ak-btn ak-btn--primary wide">Start ingest →</button></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- B2 · QUERY BUILDER -->
+  <Eyebrow style="padding-left:8px;">B2 · query builder</Eyebrow>
+  <div class="artboard rows52">
+    <div class="topbar"><ArkivLogo size={16} /><Mono dim style="font-size:10px;">v0.9.2</Mono><div class="grow"></div><button class="ak-btn">⌘K · SIMPLE SEARCH</button><button class="ak-btn">Save as Smart Pool…</button></div>
+    <div class="qbsplit">
+      <div class="qbleft">
+        <div class="qbhead"><Eyebrow style="margin-bottom:8px;">Query builder · compound</Eyebrow><div class="ak-display qbtitle">Find what<br />matches all of:</div></div>
+        <div class="qbclauses">
+          {#each clauses as [field, op, value]}
+            <div class="clause"><span class="cfield">{field}</span><span class="cop">{op}</span><span class="cvalue">{value}</span><button class="cx">✕</button></div>
+          {/each}
+          <button class="addclause">+ Add clause</button>
+        </div>
+        <div class="qbbool">
+          <Eyebrow style="margin-bottom:8px;">Boolean</Eyebrow>
+          <div class="seg">{#each boolOpts as [id, l, on], i}{#if i > 0}<div class="segsep"></div>{/if}<button class="segbtn" class:on>{l}</button>{/each}</div>
+          <Mono dim style="font-size:10px;margin-top:10px;line-height:1.5;display:block;">transcript:"氧氣" AND camera:"α7S III" AND tag IN ["cycling","tibet"]<br />AND rating &gt;= REV AND iso BETWEEN 400 AND 1600<br />AND created BETWEEN '2026-05-15' AND '2026-05-19'<br />AND duration &gt; 30</Mono>
+        </div>
+      </div>
+      <div class="qbright">
+        <div class="qbprevhead">
+          <div><Eyebrow>Preview · live</Eyebrow><Mono style="font-size:16px;font-weight:600;color:var(--ink);display:block;margin-top:6px;">14 matches <Mono dim style="font-size:11px;font-weight:400;margin-left:8px;">of 247 · 0.038s</Mono></Mono></div>
+          <div class="fbtns"><button class="ak-btn">All projects · 4</button><button class="ak-btn">Open as pool</button></div>
+        </div>
+        <div class="qbresults">
+          {#each qbPreview as m (m.id)}
+            <div class="qbrow">
+              <div class="qbthumb"><Thumb seed={m.id} kind={m.kind} {theme} /></div>
+              <div class="qbcontent"><Mono style="font-size:11.5px;color:var(--ink);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{m.name}</Mono><div class="qbtags"><Mono dim style="font-size:10px;">{m.cam.replace('Sony α', 'α')}</Mono><Mono dim style="font-size:10px;">{m.tags.slice(0, 2).join(' · ')}</Mono></div></div>
+              <Rating value={m.rating} />
+              <Mono dim style="font-size:11px;text-align:right;">{m.dur}</Mono>
+            </div>
+          {/each}
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- B3 · PROJECT REGISTRY -->
+  <Eyebrow style="padding-left:8px;">B3 · project registry</Eyebrow>
+  <div class="artboard rows52">
+    <div class="topbar"><ArkivLogo size={16} /><Mono dim style="font-size:10px;">v0.9.2</Mono><div class="grow"></div><Mono dim style="font-size:11px;">~/.arkiv-projects.json · 5 registered</Mono><button class="ak-btn">+ New project</button><button class="ak-btn">Import .arkiv</button></div>
+    <div class="regwrap">
+      <Eyebrow style="margin-bottom:8px;">Project registry</Eyebrow>
+      <div class="reghero"><div class="ak-display reghbig">5 projects · 938 files · 14.5 TB</div><Mono dim style="font-size:11px;letter-spacing:0.05em;">3 mounted · 1 unmounted · 1 archived</Mono></div>
+      <div class="reghead" style="grid-template-columns:{regCols};"><span></span><Mono dim style="font-size:10px;letter-spacing:0.12em;">PROJECT</Mono><Mono dim style="font-size:10px;letter-spacing:0.12em;text-align:right;">FILES</Mono><Mono dim style="font-size:10px;letter-spacing:0.12em;text-align:right;">SIZE</Mono><Mono dim style="font-size:10px;letter-spacing:0.12em;">PATH · MOUNT</Mono><Mono dim style="font-size:10px;letter-spacing:0.12em;">LAST INGEST</Mono><Mono dim style="font-size:10px;letter-spacing:0.12em;text-align:right;">ACTIONS</Mono></div>
+      {#each PROJECTS_FULL as p (p.name)}
+        <div class="regrow" class:archived={p.health === 'archived'} style="grid-template-columns:{regCols};">
+          <div class="hdot {p.health}"></div>
+          <div><div class="ak-display regname" class:strike={p.health === 'archived'}>{p.name}</div>{#if p.active}<Mono dim style="font-size:9.5px;letter-spacing:0.1em;margin-top:4px;color:var(--ink);">● ACTIVE</Mono>{/if}</div>
+          <Mono style="font-size:13px;text-align:right;">{p.count}</Mono>
+          <Mono dim style="font-size:12px;text-align:right;">{p.size}</Mono>
+          <div class="regpath"><Mono dim style="font-size:10.5px;display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{p.path}</Mono><Mono dim style="font-size:9.5px;letter-spacing:0.08em;margin-top:2px;display:block;">{mountText[p.mount]}</Mono></div>
+          <Mono dim style="font-size:11px;">{p.last}</Mono>
+          <div class="regactions"><button class="ak-btn sm">{mountAction[p.mount]}</button><button class="ak-btn sm">···</button></div>
+        </div>
+      {/each}
+      <div class="orphans">
+        <div class="orphanhead"><div class="orphanhl"><Eyebrow>Orphans</Eyebrow><Mono style="font-size:14px;font-weight:600;">2 files</Mono><Mono dim style="font-size:11px;">indexed but source path is gone</Mono></div><button class="ak-btn">Resolve all…</button></div>
+        {#each orphans as o (o.name)}
+          <div class="orphanrow"><div class="odot"></div><Mono style="font-size:12px;color:var(--ink);">{o.name}</Mono><div><Mono dim style="font-size:10.5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:block;">{o.path}</Mono><Mono dim style="font-size:10px;margin-top:2px;display:block;">was in: {o.proj} · last seen {o.last}</Mono></div><div class="regactions"><button class="ak-btn sm">Locate</button><button class="ak-btn sm">Forget</button></div></div>
+        {/each}
+      </div>
+    </div>
+  </div>
+
+  <!-- B4 · CONFLICT MERGE -->
+  <Eyebrow style="padding-left:8px;">B4 · conflict merge</Eyebrow>
+  <div class="artboard rel">
+    <div class="scrim s82"></div>
+    <div class="modal" style="width:1240px;height:760px;grid-template-rows:72px 1fr 72px;">
+      <div class="mhead">
+        <div><Eyebrow style="margin-bottom:4px;">Conflict · identical SHA-256</Eyebrow><div class="ak-display mt22">Two records, one file. Choose how to merge.</div></div>
+        <Mono dim style="font-size:10.5px;letter-spacing:0.04em;">7f3e8a92c1b4d5f6e2a8c9d1b3e5f7a9c2b4d6e8f1a3c5d7e9b1f3a5c7d9e1f3</Mono>
+      </div>
+      <div class="cmpbody">
+        {#each [{ label: 'A · Bicycle Diaries', data: A, pick: 'A', seed: 1, active: false }, { label: 'B · vulture.s reels', data: B, pick: 'B', seed: 7, active: true }] as col}
+          <div class="cmpcol" class:active={col.active}>
+            <div class="cmptop"><Eyebrow style={col.active ? 'color:var(--ink);' : ''}>{col.label}</Eyebrow><span class="pick" class:active={col.active}>{col.pick}</span></div>
+            <div class="cmpthumb"><Thumb seed={col.seed} kind="video" {theme} /></div>
+            <Mono style="font-size:11.5px;word-break:break-all;color:var(--ink);">{col.data.name}</Mono>
+            <Mono dim style="font-size:10px;line-height:1.5;">{col.data.path}</Mono>
+            <div class="cmpmeta"><Mono dim>PROJECT</Mono><Mono>{col.data.proj}</Mono><Mono dim>SIZE</Mono><Mono>{col.data.size}</Mono><Mono dim>DURATION</Mono><Mono>{col.data.dur}</Mono><Mono dim>INGESTED</Mono><Mono>{col.data.ingested}</Mono></div>
+            <div><Mono dim style="font-size:9.5px;letter-spacing:0.1em;display:block;margin-bottom:6px;">RATING</Mono><Rating value={col.data.rating} /></div>
+            <div><Mono dim style="font-size:9.5px;letter-spacing:0.1em;display:block;margin-bottom:6px;">TAGS · {col.data.tags.length}</Mono><div class="cmptags">{#each col.data.tags as t}<span class="cmptag">{t}</span>{/each}</div></div>
+          </div>
+        {/each}
+        <div class="mergecol">
+          <div class="cmptop"><Eyebrow>Merged result · preview</Eyebrow><span class="pick active">M</span></div>
+          {#each mergeFields as [label, source, value]}
+            <div class="fieldchoice"><Mono dim style="font-size:9.5px;letter-spacing:0.1em;">{label}</Mono><div class="fcvalue"><Mono style="font-size:11px;">{value}</Mono></div><span class="fcsource">{source}</span></div>
+          {/each}
+          <div class="fieldchoice"><Mono dim style="font-size:9.5px;letter-spacing:0.1em;">RATING</Mono><div class="fcvalue"><Rating value="rev" /></div><span class="fcsource">B</span></div>
+          <div class="grow"></div>
+          <div class="notice"><Mono dim style="font-size:9.5px;letter-spacing:0.1em;display:block;margin-bottom:4px;">◇ AFTER MERGE</Mono><Mono dim style="font-size:10.5px;line-height:1.5;">B's file deleted from /Volumes/EXT_C.<br />B's record reassigned to A. Index updated.<br />Reversible for 30 days · trash queue.</Mono></div>
+        </div>
+      </div>
+      <div class="mfoot">
+        <Mono dim style="font-size:11px;letter-spacing:0.05em;">Keep file at A · Adopt rating from B · Union tags · Use B transcript (newer)</Mono>
+        <div class="fbtns"><button class="ak-btn">Skip · keep both</button><button class="ak-btn">Keep A · delete B</button><button class="ak-btn">Keep B · delete A</button><button class="ak-btn ak-btn--primary wide">Merge →</button></div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<style>
+  .stack { display: flex; flex-direction: column; gap: 28px; padding: 24px 0; }
+  .artboard { width: 1400px; height: 900px; background: var(--bg); color: var(--ink); overflow: hidden; margin: 0 auto; }
+  .artboard.rel { position: relative; }
+  .artboard.rows52 { display: grid; grid-template-rows: 52px 1fr; }
+  .grow { flex: 1; }
+  .rel { position: relative; }
+
+  .backdrop { position: absolute; inset: 0; display: grid; grid-template-rows: 52px 1fr; }
+  .bdtop { border-bottom: 1px solid var(--rule); }
+  .bdbody { display: grid; grid-template-columns: 220px 1fr 340px; }
+  .bdside { border-right: 1px solid var(--rule); }
+  .bdside.right { border-right: none; border-left: 1px solid var(--rule); }
+  .bdgrid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px; padding: 22px; background: var(--rule); }
+  .bdcell { aspect-ratio: 16 / 9; background: var(--surface-2); }
+  .scrim { position: absolute; inset: 0; }
+  .scrim.s84 { background: rgba(10, 10, 12, 0.84); }
+  .scrim.s82 { background: rgba(10, 10, 12, 0.82); }
+
+  .modal { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); background: var(--bg); box-shadow: inset 0 0 0 1px var(--invert); display: grid; }
+  .mhead { display: flex; align-items: center; justify-content: space-between; padding: 0 28px; border-bottom: 1px solid var(--invert); }
+  .mtitle { display: flex; align-items: baseline; gap: 14px; }
+  .mt26 { font-size: 26px; letter-spacing: -0.03em; line-height: 1; color: var(--ink); }
+  .mt22 { font-size: 22px; letter-spacing: -0.03em; line-height: 1; color: var(--ink); }
+  .mfoot { display: flex; align-items: center; justify-content: space-between; padding: 0 28px; border-top: 1px solid var(--rule); }
+  .fbtns { display: flex; gap: 8px; }
+  .wide { padding: 8px 20px; }
+
+  /* form bits */
+  .fshead { margin-bottom: 12px; }
+  .fstitle { font-size: 18px; letter-spacing: -0.02em; line-height: 1.1; color: var(--ink); }
+  .frows { display: flex; flex-direction: column; gap: 10px; }
+  .frow { display: grid; grid-template-columns: 140px 1fr; align-items: center; gap: 16px; }
+  .flabel { font-family: var(--ak-mono); font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--quiet); }
+  .seg { display: flex; border: 1px solid var(--rule); width: fit-content; }
+  .segsep { width: 1px; background: var(--rule); }
+  .segbtn { font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.06em; text-transform: uppercase; padding: 5px 12px; background: transparent; color: var(--ink-2); border: none; cursor: pointer; line-height: 1; font-weight: 400; }
+  .segbtn.on { background: var(--invert); color: var(--invert-ink); font-weight: 700; }
+  .dropdown { display: flex; justify-content: space-between; align-items: center; border: 1px solid var(--rule); padding: 6px 10px; width: 100%; max-width: 360px; cursor: pointer; }
+  .langs { display: flex; gap: 4px; flex-wrap: wrap; }
+  .lang { font-family: var(--ak-mono); font-size: 10.5px; padding: 4px 8px; line-height: 1; background: transparent; color: var(--ink-2); border: 1px solid var(--rule); cursor: pointer; }
+  .lang.on { background: var(--invert); color: var(--invert-ink); border-color: var(--invert); }
+  .notice { border: 1px dashed var(--rule-hi); padding: 12px 14px; }
+
+  /* B1 setup */
+  .setupbody { display: grid; grid-template-columns: 1fr 360px; min-height: 0; overflow: hidden; }
+  .setupleft { padding: 24px 32px; overflow: hidden; display: flex; flex-direction: column; gap: 22px; }
+  .setupright { border-left: 1px solid var(--rule); padding: 24px; overflow: hidden; display: flex; flex-direction: column; gap: 18px; }
+  .maniflist { display: flex; flex-direction: column; gap: 1px; background: var(--rule); }
+  .manifrow { background: var(--bg); padding: 8px 10px; display: grid; grid-template-columns: 60px 50px 1fr 1fr; gap: 8px; align-items: baseline; }
+  .estgrid { display: grid; grid-template-columns: 80px 1fr; row-gap: 5px; column-gap: 12px; font-size: 11.5px; }
+
+  /* B2 query builder */
+  .topbar { display: flex; align-items: center; border-bottom: 1px solid var(--rule); padding: 0 16px; gap: 16px; }
+  .qbsplit { display: grid; grid-template-columns: 460px 1fr; min-height: 0; overflow: hidden; }
+  .qbleft { border-right: 1px solid var(--rule); display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
+  .qbhead { padding: 28px 28px 18px; border-bottom: 1px solid var(--rule); }
+  .qbtitle { font-size: 32px; letter-spacing: -0.03em; line-height: 1; color: var(--ink); }
+  .qbclauses { padding: 20px 28px; flex: 1; overflow: hidden; display: flex; flex-direction: column; gap: 12px; }
+  .clause { display: grid; grid-template-columns: 76px 84px 1fr 20px; gap: 6px; align-items: center; }
+  .cfield { font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.06em; text-transform: uppercase; padding: 4px 6px; border: 1px solid var(--rule); color: var(--ink-2); text-align: center; }
+  .cop { font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.06em; text-transform: uppercase; padding: 4px 6px; color: var(--quiet); text-align: center; }
+  .cvalue { font-family: var(--ak-mono); font-size: 11.5px; padding: 4px 8px; border: 1px solid var(--rule-hi); color: var(--ink); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .cx { background: transparent; border: none; color: var(--quiet); cursor: pointer; font-family: var(--ak-mono); font-size: 13px; }
+  .addclause { padding: 10px 0; border: 1px dashed var(--rule-hi); font-family: var(--ak-mono); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-2); background: transparent; cursor: pointer; margin-top: 4px; }
+  .qbbool { padding: 14px 28px; border-top: 1px solid var(--rule); }
+  .qbright { display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
+  .qbprevhead { padding: 18px 32px; border-bottom: 1px solid var(--rule); display: flex; align-items: baseline; justify-content: space-between; }
+  .qbresults { flex: 1; overflow: hidden; padding: 14px 32px; }
+  .qbrow { display: grid; grid-template-columns: 90px 1fr 70px 60px; gap: 14px; align-items: center; padding: 8px 0; border-bottom: 1px solid var(--rule); }
+  .qbthumb { position: relative; aspect-ratio: 16 / 9; background: var(--surface-2); overflow: hidden; }
+  .qbcontent { min-width: 0; }
+  .qbtags { display: flex; gap: 12px; margin-top: 3px; }
+
+  /* B3 registry */
+  .regwrap { padding: 40px 60px; overflow: hidden; }
+  .reghero { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 28px; }
+  .reghbig { font-size: 44px; letter-spacing: -0.03em; line-height: 1; color: var(--ink); }
+  .reghead { display: grid; gap: 16px; padding: 0 0 10px; border-bottom: 1px solid var(--invert); }
+  .regrow { display: grid; gap: 16px; padding: 16px 0; border-bottom: 1px solid var(--rule); align-items: center; }
+  .regrow.archived { opacity: 0.55; }
+  .hdot { width: 8px; height: 8px; border: 1px solid var(--rule-hi); }
+  .hdot.ok { background: var(--ink); border: none; }
+  .hdot.warn { border: 1px dashed var(--ink-2); }
+  .regname { font-size: 18px; letter-spacing: -0.02em; line-height: 1; color: var(--ink); }
+  .regname.strike { text-decoration: line-through; }
+  .regpath { min-width: 0; }
+  .regactions { display: flex; gap: 4px; justify-content: flex-end; }
+  .sm { padding: 5px 9px; }
+  .orphans { margin-top: 36px; }
+  .orphanhead { display: flex; align-items: baseline; justify-content: space-between; padding-bottom: 10px; border-bottom: 1px solid var(--invert); margin-bottom: 14px; }
+  .orphanhl { display: flex; align-items: baseline; gap: 14px; }
+  .orphanrow { display: grid; grid-template-columns: 24px 1fr 1fr 120px; gap: 16px; padding: 10px 0; border-bottom: 1px solid var(--rule); align-items: center; }
+  .odot { width: 8px; height: 8px; border: 1px dashed var(--ink-2); }
+
+  /* B4 conflict */
+  .cmpbody { display: grid; grid-template-columns: 1fr 1fr 1fr; min-height: 0; overflow: hidden; }
+  .cmpcol { border-right: 1px solid var(--rule); padding: 20px 22px; display: flex; flex-direction: column; gap: 14px; overflow: hidden; }
+  .cmpcol.active { background: var(--surface); box-shadow: inset 2px 0 0 var(--invert); }
+  .cmptop { display: flex; justify-content: space-between; align-items: baseline; }
+  .pick { font-family: var(--ak-mono); font-size: 9.5px; letter-spacing: 0.08em; padding: 2px 6px; background: transparent; color: var(--ink-2); border: 1px solid var(--rule); }
+  .pick.active { background: var(--invert); color: var(--invert-ink); border: none; }
+  .cmpthumb { position: relative; aspect-ratio: 16 / 9; background: var(--surface-2); overflow: hidden; }
+  .cmpmeta { display: grid; grid-template-columns: 76px 1fr; row-gap: 5px; column-gap: 12px; font-size: 11px; margin-top: 4px; }
+  .cmptags { display: flex; flex-wrap: wrap; gap: 4px; }
+  .cmptag { font-family: var(--ak-mono); font-size: 10px; padding: 2px 5px; line-height: 1; border: 1px solid var(--rule); color: var(--ink-2); }
+  .mergecol { padding: 20px 22px; display: flex; flex-direction: column; gap: 14px; overflow: hidden; }
+  .fieldchoice { display: grid; grid-template-columns: 90px 1fr 50px; gap: 10px; align-items: baseline; }
+  .fcvalue { font-size: 11.5px; color: var(--ink); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .fcsource { font-family: var(--ak-mono); font-size: 9px; letter-spacing: 0.08em; padding: 2px 5px; text-align: center; background: var(--invert); color: var(--invert-ink); }
+</style>

--- a/frontend/src/routes/Gallery.svelte
+++ b/frontend/src/routes/Gallery.svelte
@@ -1,0 +1,96 @@
+<!-- Seg 1 audit surface — mounts each shared primitive once. -->
+<script>
+  import ArkivLogo from '../lib/ArkivLogo.svelte'
+  import Rating from '../lib/Rating.svelte'
+  import Frame from '../lib/Frame.svelte'
+  import Eyebrow from '../lib/Eyebrow.svelte'
+  import Mono from '../lib/Mono.svelte'
+  import Thumb from '../lib/Thumb.svelte'
+  import { MEDIA, PROJECTS, TAGS } from '../lib/mockData.js'
+</script>
+
+<div class="gallery">
+  <Eyebrow>seg1 · shared primitives gallery</Eyebrow>
+  <h1 class="ak-display title">primitives.</h1>
+
+  <section>
+    <Eyebrow>ArkivLogo</Eyebrow>
+    <div class="row"><ArkivLogo size={18} /><ArkivLogo size={28} /><ArkivLogo size={40} /></div>
+  </section>
+
+  <section>
+    <Eyebrow>Rating</Eyebrow>
+    <div class="row"><Rating value="good" /><Rating value="ng" /><Rating value="rev" /><Rating value="none" /></div>
+  </section>
+
+  <section>
+    <Eyebrow>Frame</Eyebrow>
+    <div class="row">
+      <Frame style="padding: var(--s-4); width: 120px;"><Mono dim>rule</Mono></Frame>
+      <Frame hi style="padding: var(--s-4); width: 120px;"><Mono>invert</Mono></Frame>
+    </div>
+  </section>
+
+  <section>
+    <Eyebrow>Mono</Eyebrow>
+    <div class="row"><Mono>00:02:47</Mono><Mono dim>1.4 GB</Mono></div>
+  </section>
+
+  <section>
+    <Eyebrow>Thumb — video variants (seed 0–5)</Eyebrow>
+    <div class="thumbgrid">
+      {#each [0, 1, 2, 3, 4, 5] as s}
+        <div class="cell"><Thumb seed={s} kind="video" /></div>
+      {/each}
+    </div>
+  </section>
+
+  <section>
+    <Eyebrow>Thumb — audio</Eyebrow>
+    <div class="thumbgrid">
+      {#each [2, 8, 13] as s}
+        <div class="cell"><Thumb seed={s} kind="audio" /></div>
+      {/each}
+    </div>
+  </section>
+
+  <section>
+    <Eyebrow>mockData sanity</Eyebrow>
+    <Mono dim>MEDIA {MEDIA.length} · PROJECTS {PROJECTS.length} · TAGS {TAGS.length}</Mono>
+  </section>
+</div>
+
+<style>
+  .gallery {
+    padding: var(--s-12);
+    display: flex;
+    flex-direction: column;
+    gap: var(--s-8);
+  }
+  .title {
+    font-size: var(--fs-display-sm);
+    margin: var(--s-2) 0 var(--s-4);
+    color: var(--ink);
+  }
+  section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--s-3);
+  }
+  .row {
+    display: flex;
+    align-items: center;
+    gap: var(--s-4);
+    flex-wrap: wrap;
+  }
+  .thumbgrid {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    gap: var(--grid-gutter);
+    max-width: 900px;
+  }
+  .cell {
+    aspect-ratio: 16 / 9;
+    background: var(--surface);
+  }
+</style>

--- a/frontend/src/routes/Home.svelte
+++ b/frontend/src/routes/Home.svelte
@@ -1,0 +1,15 @@
+<!-- Seg 0 landing — proves tokens + the 3 type families render.
+     Replaced/expanded as screens land in later segments. -->
+<div class="home">
+  <div class="ak-eyebrow">arkiv · frontend scaffold</div>
+  <h1 class="ak-display">arkiv.</h1>
+  <p class="lede">Svelte 4 + Vite foundation. 螢幕逐段（per overnight segment）落地。</p>
+  <div class="ak-mono stamp">SEG 0 — shell · tokens · fonts · router</div>
+</div>
+
+<style>
+  .home { padding: var(--s-16) var(--s-12); }
+  .ak-display { font-size: var(--fs-display); margin: var(--s-4) 0; color: var(--ink); }
+  .lede { color: var(--ink-2); max-width: 46ch; font-size: var(--fs-md); }
+  .stamp { margin-top: var(--s-8); color: var(--quiet); font-size: var(--fs-tiny); }
+</style>

--- a/frontend/src/routes/Ingest.svelte
+++ b/frontend/src/routes/Ingest.svelte
@@ -1,0 +1,177 @@
+<!-- Seg 6 — Screen 5: ingest progress. Hero aggregate + per-file stage queue
+     + live log stream. Static mock (no real websocket). cyan = sanctioned
+     ingest-progress accent. -->
+<script>
+  import ArkivLogo from '../lib/ArkivLogo.svelte'
+  import Mono from '../lib/Mono.svelte'
+  import Eyebrow from '../lib/Eyebrow.svelte'
+
+  const theme = 'dark'
+  const cols = '1fr 76px 76px 80px 76px 70px 1fr'
+  const metrics = [
+    ['PROBED', '48', '/ 52'], ['TRANSCRIBED', '36', '/ 52'], ['TAGGED', '34', '/ 52'],
+    ['THROUGHPUT', '8.4', 'MB/s'], ['GPU', '84%', 'RTX 4070'],
+  ]
+  const FILES = [
+    { name: 'A7S3_C012_240519.mov', size: '1.8 GB', probe: 'done', trans: 'done', tag: 'done', pct: 100 },
+    { name: 'A7S3_C013_240519.mov', size: '2.1 GB', probe: 'done', trans: 'done', tag: 'done', pct: 100 },
+    { name: 'A7S3_C014_240519.mov', size: '780 MB', probe: 'done', trans: 'done', tag: 'done', pct: 100 },
+    { name: 'A7S3_C015_240519.mov', size: '1.4 GB', probe: 'done', trans: 'done', tag: 'running', pct: 82, eta: '00:14' },
+    { name: 'A7S3_C016_240519.mov', size: '2.4 GB', probe: 'done', trans: 'running', tag: 'queued', pct: 48, eta: '01:42' },
+    { name: 'GH6_4830.mp4', size: '186 MB', probe: 'done', trans: 'queued', tag: 'queued', pct: 22 },
+    { name: 'GH6_4831.mp4', size: '212 MB', probe: 'running', trans: 'queued', tag: 'queued', pct: 8 },
+    { name: 'INTERVIEW_AMB_03.wav', size: '64 MB', probe: 'queued', trans: 'queued', tag: 'queued', pct: 0 },
+    { name: 'A7S3_C017_240519.mov', size: '1.2 GB', probe: 'queued', trans: 'queued', tag: 'queued', pct: 0 },
+    { name: 'A7S3_C018_240519.mov', size: '980 MB', probe: 'queued', trans: 'queued', tag: 'queued', pct: 0 },
+    { name: 'A7S3_C019_240519.mov', size: '1.7 GB', probe: 'queued', trans: 'queued', tag: 'queued', pct: 0 },
+    { name: 'A7S3_C020_240519.mov', size: '2.2 GB', probe: 'queued', trans: 'queued', tag: 'queued', pct: 0 },
+  ]
+  const stageText = { done: 'OK', running: 'RUN', queued: '·' }
+  const LOG = [
+    { t: '14:12:34.214', lvl: 'info', stage: 'tag', msg: 'A7S3_C015 · vision: cycling, road, tibet, sky (4 tags)' },
+    { t: '14:12:33.108', lvl: 'info', stage: 'trans', msg: 'A7S3_C015 · whisper done · 1247 tokens · 98.3% conf' },
+    { t: '14:12:30.842', lvl: 'info', stage: 'probe', msg: 'A7S3_C016 · H.265 4K 24p · 240Mbps · S-Log3' },
+    { t: '14:12:30.114', lvl: 'info', stage: 'thumb', msg: 'A7S3_C016 · scene detection: 12 cuts found' },
+    { t: '14:12:28.491', lvl: 'warn', stage: 'trans', msg: 'GH6_4831 · low audio level (-42dB), transcript may be poor' },
+    { t: '14:12:26.808', lvl: 'info', stage: 'probe', msg: 'GH6_4831 · H.264 4K 60p · 100Mbps' },
+    { t: '14:12:24.022', lvl: 'info', stage: 'tag', msg: 'A7S3_C014 · vision: cycling, mountain, golden hour' },
+    { t: '14:12:22.717', lvl: 'info', stage: 'trans', msg: 'A7S3_C014 · whisper done · 412 tokens · 96.8% conf' },
+    { t: '14:12:18.443', lvl: 'error', stage: 'tag', msg: 'A7S3_C013 · vision model timeout, retry 1/3' },
+    { t: '14:12:14.281', lvl: 'info', stage: 'probe', msg: 'INTERVIEW_AMB_03 · 48kHz 24bit · 8min 32s' },
+    { t: '14:12:11.604', lvl: 'info', stage: 'tag', msg: 'A7S3_C013 · vision: cycling, tibet, prayer flags (5 tags)' },
+    { t: '14:12:09.218', lvl: 'info', stage: 'trans', msg: 'A7S3_C013 · whisper done · 832 tokens' },
+    { t: '14:12:06.018', lvl: 'info', stage: 'thumb', msg: 'A7S3_C013 · proxy 540p generated' },
+  ]
+  const lvlText = { error: 'ERR', warn: 'WRN', info: 'INF' }
+</script>
+
+<div class="artboard" data-theme={theme}>
+  <div class="topbar">
+    <ArkivLogo size={16} />
+    <Mono dim style="font-size:10px;">v0.9.2</Mono>
+    <div class="grow"></div>
+    <Mono dim style="font-size:11px;">ws://localhost:8501/ws/ingest · CONNECTED</Mono>
+    <button class="ak-btn">Run in background</button>
+  </div>
+
+  <div class="split">
+    <!-- LEFT -->
+    <div class="left">
+      <div class="hero">
+        <div class="herohead">
+          <Eyebrow>Ingest · folder import</Eyebrow>
+          <Mono dim style="font-size:10.5px;">started 2026-05-26 14:08 · 04:32 elapsed</Mono>
+        </div>
+        <div class="herobig">
+          <div class="ak-display bignum">34<span class="quiet">/52</span></div>
+          <div class="herometa">
+            <Mono dim style="font-size:11px;letter-spacing:0.05em;">FILES PROCESSED</Mono>
+            <Mono style="font-size:14px;font-weight:500;display:block;margin-top:4px;">/vol/nas01/bicycle-diaries/raw/day-19/</Mono>
+            <Mono dim style="font-size:10.5px;display:block;margin-top:2px;">18 remaining · est. 08:14 · 12.4 GB total</Mono>
+          </div>
+        </div>
+        <div class="aggwrap">
+          <div class="aggrow"><Mono dim style="font-size:10px;">AGGREGATE</Mono><Mono style="font-size:11px;font-weight:600;color:var(--cyan);">65.4%</Mono></div>
+          <div class="aggbar"><div class="aggfill"></div><div class="aggmark"></div></div>
+          <div class="metrics">
+            {#each metrics as [label, value, sub]}
+              <div class="metric">
+                <Mono dim style="font-size:9.5px;letter-spacing:0.1em;display:block;margin-bottom:3px;">{label}</Mono>
+                <span class="metricval">{value}</span><Mono dim style="font-size:10px;margin-left:4px;">{sub}</Mono>
+              </div>
+            {/each}
+          </div>
+        </div>
+      </div>
+
+      <div class="queue">
+        <div class="qhead">
+          <Eyebrow>Queue · 18 remaining</Eyebrow>
+          <div class="qbtns"><button class="ak-btn">Pause</button><button class="ak-btn">Skip non-video</button></div>
+        </div>
+        <div class="qrow qheadrow" style="grid-template-columns:{cols};">
+          {#each ['FILE', 'SIZE', 'PROBE', 'TRANSCRIBE', 'TAG', 'ETA', 'PROGRESS'] as h}<Mono dim style="font-size:9.5px;letter-spacing:0.1em;">{h}</Mono>{/each}
+        </div>
+        <div class="qrows">
+          {#each FILES as f (f.name)}
+            <div class="qrow" class:done={f.pct === 100} style="grid-template-columns:{cols};">
+              <Mono style="font-size:11.5px;color:var(--ink);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{f.name}</Mono>
+              <Mono dim style="font-size:10.5px;">{f.size}</Mono>
+              <span class="stage {f.probe}">{stageText[f.probe]}</span>
+              <span class="stage {f.trans}">{stageText[f.trans]}</span>
+              <span class="stage {f.tag}">{stageText[f.tag]}</span>
+              <Mono dim style="font-size:10.5px;">{f.eta || '—'}</Mono>
+              <div class="pbar"><div class="pfill" class:full={f.pct === 100} style="width:{f.pct}%;"></div></div>
+            </div>
+          {/each}
+        </div>
+      </div>
+    </div>
+
+    <!-- RIGHT: log -->
+    <div class="right">
+      <div class="loghead">
+        <div class="logheadrow"><Eyebrow>Live log · ws stream</Eyebrow><Mono style="font-size:10.5px;color:var(--cyan);letter-spacing:0.08em;">● LIVE</Mono></div>
+        <Mono dim style="font-size:10px;margin-top:4px;">464 events · auto-scroll on</Mono>
+      </div>
+      <div class="logbody">
+        {#each LOG as ln}
+          <div class="logline">
+            <span class="logt">{ln.t}</span>
+            <span class="loglvl" class:err={ln.lvl === 'error'} class:warn={ln.lvl === 'warn'}>{lvlText[ln.lvl]}</span>
+            <span class="logstage">{ln.stage}</span>
+            <span class="logmsg">{ln.msg}</span>
+          </div>
+        {/each}
+      </div>
+      <div class="logfoot"><Mono dim style="font-size:10px;letter-spacing:0.05em;">filter: <span class="ink">all</span> · errors · warnings · stage:probe · stage:tag</Mono></div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .artboard { width: 1400px; height: 900px; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 1fr; overflow: hidden; margin: 0 auto; }
+  .grow { flex: 1; }
+  .quiet { color: var(--quiet); }
+  .ink { color: var(--ink); }
+  .topbar { display: flex; align-items: center; border-bottom: 1px solid var(--rule); padding: 0 16px; gap: 16px; }
+  .split { display: grid; grid-template-columns: 1fr 380px; min-height: 0; overflow: hidden; }
+  .left { display: flex; flex-direction: column; min-height: 0; border-right: 1px solid var(--rule); }
+  .hero { padding: 32px 40px 28px; border-bottom: 1px solid var(--rule); }
+  .herohead { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 14px; }
+  .herobig { display: flex; align-items: baseline; gap: 18px; }
+  .bignum { font-size: 80px; letter-spacing: -0.04em; line-height: 1; color: var(--ink); }
+  .herometa { flex: 1; }
+  .aggwrap { margin-top: 22px; }
+  .aggrow { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 6px; }
+  .aggbar { height: 4px; background: var(--surface-3); position: relative; }
+  .aggfill { position: absolute; left: 0; top: 0; bottom: 0; width: 65.4%; background: var(--cyan); }
+  .aggmark { position: absolute; left: 65.4%; top: -2px; width: 1px; height: 8px; background: var(--cyan); }
+  .metrics { display: flex; gap: 32px; margin-top: 14px; }
+  .metricval { font-family: var(--ak-mono); font-size: 18px; font-weight: 600; color: var(--ink); }
+  .queue { flex: 1; padding: 14px 40px 20px; overflow: hidden; display: flex; flex-direction: column; }
+  .qhead { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 12px; }
+  .qbtns { display: flex; gap: 6px; }
+  .qrow { display: grid; gap: 14px; align-items: center; padding: 7px 0; border-bottom: 1px solid var(--rule); }
+  .qrow.qheadrow { align-items: baseline; padding: 6px 0 8px; }
+  .qrow.done { opacity: 0.55; }
+  .qrows { flex: 1; overflow: hidden; }
+  .stage { font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.08em; padding: 2px 6px; width: fit-content; text-align: center; line-height: 1.1; color: var(--quiet); font-weight: 400; border: 1px solid var(--rule); }
+  .stage.done { color: var(--ink); font-weight: 600; border-color: var(--ink); }
+  .stage.running { color: var(--cyan); font-weight: 700; border-color: var(--cyan); }
+  .pbar { position: relative; height: 3px; background: var(--surface-3); }
+  .pfill { position: absolute; left: 0; top: 0; bottom: 0; background: var(--cyan); }
+  .pfill.full { background: var(--quiet); }
+  .right { display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
+  .loghead { padding: 16px 20px 12px; border-bottom: 1px solid var(--rule); }
+  .logheadrow { display: flex; justify-content: space-between; align-items: baseline; }
+  .logbody { flex: 1; overflow: hidden; padding: 14px 20px; display: flex; flex-direction: column; gap: 7px; }
+  .logline { display: flex; gap: 8px; font-family: var(--ak-mono); font-size: 10.5px; line-height: 1.35; }
+  .logt { color: var(--quiet); flex: 0 0 78px; }
+  .loglvl { color: var(--quiet); flex: 0 0 30px; text-align: center; height: 14px; }
+  .loglvl.warn { color: var(--ink-2); }
+  .loglvl.err { color: var(--bg); background: var(--ink); padding: 0 4px; font-weight: 700; }
+  .logstage { color: var(--quiet); flex: 0 0 42px; text-transform: uppercase; letter-spacing: 0.05em; }
+  .logmsg { color: var(--ink-2); flex: 1; word-break: break-word; }
+  .logfoot { padding: 12px 20px; border-top: 1px solid var(--rule); }
+</style>

--- a/frontend/src/routes/InspectorFull.svelte
+++ b/frontend/src/routes/InspectorFull.svelte
@@ -1,0 +1,235 @@
+<!-- Seg 4 — Screen 3: Inspector full state. Single file open full-screen.
+     Own simplified top bar + breadcrumb + 2-col split (preview/scenes/wf/tags
+     | metadata/transcript/rate/export). Helpers (scenes/waveform/markers) inline. -->
+<script>
+  import ArkivLogo from '../lib/ArkivLogo.svelte'
+  import Mono from '../lib/Mono.svelte'
+  import Eyebrow from '../lib/Eyebrow.svelte'
+  import Thumb from '../lib/Thumb.svelte'
+  import { MEDIA } from '../lib/mockData.js'
+
+  const theme = 'dark'
+  const m = MEDIA[0]
+
+  const scenes = [
+    { w: 12, sel: false }, { w: 8, sel: false }, { w: 18, sel: true }, { w: 14, sel: false },
+    { w: 6, sel: false }, { w: 22, sel: false }, { w: 10, sel: false }, { w: 10, sel: false },
+  ]
+  const scenesTotal = scenes.reduce((a, s) => a + s.w, 0)
+
+  const N = 160
+  const bigBars = Array.from({ length: N }, (_, i) => {
+    const v = Math.sin(i * 0.42) * 0.4 + Math.sin(i * 0.13 + 1.2) * 0.32 + Math.sin(i * 0.7 + 0.4) * 0.28
+    return Math.min(1, Math.abs(v) * (0.5 + Math.abs(Math.sin(i * 0.09)) * 0.5))
+  }).map((v, i) => ({ h: Math.max(2, v * 70), inWin: i / N > 0.05 && i / N < 0.78 }))
+
+  const tags = [
+    ['cycling', 'auto'], ['road', 'auto'], ['interview', 'auto'], ['tibet', 'auto'],
+    ['documentary', 'auto'], ['day-17', 'manual'], ['hero-shot', 'manual'],
+  ]
+  const meta = [
+    ['CODEC', 'H.265 / HEVC · 10-bit 4:2:2'], ['RESOLUTION', '3840 × 2160 · 24.000 fps'],
+    ['BITRATE', '240 Mbps · CBR'], ['COLOR', 'S-Log3 · S-Gamut3.Cine'],
+    ['DURATION', '00:02:47.083 · 4010 frames'], ['SIZE', '1.44 GB'],
+    ['CAMERA', 'Sony α7S III · ILCE-7SM3'], ['LENS', 'FE 24-70mm f/2.8 GM'],
+    ['EXPOSURE', 'ISO 800 · f/2.8 · 1/50s · 35mm'], ['CREATED', '2026-05-15 14:32:08 +0800'],
+    ['INGESTED', '2026-05-16 02:14:33 +0800'],
+  ]
+  const langTabs = [['zh-Hant', true], ['en', false], ['ja', false]]
+  const lines = [
+    ['00:00.214', '今天是第十七天，我們從上海一路騎到拉薩。', false],
+    ['00:05.612', '中間最難的是格爾木到沱沱河這段。', true],
+    ['00:12.408', '海拔從 2800 一路爬到 4800，氧氣比想像中還少。', false],
+    ['00:24.811', '車架被打到變形，但人沒事。', true],
+    ['00:32.215', '想起出發前認識的那群人，現在不知道怎麼樣了。', false],
+    ['00:39.602', '明天還要再翻一座山。', false],
+  ]
+  const rateBtns = [['good', 'Good'], ['rev', 'Review'], ['ng', 'N·G'], ['none', '—']]
+  const exports = ['EDL', 'FCPXML', 'SRT', 'VTT', 'CSV']
+</script>
+
+<div class="artboard" data-theme={theme}>
+  <!-- top bar -->
+  <div class="topbar">
+    <ArkivLogo size={16} />
+    <Mono dim style="font-size:10px;">v0.9.2</Mono>
+    <div class="grow"></div>
+    <button class="ak-btn">⌕ Search</button>
+    <button class="ak-btn ak-btn--primary">+ Ingest</button>
+    <button class="ak-btn">···</button>
+  </div>
+
+  <!-- breadcrumb -->
+  <div class="crumb">
+    <Mono dim style="font-size:11px;">← BACK TO GRID</Mono>
+    <div class="vrule"></div>
+    <Mono dim style="font-size:11px;letter-spacing:0.04em;">Bicycle Diaries  /  Day 17 · Geermu → Tuotuohe  /  <span class="ink">{m.name}</span></Mono>
+    <div class="grow"></div>
+    <Mono dim style="font-size:11px;">3 of 247</Mono>
+    <div class="navbtns">
+      <button class="ak-btn navbtn">← Prev</button>
+      <button class="ak-btn navbtn">Next →</button>
+    </div>
+  </div>
+
+  <!-- split -->
+  <div class="split">
+    <!-- LEFT -->
+    <div class="left">
+      <div class="preview">
+        <Thumb seed={m.id} kind={m.kind} {theme} />
+        <div class="playbtn"><div class="tri"></div></div>
+        <div class="pscrim"></div>
+        <div class="pchrome">
+          <Mono style="font-size:12px;color:#f3f2ee;">00:00:42</Mono>
+          <div class="track"><div class="trackfill"></div><div class="trackhead"></div></div>
+          <Mono style="font-size:12px;color:#f3f2ee;">{m.dur}</Mono>
+          <div class="pvrule"></div>
+          <Mono style="font-size:11px;color:#f3f2ee;">1× ▸ ⤓</Mono>
+        </div>
+      </div>
+
+      <div class="block">
+        <div class="bhead"><Eyebrow>Scenes · cut detection</Eyebrow><Mono dim style="font-size:10px;">8 scenes · pyscenedetect 0.6.4</Mono></div>
+        <div class="scenes">
+          {#each scenes as s, i}
+            <div class="scene" class:sel={s.sel} style="width:{(s.w / scenesTotal) * 100}%;">
+              <Thumb seed={i * 3 + 7} kind="video" {theme} />
+              <div class="scenenum">{String(i + 1).padStart(2, '0')}</div>
+            </div>
+          {/each}
+        </div>
+      </div>
+
+      <div class="block">
+        <div class="bhead">
+          <Eyebrow>Audio waveform</Eyebrow>
+          <div class="wfmeta"><Mono dim style="font-size:10px;">IN  00:05.214</Mono><Mono dim style="font-size:10px;">OUT 00:42.108</Mono><Mono dim style="font-size:10px;">SEL 00:36.894</Mono></div>
+        </div>
+        <div class="bigwf">
+          <svg viewBox="0 0 160 78" preserveAspectRatio="none" class="bigwfsvg">
+            {#each bigBars as b, i}
+              <rect x={i + 0.1} y={(78 - b.h) / 2} width="0.8" height={b.h} fill={b.inWin ? 'var(--ink)' : 'var(--quiet-2)'} />
+            {/each}
+          </svg>
+          <div class="bmark" style="left:5%;"><div class="bmarklabel">IN</div></div>
+          <div class="bmark" style="left:78%;"><div class="bmarklabel">OUT</div></div>
+          <div class="bplayhead"><div class="bplaydot"></div></div>
+        </div>
+      </div>
+
+      <div class="block tagsblock">
+        <Eyebrow style="margin-bottom:10px;">Tags · 5 auto · 2 manual</Eyebrow>
+        <div class="tags">
+          {#each tags as [t, src]}
+            <span class="tag" class:manual={src === 'manual'}>{t}{#if src === 'manual'}<Mono dim style="font-size:9px;letter-spacing:0.06em;">✕</Mono>{/if}</span>
+          {/each}
+          <span class="addtag">+ add tag</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- RIGHT -->
+    <div class="right">
+      <div class="rblock">
+        <Eyebrow style="margin-bottom:6px;">Inspector · full</Eyebrow>
+        <div class="fname">{m.name}</div>
+        <Mono dim style="font-size:10.5px;margin-top:4px;letter-spacing:0.03em;">/vol/nas01/bicycle-diaries/raw/{m.name}</Mono>
+        <Mono dim style="font-size:10px;margin-top:6px;display:block;">SHA-256 · 7f3e8a92c1b4d5f6e2a8c9d1b3e5f7a9c2b4d6e8f1a3c5d7e9b1f3a5c7d9e1f3</Mono>
+      </div>
+
+      <div class="rblock">
+        <Eyebrow style="margin-bottom:10px;">Technical metadata</Eyebrow>
+        <div class="metagrid">
+          {#each meta as [k, v]}<Mono dim>{k}</Mono><Mono>{v}</Mono>{/each}
+        </div>
+      </div>
+
+      <div class="rblock transcript">
+        <div class="bhead"><Eyebrow>Transcript</Eyebrow><Mono dim style="font-size:9.5px;">whisper-large-v3 · conf 98.2%</Mono></div>
+        <div class="langtabs">
+          {#each langTabs as [l, on]}<button class="langtab" class:on>{l}</button>{/each}
+        </div>
+        <div class="lines">
+          {#each lines as [tc, text, hl]}
+            <div class="line"><Mono dim style="font-size:10.5px;flex:0 0 64px;padding-top:2px;">{tc}</Mono><span class="ttext" class:hl>{text}</span></div>
+          {/each}
+        </div>
+      </div>
+
+      <div class="rblock rate">
+        <div class="bhead"><Eyebrow>Rate</Eyebrow><Mono dim style="font-size:9.5px;">last edit: 2026-05-24 23:08</Mono></div>
+        <div class="ratebtns">
+          {#each rateBtns as [r, label]}<button class="ratebtn" class:active={m.rating === r} class:rev={r === 'rev'}>{label}</button>{/each}
+        </div>
+        <Eyebrow style="margin-top:4px;">Export</Eyebrow>
+        <div class="exports">
+          {#each exports as f}<button class="ak-btn expbtn">{f}</button>{/each}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .artboard { width: 1400px; height: 900px; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 56px 1fr; overflow: hidden; margin: 0 auto; }
+  .grow { flex: 1; }
+  .ink { color: var(--ink); }
+  .vrule { width: 1px; height: 14px; background: var(--rule); }
+  .topbar { display: flex; align-items: center; border-bottom: 1px solid var(--rule); padding: 0 16px; gap: 16px; }
+  .crumb { display: flex; align-items: center; gap: 14px; padding: 0 24px; border-bottom: 1px solid var(--rule); }
+  .navbtns { display: flex; gap: 1px; }
+  .navbtn { padding: 6px 12px; }
+
+  .split { display: grid; grid-template-columns: 1fr 460px; min-height: 0; overflow: hidden; }
+  .left { border-right: 1px solid var(--rule); display: flex; flex-direction: column; min-height: 0; }
+  .preview { position: relative; flex: 0 0 auto; height: 420px; background: var(--surface-2); overflow: hidden; }
+  .playbtn { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); width: 56px; height: 56px; box-shadow: inset 0 0 0 1px #f3f2ee; display: flex; align-items: center; justify-content: center; cursor: pointer; }
+  .tri { width: 0; height: 0; border-left: 13px solid #f3f2ee; border-top: 8px solid transparent; border-bottom: 8px solid transparent; margin-left: 4px; }
+  .pscrim { position: absolute; left: 0; right: 0; bottom: 0; height: 80px; background-image: linear-gradient(to top, rgba(0, 0, 0, 0.65), transparent); }
+  .pchrome { position: absolute; left: 24px; right: 24px; bottom: 22px; display: flex; align-items: center; gap: 14px; }
+  .track { flex: 1; height: 2px; background: rgba(243, 242, 238, 0.25); position: relative; }
+  .trackfill { position: absolute; left: 0; top: 0; bottom: 0; width: 25%; background: #f3f2ee; }
+  .trackhead { position: absolute; left: 25%; top: -4px; width: 1px; height: 10px; background: #f3f2ee; }
+  .pvrule { width: 1px; height: 16px; background: rgba(243, 242, 238, 0.25); }
+
+  .block { padding: 18px 24px 14px; border-bottom: 1px solid var(--rule); }
+  .bhead { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 12px; }
+  .scenes { display: flex; gap: 1px; height: 56px; background: var(--rule); }
+  .scene { position: relative; overflow: hidden; background: var(--surface-2); }
+  .scene.sel { box-shadow: inset 0 0 0 1px var(--invert); }
+  .scenenum { position: absolute; bottom: 2px; left: 4px; font-family: var(--ak-mono); font-size: 9px; color: #f3f2ee; background: rgba(10, 10, 12, 0.7); padding: 1px 3px; letter-spacing: 0.02em; }
+  .wfmeta { display: flex; gap: 14px; }
+  .bigwf { position: relative; height: 78px; }
+  .bigwfsvg { width: 100%; height: 100%; display: block; }
+  .bmark { position: absolute; top: -4px; bottom: -4px; width: 1px; background: var(--invert); }
+  .bmarklabel { position: absolute; top: -14px; left: -10px; font-family: var(--ak-mono); font-size: 8.5px; letter-spacing: 0.08em; color: var(--ink); padding: 1px 3px; background: var(--bg); border: 1px solid var(--invert); line-height: 1; }
+  .bplayhead { position: absolute; top: -8px; bottom: -8px; left: 32%; width: 1px; background: var(--invert); }
+  .bplaydot { position: absolute; top: -3px; left: -3px; width: 7px; height: 7px; background: var(--invert); }
+  .tagsblock { flex: 1; overflow: hidden; border-bottom: none; padding: 16px 24px; }
+  .tags { display: flex; flex-wrap: wrap; gap: 6px; }
+  .tag { font-family: var(--ak-mono); font-size: 11.5px; line-height: 1; padding: 5px 9px; border: 1px solid var(--rule); color: var(--ink-2); display: inline-flex; align-items: center; gap: 6px; }
+  .tag.manual { border-color: var(--ink); }
+  .addtag { font-family: var(--ak-mono); font-size: 11.5px; padding: 5px 9px; border: 1px dashed var(--rule-hi); color: var(--quiet); }
+
+  .right { display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
+  .rblock { padding: 16px 24px; border-bottom: 1px solid var(--rule); }
+  .rblock:first-child { padding: 20px 24px 18px; }
+  .fname { font-family: var(--ak-mono); font-size: 14px; font-weight: 500; line-height: 1.3; word-break: break-all; color: var(--ink); }
+  .metagrid { display: grid; grid-template-columns: 90px 1fr; row-gap: 5px; column-gap: 14px; font-size: 12px; }
+  .transcript { flex: 1; overflow: hidden; display: flex; flex-direction: column; min-height: 0; }
+  .langtabs { display: flex; margin-bottom: 10px; border-bottom: 1px solid var(--rule); }
+  .langtab { font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.06em; text-transform: uppercase; padding: 6px 10px; background: transparent; color: var(--quiet); border: none; border-bottom: 2px solid transparent; margin-bottom: -1px; cursor: pointer; }
+  .langtab.on { color: var(--ink); border-bottom-color: var(--invert); font-weight: 700; }
+  .lines { flex: 1; overflow: hidden; display: flex; flex-direction: column; gap: 9px; font-size: 12.5px; line-height: 1.45; }
+  .line { display: flex; gap: 12px; }
+  .ttext { color: var(--ink); }
+  .ttext.hl { border-bottom: 1px solid var(--invert); padding-bottom: 1px; }
+  .rate { display: flex; flex-direction: column; gap: 10px; border-bottom: none; }
+  .ratebtns { display: flex; gap: 4px; }
+  .ratebtn { flex: 1; font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; padding: 8px 0; background: transparent; color: var(--ink-2); border: 1px solid var(--rule); cursor: pointer; }
+  .ratebtn.rev { border: 1px dashed var(--rule-hi); }
+  .ratebtn.active { background: var(--invert); color: var(--invert-ink); border-color: var(--invert); font-weight: 700; }
+  .exports { display: grid; grid-template-columns: repeat(5, 1fr); gap: 4px; }
+  .expbtn { padding: 7px 0; }
+</style>

--- a/frontend/src/routes/MainDark.svelte
+++ b/frontend/src/routes/MainDark.svelte
@@ -1,0 +1,89 @@
+<!-- Seg 2 — Screen 1 hero (interactive). 1400×900 artboard.
+     Three-column shell: PoolSidebar (220) | grid (flex) | Inspector (340). -->
+<script>
+  import TopBar from '../lib/TopBar.svelte'
+  import PoolSidebar from '../lib/PoolSidebar.svelte'
+  import MediaCard from '../lib/MediaCard.svelte'
+  import FilterRow from '../lib/FilterRow.svelte'
+  import ViewToggle from '../lib/ViewToggle.svelte'
+  import Inspector from '../lib/Inspector.svelte'
+  import Mono from '../lib/Mono.svelte'
+  import { MEDIA } from '../lib/mockData.js'
+
+  export let theme = 'dark'
+  let selectedId = 1
+  let hoverId = null
+  let activeFilter = 'all'
+  let activeRating = null
+  let crossProject = false
+  let view = 'grid'
+
+  $: selected = MEDIA.find((m) => m.id === selectedId) || MEDIA[0]
+  $: visibleMedia = MEDIA.filter((m) => {
+    if (activeFilter === 'video' && m.kind !== 'video') return false
+    if (activeFilter === 'audio' && m.kind !== 'audio') return false
+    if (activeRating && m.rating !== activeRating) return false
+    return true
+  })
+</script>
+
+<div class="artboard" data-theme={theme}>
+  <TopBar bind:crossProject />
+
+  <div class="body">
+    <PoolSidebar />
+
+    <main class="center">
+      <div class="toolrow">
+        <div class="proj">
+          <div class="ak-display projtitle">Bicycle Diaries</div>
+          <Mono dim style="font-size:11px;margin-top:5px;letter-spacing:0.04em;">
+            247 items · 11h 42m · last ingest 2026-05-24 23:08
+          </Mono>
+        </div>
+        <FilterRow bind:activeFilter bind:activeRating />
+        <ViewToggle bind:view />
+      </div>
+
+      <div class="gridwrap">
+        <div class="mediagrid">
+          {#each visibleMedia.slice(0, 12) as m (m.id)}
+            <MediaCard
+              {m}
+              {theme}
+              selected={m.id === selectedId}
+              hover={m.id === hoverId}
+              on:click={() => (selectedId = m.id)}
+              on:mouseenter={() => (hoverId = m.id)}
+              on:mouseleave={() => (hoverId = null)}
+            />
+          {/each}
+        </div>
+      </div>
+    </main>
+
+    <Inspector media={selected} {theme} />
+  </div>
+</div>
+
+<style>
+  .artboard {
+    width: 1400px; height: 900px; position: relative;
+    display: grid; grid-template-rows: 52px 1fr;
+    background: var(--bg); color: var(--ink); overflow: hidden;
+    margin: 0 auto;
+  }
+  .body { display: grid; grid-template-columns: 220px 1fr 340px; min-height: 0; }
+  .center { display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
+  .toolrow {
+    display: flex; align-items: center; gap: 14px;
+    padding: 14px 22px; border-bottom: 1px solid var(--rule);
+  }
+  .proj { flex: 1; min-width: 0; }
+  .projtitle { font-size: 28px; letter-spacing: -0.04em; line-height: 1; color: var(--ink); }
+  .gridwrap { flex: 1; overflow: hidden; position: relative; }
+  .mediagrid {
+    display: grid; grid-template-columns: repeat(4, 1fr);
+    gap: 1px; padding: 22px; background: var(--rule);
+  }
+</style>

--- a/frontend/src/routes/MainStates.svelte
+++ b/frontend/src/routes/MainStates.svelte
@@ -1,0 +1,371 @@
+<!-- Seg 3 — Screen 1 state variants (01a–01f). Reuses chrome from lib;
+     only the CENTER (and sometimes inspector/footer) changes per state.
+     All 6 artboards stacked vertically for audit. -->
+<script>
+  import MainShell from '../lib/MainShell.svelte'
+  import Thumb from '../lib/Thumb.svelte'
+  import Rating from '../lib/Rating.svelte'
+  import Mono from '../lib/Mono.svelte'
+  import Eyebrow from '../lib/Eyebrow.svelte'
+  import FilterRow from '../lib/FilterRow.svelte'
+  import ViewToggle from '../lib/ViewToggle.svelte'
+  import Sweep from '../lib/Sweep.svelte'
+  import { MEDIA } from '../lib/mockData.js'
+
+  const theme = 'dark'
+  const listCols = '110px 1fr 70px 80px 76px 84px 70px 80px'
+  const listHeaders = ['THUMB', 'FILENAME', 'RATING', 'DURATION', 'SIZE', 'CAMERA', 'LENS', 'CREATED']
+  const camAbbr = (c) => c.replace('Sony α', 'α').replace('Panasonic ', '')
+
+  const navItems = [
+    ['↑ ↓ ← →', 'Move selection'], ['Space', 'Preview play / pause'], ['Enter', 'Open in Inspector'],
+    ['⌘K', 'Search'], ['⌘P', 'Pool / project switcher'], ['⌘1…4', 'Jump to project'],
+    ['G G', 'Top of grid'], ['G E', 'End of grid'],
+  ]
+  const actItems = [
+    ['1', 'Rate Good'], ['2', 'Rate Review'], ['3', 'Rate N·G'], ['0', 'Clear rating'],
+    ['T', 'Add tag…'], ['I  O', 'Set In / Out'], ['⌘E', 'Export EDL'], ['⌘⇧E', 'Export FCPXML'],
+  ]
+  const probe = [
+    ['PROBE', 'codec · resolution · bitrate · color · duration'],
+    ['THUMB', 'scene-detect cuts · proxy 540p · waveform'],
+    ['TRANS', 'whisper-large-v3 · zh/en/ja/auto'],
+    ['TAG', 'llava 13b · max 8 tags per clip'],
+    ['HASH', 'sha-256 dedupe · arkiv://...'],
+  ]
+  const ratingDist = [
+    { label: 'GOOD', count: 158, fill: 'var(--invert)' },
+    { label: 'REV', count: 34, fill: 'var(--ink-2)' },
+    { label: 'N·G', count: 19, fill: 'var(--quiet)' },
+    { label: '—', count: 36, fill: 'var(--surface-3)' },
+  ]
+  const distTotal = ratingDist.reduce((a, s) => a + s.count, 0)
+  const ingest7 = [8, 12, 18, 5, 9, 0, 0]
+  const ingest7max = Math.max(...ingest7, 1)
+  const ingestLabels = ['M', 'T', 'W', 'T', 'F', 'S', 'S']
+  const topTags = [['cycling', 88, 0.55], ['b-roll', 71, 0.46], ['product', 62, 0.4], ['portrait', 41, 0.27], ['documentary', 28, 0.18]]
+  const skelMeta = [0, 1, 2, 3]
+</script>
+
+<div class="stack">
+
+  <!-- 01a · LIST VIEW -->
+  <Eyebrow style="padding-left:8px;">01a · list view</Eyebrow>
+  <MainShell {theme}>
+    <main slot="center" class="col">
+      <div class="toolrow">
+        <div class="grow">
+          <div class="ak-display title28">Bicycle Diaries</div>
+          <Mono dim style="font-size:11px;margin-top:5px;letter-spacing:0.04em;">247 items · 11h 42m · sorted by created ▾</Mono>
+        </div>
+        <FilterRow activeFilter="all" activeRating={null} />
+        <ViewToggle view="list" />
+      </div>
+      <div class="lrow lhead" style="grid-template-columns:{listCols};">
+        {#each listHeaders as h}<Mono dim style="font-size:9.5px;letter-spacing:0.12em;">{h}</Mono>{/each}
+      </div>
+      <div class="grow ovh">
+        {#each MEDIA.slice(0, 14) as m, i (m.id)}
+          <div class="lrow" class:first={i === 0} class:ng={m.rating === 'ng'} style="grid-template-columns:{listCols};">
+            <div class="lthumb"><Thumb seed={m.id} kind={m.kind} {theme} /></div>
+            <Mono style="font-size:11.5px;color:var(--ink);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;{m.rating === 'ng' ? 'text-decoration:line-through;' : ''}">{m.name}</Mono>
+            <Rating value={m.rating} />
+            <Mono dim style="font-size:11px;">{m.dur}</Mono>
+            <Mono dim style="font-size:11px;">{m.size}</Mono>
+            <Mono dim style="font-size:11px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{camAbbr(m.cam)}</Mono>
+            <Mono dim style="font-size:11px;">{m.fl}</Mono>
+            <Mono dim style="font-size:11px;">05-{15 + (m.id % 7)}</Mono>
+          </div>
+        {/each}
+      </div>
+    </main>
+  </MainShell>
+
+  <!-- 01b · DROP ZONE -->
+  <Eyebrow style="padding-left:8px;">01b · drop-zone</Eyebrow>
+  <MainShell {theme}>
+    <main slot="center" class="rel ovh">
+      <div class="grid4 dim" style="height:100%;">
+        {#each MEDIA.slice(0, 12) as m (m.id)}
+          <div class="cellbg"><div class="thumb169"><Thumb seed={m.id} kind={m.kind} {theme} /></div></div>
+        {/each}
+      </div>
+      <div class="dropzone">
+        <Eyebrow style="color:var(--cyan);">DROP TO INGEST</Eyebrow>
+        <div class="ak-display dzbig">23 files<br /><span class="quiet">·  18.4 GB</span></div>
+        <Mono dim style="font-size:12px;letter-spacing:0.05em;">16 video · 5 audio · 2 unsupported · Bicycle Diaries</Mono>
+        <div class="dzfoot">
+          <Mono dim style="font-size:10.5px;">HOLD ⌥ TO SKIP DUPLICATES</Mono>
+          <Mono dim style="font-size:10.5px;">RELEASE TO START · Esc CANCEL</Mono>
+        </div>
+      </div>
+    </main>
+  </MainShell>
+
+  <!-- 01c · SKELETON -->
+  <Eyebrow style="padding-left:8px;">01c · skeleton</Eyebrow>
+  <MainShell {theme}>
+    <main slot="center" class="col">
+      <div class="toolrow">
+        <div class="grow">
+          <div class="skel" style="width:200px;height:28px;background:var(--surface-3);"><Sweep /></div>
+          <div class="skel" style="width:280px;height:11px;background:var(--surface-2);margin-top:8px;"><Sweep delay={0.3} /></div>
+        </div>
+        <Mono style="font-size:11px;color:var(--cyan);letter-spacing:0.08em;">● LOADING · 0.4s</Mono>
+      </div>
+      <div class="grow ovh rel">
+        <div class="grid4">
+          {#each Array(12) as _, i}
+            <div class="cellbg">
+              <div class="thumb169 skel"><Sweep delay={i * 0.08} /></div>
+              <div class="skelmeta">
+                <div class="skel" style="width:85%;height:11px;background:var(--surface-2);"><Sweep delay={i * 0.08 + 0.2} /></div>
+                <div class="skelrow"><div style="width:30px;height:10px;background:var(--surface-2);"></div><div style="width:46px;height:10px;background:var(--surface-2);"></div></div>
+              </div>
+            </div>
+          {/each}
+        </div>
+      </div>
+    </main>
+    <aside slot="inspector" class="skelinsp">
+      <div class="skel" style="width:140px;height:11px;background:var(--surface-3);"><Sweep /></div>
+      <div style="width:100%;height:14px;background:var(--surface-2);"></div>
+      <div class="thumb169 skel"><Sweep delay={0.5} /></div>
+      <div class="skelmetagrid">
+        {#each skelMeta as i}
+          <div class="skelmg"><div style="height:9px;background:var(--surface-3);"></div><div style="height:9px;background:var(--surface-2);width:{50 + (i * 13) % 40}%;"></div></div>
+        {/each}
+      </div>
+      <div class="skel" style="height:56px;background:var(--surface-2);"><Sweep delay={0.7} /></div>
+    </aside>
+  </MainShell>
+
+  <!-- 01d · EMPTY PROJECT -->
+  <Eyebrow style="padding-left:8px;">01d · empty project</Eyebrow>
+  <MainShell {theme}>
+    <main slot="center" class="col">
+      <div class="toolrow">
+        <div class="grow">
+          <div class="ak-display title28">KOL_2026Q1</div>
+          <Mono dim style="font-size:11px;margin-top:5px;letter-spacing:0.04em;">0 items · created 2026-05-26 · NAS not mounted</Mono>
+        </div>
+        <button class="ak-btn">Configure NAS</button>
+      </div>
+      <div class="emptywrap">
+        <div class="emptyhero">
+          <Eyebrow>EMPTY PROJECT</Eyebrow>
+          <div class="ak-display emptybig">Nothing<br />here yet.</div>
+          <Mono dim style="font-size:12px;line-height:1.6;max-width:400px;margin-top:4px;">Drop a folder anywhere in this window to start ingesting, or point arkiv at a watched directory. Local-first. No cloud.</Mono>
+          <div class="emptybtns">
+            <button class="ak-btn ak-btn--primary">Choose folder…</button>
+            <button class="ak-btn">Watch directory…</button>
+            <button class="ak-btn">Import from .arkiv</button>
+          </div>
+          <div class="supported">
+            <Mono dim style="font-size:10.5px;letter-spacing:0.08em;">SUPPORTED</Mono>
+            <Mono dim style="font-size:10.5px;">.mov · .mp4 · .mxf · .braw · .r3d · .wav · .flac</Mono>
+          </div>
+        </div>
+      </div>
+    </main>
+    <aside slot="inspector" class="emptyinsp">
+      <Eyebrow>Inspector · no selection</Eyebrow>
+      <div class="ak-display emptyinsptitle">Pick a clip<br />to inspect.</div>
+      <Mono dim style="font-size:11px;line-height:1.6;margin-top:8px;">Once ingestion finishes, files appear in the grid and metadata shows here. Every file gets:</Mono>
+      <div class="probe">
+        {#each probe as [k, v]}
+          <div class="probrow"><Mono dim style="font-size:10px;letter-spacing:0.1em;">{k}</Mono><Mono dim style="font-size:10.5px;">{v}</Mono></div>
+        {/each}
+      </div>
+      <div class="grow"></div>
+      <div class="emptyfoot"><Mono dim style="font-size:10px;letter-spacing:0.08em;">Local-first · MIT · arkiv v0.9.2</Mono></div>
+    </aside>
+  </MainShell>
+
+  <!-- 01e · SHORTCUTS -->
+  <Eyebrow style="padding-left:8px;">01e · shortcuts</Eyebrow>
+  <MainShell {theme}>
+    <main slot="center" class="rel ovh">
+      <div class="grid4 dim" style="height:100%;">
+        {#each MEDIA.slice(0, 12) as m (m.id)}
+          <div class="cellbg"><div class="thumb169"><Thumb seed={m.id} kind={m.kind} {theme} /></div></div>
+        {/each}
+      </div>
+      <div class="scrim"></div>
+      <div class="sheet">
+        <div class="sheethead">
+          <div>
+            <Eyebrow style="margin-bottom:4px;">Keyboard</Eyebrow>
+            <div class="ak-display sheettitle">Shortcuts</div>
+          </div>
+          <Mono dim style="font-size:11px;">? · TOGGLE  ·  Esc · CLOSE</Mono>
+        </div>
+        <div class="sheetbody">
+          <div class="scgroup">
+            <Eyebrow style="margin-bottom:14px;">Navigate</Eyebrow>
+            <div class="sclist">
+              {#each navItems as [k, label]}<div class="scrow"><span class="sckey">{k}</span><span class="sclabel">{label}</span></div>{/each}
+            </div>
+          </div>
+          <div class="scgroup right">
+            <Eyebrow style="margin-bottom:14px;">Act</Eyebrow>
+            <div class="sclist">
+              {#each actItems as [k, label]}<div class="scrow"><span class="sckey">{k}</span><span class="sclabel">{label}</span></div>{/each}
+            </div>
+          </div>
+        </div>
+        <div class="sheetfoot">
+          <Mono dim style="font-size:10.5px;letter-spacing:0.05em;">Reconfigure in Settings · Advanced · Keyboard</Mono>
+          <Mono dim style="font-size:10.5px;">32 shortcuts · 8 hidden</Mono>
+        </div>
+      </div>
+    </main>
+  </MainShell>
+
+  <!-- 01f · ANALYTICS FOOTER -->
+  <Eyebrow style="padding-left:8px;">01f · analytics footer</Eyebrow>
+  <MainShell {theme} rows="52px 1fr 220px">
+    <main slot="center" class="col">
+      <div class="toolrow">
+        <div class="grow">
+          <div class="ak-display title28">Bicycle Diaries</div>
+          <Mono dim style="font-size:11px;margin-top:5px;letter-spacing:0.04em;">247 items · 11h 42m · last ingest 23:08</Mono>
+        </div>
+        <FilterRow activeFilter="all" activeRating={null} />
+        <ViewToggle view="grid" />
+      </div>
+      <div class="grow grid4 ovh">
+        {#each MEDIA.slice(0, 8) as m (m.id)}
+          <div class="cellbg">
+            <div class="thumb169"><Thumb seed={m.id} kind={m.kind} {theme} /></div>
+            <div class="acard">
+              <Mono style="font-size:11px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:block;">{m.name}</Mono>
+              <div class="acardrow"><Rating value={m.rating} /><Mono dim style="font-size:10px;">{m.size}</Mono></div>
+            </div>
+          </div>
+        {/each}
+      </div>
+    </main>
+    <footer slot="footer" class="analytics">
+      <div class="anleft">
+        <div class="anrow"><Eyebrow>Analytics</Eyebrow><Mono dim style="font-size:10px;">▾</Mono></div>
+        <div class="ak-display antitle">Bicycle Diaries · last 7 days</div>
+        <Mono dim style="font-size:10.5px;line-height:1.5;margin-top:2px;">+52 ingested · 38 rated GOOD · 14 N·G ·<br />avg transcribe 0.41s/min · 0 errors</Mono>
+      </div>
+      <div class="anmid">
+        <div>
+          <div class="anrow mb10"><Eyebrow>Rating distribution</Eyebrow><Mono dim style="font-size:10px;">247 total</Mono></div>
+          <div class="stackbar">{#each ratingDist as s}<div style="flex:{s.count};background:{s.fill};"></div>{/each}</div>
+          <div class="stacklegend">
+            {#each ratingDist as s}
+              <div class="stackseg"><Mono dim style="font-size:9.5px;letter-spacing:0.08em;">{s.label}</Mono><Mono style="font-size:13px;font-weight:600;">{s.count}</Mono><Mono dim style="font-size:9.5px;">{Math.round((s.count / distTotal) * 100)}%</Mono></div>
+            {/each}
+          </div>
+        </div>
+        <div>
+          <div class="anrow mb10"><Eyebrow>Ingest · 7 days</Eyebrow><Mono dim style="font-size:10px;">peak Tue · 18</Mono></div>
+          <div class="barchart">
+            {#each ingest7 as v}
+              <div class="barcol"><div class="barcolinner"><div class="bar" class:zero={v === 0} style="height:{(v / ingest7max) * 100}%;"></div></div></div>
+            {/each}
+          </div>
+          <div class="barlabels">{#each ingestLabels as l}<Mono dim style="flex:1;text-align:center;font-size:9.5px;letter-spacing:0.1em;">{l}</Mono>{/each}</div>
+        </div>
+      </div>
+      <div class="anright">
+        <div class="anrow mb10"><Eyebrow>Top tags · auto</Eyebrow><Mono dim style="font-size:10px;">view all →</Mono></div>
+        <div class="taglist">
+          {#each topTags as [t, n, frac]}
+            <div class="tagrow"><Mono style="font-size:11px;">{t}</Mono><div class="tagbar"><div class="tagbarfill" style="width:{frac * 100}%;"></div></div><Mono dim style="font-size:10.5px;text-align:right;">{n}</Mono></div>
+          {/each}
+        </div>
+      </div>
+    </footer>
+  </MainShell>
+
+</div>
+
+<style>
+  .stack { display: flex; flex-direction: column; gap: 28px; padding: 24px 0; }
+  .col { display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
+  .grow { flex: 1; min-width: 0; }
+  .ovh { overflow: hidden; }
+  .rel { position: relative; }
+  .toolrow { display: flex; align-items: center; gap: 14px; padding: 14px 22px; border-bottom: 1px solid var(--rule); }
+  .title28 { font-size: 28px; letter-spacing: -0.04em; line-height: 1; color: var(--ink); }
+  .grid4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px; padding: 22px; background: var(--rule); }
+  .grid4.dim { opacity: 0.18; }
+  .cellbg { background: var(--bg); }
+  .thumb169 { position: relative; aspect-ratio: 16 / 9; background: var(--surface-2); overflow: hidden; }
+
+  /* list */
+  .lrow { display: grid; gap: 14px; align-items: center; padding: 7px 22px; border-bottom: 1px solid var(--rule); cursor: pointer; }
+  .lrow.lhead { align-items: baseline; padding: 10px 22px 8px; }
+  .lrow.first { background: var(--surface); box-shadow: inset 2px 0 0 var(--invert); }
+  .lrow.ng { opacity: 0.55; }
+  .lthumb { position: relative; aspect-ratio: 16 / 9; background: var(--surface-2); overflow: hidden; }
+
+  /* dropzone */
+  .dropzone { position: absolute; inset: 22px; border: 2px dashed var(--cyan); display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 18px; background: rgba(10, 10, 12, 0.65); }
+  .dzbig { font-size: 64px; letter-spacing: -0.04em; line-height: 1; color: var(--ink); text-align: center; }
+  .dzbig .quiet { color: var(--quiet); }
+  .dzfoot { display: flex; align-items: baseline; gap: 24px; margin-top: 14px; padding-top: 18px; border-top: 1px solid var(--cyan); }
+
+  /* skeleton */
+  .skel { position: relative; overflow: hidden; }
+  .skelmeta { padding: 8px 10px 10px; display: flex; flex-direction: column; gap: 6px; }
+  .skelrow { display: flex; justify-content: space-between; }
+  .skelinsp { border-left: 1px solid var(--rule); padding: 18px; display: flex; flex-direction: column; gap: 16px; }
+  .skelmetagrid { display: flex; flex-direction: column; gap: 8px; }
+  .skelmg { display: grid; grid-template-columns: 60px 1fr; gap: 12px; }
+
+  /* empty */
+  .emptywrap { flex: 1; padding: 22px; display: flex; }
+  .emptyhero { flex: 1; border: 1px dashed var(--rule-hi); display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 80px 60px; gap: 16px; text-align: center; }
+  .emptybig { font-size: 72px; letter-spacing: -0.04em; line-height: 0.95; color: var(--ink); }
+  .emptybtns { display: flex; gap: 8px; margin-top: 14px; }
+  .supported { display: flex; align-items: center; gap: 18px; margin-top: 24px; padding-top: 16px; border-top: 1px solid var(--rule); width: 60%; }
+  .emptyinsp { border-left: 1px solid var(--rule); padding: 24px 20px; display: flex; flex-direction: column; gap: 18px; }
+  .emptyinsptitle { font-size: 28px; letter-spacing: -0.03em; line-height: 1; color: var(--quiet); }
+  .probe { display: flex; flex-direction: column; gap: 10px; margin-top: 4px; }
+  .probrow { display: grid; grid-template-columns: 52px 1fr; gap: 10px; }
+  .emptyfoot { padding-top: 14px; border-top: 1px solid var(--rule); }
+
+  /* shortcuts */
+  .scrim { position: absolute; inset: 0; background: rgba(10, 10, 12, 0.82); }
+  .sheet { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); width: 720px; background: var(--bg); box-shadow: inset 0 0 0 1px var(--invert); }
+  .sheethead { padding: 18px 24px; border-bottom: 1px solid var(--invert); display: flex; align-items: baseline; justify-content: space-between; }
+  .sheettitle { font-size: 24px; letter-spacing: -0.03em; line-height: 1; color: var(--ink); }
+  .sheetbody { display: grid; grid-template-columns: 1fr 1fr; padding: 24px; }
+  .scgroup { padding-right: 24px; }
+  .scgroup.right { padding-right: 0; padding-left: 24px; border-left: 1px solid var(--rule); }
+  .sclist { display: flex; flex-direction: column; gap: 9px; }
+  .scrow { display: grid; grid-template-columns: 110px 1fr; align-items: baseline; gap: 14px; }
+  .sckey { font-family: var(--ak-mono); font-size: 11.5px; letter-spacing: 0.04em; padding: 3px 7px; border: 1px solid var(--rule-hi); color: var(--ink); width: fit-content; line-height: 1; }
+  .sclabel { font-size: 12.5px; color: var(--ink-2); }
+  .sheetfoot { padding: 14px 24px; border-top: 1px solid var(--rule); display: flex; justify-content: space-between; align-items: baseline; }
+
+  /* analytics */
+  .acard { padding: 8px 10px 10px; }
+  .acardrow { display: flex; justify-content: space-between; margin-top: 4px; }
+  .analytics { border-top: 1px solid var(--rule); display: grid; grid-template-columns: 220px 1fr 340px; background: var(--surface); }
+  .anleft { padding: 16px; border-right: 1px solid var(--rule); display: flex; flex-direction: column; gap: 10px; }
+  .anrow { display: flex; justify-content: space-between; align-items: baseline; }
+  .anrow.mb10 { margin-bottom: 10px; }
+  .antitle { font-size: 16px; letter-spacing: -0.02em; line-height: 1.1; color: var(--ink); }
+  .anmid { padding: 14px 22px; border-right: 1px solid var(--rule); display: grid; grid-template-columns: 1fr 1fr; gap: 28px; }
+  .stackbar { display: flex; height: 8px; gap: 1px; background: var(--rule); }
+  .stacklegend { display: flex; justify-content: space-between; margin-top: 8px; gap: 8px; }
+  .stackseg { display: flex; flex-direction: column; gap: 1px; }
+  .barchart { display: flex; align-items: flex-end; gap: 4px; height: 56px; }
+  .barcol { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 4px; }
+  .barcolinner { flex: 1; width: 100%; display: flex; align-items: flex-end; }
+  .bar { width: 100%; background: var(--ink-2); min-height: 4px; }
+  .bar.zero { background: transparent; border-top: 1px solid var(--rule); min-height: 1px; }
+  .barlabels { display: flex; gap: 4px; margin-top: 4px; }
+  .anright { padding: 14px 18px; }
+  .taglist { display: flex; flex-direction: column; gap: 5px; }
+  .tagrow { display: grid; grid-template-columns: 70px 1fr 30px; align-items: center; gap: 10px; }
+  .tagbar { height: 4px; background: var(--surface-3); position: relative; }
+  .tagbarfill { position: absolute; left: 0; top: 0; bottom: 0; background: var(--ink-2); }
+</style>

--- a/frontend/src/routes/Search.svelte
+++ b/frontend/src/routes/Search.svelte
@@ -1,0 +1,157 @@
+<!-- Seg 5 — Screen 4: cross-project search. Hero query + facets + result
+     groups by project (with NAS-unmounted empty state). -->
+<script>
+  import ArkivLogo from '../lib/ArkivLogo.svelte'
+  import Mono from '../lib/Mono.svelte'
+  import Eyebrow from '../lib/Eyebrow.svelte'
+  import Thumb from '../lib/Thumb.svelte'
+
+  const theme = 'dark'
+  const facets = [
+    ['All projects · 4', true, false], ['Current only', false, false], ['', false, true],
+    ['Video · 124', false, false], ['Audio · 38', false, false],
+    ['Transcript only', false, false], ['Tags only', false, false], ['', false, true],
+  ]
+  const groups = [
+    {
+      project: 'Bicycle Diaries', count: 3, total: 247, health: 'ok',
+      results: [
+        { id: 1, name: 'A7S3_C001_240515.mov', dur: '00:02:47', score: 0.94, snippet: '氧氣比想像中還少，海拔 4800。', tc: '00:24', tags: ['cycling', 'tibet', 'documentary'] },
+        { id: 12, name: 'A7S3_C007_240518.mov', dur: '00:02:04', score: 0.81, snippet: '高度太高，氧氣稀薄到呼吸都吃力。', tc: '00:48', tags: ['cycling', 'tibet'] },
+        { id: 4, name: 'A7S3_C003_240516.mov', dur: '00:01:12', score: 0.72, snippet: '其實主要是氧氣的問題，不是體力。', tc: '00:36', tags: ['interview', 'tibet'] },
+      ],
+    },
+    {
+      project: 'vulture.s reels', count: 2, total: 89, health: 'ok',
+      results: [
+        { id: 3, name: 'INTERVIEW_HEVIN_01.wav', dur: '00:18:04', score: 0.66, snippet: '我那時候完全沒氧氣可以呼吸的感覺。', tc: '04:12', tags: ['interview', 'podcast'] },
+        { id: 9, name: 'A7S3_C005_240517.mov', dur: '00:00:42', score: 0.58, snippet: '氧氣罐用完了，只能慢慢撐。', tc: '00:08', tags: ['portrait', 'documentary'] },
+      ],
+    },
+    {
+      project: 'Furutech RCA spot', count: 2, total: 152, health: 'ok',
+      results: [
+        { id: 7, name: 'GH6_4825.mp4', dur: '00:00:14', score: 0.42, snippet: '聲音密度像氧氣一樣稀薄又透明。', tc: '00:04', tags: ['b-roll', 'product'] },
+      ],
+    },
+    { project: 'KOL_2026Q1', count: '?', total: 38, health: 'unmounted', results: [] },
+  ]
+
+  const Q = '氧氣'
+  const hl = (text) => {
+    const i = text.indexOf(Q)
+    return i === -1 ? { b: text, m: '', a: '' } : { b: text.slice(0, i), m: Q, a: text.slice(i + Q.length) }
+  }
+</script>
+
+<div class="artboard" data-theme={theme}>
+  <div class="topbar">
+    <ArkivLogo size={16} />
+    <Mono dim style="font-size:10px;">v0.9.2</Mono>
+    <div class="grow"></div>
+    <button class="ak-btn">Esc · CLOSE SEARCH</button>
+  </div>
+
+  <div class="main">
+    <div class="hero">
+      <Eyebrow style="margin-bottom:10px;">Search · cross-project federation</Eyebrow>
+      <div class="queryrow">
+        <Mono dim style="font-size:26px;font-weight:400;">⌕</Mono>
+        <div class="querywrap">
+          <div class="ak-display query">氧氣比想像中還少<span class="caret"></span></div>
+          <div class="queryunderline"></div>
+        </div>
+        <Mono dim style="font-size:11px;">⌘K</Mono>
+      </div>
+      <div class="facets">
+        {#each facets as [label, active, sep]}
+          {#if sep}<div class="fvrule"></div>{:else}<button class="facet" class:active>{label}</button>{/if}
+        {/each}
+        <Mono dim style="font-size:10.5px;">7 matches · 4 projects · 0.043s · semantic + lexical</Mono>
+      </div>
+    </div>
+
+    <div class="results">
+      {#each groups as g}
+        {@const offline = g.health !== 'ok'}
+        <section class="rgroup" style="opacity:{offline ? 0.55 : 1};">
+          <div class="ghead">
+            <Mono dim style="font-size:10px;letter-spacing:0.1em;">PROJECT</Mono>
+            <div class="ak-display gproj">{g.project}</div>
+            <Mono dim style="font-size:10.5px;">{g.count} of {g.total}</Mono>
+            <div class="grow"></div>
+            {#if offline}
+              <div class="offline">◇ NAS unmounted · cannot search</div>
+            {:else}
+              <Mono dim style="font-size:9.5px;letter-spacing:0.08em;">● ONLINE · 4.8 TB</Mono>
+            {/if}
+          </div>
+
+          {#if g.results.length === 0}
+            <div class="emptyresult">Mount NAS to search this project · ~/.arkiv-projects.json</div>
+          {/if}
+
+          <div class="rows">
+            {#each g.results as r, i (r.id)}
+              {@const p = hl(r.snippet)}
+              <div class="rrow" class:first={i === 0}>
+                <div class="rthumb">
+                  <Thumb seed={r.id} kind="video" {theme} />
+                  <Mono style="position:absolute;bottom:2px;right:3px;font-size:9px;color:#f3f2ee;background:rgba(10,10,12,.78);padding:1px 3px;">{r.dur}</Mono>
+                </div>
+                <div class="rcontent">
+                  <div class="rtop">
+                    <Mono style="font-size:11.5px;font-weight:500;color:var(--ink);">{r.name}</Mono>
+                    <Mono dim style="font-size:9.5px;">{r.tc}</Mono>
+                    <div class="rtags">{#each r.tags as t}<span class="rtag">{t}</span>{/each}</div>
+                  </div>
+                  <div class="snippet">{p.b}<span class="mark">{p.m}</span>{p.a}</div>
+                </div>
+                <div class="rscore">
+                  <Mono style="font-size:13px;font-weight:600;color:var(--ink);">{r.score.toFixed(2)}</Mono>
+                  <Mono dim style="font-size:9px;display:block;margin-top:1px;letter-spacing:0.08em;">SCORE</Mono>
+                </div>
+                <div class="raction"><button class="ak-btn openbtn">Open →</button></div>
+              </div>
+            {/each}
+          </div>
+        </section>
+      {/each}
+    </div>
+  </div>
+</div>
+
+<style>
+  .artboard { width: 1400px; height: 900px; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 1fr; overflow: hidden; margin: 0 auto; }
+  .grow { flex: 1; }
+  .topbar { display: flex; align-items: center; border-bottom: 1px solid var(--rule); padding: 0 16px; gap: 16px; }
+  .main { display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
+  .hero { padding: 24px 64px 18px; border-bottom: 1px solid var(--rule); }
+  .queryrow { display: flex; align-items: baseline; gap: 16px; margin-bottom: 12px; }
+  .querywrap { flex: 1; position: relative; }
+  .query { font-size: 34px; letter-spacing: -0.03em; line-height: 1.05; color: var(--ink); }
+  .caret { display: inline-block; width: 2px; height: 28px; background: var(--ink); margin-left: 5px; vertical-align: middle; }
+  .queryunderline { height: 1px; background: var(--ink); margin-top: 10px; }
+  .facets { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+  .facet { font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; padding: 5px 10px; background: transparent; color: var(--ink-2); border: 1px solid var(--rule); cursor: pointer; line-height: 1; }
+  .facet.active { background: var(--invert); color: var(--invert-ink); border-color: var(--invert); }
+  .fvrule { width: 1px; height: 14px; background: var(--rule); margin: 0 4px; }
+  .results { flex: 1; overflow: hidden; padding: 14px 64px 18px; }
+  .rgroup { margin-bottom: 16px; }
+  .ghead { display: flex; align-items: baseline; gap: 12px; margin-bottom: 8px; padding-bottom: 6px; border-bottom: 1px solid var(--rule); }
+  .gproj { font-size: 18px; letter-spacing: -0.03em; line-height: 1; color: var(--ink); }
+  .offline { font-family: var(--ak-mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; padding: 3px 7px; border: 1px dashed var(--rule-hi); color: var(--ink-2); }
+  .emptyresult { padding: 12px 16px; font-family: var(--ak-mono); font-size: 10.5px; color: var(--quiet); text-align: center; letter-spacing: 0.05em; }
+  .rrow { display: grid; grid-template-columns: 100px 1fr 60px 78px; gap: 14px; align-items: center; padding: 5px 0; border-top: 1px solid var(--rule); cursor: pointer; }
+  .rrow.first { border-top: none; }
+  .rthumb { position: relative; aspect-ratio: 16 / 9; background: var(--surface-2); overflow: hidden; }
+  .rcontent { min-width: 0; }
+  .rtop { display: flex; align-items: baseline; gap: 8px; }
+  .rtags { display: flex; gap: 4px; }
+  .rtag { font-family: var(--ak-mono); font-size: 9px; padding: 1px 4px; border: 1px solid var(--rule); color: var(--quiet); line-height: 1.2; }
+  .snippet { margin-top: 3px; font-size: 12.5px; color: var(--ink-2); line-height: 1.35; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .mark { background: var(--invert); color: var(--invert-ink); padding: 0 2px; }
+  .rscore { text-align: right; }
+  .raction { display: flex; justify-content: flex-end; }
+  .openbtn { padding: 5px 9px; }
+</style>

--- a/frontend/src/routes/Settings.svelte
+++ b/frontend/src/routes/Settings.svelte
@@ -1,0 +1,168 @@
+<!-- Seg 7 — Screen 6: Settings modal over dimmed backdrop. 1px frame chrome
+     (no drop shadow). Left nav + form sections. Form helpers inline. -->
+<script>
+  import Mono from '../lib/Mono.svelte'
+  import Eyebrow from '../lib/Eyebrow.svelte'
+
+  const theme = 'dark'
+  const nav = [
+    ['general', 'General', true], ['ingest', 'Ingest', false], ['transcription', 'Transcription', false],
+    ['vision', 'Vision tagging', false], ['export', 'Export defaults', false], ['storage', 'Storage · proxy', false],
+    ['projects', 'Project registry', false], ['advanced', 'Advanced', false], ['about', 'About', false],
+  ]
+  const themeOpts = [['dark', 'Dark', true], ['light', 'Light', false], ['system', 'System', false]]
+  const densityOpts = [['comfort', 'Comfortable', false], ['default', 'Default', true], ['dense', 'Dense', false]]
+  const langs = [['zh-Hant', true], ['en', true], ['ja', true], ['ko', false], ['auto', true]]
+  const edlFps = [['24', '24', true], ['25', '25', false], ['30', '30', false], ['60', '60', false]]
+  const proxyRes = [['540', '540p', false], ['1080', '1080p', true], ['off', 'Off', false]]
+  const ticks = [0, 1, 2, 3, 4]
+  const backdrop = Array(12)
+</script>
+
+<div class="artboard" data-theme={theme}>
+  <!-- backdrop -->
+  <div class="backdrop">
+    <div class="bdtop"></div>
+    <div class="bdbody">
+      <div class="bdside"></div>
+      <div class="bdgrid">{#each backdrop as _}<div class="bdcell"></div>{/each}</div>
+      <div class="bdside right"></div>
+    </div>
+  </div>
+  <div class="scrim"></div>
+
+  <!-- modal -->
+  <div class="modal">
+    <div class="mhead">
+      <div class="mtitle">
+        <Eyebrow style="color:var(--ink-2);">Settings</Eyebrow>
+        <div class="ak-display mtitlebig">Preferences</div>
+      </div>
+      <button class="mclose">ESC · CLOSE</button>
+    </div>
+
+    <div class="mbody">
+      <nav class="mnav">
+        {#each nav as [id, label, active]}
+          <button class="navbtn" class:active>{label}</button>
+        {/each}
+      </nav>
+
+      <div class="form">
+        <!-- Appearance -->
+        <section>
+          <div class="fshead">
+            <Eyebrow style="margin-bottom:4px;">THEME · INTERFACE</Eyebrow>
+            <div class="ak-display fstitle">Appearance</div>
+            <div class="fsdesc">vulture.s editorial · dark default. UI scale adjusts root font-size only.</div>
+          </div>
+          <div class="frows">
+            <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Theme</Mono>
+              <div class="seg">{#each themeOpts as [id, label, on], i}{#if i > 0}<div class="segsep"></div>{/if}<button class="segbtn" class:on>{label}</button>{/each}</div>
+            </div>
+            <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">UI scale</Mono>
+              <div class="scale">
+                <button class="ak-btn scalebtn">−</button>
+                <div class="scaletrack"><div class="scaleticks">{#each ticks as _}<div class="tick"></div>{/each}</div><div class="scaleknob"></div></div>
+                <button class="ak-btn scalebtn">+</button>
+                <Mono style="font-size:12px;font-weight:600;color:var(--ink);min-width:48px;">100%</Mono>
+              </div>
+            </div>
+            <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Type density</Mono>
+              <div class="seg">{#each densityOpts as [id, label, on], i}{#if i > 0}<div class="segsep"></div>{/if}<button class="segbtn" class:on>{label}</button>{/each}</div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Transcription -->
+        <section>
+          <div class="fshead"><Eyebrow style="margin-bottom:4px;">WHISPER · LOCAL</Eyebrow><div class="ak-display fstitle">Transcription model</div></div>
+          <div class="frows">
+            <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Model</Mono>
+              <div class="dropdown"><Mono style="font-size:11.5px;color:var(--ink);">whisper-large-v3</Mono><Mono dim style="font-size:10px;">▾</Mono></div>
+            </div>
+            <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Languages</Mono>
+              <div class="langs">{#each langs as [l, on]}<span class="lang" class:on>{l}</span>{/each}</div>
+            </div>
+            <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">GPU</Mono>
+              <div class="dropdown"><Mono style="font-size:11.5px;color:var(--ink);">CUDA · NVIDIA RTX 4070 · 12 GB</Mono><Mono dim style="font-size:10px;">▾</Mono></div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Vision -->
+        <section>
+          <div class="fshead"><Eyebrow style="margin-bottom:4px;">OLLAMA · LOCAL</Eyebrow><div class="ak-display fstitle">Vision tagging</div></div>
+          <div class="frows">
+            <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Model</Mono>
+              <div class="dropdown"><Mono style="font-size:11.5px;color:var(--ink);">llava:13b-v1.6-q4_K_M</Mono><Mono dim style="font-size:10px;">▾</Mono></div>
+            </div>
+            <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Tag pool</Mono>
+              <Mono style="font-size:12.5px;color:var(--ink-2);">auto · max 8 tags per file · min confidence 0.62</Mono>
+            </div>
+          </div>
+        </section>
+
+        <!-- Export -->
+        <section>
+          <div class="fshead"><Eyebrow style="margin-bottom:4px;">DAVINCI RESOLVE · EXPORT</Eyebrow><div class="ak-display fstitle">Editor handoff</div></div>
+          <div class="frows">
+            <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">EDL frame rate</Mono>
+              <div class="seg">{#each edlFps as [id, label, on], i}{#if i > 0}<div class="segsep"></div>{/if}<button class="segbtn" class:on>{label}</button>{/each}</div>
+            </div>
+            <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Proxy resolution</Mono>
+              <div class="seg">{#each proxyRes as [id, label, on], i}{#if i > 0}<div class="segsep"></div>{/if}<button class="segbtn" class:on>{label}</button>{/each}</div>
+            </div>
+            <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Drop frame</Mono>
+              <div class="toggle"><div class="toggleknob"></div></div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .artboard { width: 1400px; height: 900px; background: var(--bg); color: var(--ink); position: relative; overflow: hidden; margin: 0 auto; }
+  .backdrop { position: absolute; inset: 0; display: grid; grid-template-rows: 52px 1fr; }
+  .bdtop { border-bottom: 1px solid var(--rule); }
+  .bdbody { display: grid; grid-template-columns: 220px 1fr 340px; }
+  .bdside { border-right: 1px solid var(--rule); }
+  .bdside.right { border-right: none; border-left: 1px solid var(--rule); }
+  .bdgrid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px; padding: 22px; background: var(--rule); }
+  .bdcell { aspect-ratio: 16 / 9; background: var(--surface-2); }
+  .scrim { position: absolute; inset: 0; background: rgba(10, 10, 12, 0.82); }
+
+  .modal { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); width: 960px; height: 700px; background: var(--bg); box-shadow: inset 0 0 0 1px var(--invert); display: grid; grid-template-rows: 56px 1fr; }
+  .mhead { display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--invert); padding: 0 24px; }
+  .mtitle { display: flex; align-items: baseline; gap: 16px; }
+  .mtitlebig { font-size: 22px; letter-spacing: -0.03em; line-height: 1; color: var(--ink); }
+  .mclose { font-family: var(--ak-mono); font-size: 11px; letter-spacing: 0.08em; background: transparent; border: none; color: var(--ink-2); cursor: pointer; padding: 0; }
+  .mbody { display: grid; grid-template-columns: 200px 1fr; min-height: 0; overflow: hidden; }
+  .mnav { border-right: 1px solid var(--rule); padding: 20px 0; display: flex; flex-direction: column; }
+  .navbtn { text-align: left; padding: 7px 24px; background: transparent; border: none; border-left: 2px solid transparent; color: var(--ink-2); font-size: 13px; font-weight: 400; cursor: pointer; font-family: inherit; }
+  .navbtn.active { border-left-color: var(--invert); color: var(--ink); font-weight: 600; }
+  .form { overflow: hidden; padding: 24px 32px; display: flex; flex-direction: column; gap: 22px; }
+  .fshead { margin-bottom: 12px; }
+  .fstitle { font-size: 18px; letter-spacing: -0.02em; line-height: 1.1; color: var(--ink); }
+  .fsdesc { font-size: 11.5px; color: var(--quiet); margin-top: 3px; }
+  .frows { display: flex; flex-direction: column; gap: 10px; }
+  .frow { display: grid; grid-template-columns: 140px 1fr; align-items: center; gap: 16px; }
+  .seg { display: flex; border: 1px solid var(--rule); width: fit-content; }
+  .segsep { width: 1px; background: var(--rule); }
+  .segbtn { font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.06em; text-transform: uppercase; padding: 5px 12px; background: transparent; color: var(--ink-2); border: none; cursor: pointer; line-height: 1; font-weight: 400; }
+  .segbtn.on { background: var(--invert); color: var(--invert-ink); font-weight: 700; }
+  .scale { display: flex; align-items: center; gap: 14px; }
+  .scalebtn { width: 28px; padding: 5px 0; text-align: center; }
+  .scaletrack { flex: 1; max-width: 240px; height: 1px; background: var(--rule); position: relative; }
+  .scaleticks { position: absolute; left: 0; right: 0; top: -2px; height: 5px; display: flex; justify-content: space-between; }
+  .tick { width: 1px; height: 5px; background: var(--rule); }
+  .scaleknob { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); width: 10px; height: 10px; background: var(--ink); }
+  .dropdown { display: flex; justify-content: space-between; align-items: center; border: 1px solid var(--rule); padding: 6px 10px; width: 100%; max-width: 360px; cursor: pointer; }
+  .langs { display: flex; gap: 4px; }
+  .lang { font-family: var(--ak-mono); font-size: 10.5px; padding: 4px 8px; line-height: 1; background: transparent; color: var(--ink-2); border: 1px solid var(--rule); cursor: pointer; }
+  .lang.on { background: var(--invert); color: var(--invert-ink); border-color: var(--invert); }
+  .toggle { width: 36px; height: 18px; border: 1px solid var(--rule-hi); position: relative; cursor: pointer; background: transparent; }
+  .toggleknob { position: absolute; top: 1px; left: 1px; bottom: 1px; width: 14px; background: var(--ink-2); }
+</style>

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
+
+export default {
+  preprocess: vitePreprocess(),
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
+
+// arkiv frontend — Svelte 4 + Vite 5. Backend (FastAPI) runs on :8501;
+// dev proxy forwards /api + /thumbnails so the SPA can call it during `npm run dev`.
+export default defineConfig({
+  plugins: [svelte()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': 'http://localhost:8501',
+      '/thumbnails': 'http://localhost:8501',
+    },
+  },
+})


### PR DESCRIPTION
Rebuilds the arkiv UI from the legacy single-file `index.html` (~1819 lines + Tailwind CDN) into a component-based **Svelte 4 + Vite** frontend under `frontend/`, per the locked design baseline (`design-2026-05-27/`). Built **screen-by-screen with a mechanical audit gate between each segment** (build → 0 console errors → forbidden-CSS scan → screenshot), so mistakes don't compound.

## What's in scope (this PR)
Visual implementation only — **mock data**, browser-validated. **22 artboards** (everything except gated insta360).

| seg | screen | route |
|---|---|---|
| 0 | scaffold: pinned svelte@4.2 / vite-plugin-svelte@3 / vite@5 / svelte-spa-router@4, `tokens.css` drop-in, 4 self-hosted fonts (@fontsource), `.ak-root`/`data-theme` shell | `#/` |
| 1 | shared primitives (ArkivLogo/Rating/Frame/Eyebrow/Mono/Thumb) + mockData | `#/gallery` |
| 2 | main-dark hero (only stateful screen) + shared chrome → `src/lib/` | `#/main` |
| 3 | main-states ×6 (list/drop/skeleton/empty/shortcuts/analytics) | `#/states` |
| 4 | inspector full | `#/inspector` |
| 5 | cross-project search | `#/search` |
| 6 | ingest progress | `#/ingest` |
| 7 | settings modal | `#/settings` |
| 8 | flows ×4 (ingest-setup/query-builder/registry/conflict-merge) | `#/flows` |
| 9 | edge ×4 (ws-error/update-banner/**splash⚠**/onboarding) | `#/edge` |

## Audit evidence (per segment)
Every segment: `npm run build` exit 0 · **0 console errors** (headless Chrome) · forbidden-CSS clean (`backdrop-filter`/`color-mix(`/`oklch(` absent, `mix-blend-mode` allowlisted, cyan stays `#18b6dc`, no icon lib) · 0 build warnings. Full-page screenshots saved under `frontend/.audit/seg*/` — open `frontend/.audit/contact-sheet.html` for all 10 side-by-side.

Reusable harness: `frontend/scripts/audit/{forbidden-css,shoot}.mjs`.

## ⚠ Review checklist (human, before merge)
- [ ] **§13.6 four tests** — compare contact sheet vs canonical `design-2026-05-27/index.html` (re-read vulture.s portfolio + `positioning.md` first): wrapper×content tension / 塩田千春 distance / parent-motif +1 / grayscale-mockup delusion.
- [ ] **C3 splash** (in `#/edge`) — §11.1 Nordic-depth brand mark; most brand-sensitive surface, needs eyes.
- [ ] `cd frontend && npm run dev`, click through every route.

## Explicitly NOT in this PR (supervised phase)
- No real API wiring (mock data only) — backend exposes 43 endpoints to wire later.
- No Tauri/Rust build, no WebView2 (Windows) validation — mini has no Rust; WKWebView/WebView2 dual-render check is a follow-up (PC).
- insta360 screen — gated on the 8.3a 360 POC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)