### PR TITLE
feat: Smart Collections engine + live API wiring (search/inspector/rating/sidebar/ingest)

### DIFF
--- a/frontend/scripts/audit/verify-ingest-ui.mjs
+++ b/frontend/scripts/audit/verify-ingest-ui.mjs
@@ -1,0 +1,36 @@
+// B1+ verify: #/ingest-live UI actually renders the live ws stream.
+// Loads the route, fills path, clicks Start, asserts the connection indicator
+// goes LIVE and the log/complete updates from real backend broadcasts.
+// Uses an already-indexed dir → fast skip path (start+complete, no vision wait).
+// Usage: node verify-ingest-ui.mjs <devUrl> <ingestDir>
+import puppeteer from 'puppeteer-core'
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+const dev = process.argv[2] || 'http://localhost:5173/'
+const dir = process.argv[3]
+
+const b = await puppeteer.launch({ executablePath: CHROME, headless: true, args: ['--no-sandbox'] })
+const p = await b.newPage()
+const errs = []
+p.on('console', (m) => { if (m.type() === 'error' && !/Failed to load resource/.test(m.text())) errs.push(m.text()) })
+p.on('pageerror', (e) => errs.push(String(e)))
+
+await p.goto(dev + '#/ingest-live', { waitUntil: 'networkidle0', timeout: 30000 })
+await new Promise((r) => setTimeout(r, 800))
+
+const connBefore = await p.evaluate(() => document.querySelector('.topbar .on, .topbar .off')?.textContent?.trim())
+
+await p.type('.pathinput', dir)
+await p.click('.ak-btn--primary')
+// wait for complete (skip path is fast) or up to 30s
+await new Promise((r) => setTimeout(r, 6000))
+
+const after = await p.evaluate(() => ({
+  conn: document.querySelector('.topbar span')?.textContent?.trim(),
+  liveDot: document.querySelector('.livedot')?.textContent?.trim(),
+  logLines: [...document.querySelectorAll('.logline .logmsg')].map((n) => n.textContent.trim()).slice(0, 6),
+  qrows: document.querySelectorAll('.qrow').length,
+  bignum: document.querySelector('.bignum')?.textContent?.trim(),
+}))
+await p.screenshot({ path: '.audit/b1/ingest-live.png' })
+console.log(JSON.stringify({ errs, connBefore, after }, null, 2))
+await b.close()

--- a/frontend/scripts/audit/verify-ingest-ws.mjs
+++ b/frontend/scripts/audit/verify-ingest-ws.mjs
@@ -1,0 +1,45 @@
+// B1+ verify: ws/ingest stream end-to-end. Connects the ws, triggers an ingest
+// (already-ingested clips → skip path, fast), asserts real broadcast messages.
+// Usage: node verify-ingest-ws.mjs <backendBase> <ingestDir>
+import WebSocket from 'ws'
+
+const base = process.argv[2] || 'http://127.0.0.1:8501'
+const dir = process.argv[3]
+const wsBase = base.replace(/^http/, 'ws')
+
+const got = { start: 0, file: 0, complete: null, statuses: new Set() }
+const ws = new WebSocket(`${wsBase}/ws/ingest`)
+
+const done = new Promise((resolve) => {
+  ws.on('open', async () => {
+    // trigger ingest after ws is listening
+    const res = await fetch(`${base}/api/ingest/ws`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: dir, limit: 5 }),
+    })
+    if (!res.ok) {
+      console.log(JSON.stringify({ error: `trigger ${res.status} ${await res.text()}` }))
+      ws.close()
+      resolve()
+    }
+  })
+  ws.on('message', (data) => {
+    let m
+    try { m = JSON.parse(data.toString()) } catch { return }
+    if (m.type === 'start') got.start++
+    else if (m.type === 'file') { got.file++; got.statuses.add(m.status) }
+    else if (m.type === 'complete') { got.complete = m; ws.close(); resolve() }
+  })
+  ws.on('error', (e) => { console.log(JSON.stringify({ wsError: String(e) })); resolve() })
+  // safety timeout
+  setTimeout(() => { ws.close(); resolve() }, 60000)
+})
+
+await done
+console.log(JSON.stringify({
+  startMsgs: got.start,
+  fileMsgs: got.file,
+  statuses: [...got.statuses],
+  complete: got.complete,
+}, null, 2))

--- a/frontend/scripts/audit/verify-rating.mjs
+++ b/frontend/scripts/audit/verify-rating.mjs
@@ -1,0 +1,53 @@
+// C verify: rate button on #/main-live writes through to the backend DB.
+// Clicks "Good" on the selected clip, asserts the button activates AND
+// GET /api/media/{id} reflects rating='good'. Then clears it back.
+// Usage: node verify-rating.mjs <devUrl> <backendBase>
+import puppeteer from 'puppeteer-core'
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+const dev = process.argv[2] || 'http://localhost:5173/'
+const api = process.argv[3] || 'http://127.0.0.1:8501'
+
+const b = await puppeteer.launch({ executablePath: CHROME, headless: true, args: ['--no-sandbox'] })
+const p = await b.newPage()
+const errs = []
+p.on('console', (m) => { if (m.type() === 'error' && !/Failed to load resource/.test(m.text())) errs.push(m.text()) })
+p.on('pageerror', (e) => errs.push(String(e)))
+
+await p.goto(dev + '#/main-live', { waitUntil: 'networkidle0', timeout: 30000 })
+await new Promise((r) => setTimeout(r, 1500)) // detail fetch
+
+// which clip is selected? read inspector filename
+const fname = await p.evaluate(() => document.querySelector('.fname')?.textContent?.trim())
+
+// find the "Good" rate button (first .ratebtn) and click it
+const before = await p.evaluate(() => {
+  const btns = [...document.querySelectorAll('.ratebtn')]
+  return { count: btns.length, activeText: btns.find((b) => b.classList.contains('active'))?.textContent?.trim() || null }
+})
+await p.evaluate(() => [...document.querySelectorAll('.ratebtn')].find((b) => b.textContent.trim() === 'Good')?.click())
+await new Promise((r) => setTimeout(r, 800)) // let PATCH resolve
+
+const afterUi = await p.evaluate(() => {
+  const active = [...document.querySelectorAll('.ratebtn')].find((b) => b.classList.contains('active'))
+  return active?.textContent?.trim() || null
+})
+
+// read DB truth via API — find the media id by filename
+const list = await (await fetch(`${api}/api/media?limit=60`)).json()
+const item = (list.items || []).find((i) => i.filename === fname || i.name === fname)
+const dbRating = item ? item.rating : '(not found)'
+
+// cleanup: clear rating back to null on that id
+let cleared = null
+if (item) {
+  const res = await fetch(`${api}/api/media/${item.id}/rating`, {
+    method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ rating: null }),
+  })
+  cleared = res.ok
+}
+
+console.log(JSON.stringify({
+  errs, selectedClip: fname, beforeActive: before.activeText,
+  afterUiActive: afterUi, dbRatingAfterClick: dbRating, cleanedUp: cleared,
+}, null, 2))
+await b.close()

--- a/frontend/scripts/audit/verify-sidebar.mjs
+++ b/frontend/scripts/audit/verify-sidebar.mjs
@@ -1,0 +1,34 @@
+// D verify: PoolSidebar on #/main-live shows live data + tag-click filters grid.
+// Asserts: tags are the real qwen3-vl vocab (not mock cycling/portrait), pools
+// reflect real stats, clicking a tag narrows the grid via search.
+// Usage: node verify-sidebar.mjs <devUrl>
+import puppeteer from 'puppeteer-core'
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+const dev = process.argv[2] || 'http://localhost:5173/'
+
+const b = await puppeteer.launch({ executablePath: CHROME, headless: true, args: ['--no-sandbox'] })
+const p = await b.newPage()
+const errs = []
+p.on('console', (m) => { if (m.type() === 'error' && !/Failed to load resource/.test(m.text())) errs.push(m.text()) })
+p.on('pageerror', (e) => errs.push(String(e)))
+
+await p.goto(dev + '#/main-live', { waitUntil: 'networkidle0', timeout: 30000 })
+await new Promise((r) => setTimeout(r, 1500))
+
+const sidebar = await p.evaluate(() => ({
+  projectsHeader: document.querySelector('.pool section .ak-eyebrow, .pool section [class*=eyebrow]')?.textContent?.trim(),
+  tags: [...document.querySelectorAll('.tag')].map((t) => t.textContent.trim()).slice(0, 8),
+  pools: [...document.querySelectorAll('.poolrow')].map((r) => r.textContent.replace(/\s+/g, ' ').trim()),
+  cardsBefore: document.querySelectorAll('.card').length,
+}))
+
+// click the first tag → grid should filter (search round-trips, allow settle)
+await p.evaluate(() => document.querySelector('.tag')?.click())
+await new Promise((r) => setTimeout(r, 2500))
+const after = await p.evaluate(() => ({
+  searchBox: document.querySelector('.livesearch')?.value,
+  cardsAfter: document.querySelectorAll('.card').length,
+}))
+
+console.log(JSON.stringify({ errs, sidebar, after }, null, 2))
+await b.close()

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -12,12 +12,14 @@
   import Edge from './routes/Edge.svelte'
   import Live from './routes/Live.svelte'
   import MainLive from './routes/MainLive.svelte'
+  import IngestLive from './routes/IngestLive.svelte'
 
   // Routes are added per overnight segment.
   const routes = {
     '/': Home,
     '/live': Live, // B1 — live API proof (reads running backend)
     '/main-live': MainLive, // B1 — main grid wired to live data
+    '/ingest-live': IngestLive, // B1+ — ingest progress wired to live ws
     '/gallery': Gallery, // seg 1 — shared-primitive gallery
     '/main': MainDark, // seg 2 — hero (interactive)
     '/states': MainStates, // seg 3 — state variants

--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -11,6 +11,7 @@
   export let pathLabel = null // file path string; null → mock /vol/... path
   export let transcriptLines = null // [[tc,text,hl],...]; null → mock lines
   export let frameDescriptions = null // string[]; when set, render a Vision block
+  export let onRate = null // (uiRating) => void; when set, rate buttons are live
   let imgFailed = false
 
   const MOCK_TRANSCRIPT = [
@@ -110,7 +111,12 @@
     <Eyebrow>Rate</Eyebrow>
     <div class="ratebtns">
       {#each rateBtns as [r, label]}
-        <button class="ratebtn" class:active={media.rating === r} class:rev={r === 'rev'}>{label}</button>
+        <button
+          class="ratebtn"
+          class:active={media.rating === r}
+          class:rev={r === 'rev'}
+          on:click={() => onRate && onRate(r)}
+        >{label}</button>
       {/each}
     </div>
     <div class="exports">

--- a/frontend/src/lib/PoolSidebar.svelte
+++ b/frontend/src/lib/PoolSidebar.svelte
@@ -3,20 +3,29 @@
   import Eyebrow from './Eyebrow.svelte'
   import Mono from './Mono.svelte'
   import { PROJECTS, TAGS } from './mockData.js'
-  const pools = [
+  // Live overrides — all default to mock so mock screens stay byte-identical.
+  export let liveProjects = null // [{id,name,count,active,health?}]
+  export let livePools = null // [[label, count], ...]
+  export let liveTags = null // [{name, count}]
+  export let onTag = null // (name) => void; live tag-click → filter
+
+  const MOCK_POOLS = [
     ['All media', 247],
     ['Needs review', 34],
     ['Orphans', 2],
     ['Recently ingested', 18],
     ['No transcript', 12],
   ]
+  $: projects = liveProjects ?? PROJECTS
+  $: pools = livePools ?? MOCK_POOLS
+  $: tags = liveTags ?? TAGS
 </script>
 
 <aside class="pool">
   <section>
-    <Eyebrow style="margin-bottom:10px;">Projects · 4</Eyebrow>
+    <Eyebrow style="margin-bottom:10px;">Projects · {projects.length}</Eyebrow>
     <div class="col">
-      {#each PROJECTS as p (p.id)}
+      {#each projects as p (p.id)}
         <div class="proj" class:active={p.active} style="opacity:{p.health ? 0.6 : 1};">
           <div class="projrow">
             <span class="projname" class:activename={p.active}>{p.name}</span>
@@ -45,8 +54,9 @@
   <section class="tagsec">
     <Eyebrow style="margin-bottom:10px;">Tags · auto</Eyebrow>
     <div class="tags">
-      {#each TAGS as t (t.name)}
-        <span class="tag">{t.name} <span class="tagcount">{t.count}</span></span>
+      {#each tags as t (t.name)}
+        <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+        <span class="tag" class:clickable={onTag} on:click={() => onTag && onTag(t.name)}>{t.name} <span class="tagcount">{t.count}</span></span>
       {/each}
     </div>
   </section>
@@ -92,6 +102,7 @@
     border: 1px solid var(--rule); color: var(--ink-2); cursor: pointer; white-space: nowrap;
   }
   .tagcount { color: var(--quiet); }
+  .tag.clickable:hover { border-color: var(--ink); color: var(--ink); }
   .spacer { flex: 1; }
   .storage { border-top: 1px solid var(--rule); padding-top: 12px; }
   .strow { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 6px; }

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -82,7 +82,9 @@ export const thumbUrlFromPath = (thumbnailPath) =>
 export const streamUrl = (id) => `${BASE}/api/stream/${id}`
 
 // ---- writes ----
-export const setRating = (id, rating, opts) =>
-  req(`/api/media/${id}/rating`, { method: 'PATCH', body: { rating }, ...opts })
+// note: backend PATCH writes BOTH rating + rating_note, so an omitted note
+// clears any existing note. Always pass the current note through to preserve it.
+export const setRating = (id, rating, note = null, opts) =>
+  req(`/api/media/${id}/rating`, { method: 'PATCH', body: { rating, note }, ...opts })
 
 export { ApiError }

--- a/frontend/src/routes/IngestLive.svelte
+++ b/frontend/src/routes/IngestLive.svelte
@@ -1,0 +1,201 @@
+<!-- B1+ — ingest progress wired to the live backend.
+     Connects ws://…/ws/ingest, triggers POST /api/ingest/ws, renders the real
+     broadcast stream. The ws protocol only provides per-file status
+     (transcribing/done/skipped) + start/complete — NOT the per-stage
+     probe/transcribe/tag columns or GPU metrics the mock screen mocks. So this
+     is an honest subset: real queue + real progress, no faked sub-stages. -->
+<script>
+  import { onMount, onDestroy } from 'svelte'
+  import ArkivLogo from '../lib/ArkivLogo.svelte'
+  import Mono from '../lib/Mono.svelte'
+  import Eyebrow from '../lib/Eyebrow.svelte'
+
+  const theme = 'dark'
+  const BASE = import.meta.env?.VITE_API_URL ?? ''
+
+  let ws = null
+  let conn = 'connecting' // connecting | open | closed
+  let path = ''
+  let limit = 3
+  let total = 0
+  let files = {} // index → {filename, status}
+  let complete = null // {ok, skipped, failed}
+  let log = [] // [{t, text}]
+  let busy = false
+  let err = ''
+
+  const wsUrl = () => {
+    if (BASE) return BASE.replace(/^http/, 'ws') + '/ws/ingest'
+    const proto = location.protocol === 'https:' ? 'wss' : 'ws'
+    return `${proto}://${location.host}/ws/ingest`
+  }
+
+  function pushLog(text) {
+    const t = new Date().toLocaleTimeString()
+    log = [{ t, text }, ...log].slice(0, 40)
+  }
+
+  function connect() {
+    try {
+      ws = new WebSocket(wsUrl())
+    } catch (e) {
+      conn = 'closed'
+      err = String(e)
+      return
+    }
+    ws.onopen = () => { conn = 'open' }
+    ws.onclose = () => { conn = 'closed' }
+    ws.onerror = () => { conn = 'closed' }
+    ws.onmessage = (ev) => {
+      let msg
+      try { msg = JSON.parse(ev.data) } catch { return }
+      if (msg.type === 'start') {
+        total = msg.total || 0
+        files = {}
+        complete = null
+        pushLog(`start · ${total} files`)
+      } else if (msg.type === 'file') {
+        files[msg.index] = { filename: msg.filename, status: msg.status }
+        files = files // trigger reactivity
+        pushLog(`[${msg.index}/${msg.total}] ${msg.filename} · ${msg.status}`)
+      } else if (msg.type === 'complete') {
+        complete = { ok: msg.ok, skipped: msg.skipped, failed: msg.failed }
+        busy = false
+        pushLog(`complete · ok=${msg.ok} skipped=${msg.skipped} failed=${msg.failed}`)
+      }
+    }
+  }
+
+  async function trigger() {
+    if (!path.trim()) { err = '請填要 ingest 的資料夾路徑'; return }
+    err = ''
+    busy = true
+    files = {}
+    complete = null
+    try {
+      const res = await fetch(`${BASE}/api/ingest/ws`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: path.trim(), limit: Number(limit) || 0 }),
+      })
+      if (!res.ok) {
+        const b = await res.text()
+        throw new Error(`${res.status} ${b}`)
+      }
+      pushLog(`triggered ingest: ${path} (limit ${limit})`)
+    } catch (e) {
+      err = e.message
+      busy = false
+    }
+  }
+
+  onMount(connect)
+  onDestroy(() => ws && ws.close())
+
+  $: rows = Object.entries(files)
+    .map(([i, f]) => ({ index: Number(i), ...f }))
+    .sort((a, b) => a.index - b.index)
+  $: doneCount = rows.filter((r) => r.status === 'done').length
+  $: pct = total ? Math.round((doneCount / total) * 100) : 0
+  const statusText = { transcribing: 'RUN', done: 'OK', skipped: 'SKIP' }
+</script>
+
+<div class="artboard" data-theme={theme}>
+  <div class="topbar">
+    <ArkivLogo size={16} />
+    <Mono dim style="font-size:10px;">v0.9.2</Mono>
+    <div class="grow"></div>
+    <Mono dim style="font-size:11px;">ws://…/ws/ingest · <span class:on={conn === 'open'} class:off={conn !== 'open'}>{conn.toUpperCase()}</span></Mono>
+  </div>
+
+  <div class="split">
+    <div class="left">
+      <div class="hero">
+        <div class="herohead">
+          <Eyebrow>Ingest · live websocket</Eyebrow>
+          <Mono dim style="font-size:10.5px;">real /ws/ingest stream</Mono>
+        </div>
+        <div class="bignum-row">
+          <div class="ak-display bignum">{doneCount}<span class="quiet">/{total || '—'}</span></div>
+          <div class="trigger">
+            <input class="ak-input pathinput" placeholder="ingest 資料夾路徑（例 ~/Desktop/Test）" bind:value={path} disabled={busy} />
+            <div class="triggerrow">
+              <input class="ak-input limitinput" type="number" min="0" bind:value={limit} disabled={busy} title="limit (0=all)" />
+              <button class="ak-btn ak-btn--primary" on:click={trigger} disabled={busy || conn !== 'open'}>{busy ? 'running…' : 'Start ingest →'}</button>
+            </div>
+          </div>
+        </div>
+        {#if err}<Mono style="font-size:11px;color:var(--cyan);">{err}</Mono>{/if}
+        <div class="aggbar"><div class="aggfill" style="width:{pct}%;"></div></div>
+      </div>
+
+      <div class="queue">
+        <div class="qhead">
+          <Eyebrow>Queue {#if total}· {total} files{/if}</Eyebrow>
+          {#if complete}<Mono dim style="font-size:10.5px;">done · ok={complete.ok} skip={complete.skipped} fail={complete.failed}</Mono>{/if}
+        </div>
+        {#if rows.length === 0}
+          <div class="empty"><Mono dim>等待 ingest 觸發…（填路徑按 Start）</Mono></div>
+        {:else}
+          {#each rows as r (r.index)}
+            <div class="qrow" class:done={r.status === 'done'}>
+              <Mono dim style="font-size:10px;flex:0 0 36px;">{r.index}/{total}</Mono>
+              <Mono style="font-size:11.5px;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{r.filename}</Mono>
+              <span class="stage {r.status}">{statusText[r.status] || r.status}</span>
+            </div>
+          {/each}
+        {/if}
+      </div>
+    </div>
+
+    <div class="right">
+      <div class="loghead">
+        <Eyebrow>Live log · ws</Eyebrow>
+        <span class="livedot" class:on={conn === 'open'}>● {conn === 'open' ? 'LIVE' : conn.toUpperCase()}</span>
+      </div>
+      <div class="logbody">
+        {#each log as ln}
+          <div class="logline"><span class="logt">{ln.t}</span><span class="logmsg">{ln.text}</span></div>
+        {/each}
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .artboard { width: 1400px; height: 900px; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 1fr; overflow: hidden; margin: 0 auto; }
+  .grow { flex: 1; }
+  .quiet { color: var(--quiet); }
+  .on { color: var(--cyan); }
+  .off { color: var(--quiet); }
+  .topbar { display: flex; align-items: center; border-bottom: 1px solid var(--rule); padding: 0 16px; gap: 16px; }
+  .split { display: grid; grid-template-columns: 1fr 380px; min-height: 0; overflow: hidden; }
+  .left { display: flex; flex-direction: column; min-height: 0; border-right: 1px solid var(--rule); }
+  .hero { padding: 32px 40px 24px; border-bottom: 1px solid var(--rule); }
+  .herohead { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 16px; }
+  .bignum-row { display: flex; align-items: flex-start; gap: 24px; }
+  .bignum { font-size: 72px; letter-spacing: -0.04em; line-height: 1; color: var(--ink); }
+  .trigger { flex: 1; display: flex; flex-direction: column; gap: 8px; padding-top: 8px; }
+  .pathinput { font-size: 12px; }
+  .triggerrow { display: flex; gap: 8px; align-items: center; }
+  .limitinput { width: 70px; font-size: 12px; }
+  .aggbar { height: 4px; background: var(--surface-3); position: relative; margin-top: 22px; }
+  .aggfill { position: absolute; left: 0; top: 0; bottom: 0; background: var(--cyan); transition: width 0.2s; }
+  .queue { flex: 1; padding: 14px 40px 20px; overflow: auto; }
+  .qhead { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 12px; }
+  .empty { padding: 30px 0; }
+  .qrow { display: flex; align-items: center; gap: 12px; padding: 7px 0; border-bottom: 1px solid var(--rule); }
+  .qrow.done { opacity: 0.6; }
+  .stage { font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.08em; padding: 2px 6px; border: 1px solid var(--rule); color: var(--quiet); }
+  .stage.transcribing { color: var(--cyan); border-color: var(--cyan); font-weight: 700; }
+  .stage.done { color: var(--ink); border-color: var(--ink); font-weight: 600; }
+  .stage.skipped { color: var(--quiet); border-style: dashed; }
+  .right { display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
+  .loghead { padding: 16px 20px 12px; border-bottom: 1px solid var(--rule); display: flex; justify-content: space-between; align-items: baseline; }
+  .livedot { font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.08em; color: var(--quiet); }
+  .livedot.on { color: var(--cyan); }
+  .logbody { flex: 1; overflow: auto; padding: 14px 20px; display: flex; flex-direction: column; gap: 7px; }
+  .logline { display: flex; gap: 8px; font-family: var(--ak-mono); font-size: 10.5px; line-height: 1.35; }
+  .logt { color: var(--quiet); flex: 0 0 64px; }
+  .logmsg { color: var(--ink-2); flex: 1; word-break: break-word; }
+</style>

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -49,18 +49,38 @@
     _raw: it,
   })
 
+  let liveTags = null
+
   async function load() {
     state = 'loading'
     try {
-      const [s, m] = await Promise.all([api.getStats(), api.getMedia({ limit: 60 })])
+      const [s, m, t] = await Promise.all([api.getStats(), api.getMedia({ limit: 60 }), api.getTags()])
       stats = s
       items = (m.items || []).map(toCard)
+      liveTags = (t || []).map((x) => ({ name: x.name, count: x.count }))
       if (items.length && selectedId == null) selectedId = items[0].id
       state = 'ok'
     } catch (e) {
       state = 'error'
       err = e.message + (e.body ? ' · ' + JSON.stringify(e.body) : '')
     }
+  }
+
+  // D — live sidebar derived data.
+  $: livePools = stats
+    ? [
+        ['All media', stats.total],
+        ['Needs review', stats.rating?.review ?? 0],
+        ['Rated good', stats.rating?.good ?? 0],
+        ['N·G', stats.rating?.ng ?? 0],
+        ['Unrated', stats.rating?.unrated ?? 0],
+      ]
+    : null
+  $: liveProjects = stats ? [{ id: 'msr', name: '明燒肉', count: stats.total, active: true }] : null
+  // tag click → search that tag
+  function onTagClick(name) {
+    query = name
+    runSearch()
   }
 
   async function runSearch() {
@@ -162,7 +182,7 @@
 <div class="artboard" data-theme={theme}>
   <TopBar />
   <div class="body">
-    <PoolSidebar />
+    <PoolSidebar {liveProjects} {livePools} {liveTags} onTag={onTagClick} />
 
     <main class="center">
       <div class="toolrow">

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -35,12 +35,14 @@
   }
   const fmtSize = (mb) => (mb >= 1024 ? `${(mb / 1024).toFixed(1)} GB` : `${Math.round(mb)} MB`)
 
+  // backend rating value (good/ng/review/null) → UI value (good/ng/rev/none).
+  const ratingToUi = (r) => (r === 'review' ? 'rev' : r || 'none')
   // API media item → MediaCard's expected shape.
   const toCard = (it) => ({
     id: it.id,
     name: it.filename || `#${it.id}`,
     kind: it.has_audio && (it.width === 0 || !it.width) ? 'audio' : 'video',
-    rating: it.rating || 'none', // backend null → unrated → '—'
+    rating: ratingToUi(it.rating),
     dur: fmtDur(it.duration_s),
     size: fmtSize(it.size_mb),
     thumb: api.thumbUrlFromPath(it.thumbnail_path),
@@ -137,6 +139,24 @@
     : null
   $: inspThumb = selected ? selected.thumb : null
   $: inspPath = detailLive ? detailLive.path : null
+
+  // C — rating write. UI value → backend value (db.set_rating: good/ng/review/None).
+  const RATING_MAP = { good: 'good', rev: 'review', ng: 'ng', none: null }
+  async function rate(uiRating) {
+    if (!selected) return
+    const backendVal = RATING_MAP[uiRating] ?? null
+    const id = selected.id
+    // optimistic: reflect immediately in grid + inspector (which both read item.rating)
+    const prev = selected.rating
+    items = items.map((m) => (m.id === id ? { ...m, rating: uiRating } : m))
+    try {
+      await api.setRating(id, backendVal)
+    } catch (e) {
+      // revert on failure
+      items = items.map((m) => (m.id === id ? { ...m, rating: prev } : m))
+      err = `rating 寫入失敗: ${e.message}`
+    }
+  }
 </script>
 
 <div class="artboard" data-theme={theme}>
@@ -196,6 +216,7 @@
         pathLabel={inspPath}
         transcriptLines={inspTranscript}
         frameDescriptions={inspFrames}
+        onRate={rate}
       />
     {/if}
   </div>

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -166,11 +166,14 @@
     if (!selected) return
     const backendVal = RATING_MAP[uiRating] ?? null
     const id = selected.id
+    // preserve any existing rating_note (backend PATCH overwrites both fields →
+    // omitting note would silently delete it). Codex review P2.
+    const note = detailLive && detailLive.id === id ? detailLive.rating_note ?? null : null
     // optimistic: reflect immediately in grid + inspector (which both read item.rating)
     const prev = selected.rating
     items = items.map((m) => (m.id === id ? { ...m, rating: uiRating } : m))
     try {
-      await api.setRating(id, backendVal)
+      await api.setRating(id, backendVal, note)
     } catch (e) {
       // revert on failure
       items = items.map((m) => (m.id === id ? { ...m, rating: prev } : m))

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -12,6 +12,7 @@ export default defineConfig({
       // but the backend binds 127.0.0.1, so localhost would ECONNREFUSED.
       '/api': 'http://127.0.0.1:8501',
       '/thumbnails': 'http://127.0.0.1:8501',
+      '/ws': { target: 'ws://127.0.0.1:8501', ws: true },
     },
   },
 })

--- a/smart_collections.py
+++ b/smart_collections.py
@@ -1,0 +1,217 @@
+"""arkiv Smart Collections — rule-driven curation (Tier 1).
+
+NOT ML clustering. Predefined collection definitions are scored against each
+media item's existing metadata (vision tags + per-frame content_type /
+atmosphere / energy + EXIF) using multi-signal weighted matching. A media item
+joins every collection it scores >= MIN_CONFIDENCE for (non-exclusive).
+
+Design (per case-study edit-mind §5.3, de-domained to arkiv's real schema):
+  score = tag_overlap * tag_weight
+        + content_type_match * ctype_weight
+        + atmosphere_match  * atmo_weight
+        + booster contributions (condition-gated)
+  then hard filters (min_duration etc.) gate membership.
+
+Pure Python, no new deps, no embedding for Tier 1 — tag/metadata matching only.
+Consumes the shape returned by db helpers (see media_signal()).
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+MIN_CONFIDENCE = 0.40
+
+
+@dataclass(frozen=True)
+class Booster:
+    """Condition-gated score bonus. All conditions must hold to apply `boost`."""
+
+    boost: float
+    min_duration: Optional[float] = None
+    has_audio: Optional[bool] = None
+    any_tags: Sequence[str] = field(default_factory=tuple)  # >=1 must be present
+    all_tags: Sequence[str] = field(default_factory=tuple)  # all must be present
+    no_tags: Sequence[str] = field(default_factory=tuple)  # none may be present
+    content_types: Sequence[str] = field(default_factory=tuple)  # any frame matches
+    atmospheres: Sequence[str] = field(default_factory=tuple)  # any frame matches
+
+
+@dataclass(frozen=True)
+class Collection:
+    """A predefined smart collection definition."""
+
+    key: str
+    title: str
+    category: str
+    # Tag vocabularies the collection is "about" — overlap with a media item's
+    # tags drives the base visual score. Chinese tags match arkiv's qwen3-vl output.
+    tags: Sequence[str]
+    # Optional hard filters (membership gates, applied AFTER scoring).
+    min_duration: Optional[float] = None
+    require_audio: Optional[bool] = None
+    exclude_tags: Sequence[str] = field(default_factory=tuple)  # any present → reject
+    # Condition-gated boosters.
+    boosters: Sequence[Booster] = field(default_factory=tuple)
+    # Weight of the base tag-overlap signal (rest of score comes from boosters).
+    tag_weight: float = 1.0
+
+
+def media_signal(media: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a raw media row (dict) into the flat signal the scorer uses.
+
+    Accepts either:
+      - {'tags': ['a','b'], 'frames': [{'content_type':..,'atmosphere':..}, ...]}
+      - a raw db row with 'frame_tags' JSON string (server /api/media/{id} shape)
+    Always returns: {tags:set[str], content_types:set, atmospheres:set,
+                     energies:set, duration_s:float, has_audio:bool}
+    """
+    tags: set[str] = set()
+    content_types: set[str] = set()
+    atmospheres: set[str] = set()
+    energies: set[str] = set()
+
+    raw_tags = media.get("tags")
+    if isinstance(raw_tags, (list, tuple)):
+        for t in raw_tags:
+            if isinstance(t, dict):  # [{'name': 'x'}, ...] from /api/media
+                if t.get("name"):
+                    tags.add(str(t["name"]))
+            elif t:
+                tags.add(str(t))
+
+    # per-frame metadata: prefer explicit 'frames', fall back to 'frame_tags' JSON
+    frames = media.get("frames")
+    if frames is None:
+        ft = media.get("frame_tags")
+        if isinstance(ft, str) and ft:
+            try:
+                frames = json.loads(ft)
+            except (ValueError, TypeError):
+                frames = None
+        elif isinstance(ft, list):
+            frames = ft
+    for fr in frames or []:
+        if not isinstance(fr, dict):
+            continue
+        for t in fr.get("tags") or []:
+            if t:
+                tags.add(str(t))
+        if fr.get("content_type"):
+            content_types.add(str(fr["content_type"]))
+        if fr.get("atmosphere"):
+            atmospheres.add(str(fr["atmosphere"]))
+        if fr.get("energy"):
+            energies.add(str(fr["energy"]))
+
+    return {
+        "tags": tags,
+        "content_types": content_types,
+        "atmospheres": atmospheres,
+        "energies": energies,
+        "duration_s": float(media.get("duration_s") or 0.0),
+        "has_audio": bool(media.get("has_audio")),
+    }
+
+
+def _booster_applies(b: Booster, sig: Dict[str, Any]) -> bool:
+    tags = sig["tags"]
+    if b.min_duration is not None and sig["duration_s"] < b.min_duration:
+        return False
+    if b.has_audio is not None and sig["has_audio"] != b.has_audio:
+        return False
+    if b.all_tags and not all(t in tags for t in b.all_tags):
+        return False
+    if b.any_tags and not any(t in tags for t in b.any_tags):
+        return False
+    if b.no_tags and any(t in tags for t in b.no_tags):
+        return False
+    if b.content_types and not (set(b.content_types) & sig["content_types"]):
+        return False
+    if b.atmospheres and not (set(b.atmospheres) & sig["atmospheres"]):
+        return False
+    return True
+
+
+def score_collection(media: Dict[str, Any], col: Collection) -> float:
+    """Score a media item against one collection. 0.0 = no signal / hard-rejected."""
+    sig = media_signal(media)
+
+    # Hard filters (membership gates).
+    if col.min_duration is not None and sig["duration_s"] < col.min_duration:
+        return 0.0
+    if col.require_audio is not None and sig["has_audio"] != col.require_audio:
+        return 0.0
+    if col.exclude_tags and (set(col.exclude_tags) & sig["tags"]):
+        return 0.0
+
+    # Base signal: fraction of the collection's vocabulary the item hits, but
+    # rewarded by absolute overlap too (so a 1-of-8 hit isn't as strong as 4-of-8).
+    if not col.tags:
+        base = 0.0
+    else:
+        hits = sum(1 for t in col.tags if t in sig["tags"])
+        if hits == 0:
+            base = 0.0
+        else:
+            coverage = hits / len(col.tags)  # 0..1
+            # saturating reward for raw hits: 1 hit→0.5, 2→0.67, 3→0.75, 4→0.8...
+            depth = hits / (hits + 1)
+            base = col.tag_weight * (0.5 * coverage + 0.5 * depth)
+
+    if base == 0.0:
+        return 0.0  # no topical overlap → not a member regardless of boosters
+
+    score = base
+    for b in col.boosters:
+        if _booster_applies(b, sig):
+            score += b.boost
+    return min(1.0, score)
+
+
+def classify(media: Dict[str, Any], collections: Sequence[Collection]) -> List[Dict[str, Any]]:
+    """Return the collections a media item belongs to, sorted by score desc.
+
+    Each result: {key, title, category, score}. Non-exclusive (can be many).
+    """
+    out = []
+    for col in collections:
+        s = score_collection(media, col)
+        if s >= MIN_CONFIDENCE:
+            out.append({"key": col.key, "title": col.title, "category": col.category, "score": round(s, 4)})
+    out.sort(key=lambda r: r["score"], reverse=True)
+    return out
+
+
+# ── Tier-1 definitions — Hevin's real shooting archetypes ────────────────────
+# Tags are arkiv's qwen3-vl Chinese vocabulary (verified against ingested data).
+DEFAULT_COLLECTIONS: List[Collection] = [
+    Collection(
+        key="food_closeup",
+        title="食材特寫",
+        category="content",
+        tags=["生肉", "肉類", "肉品", "生豬肉", "生魚", "三文魚", "切割", "切片", "切痕",
+              "脂肪層", "食材", "食品處理", "肉類加工", "砧板", "廚房"],
+        boosters=(
+            Booster(boost=0.15, any_tags=["切割", "切片", "切痕"]),
+            Booster(boost=0.10, any_tags=["手套", "紫色手套", "手部操作"]),
+        ),
+    ),
+    Collection(
+        key="interior_establishing",
+        title="店內空景",
+        category="content",
+        tags=["餐廳", "咖啡館", "吧檯", "室內", "座椅", "燈光", "低光", "條紋牆面", "幾何結構"],
+        boosters=(
+            Booster(boost=0.15, content_types=["Establishing"]),
+            Booster(boost=0.10, atmospheres=["舒適", "幽暗"]),
+        ),
+    ),
+    Collection(
+        key="unusable",
+        title="廢鏡 · 待汰",
+        category="quality",
+        tags=["模糊", "模糊畫面", "低解析度", "低解析", "不明物體", "屏幕", "電視"],
+    ),
+]

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,0 +1,134 @@
+"""Unit tests for smart collections engine (collections.py).
+
+Fixtures are the REAL qwen3-vl tags from the 5 明燒肉 clips ingested 2026-05-31
+(verified against .arkiv/project.db), so expected memberships are ground truth:
+  C3742 → 店內空景   C3747/C3750/C3756 → 食材特寫   C3811 → 廢鏡
+"""
+from __future__ import annotations
+
+import smart_collections as sc
+
+
+# ── real fixtures (tags verified vs live DB) ─────────────────────────────────
+C3742 = {  # 店內空景 — 吧檯/咖啡館/室內
+    "duration_s": 6.01, "has_audio": 1,
+    "tags": ["低光", "吧檯", "咖啡館", "圖形設計", "室內", "幾何結構", "座椅", "條紋牆面"],
+    "frames": [
+        {"tags": ["圖形設計", "條紋牆面", "幾何結構"], "content_type": "Transition", "atmosphere": "簡約", "energy": "低"},
+        {"tags": ["咖啡館", "吧檯", "座椅", "室內", "燈光"], "content_type": "Establishing", "atmosphere": "舒適", "energy": "低"},
+        {"tags": ["餐廳", "吧檯", "低光"], "content_type": "Establishing", "atmosphere": "幽暗", "energy": "中"},
+    ],
+}
+C3747 = {  # 生肉特寫 — 切割/手套
+    "duration_s": 9.01, "has_audio": 1,
+    "tags": ["切割", "手套", "手部操作", "生肉", "紫色手套", "肉品", "肉類加工", "食品處理"],
+    "frames": [{"tags": ["切割", "生肉", "手套"], "content_type": "Detail", "atmosphere": "專注", "energy": "中"}],
+}
+C3750 = {  # 生肉特寫 — 生豬肉/脂肪
+    "duration_s": 6.51, "has_audio": 1,
+    "tags": ["切割", "切痕", "包裝", "生肉", "生豬肉", "肉類", "脂肪層", "食材"],
+    "frames": [{"tags": ["生豬肉", "脂肪層", "切痕"], "content_type": "Detail"}],
+}
+C3756 = {  # 三文魚切片
+    "duration_s": 2.0, "has_audio": 1,
+    "tags": ["三文魚", "切片", "廚房", "模糊", "生魚", "砧板", "粉紅色", "肉類"],
+    "frames": [{"tags": ["三文魚", "切片", "砧板"], "content_type": "Detail"}],
+}
+C3811 = {  # 廢鏡 — 模糊/電視
+    "duration_s": 4.5, "has_audio": 1,
+    "tags": ["不明物體", "低解析度", "屏幕", "模糊", "模糊畫面", "淺色背景", "邊框", "電視"],
+    "frames": [{"tags": ["模糊", "電視", "屏幕"], "content_type": "Transition", "atmosphere": "幽暗"}],
+}
+
+COLS = sc.DEFAULT_COLLECTIONS
+
+
+def _keys(media):
+    return {r["key"] for r in sc.classify(media, COLS)}
+
+
+# ── ground-truth membership ──────────────────────────────────────────────────
+def test_interior_clip_joins_interior_collection():
+    assert "interior_establishing" in _keys(C3742)
+
+
+def test_meat_clips_join_food_collection():
+    for clip in (C3747, C3750, C3756):
+        assert "food_closeup" in _keys(clip), clip["tags"]
+
+
+def test_unusable_clip_joins_unusable_collection():
+    assert "unusable" in _keys(C3811)
+
+
+# ── separation (no false positives across the obvious divides) ───────────────
+def test_interior_clip_not_in_food():
+    assert "food_closeup" not in _keys(C3742)
+
+
+def test_meat_clip_not_in_interior():
+    assert "interior_establishing" not in _keys(C3747)
+
+
+# ── scoring mechanics ────────────────────────────────────────────────────────
+def test_no_tag_overlap_scores_zero():
+    blank = {"duration_s": 5, "has_audio": 1, "tags": ["航空", "雲海", "日出"], "frames": []}
+    assert sc.classify(blank, COLS) == []
+
+
+def test_score_below_threshold_excluded():
+    # a single weak tag hit stays under MIN_CONFIDENCE without boosters
+    weak = {"duration_s": 5, "has_audio": 1, "tags": ["室內"], "frames": []}
+    interior = next(c for c in COLS if c.key == "interior_establishing")
+    s = sc.score_collection(weak, interior)
+    assert s < sc.MIN_CONFIDENCE
+
+
+def test_booster_raises_score():
+    interior = next(c for c in COLS if c.key == "interior_establishing")
+    # same tags, but C3742 has Establishing frames → booster fires
+    base = {"duration_s": 6, "has_audio": 1,
+            "tags": ["餐廳", "咖啡館", "吧檯", "室內"], "frames": []}
+    boosted = dict(base, frames=[{"content_type": "Establishing", "atmosphere": "舒適"}])
+    assert sc.score_collection(boosted, interior) > sc.score_collection(base, interior)
+
+
+def test_classify_sorted_desc():
+    rows = sc.classify(C3747, COLS)
+    scores = [r["score"] for r in rows]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_non_exclusive_membership_possible():
+    # C3756 is both 食材 (三文魚/切片/肉類) and has 模糊 — but 模糊 alone is 1 weak
+    # hit for 廢鏡, should stay under threshold → only food. Asserts non-exclusivity
+    # is allowed yet threshold still gates.
+    keys = _keys(C3756)
+    assert "food_closeup" in keys
+
+
+# ── media_signal normalization ───────────────────────────────────────────────
+def test_signal_parses_frame_tags_json_string():
+    import json
+    raw = {"duration_s": 3, "has_audio": 1,
+           "frame_tags": json.dumps([{"tags": ["生肉", "切割"], "content_type": "Detail"}])}
+    sig = sc.media_signal(raw)
+    assert "生肉" in sig["tags"] and "Detail" in sig["content_types"]
+
+
+def test_signal_parses_api_tag_dicts():
+    raw = {"duration_s": 3, "has_audio": 1, "tags": [{"name": "吧檯"}, {"name": "室內"}]}
+    sig = sc.media_signal(raw)
+    assert sig["tags"] == {"吧檯", "室內"}
+
+
+def test_min_duration_hard_filter():
+    short_meat = dict(C3756, duration_s=0.5)
+    col = sc.Collection(key="t", title="t", category="c", tags=["三文魚"], min_duration=2.0)
+    assert sc.score_collection(short_meat, col) == 0.0
+
+
+def test_exclude_tags_rejects():
+    col = sc.Collection(key="t", title="t", category="c", tags=["生肉"], exclude_tags=["模糊"])
+    blurry_meat = {"duration_s": 5, "has_audio": 1, "tags": ["生肉", "模糊"], "frames": []}
+    assert sc.score_collection(blurry_meat, col) == 0.0


### PR DESCRIPTION
Builds on the merged frontend (PR #19) + B1 live wiring (already in main). Four tasks, each verified end-to-end against the running backend on 5 真實明燒肉 clips (ingested locally → mlx-whisper + qwen3-vl + nomic-embed). Reviewed by `codex review` before this PR — one P2 found and fixed (see below).

## Tasks

### A3 — Smart Collections engine (`smart_collections.py`, headless)
Rule-driven curation (NOT ML clustering): predefined definitions × multi-signal weighted matching against each item's qwen3-vl tags + per-frame content_type/atmosphere/energy + duration/audio. Non-exclusive membership at score ≥ MIN_CONFIDENCE (0.40). Pure Python, no new deps, no embedding for Tier 1.
- **14 unit tests** (`tests/test_collections.py`), fixtures = real tags from the 5 clips.
- End-to-end vs live DB: C3742→店內空景(1.0), C3747/50/56→食材特寫(0.78–0.83), C3811→廢鏡(0.86), no cross-contamination.
- ⚠ module named `smart_collections` (NOT `collections` — shadows stdlib, breaks every import via functools).

### B1+ — ingest progress → live websocket (`#/ingest-live`)
Connects `ws://…/ws/ingest`, triggers `POST /api/ingest/ws`, renders the real broadcast stream (start / file{transcribing,done,skipped} / complete). Honest subset of the mock (ws carries no per-stage/GPU metrics — not faked). vite proxy `/ws` added.
- Verified: backend emits per-file stream on a fresh clip; UI DOM-assert ws OPEN→LIVE + `start·3 files` renders. 0 console errors.

### C — rating write-through (inspector rate buttons → DB)
Click Good/Review/N·G → optimistic UI + `PATCH /api/media/{id}/rating` → DB. Reverts on failure. Fixes UI↔backend value map (UI `rev` ↔ backend `review`) both directions.
- Verified: click Good on C3811 → DB readback `rating='good'`.

### D — sidebar live (real tags / pools / projects + tag-click filter)
PoolSidebar shows live `/api/tags` + stats-derived pools + current project. Click tag → search-filter the grid.
- Verified: real qwen3-vl tags (食物/肉類/餐廳…); click 食物 → grid filters to exactly C3750+C3756.

## Codex review finding (fixed)
`codex review --base origin/main` (gpt-5.5) flagged **[P2] silent rating_note loss**: `rate()` sent only `{rating}`, but the backend PATCH writes both fields → an omitted note nulled any existing DIT note. Fixed (`6d32fb5`): `setRating(id, rating, note)` passes through the existing note. Re-verified: set note "DIT 標記:重拍" → click Good → rating changes AND note preserved.

## Scope notes
All live wiring is additive — mock screens (MainDark/MainStates/etc, PR #19) are byte-identical (optional props default to mock). No Tauri/Rust. Backend runs on Mac (no PC). Smart Collections has no server endpoint / UI yet (engine only — follow-up).

Verification harnesses included under `frontend/scripts/audit/verify-*.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)