### PR TITLE
feat: Smart Collections UI (E1) + chat live (E2) — Codex-reviewed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ frontend/.audit/
 # Local overnight work-order (ephemeral, mini-only)
 OVERNIGHT_UI_BUILD.md
 .testdata/
+frontend/vite.config.tailnet.js
+frontend/vite.config.dev8502.js

--- a/frontend/scripts/audit/verify-chat.mjs
+++ b/frontend/scripts/audit/verify-chat.mjs
@@ -1,0 +1,41 @@
+// E2 verify: #/chat-live sends a real query and renders the live response.
+// Types a compilation prompt, waits for the assistant message + scene
+// thumbnails, asserts real text + scene_ids resolved. Usage: node verify-chat.mjs <devUrl>
+import puppeteer from 'puppeteer-core'
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+const dev = process.argv[2] || 'http://localhost:5174/'
+
+const b = await puppeteer.launch({ executablePath: CHROME, headless: true, args: ['--no-sandbox'] })
+const p = await b.newPage()
+const errs = []
+p.on('console', (m) => { if (m.type() === 'error' && !/Failed to load resource/.test(m.text())) errs.push(m.text()) })
+p.on('pageerror', (e) => errs.push(String(e)))
+
+await p.goto(dev + '#/chat-live', { waitUntil: 'networkidle0', timeout: 30000 })
+await new Promise((r) => setTimeout(r, 800))
+
+await p.type('.chatinput', '幫我把生肉切割的鏡頭剪成一段')
+await p.keyboard.press('Enter')
+// chat LLM ~8-10s; wait for assistant message to appear
+let waited = 0
+while (waited < 40000) {
+  const has = await p.evaluate(() => document.querySelectorAll('.msg.assistant').length > 0 &&
+    !document.querySelector('.msg.assistant .text')?.textContent?.includes('thinking'))
+  if (has) break
+  await new Promise((r) => setTimeout(r, 1000)); waited += 1000
+}
+await new Promise((r) => setTimeout(r, 500))
+
+const result = await p.evaluate(() => {
+  const assistant = [...document.querySelectorAll('.msg.assistant')].pop()
+  return {
+    userMsgs: document.querySelectorAll('.msg.user').length,
+    assistantText: assistant?.querySelector('.text')?.textContent?.trim()?.slice(0, 120),
+    intent: assistant?.querySelector('.ak-mono')?.textContent?.trim(),
+    sceneCount: assistant?.querySelectorAll('.scene').length || 0,
+    sceneThumbsLoaded: [...(assistant?.querySelectorAll('.scenethumb img') || [])].filter((i) => i.naturalWidth > 0).length,
+  }
+})
+await p.screenshot({ path: '.audit/b1/chat-live.png' })
+console.log(JSON.stringify({ errs, result }, null, 2))
+await b.close()

--- a/frontend/scripts/audit/verify-collections.mjs
+++ b/frontend/scripts/audit/verify-collections.mjs
@@ -1,0 +1,36 @@
+// E1 verify: Smart Collections section in sidebar + click filters grid.
+// Asserts the section shows real groups (食材特寫/店內空景/廢鏡) and clicking
+// 店內空景 (1 member, C3742) narrows the grid to exactly that clip.
+// Usage: node verify-collections.mjs <devUrl>
+import puppeteer from 'puppeteer-core'
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+const dev = process.argv[2] || 'http://localhost:5173/'
+
+const b = await puppeteer.launch({ executablePath: CHROME, headless: true, args: ['--no-sandbox'] })
+const p = await b.newPage()
+const errs = []
+p.on('console', (m) => { if (m.type() === 'error' && !/Failed to load resource/.test(m.text())) errs.push(m.text()) })
+p.on('pageerror', (e) => errs.push(String(e)))
+
+await p.goto(dev + '#/main-live', { waitUntil: 'networkidle0', timeout: 30000 })
+await new Promise((r) => setTimeout(r, 1800))
+
+const collections = await p.evaluate(() =>
+  [...document.querySelectorAll('.collrow')].map((r) => r.textContent.replace(/\s+/g, ' ').trim())
+)
+
+// click 店內空景 (the single-member collection) → grid should show exactly 1 card
+const clicked = await p.evaluate(() => {
+  const row = [...document.querySelectorAll('.collrow')].find((r) => r.textContent.includes('店內空景'))
+  if (row) { row.click(); return true }
+  return false
+})
+await new Promise((r) => setTimeout(r, 2000))
+const after = await p.evaluate(() => ({
+  cards: document.querySelectorAll('.card').length,
+  names: [...document.querySelectorAll('.name')].map((n) => n.textContent.trim()),
+}))
+await p.screenshot({ path: '.audit/b1/collections.png' })
+
+console.log(JSON.stringify({ errs, collections, clicked店內: clicked, afterClick: after }, null, 2))
+await b.close()

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -13,6 +13,7 @@
   import Live from './routes/Live.svelte'
   import MainLive from './routes/MainLive.svelte'
   import IngestLive from './routes/IngestLive.svelte'
+  import ChatLive from './routes/ChatLive.svelte'
 
   // Routes are added per overnight segment.
   const routes = {
@@ -20,6 +21,7 @@
     '/live': Live, // B1 — live API proof (reads running backend)
     '/main-live': MainLive, // B1 — main grid wired to live data
     '/ingest-live': IngestLive, // B1+ — ingest progress wired to live ws
+    '/chat-live': ChatLive, // E2 — chat wired to live /api/chat
     '/gallery': Gallery, // seg 1 — shared-primitive gallery
     '/main': MainDark, // seg 2 — hero (interactive)
     '/states': MainStates, // seg 3 — state variants

--- a/frontend/src/lib/PoolSidebar.svelte
+++ b/frontend/src/lib/PoolSidebar.svelte
@@ -8,6 +8,8 @@
   export let livePools = null // [[label, count], ...]
   export let liveTags = null // [{name, count}]
   export let onTag = null // (name) => void; live tag-click → filter
+  export let liveCollections = null // [{key,title,count,items}]; null → section hidden
+  export let onCollection = null // (collection) => void; click → filter to members
 
   const MOCK_POOLS = [
     ['All media', 247],
@@ -50,6 +52,21 @@
       {/each}
     </div>
   </section>
+
+  {#if liveCollections && liveCollections.length}
+    <section>
+      <Eyebrow style="margin-bottom:10px;">Smart Collections · auto</Eyebrow>
+      <div class="col">
+        {#each liveCollections as c (c.key)}
+          <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+          <div class="poolrow collrow" on:click={() => onCollection && onCollection(c)}>
+            <span class="ellip">{c.title}</span>
+            <Mono dim style="font-size:10px;flex:0 0 auto;">{c.count}</Mono>
+          </div>
+        {/each}
+      </div>
+    </section>
+  {/if}
 
   <section class="tagsec">
     <Eyebrow style="margin-bottom:10px;">Tags · auto</Eyebrow>
@@ -95,6 +112,7 @@
     padding: 4px 10px; font-size: 12.5px; color: var(--ink-2); cursor: pointer;
   }
   .ellip { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; }
+  .collrow:hover { color: var(--ink); }
   .tagsec { min-height: 0; }
   .tags { display: flex; flex-wrap: wrap; gap: 4px; }
   .tag {

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -64,6 +64,12 @@ export const getTags = (opts) => req('/api/tags', opts)
 // /api/collections → {collections:[{key,title,category,count,items:[{id,filename,thumb,score}]}], total}
 export const getCollections = (opts) => req('/api/collections', opts)
 
+// POST /api/chat {prompt, conversation_id?, project_scope?} →
+//   {conversation_id, assistant_text, scene_ids[], intent, tokens_used, latency_ms}
+// Requires chat_write scope (token-free on loopback).
+export const chat = (prompt, conversationId = null, opts) =>
+  req('/api/chat', { method: 'POST', body: { prompt, conversation_id: conversationId }, ...opts })
+
 // /api/media?limit&offset&projects&tag&rating  → {items, total, search}
 export const getMedia = (params = {}, opts) => req(`/api/media${qs(params)}`, opts)
 export const getMediaDetail = (id, opts) => req(`/api/media/${id}`, opts)

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -61,6 +61,8 @@ export const getStats = (opts) => req('/api/stats', opts)
 export const getProjects = (opts) => req('/api/projects', opts)
 export const getProjectsHealth = (opts) => req('/api/projects/health', opts)
 export const getTags = (opts) => req('/api/tags', opts)
+// /api/collections → {collections:[{key,title,category,count,items:[{id,filename,thumb,score}]}], total}
+export const getCollections = (opts) => req('/api/collections', opts)
 
 // /api/media?limit&offset&projects&tag&rating  → {items, total, search}
 export const getMedia = (params = {}, opts) => req(`/api/media${qs(params)}`, opts)

--- a/frontend/src/routes/ChatLive.svelte
+++ b/frontend/src/routes/ChatLive.svelte
@@ -20,6 +20,8 @@
 
   const suggestions = ['幫我把生肉切割的鏡頭剪成一段', '找店內空景的畫面', '哪些素材有餐廳']
 
+  // Prefetch the first page as a cheap cache; misses are resolved by id below
+  // (so scene_ids outside the first page still get a thumbnail — Codex review P2).
   async function loadMediaIndex() {
     try {
       const m = await api.getMedia({ limit: 200 })
@@ -30,15 +32,32 @@
         ])
       )
     } catch (e) {
-      /* non-fatal — scenes just won't show thumbs */
+      /* non-fatal — resolveScenes will fetch by id */
     }
   }
 
-  function resolveScenes(ids) {
-    return (ids || []).map((id) => {
-      const m = mediaById.get(String(id))
-      return { id, name: m?.filename || `#${id}`, thumb: m?.thumb || null }
-    })
+  // Resolve each scene id: index hit first, else fetch /api/media/{id} detail.
+  // Never permanently fails for ids outside the prefetched page.
+  async function resolveScenes(ids) {
+    return Promise.all(
+      (ids || []).map(async (id) => {
+        const key = String(id)
+        let m = mediaById.get(key)
+        if (!m) {
+          try {
+            const d = await api.getMediaDetail(id)
+            m = {
+              filename: d.filename || d.name,
+              thumb: d.thumbnail_path ? api.thumbUrlFromPath(d.thumbnail_path) : d.thumb,
+            }
+            mediaById.set(key, m) // cache for next time
+          } catch (e) {
+            m = null
+          }
+        }
+        return { id, name: m?.filename || `#${id}`, thumb: m?.thumb || null }
+      })
+    )
   }
 
   async function scrollDown() {
@@ -57,13 +76,14 @@
     try {
       const r = await api.chat(prompt, convId)
       convId = r.conversation_id || convId
+      const scenes = await resolveScenes(r.scene_ids)
       messages = [
         ...messages,
         {
           role: 'assistant',
           text: r.assistant_text || '',
           intent: r.intent,
-          scenes: resolveScenes(r.scene_ids),
+          scenes,
         },
       ]
     } catch (e) {

--- a/frontend/src/routes/ChatLive.svelte
+++ b/frontend/src/routes/ChatLive.svelte
@@ -1,0 +1,174 @@
+<!-- E2 — chat wired to live /api/chat. Natural-language → 5-intent classifier
+     → vector search → LLM response. When the assistant returns scene_ids
+     (compilation intent), resolve them to media items and show thumbnails
+     inline. Requires chat_write scope (token-free on loopback). -->
+<script>
+  import { onMount, tick } from 'svelte'
+  import * as api from '../lib/api.js'
+  import ArkivLogo from '../lib/ArkivLogo.svelte'
+  import Mono from '../lib/Mono.svelte'
+  import Eyebrow from '../lib/Eyebrow.svelte'
+
+  const theme = 'dark'
+  let messages = [] // {role:'user'|'assistant', text, intent?, scenes?:[{id,name,thumb}]}
+  let input = ''
+  let busy = false
+  let convId = null
+  let err = ''
+  let mediaById = new Map() // id → {filename, thumb} for scene resolution
+  let scroller
+
+  const suggestions = ['幫我把生肉切割的鏡頭剪成一段', '找店內空景的畫面', '哪些素材有餐廳']
+
+  async function loadMediaIndex() {
+    try {
+      const m = await api.getMedia({ limit: 200 })
+      mediaById = new Map(
+        (m.items || []).map((it) => [
+          String(it.id),
+          { filename: it.filename || it.name, thumb: it.thumbnail_path ? api.thumbUrlFromPath(it.thumbnail_path) : it.thumb },
+        ])
+      )
+    } catch (e) {
+      /* non-fatal — scenes just won't show thumbs */
+    }
+  }
+
+  function resolveScenes(ids) {
+    return (ids || []).map((id) => {
+      const m = mediaById.get(String(id))
+      return { id, name: m?.filename || `#${id}`, thumb: m?.thumb || null }
+    })
+  }
+
+  async function scrollDown() {
+    await tick()
+    if (scroller) scroller.scrollTop = scroller.scrollHeight
+  }
+
+  async function send(text) {
+    const prompt = (text ?? input).trim()
+    if (!prompt || busy) return
+    err = ''
+    input = ''
+    messages = [...messages, { role: 'user', text: prompt }]
+    busy = true
+    scrollDown()
+    try {
+      const r = await api.chat(prompt, convId)
+      convId = r.conversation_id || convId
+      messages = [
+        ...messages,
+        {
+          role: 'assistant',
+          text: r.assistant_text || '',
+          intent: r.intent,
+          scenes: resolveScenes(r.scene_ids),
+        },
+      ]
+    } catch (e) {
+      err = e.status === 401 ? '需要 chat_write token（tailnet）— 本機 loopback 可直接用' : e.message
+      messages = [...messages, { role: 'assistant', text: `⚠ ${err}`, error: true }]
+    } finally {
+      busy = false
+      scrollDown()
+    }
+  }
+
+  function onKey(e) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      send()
+    }
+  }
+
+  onMount(loadMediaIndex)
+</script>
+
+<div class="artboard" data-theme={theme}>
+  <div class="topbar">
+    <ArkivLogo size={16} />
+    <Mono dim style="font-size:10px;">v0.9.2</Mono>
+    <div class="grow"></div>
+    <Mono dim style="font-size:11px;">chat · 5-intent · vector + LLM</Mono>
+  </div>
+
+  <div class="body">
+    <div class="thread" bind:this={scroller}>
+      {#if messages.length === 0}
+        <div class="empty">
+          <Eyebrow>arkiv chat</Eyebrow>
+          <div class="ak-display emptytitle">問你的素材庫。</div>
+          <Mono dim style="font-size:12px;line-height:1.6;max-width:440px;">
+            用中文問。例如「幫我把生肉切割的鏡頭剪成一段」→ 自動分類意圖 + 語意搜尋 + 回答 + 列出符合的片段。
+          </Mono>
+          <div class="suggest">
+            {#each suggestions as s}
+              <button class="ak-btn sg" on:click={() => send(s)}>{s}</button>
+            {/each}
+          </div>
+        </div>
+      {/if}
+
+      {#each messages as m}
+        <div class="msg {m.role}" class:error={m.error}>
+          <Mono dim style="font-size:9.5px;letter-spacing:0.1em;">
+            {m.role === 'user' ? 'YOU' : 'ARKIV'}{#if m.intent} · {m.intent}{/if}
+          </Mono>
+          <div class="text">{m.text}</div>
+          {#if m.scenes && m.scenes.length}
+            <div class="scenes">
+              {#each m.scenes as sc (sc.id)}
+                <div class="scene">
+                  <div class="scenethumb">
+                    {#if sc.thumb}<img src={sc.thumb} alt={sc.name} loading="lazy" />{/if}
+                  </div>
+                  <Mono dim style="font-size:9.5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:block;">{sc.name}</Mono>
+                </div>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {/each}
+
+      {#if busy}
+        <div class="msg assistant"><Mono dim style="font-size:11px;color:var(--cyan);">● thinking…</Mono></div>
+      {/if}
+    </div>
+
+    <div class="composer">
+      <input
+        class="ak-input chatinput"
+        placeholder="問你的素材庫…（Enter 送出）"
+        bind:value={input}
+        on:keydown={onKey}
+        disabled={busy}
+      />
+      <button class="ak-btn ak-btn--primary" on:click={() => send()} disabled={busy || !input.trim()}>送出 →</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .artboard { width: 1400px; height: 900px; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 1fr; overflow: hidden; margin: 0 auto; }
+  .grow { flex: 1; }
+  .topbar { display: flex; align-items: center; border-bottom: 1px solid var(--rule); padding: 0 16px; gap: 16px; }
+  .body { display: flex; flex-direction: column; min-height: 0; }
+  .thread { flex: 1; overflow: auto; padding: 24px 18%; display: flex; flex-direction: column; gap: 20px; }
+  .empty { display: flex; flex-direction: column; gap: 10px; padding-top: 40px; }
+  .emptytitle { font-size: var(--fs-display-sm); color: var(--ink); margin: 4px 0; }
+  .suggest { display: flex; flex-direction: column; gap: 8px; margin-top: 16px; align-items: flex-start; }
+  .sg { text-align: left; text-transform: none; letter-spacing: 0; font-family: var(--ak-sans); }
+  .msg { display: flex; flex-direction: column; gap: 6px; }
+  .msg.user { align-items: flex-end; }
+  .msg.user .text { background: var(--surface-2); padding: 10px 14px; max-width: 80%; }
+  .msg.assistant .text { color: var(--ink-2); line-height: 1.6; max-width: 80%; }
+  .msg.error .text { color: var(--cyan); }
+  .text { font-size: 13.5px; white-space: pre-wrap; }
+  .scenes { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; margin-top: 6px; max-width: 560px; }
+  .scene { display: flex; flex-direction: column; gap: 4px; }
+  .scenethumb { aspect-ratio: 16 / 9; background: var(--surface-2); overflow: hidden; box-shadow: inset 0 0 0 1px var(--rule); }
+  .scenethumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
+  .composer { border-top: 1px solid var(--rule); padding: 16px 18%; display: flex; gap: 10px; align-items: center; }
+  .chatinput { flex: 1; font-size: 13px; }
+</style>

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -63,7 +63,7 @@
       liveTags = (t || []).map((x) => ({ name: x.name, count: x.count }))
       liveCollections = (c?.collections || []).map((col) => ({
         key: col.key, title: col.title, count: col.count,
-        ids: (col.items || []).map((i) => i.id),
+        items: col.items || [], // full member items (id/filename/thumb/duration_s/score)
       }))
       if (items.length && selectedId == null) selectedId = items[0].id
       state = 'ok'
@@ -73,15 +73,25 @@
     }
   }
 
-  // E1 — click a Smart Collection → filter grid to its member ids. Reloads the
-  // full library first (so it works after a search), then narrows by id set.
+  // E1 — click a Smart Collection → show its members directly. /api/collections
+  // already returns every member with id/filename/thumb/duration_s (classified
+  // over the FULL library server-side), so build cards straight from those —
+  // no /api/media re-fetch, no first-N cap (Codex review P2).
+  const fmtDurS = (s) => fmtDur(s)
   let activeCollection = null
-  async function onCollectionClick(col) {
+  function onCollectionClick(col) {
     query = ''
     activeCollection = col.key
-    const full = await api.getMedia({ limit: 200 })
-    const idSet = new Set(col.ids)
-    items = (full.items || []).map(toCard).filter((m) => idSet.has(m.id))
+    items = (col.items || []).map((it) => ({
+      id: it.id,
+      name: it.filename || `#${it.id}`,
+      kind: 'video',
+      rating: 'none',
+      dur: fmtDurS(it.duration_s),
+      size: '—',
+      thumb: it.thumb || null, // already a root-relative /thumbnails/<name> path
+      _raw: it,
+    }))
     selectedId = items.length ? items[0].id : null
   }
 

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -50,20 +50,39 @@
   })
 
   let liveTags = null
+  let liveCollections = null
 
   async function load() {
     state = 'loading'
     try {
-      const [s, m, t] = await Promise.all([api.getStats(), api.getMedia({ limit: 60 }), api.getTags()])
+      const [s, m, t, c] = await Promise.all([
+        api.getStats(), api.getMedia({ limit: 60 }), api.getTags(), api.getCollections(),
+      ])
       stats = s
       items = (m.items || []).map(toCard)
       liveTags = (t || []).map((x) => ({ name: x.name, count: x.count }))
+      liveCollections = (c?.collections || []).map((col) => ({
+        key: col.key, title: col.title, count: col.count,
+        ids: (col.items || []).map((i) => i.id),
+      }))
       if (items.length && selectedId == null) selectedId = items[0].id
       state = 'ok'
     } catch (e) {
       state = 'error'
       err = e.message + (e.body ? ' · ' + JSON.stringify(e.body) : '')
     }
+  }
+
+  // E1 — click a Smart Collection → filter grid to its member ids. Reloads the
+  // full library first (so it works after a search), then narrows by id set.
+  let activeCollection = null
+  async function onCollectionClick(col) {
+    query = ''
+    activeCollection = col.key
+    const full = await api.getMedia({ limit: 200 })
+    const idSet = new Set(col.ids)
+    items = (full.items || []).map(toCard).filter((m) => idSet.has(m.id))
+    selectedId = items.length ? items[0].id : null
   }
 
   // D — live sidebar derived data.
@@ -185,7 +204,7 @@
 <div class="artboard" data-theme={theme}>
   <TopBar />
   <div class="body">
-    <PoolSidebar {liveProjects} {livePools} {liveTags} onTag={onTagClick} />
+    <PoolSidebar {liveProjects} {livePools} {liveTags} {liveCollections} onTag={onTagClick} onCollection={onCollectionClick} />
 
     <main class="center">
       <div class="toolrow">

--- a/server.py
+++ b/server.py
@@ -28,6 +28,7 @@ import config
 import db
 import federation
 import projects as project_registry
+import smart_collections
 
 
 # ── WebSocket connection manager ────────────────────────────────────────────
@@ -677,6 +678,49 @@ def get_all_tags(
 ):
     """All unique tag names for autocomplete."""
     return db.get_all_tag_names()
+
+
+def _thumb_url(thumbnail_path):
+    """Absolute fs thumbnail_path → served /thumbnails/<basename> URL (or None)."""
+    if not thumbnail_path:
+        return None
+    base = str(thumbnail_path).replace("\\", "/").rsplit("/", 1)[-1]
+    return "/thumbnails/{0}".format(base)
+
+
+@app.get("/api/collections")
+def list_collections(
+    _tok: dict = Depends(require_scopes("collections_read")),
+):
+    """Smart Collections — classify every media item against the Tier-1
+    definitions (smart_collections.DEFAULT_COLLECTIONS) and group the results.
+
+    Rule-driven (not ML clustering): see smart_collections.py. Returns one entry
+    per collection that has >=1 member, each with its member media (id/filename/
+    thumb/duration/score), sorted by score desc. Membership is non-exclusive.
+    """
+    defs = smart_collections.DEFAULT_COLLECTIONS
+    buckets = {c.key: {"key": c.key, "title": c.title, "category": c.category, "items": []} for c in defs}
+
+    for rec in db.get_all_records():
+        for hit in smart_collections.classify(rec, defs):
+            buckets[hit["key"]]["items"].append({
+                "id": rec["id"],
+                "filename": rec.get("filename"),
+                "thumb": _thumb_url(rec.get("thumbnail_path")),
+                "duration_s": rec.get("duration_s"),
+                "score": hit["score"],
+            })
+
+    out = []
+    for b in buckets.values():
+        if not b["items"]:
+            continue
+        b["items"].sort(key=lambda r: r["score"], reverse=True)
+        b["count"] = len(b["items"])
+        out.append(b)
+    out.sort(key=lambda c: c["count"], reverse=True)
+    return {"collections": out, "total": len(out)}
 
 
 @app.get("/api/duration-by-lang")


### PR DESCRIPTION
Two live features on top of the merged B1 wiring, each verified end-to-end and **reviewed by `codex review` before this PR** (2 P2s found + fixed — see below).

## E1 — Smart Collections wired to UI (`#/main-live` sidebar)
Connects the A3 engine (`smart_collections.py`) to the screen.
- **Backend**: `GET /api/collections` (collections_read) — classifies every db record via `DEFAULT_COLLECTIONS`, groups members with thumb/score, sorts by count.
- **Frontend**: PoolSidebar "Smart Collections · auto" section (optional prop, default null → hidden, mock screens byte-identical); click → grid shows that collection's members.
- Verified: sidebar shows 食材特寫 3 / 店內空景 1 / 廢鏡 1; click 食材特寫 → grid = exactly C3747/C3750/C3756. 0 console errors.

## E2 — chat wired to live `/api/chat` (`#/chat-live`)
Natural-language over the素材庫: prompt → 5-intent classifier → vector search → LLM reply, with compilation `scene_ids` resolved to thumbnails inline.
- **Frontend**: `ChatLive.svelte` — message thread, conversation_id threading, suggestion chips, scene resolution.
- Verified: "幫我把生肉切割的鏡頭剪成一段" → intent=compilation, real zh reply, 5 scene cards, 5 thumbnails decoded. 0 console errors.

## Codex review (2 × P2, both fixed)
`codex review --base 8c1533f` flagged two functional-correctness bugs — same root cause: assuming `/api/media`'s first page holds every needed item. Invisible at 5 clips, **guaranteed to break on a 5yr library**:
- **E1**: collection click re-fetched `getMedia({limit:200})` then intersected ids → members past row 200 silently dropped. **Fix**: `/api/collections` already returns every member (classified over the full library server-side) — build cards straight from `col.items`, no re-fetch/cap.
- **E2**: scene index capped at 200 → `scene_ids` outside it rendered as `#id` with no thumb forever. **Fix**: `resolveScenes` is async — index hit first, else fetch `/api/media/{id}` detail (cached).
- Bonus: a `BASE is not defined` ReferenceError caught by re-verify (thumb paths are already root-relative).

## Surfaced (real backend gaps, documented in E2 commit — not frontend)
- **chroma index was empty**: ingest doesn't auto-write embeddings; `embed.py` is a separate step (ingest → embed → chat). Ran it → vector search + chat compilation now return scenes.
- **stale chroma connection**: rebuilding the index under a running server → 500 until restart (matches known tech-debt "server 重啟才讀 frames/chroma").

## Scope
All live wiring additive; mock screens (PR #19) unchanged. No Tauri/Rust. Backend on Mac (no PC). Per the roadmap decision, remaining mock screens stay as design baseline. chat needs chat_write (token-free on loopback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)