### PR TITLE
fix: fresh-install robustness (auto-create .arkiv + auto-embed)

### DIFF
--- a/db.py
+++ b/db.py
@@ -12,6 +12,13 @@ from contextlib import contextmanager
 
 @contextmanager
 def get_conn():
+    # Ensure the DB's parent dir exists. On a fresh clone the .arkiv/ data dir
+    # doesn't exist yet, and server.py calls init_db() at import → sqlite would
+    # raise "unable to open database file". Covers every DB-opening path
+    # (server / ingest / embed / tests), not just server startup.
+    parent = Path(DB_PATH).expanduser().parent
+    if parent and not parent.exists():
+        parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(DB_PATH, timeout=30)
     conn.row_factory = sqlite3.Row
     try:

--- a/ingest.py
+++ b/ingest.py
@@ -801,6 +801,7 @@ def main():
     )
     parser.add_argument("--recursive", "-r", action="store_true", help="Recursively scan subdirectories")
     parser.add_argument("--db", default="", help="Path to SQLite DB (default: media.db next to ingest.py)")
+    parser.add_argument("--no-embed", action="store_true", help="Skip building the vector index after ingest (default: auto-embed so search/chat work immediately)")
     args = parser.parse_args()
 
     # --dir validation: required only when actually ingesting
@@ -1131,6 +1132,19 @@ def main():
 
     print(f"\nDone. OK={ok}  skip={skipped}  fail={failed}")
     print(f"DB: {db.DB_PATH}")
+
+    # Auto-build the vector index so semantic search + chat work immediately.
+    # ingest writes SQLite records; embeddings live in ChromaDB and were a
+    # separate `embed.py` step — easy to forget, leaving search/chat returning
+    # nothing. Default ON; --no-embed to skip (e.g. batch-ingest then embed once).
+    if ok > 0 and not getattr(args, "no_embed", False):
+        try:
+            import embed
+            print(f"\n{'─'*60}")
+            embed.run_embed()
+        except Exception as exc:
+            print(f"\n[embed] ⚠ vector index build failed: {exc}")
+            print("[embed] run `python embed.py` manually; ingest itself succeeded.")
 
     if bench_log:
         print(f"\n{'='*60}")


### PR DESCRIPTION
Two "first-run" bugs that bite anyone installing arkiv fresh — both found during real use (PC handover + E2 chat debugging), both fixed + verified.

## 1. Fresh-clone crash — `.arkiv/` not created
`server.py` calls `db.init_db()` at import, but nothing creates the `.arkiv/` data dir first → `sqlite3: unable to open database file`. Every fresh clone hits this (PC handover documented it; I hit it on Mac too).

**Fix**: `db.get_conn()` ensures the DB parent dir exists before connecting. Covers every DB-opening path (server / ingest / embed / tests), not just startup. Verified: `init_db()` on a totally empty dir now succeeds.

## 2. Search/chat silently empty — embeddings never built
`ingest.py` writes SQLite records, but embeddings live in ChromaDB via a **separate `embed.py` step**. Forget it and semantic search + chat return nothing (this exact gap broke E2 until I ran `embed.py` manually).

**Fix**: ingest auto-runs `embed.run_embed()` at the end (default ON; `--no-embed` to skip for batch-then-embed-once). Embed failure is non-fatal — ingest itself still succeeded. Verified: fresh ingest on an empty root → `.arkiv` auto-created + chroma `count=1`, search/chat work immediately with zero manual steps.

Full suite: `test_db` + `test_ingest` + `test_collections` 31 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)