### PR TITLE
dist: fresh-install clean-room — fix stale copy-list + smoke-test passes from zero

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -58,10 +58,16 @@ if [ "$SRC" = "$INSTALL_DIR" ]; then
     # Already running from install dir (git clone directly to ~/.arkiv)
     echo "Setting up arkiv at $INSTALL_DIR..."
 elif [ -f "$SRC/server.py" ]; then
-    # Running from a different local directory — copy files
+    # Running from a different local directory — copy files.
+    # Copy ALL top-level Python modules with a glob, not a hand-maintained list:
+    # the old explicit list went stale (it predated auth.py / chat.py / admin.py /
+    # federation.py / projects.py / smart_collections.py / tag_quality.py / …,
+    # all imported by server.py) so this path produced an install that crashed on
+    # first run with ImportError. A glob can't drift.
     echo "Setting up arkiv at $INSTALL_DIR (from $SRC)..."
     mkdir -p "$INSTALL_DIR"
-    for f in server.py db.py config.py health.py index.html ingest.py transcribe.py embed.py frames.py vision.py vectordb.py requirements.txt .env.example smoke-test.sh install.sh uninstall.sh arkiv.command LICENSE README.md watch.py; do
+    cp "$SRC"/*.py "$INSTALL_DIR"/
+    for f in index.html requirements.txt .env.example smoke-test.sh install.sh uninstall.sh arkiv.command LICENSE README.md; do
         [ -f "$SRC/$f" ] && cp "$SRC/$f" "$INSTALL_DIR/"
     done
 else

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -81,9 +81,12 @@ done
 # only Docker got this pass-with-note, so `pc` smoke-tests failed immediately
 # after a clean install — a bad first-run experience.)
 echo "── Data ──"
-COUNT=$(curl -s --max-time 5 "$BASE/api/stats" 2>/dev/null | $PYTHON -c "import sys,json; print(json.load(sys.stdin).get('total',0))" 2>/dev/null || echo "")
-if [ -z "$COUNT" ]; then
-    check "Media files indexed" "false" "stats endpoint unreadable"
+# Require a NUMERIC total — a schema regression returning {} or {"total": null}
+# must read as "unreadable", not be silently accepted as an empty library. The
+# parser prints the int only when total is genuinely an int, else nothing.
+COUNT=$(curl -s --max-time 5 "$BASE/api/stats" 2>/dev/null | $PYTHON -c "import sys,json; t=json.load(sys.stdin).get('total'); print(t if isinstance(t,int) else '')" 2>/dev/null || echo "")
+if ! printf '%s' "$COUNT" | grep -Eq '^[0-9]+$'; then
+    check "Media files indexed" "false" "stats total missing/non-numeric"
 elif [ "$COUNT" = "0" ]; then
     check "Media files indexed" "true" "0 files (fresh install — ingest media to populate)"
 else

--- a/smoke-test.sh
+++ b/smoke-test.sh
@@ -75,13 +75,19 @@ for ep in "/api/media?limit=1" "/api/stats" "/api/tags" "/api/duration-by-lang" 
     check "GET $ep" "$([ "$HTTP" = "200" ] && echo true || echo false)" "HTTP $HTTP"
 done
 
-# 4. Media count
+# 4. Media count — an empty library is a VALID state for a fresh install, not a
+# failure (a brand-new user hasn't ingested anything yet). We only need the stats
+# endpoint to answer with a parseable count; 0 is reported as a note. (Previously
+# only Docker got this pass-with-note, so `pc` smoke-tests failed immediately
+# after a clean install — a bad first-run experience.)
 echo "── Data ──"
-COUNT=$(curl -s --max-time 5 "$BASE/api/stats" 2>/dev/null | $PYTHON -c "import sys,json; print(json.load(sys.stdin).get('total',0))" 2>/dev/null || echo "0")
-if [ "$PLATFORM" = "docker" ] && [ "$COUNT" = "0" ]; then
-    check "Media files indexed" "true" "0 files (fresh Docker — ingest media to populate)"
+COUNT=$(curl -s --max-time 5 "$BASE/api/stats" 2>/dev/null | $PYTHON -c "import sys,json; print(json.load(sys.stdin).get('total',0))" 2>/dev/null || echo "")
+if [ -z "$COUNT" ]; then
+    check "Media files indexed" "false" "stats endpoint unreadable"
+elif [ "$COUNT" = "0" ]; then
+    check "Media files indexed" "true" "0 files (fresh install — ingest media to populate)"
 else
-    check "Media files indexed" "$([ "$COUNT" -gt "0" ] && echo true || echo false)" "$COUNT files"
+    check "Media files indexed" "true" "$COUNT files"
 fi
 
 # 5. Search

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2,22 +2,12 @@
 module server.py needs. A hand-maintained copy list in install.sh once went
 stale and dropped auth/chat/admin/… → the install crashed on first run with
 ModuleNotFoundError. These tests fail loudly if that can recur."""
-import ast
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-
-
-def _first_party_imports(py_file: Path) -> set:
-    """Top-level modules imported by a file that resolve to a repo-root *.py."""
-    tree = ast.parse(py_file.read_text(encoding="utf-8"))
-    names = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            names.update(a.name.split(".")[0] for a in node.names)
-        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
-            names.add(node.module.split(".")[0])
-    return {n for n in names if (REPO_ROOT / f"{n}.py").is_file()}
 
 
 def test_install_copies_python_modules_via_glob_not_a_stale_list():
@@ -26,27 +16,17 @@ def test_install_copies_python_modules_via_glob_not_a_stale_list():
     assert 'cp "$SRC"/*.py' in install, "install.sh must copy all *.py via glob"
 
 
-def test_every_first_party_module_server_imports_exists():
-    """If server.py imports a local module, the file must exist (catches a
-    rename/delete that a glob-copy would silently miss)."""
-    missing = [m for m in _first_party_imports(REPO_ROOT / "server.py")
-               if not (REPO_ROOT / f"{m}.py").is_file()]
-    assert not missing, f"server.py imports modules with no file: {missing}"
-
-
-def test_first_party_import_closure_is_self_contained():
-    """Transitively: every repo-root module reachable from server.py only imports
-    other repo-root modules that also exist — no dangling local import anywhere in
-    the dependency closure that a fresh install would ship."""
-    seen, stack = set(), ["server"]
-    while stack:
-        mod = stack.pop()
-        if mod in seen:
-            continue
-        seen.add(mod)
-        f = REPO_ROOT / f"{mod}.py"
-        if not f.is_file():
-            continue
-        for dep in _first_party_imports(f):
-            assert (REPO_ROOT / f"{dep}.py").is_file(), f"{mod} imports missing {dep}"
-            stack.append(dep)
+def test_server_imports_cleanly_from_repo_root(tmp_path):
+    """The DEFINITIVE 'good install' check: actually import server in a fresh
+    subprocess from the repo root. A renamed/deleted/uncopied first-party module
+    surfaces here as a real ModuleNotFoundError — unlike a static AST scan, which
+    can only see names that already resolve to a file."""
+    env = dict(os.environ)
+    env["ARKIV_DB_PATH"] = str(tmp_path / "import-probe.db")
+    result = subprocess.run(
+        [sys.executable, "-c", "import server"],
+        cwd=str(REPO_ROOT), capture_output=True, text=True, env=env,
+    )
+    assert result.returncode == 0, (
+        "importing server failed (a fresh install would crash):\n" + result.stderr
+    )

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,52 @@
+"""Guards for the 'good install' contract — that a fresh install ships every
+module server.py needs. A hand-maintained copy list in install.sh once went
+stale and dropped auth/chat/admin/… → the install crashed on first run with
+ModuleNotFoundError. These tests fail loudly if that can recur."""
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _first_party_imports(py_file: Path) -> set:
+    """Top-level modules imported by a file that resolve to a repo-root *.py."""
+    tree = ast.parse(py_file.read_text(encoding="utf-8"))
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            names.add(node.module.split(".")[0])
+    return {n for n in names if (REPO_ROOT / f"{n}.py").is_file()}
+
+
+def test_install_copies_python_modules_via_glob_not_a_stale_list():
+    install = (REPO_ROOT / "install.sh").read_text(encoding="utf-8")
+    # the local-copy path must glob *.py so it can't drift behind new modules
+    assert 'cp "$SRC"/*.py' in install, "install.sh must copy all *.py via glob"
+
+
+def test_every_first_party_module_server_imports_exists():
+    """If server.py imports a local module, the file must exist (catches a
+    rename/delete that a glob-copy would silently miss)."""
+    missing = [m for m in _first_party_imports(REPO_ROOT / "server.py")
+               if not (REPO_ROOT / f"{m}.py").is_file()]
+    assert not missing, f"server.py imports modules with no file: {missing}"
+
+
+def test_first_party_import_closure_is_self_contained():
+    """Transitively: every repo-root module reachable from server.py only imports
+    other repo-root modules that also exist — no dangling local import anywhere in
+    the dependency closure that a fresh install would ship."""
+    seen, stack = set(), ["server"]
+    while stack:
+        mod = stack.pop()
+        if mod in seen:
+            continue
+        seen.add(mod)
+        f = REPO_ROOT / f"{mod}.py"
+        if not f.is_file():
+            continue
+        for dep in _first_party_imports(f):
+            assert (REPO_ROOT / f"{dep}.py").is_file(), f"{mod} imports missing {dep}"
+            stack.append(dep)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2,12 +2,38 @@
 module server.py needs. A hand-maintained copy list in install.sh once went
 stale and dropped auth/chat/admin/… → the install crashed on first run with
 ModuleNotFoundError. These tests fail loudly if that can recur."""
-import os
-import subprocess
+import ast
+import importlib.util
 import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _imported_top_level(py_file: Path) -> set:
+    """Top-level module names this file imports (absolute imports only)."""
+    tree = ast.parse(py_file.read_text(encoding="utf-8"))
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            names.add(node.module.split(".")[0])
+    return names
+
+
+def _resolvable(name: str) -> bool:
+    """Is this import name available? Honors conftest's sys.modules stubs (so a
+    heavy dep like chromadb/torch doesn't false-fail a lightweight test env),
+    plus real installed/stdlib packages via find_spec. A DELETED first-party
+    module is neither in sys.modules (nothing imported it) nor findable nor a
+    repo file → unresolved."""
+    if name in sys.modules:
+        return True
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
 
 
 def test_install_copies_python_modules_via_glob_not_a_stale_list():
@@ -16,17 +42,27 @@ def test_install_copies_python_modules_via_glob_not_a_stale_list():
     assert 'cp "$SRC"/*.py' in install, "install.sh must copy all *.py via glob"
 
 
-def test_server_imports_cleanly_from_repo_root(tmp_path):
-    """The DEFINITIVE 'good install' check: actually import server in a fresh
-    subprocess from the repo root. A renamed/deleted/uncopied first-party module
-    surfaces here as a real ModuleNotFoundError — unlike a static AST scan, which
-    can only see names that already resolve to a file."""
-    env = dict(os.environ)
-    env["ARKIV_DB_PATH"] = str(tmp_path / "import-probe.db")
-    result = subprocess.run(
-        [sys.executable, "-c", "import server"],
-        cwd=str(REPO_ROOT), capture_output=True, text=True, env=env,
-    )
-    assert result.returncode == 0, (
-        "importing server failed (a fresh install would crash):\n" + result.stderr
-    )
+def test_no_unresolved_import_in_install_closure():
+    """Walk the import closure from server.py over repo-root modules. Every
+    imported name must resolve to a repo-root *.py (shipped by the glob copy) OR
+    an available package/stdlib. A renamed/deleted first-party module surfaces
+    here as unresolved — the exact ModuleNotFoundError a fresh install would hit.
+
+    Runs in-process so it inherits conftest's dependency stubs (unlike a clean
+    subprocess, which would false-fail on missing heavy deps)."""
+    local = {p.stem for p in REPO_ROOT.glob("*.py")}
+    seen, stack, missing = set(), ["server"], []
+    while stack:
+        mod = stack.pop()
+        if mod in seen:
+            continue
+        seen.add(mod)
+        f = REPO_ROOT / f"{mod}.py"
+        if not f.is_file():
+            continue
+        for name in _imported_top_level(f):
+            if name in local:
+                stack.append(name)  # recurse into first-party modules
+            elif not _resolvable(name):
+                missing.append((mod, name))
+    assert not missing, f"unresolved imports a fresh install would crash on: {missing}"


### PR DESCRIPTION
Overnight **fresh-install clean-room** ("每人自己裝 arkiv"). Built a repeatable clean-room (fresh `git clone` → venv → `pip install` → import → boot → smoke) and fixed every first-run blocker. The **primary path (README's git-clone) verified green end-to-end from zero**.

## Fixes
- **install.sh shipped a broken install via the copy path.** Its hand-maintained `.py` copy-list had gone stale — it predated `auth.py / chat.py / admin.py / federation.py / projects.py / smart_collections.py / tag_quality.py` (all imported by `server.py`), so a download-and-run install crashed on first run with `ModuleNotFoundError: No module named 'admin'`. Replaced with a `cp "$SRC"/*.py` glob that can't drift. (Proven in the clean room: old list → ImportError, glob → boots.)
- **smoke-test.sh hard-failed on a fresh install** ("Media files indexed: 0 files") — but an empty library is the correct state for a brand-new user. Now a pass-with-note (while still requiring a *numeric* `total`, so a `{}`/`null` schema regression reads as unreadable). A clean install now smoke-tests **9 PASS / 0 FAIL**.

## Regression guards (tests/test_install.py)
- install.sh copies via glob;
- in-process import-closure check: every name reachable from `server.py` resolves to a shipped repo file or an available package (honors conftest's dep stubs, so no false-fail on missing heavy deps; still catches a deleted first-party module — verified by hiding `admin.py`).

## Verified end-to-end in a throwaway clone
`git clone` → `python -m venv` → `pip install -r requirements.txt` → `import server` (OK) → `uvicorn` boots (no errors) → `.arkiv/project.db` auto-created on first run → all endpoints 200 → smoke-test green.

`codex review` clean. No changes to the user's real `~/.arkiv` or working install — all testing in throwaway dirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)