### PR TITLE
harden: security round 2 — loopback escalation, WS auth, token-in-logs, weak bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,21 @@
 # ── Server ─────────────────────────────────────────────────
 # ARKIV_HOST=0.0.0.0                    # Server bind address
 # ARKIV_PORT=8501                       # Server port
+
+# ── Security / Auth ────────────────────────────────────────
+# Loopback trust: requests from 127.0.0.1/::1 are treated as the local owner
+# (full access, no token) UNLESS a forwarding header (X-Forwarded-For/Forwarded/
+# X-Real-IP) is present. Set to false to require a token even for local requests.
+# IMPORTANT: if you put arkiv behind a same-host reverse proxy that does NOT add a
+# forwarding header, set this false — otherwise proxied requests look local.
+# ARKIV_TRUST_LOOPBACK=true
+#
+# One-time admin bootstrap token: when the token table is empty, seeds a full-admin
+# token from this value (delete it after minting per-machine tokens). MUST be ≥24
+# chars and high-entropy — it is allowed from ANY IP. Generate with:
+#   python -c "import secrets; print(secrets.token_urlsafe(32))"
+# ARKIV_ADMIN_BOOTSTRAP_TOKEN=
+#
+# NOTE: /api/stream accepts the token via ?token= (a <video> tag can't send a
+# header). arkiv scrubs token= from its own access logs, but avoid persisting
+# uvicorn access logs to a shared location if you rely on query-token streaming.

--- a/admin.py
+++ b/admin.py
@@ -118,6 +118,16 @@ def bootstrap_admin_token_if_empty() -> Optional[str]:
     if not ARKIV_ADMIN_BOOTSTRAP_TOKEN:
         return None
 
+    # This seeds a FULL-ADMIN token allowed from ANY IP (["*"]). A weak,
+    # operator-chosen value (e.g. "admin") would therefore be a remotely
+    # brute-forceable admin credential. Refuse to seed anything below ~128 bits
+    # of typical entropy — fail loud at startup instead of silently accepting it.
+    if len(ARKIV_ADMIN_BOOTSTRAP_TOKEN) < 24:
+        raise ValueError(
+            "ARKIV_ADMIN_BOOTSTRAP_TOKEN is too weak (min 24 chars). "
+            "Generate one with: python -c \"import secrets; print(secrets.token_urlsafe(32))\""
+        )
+
     token_id = new_token_id()
     with get_conn() as conn:
         conn.execute(

--- a/auth.py
+++ b/auth.py
@@ -43,6 +43,19 @@ def _trust_loopback() -> bool:
     )
 
 
+# A genuine same-machine request carries none of these. A reverse proxy /
+# `tailscale serve` / host-net forwarder connects to the backend FROM 127.0.0.1
+# but adds a forwarding header — so their presence means the real client is
+# remote and loopback trust must NOT apply (else any proxied remote request
+# would be handed full admin). This also neutralizes a spoofed
+# `X-Forwarded-For: 127.0.0.1` from a remote attacker.
+_PROXY_HEADERS = ("x-forwarded-for", "x-forwarded-host", "x-real-ip", "forwarded")
+
+
+def _looks_proxied(request: Request) -> bool:
+    return any(h in request.headers for h in _PROXY_HEADERS)
+
+
 def hash_token(raw):
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
@@ -81,7 +94,12 @@ def _check_ip_allowed(client_ip, allowed_ips_json):
 
 def verify_token(request: Request) -> dict:
     client_host = request.client.host if request.client is not None else ""
-    if _trust_loopback() and client_host in _LOOPBACK_HOSTS:
+    # Loopback trust requires BOTH a loopback peer AND no forwarding header — a
+    # reverse proxy / tailscale-serve forwards from 127.0.0.1 but adds one, so
+    # this stops a proxied remote request from being handed full admin (and a
+    # spoofed X-Forwarded-For from a remote peer, whose own host isn't loopback,
+    # never reaches here anyway).
+    if _trust_loopback() and client_host in _LOOPBACK_HOSTS and not _looks_proxied(request):
         return {"id": "loopback", "name": "loopback (local)", "scopes": SCOPES}
 
     auth_header = request.headers.get("Authorization", "")

--- a/db.py
+++ b/db.py
@@ -20,11 +20,16 @@ def get_conn():
     parent = Path(DB_PATH).expanduser().parent
     if parent and not parent.exists():
         parent.mkdir(parents=True, exist_ok=True)
+        # Only tighten a dir WE just created — never an existing (possibly shared)
+        # parent, which could strip access from unrelated files.
+        try:
+            os.chmod(parent, 0o700)
+        except OSError:
+            pass
     conn = sqlite3.connect(DB_PATH, timeout=30)
-    # The DB holds token hashes — keep it owner-only, not world-readable on a
-    # shared/multi-user host. Best-effort (chmod is a no-op / may fail on Windows).
+    # Our own token-hash DB file — keep it owner-only on shared hosts.
+    # Best-effort (no-op / may fail on Windows).
     try:
-        os.chmod(parent, 0o700)
         os.chmod(DB_PATH, 0o600)
     except OSError:
         pass

--- a/db.py
+++ b/db.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sqlite3
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -20,6 +21,13 @@ def get_conn():
     if parent and not parent.exists():
         parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(DB_PATH, timeout=30)
+    # The DB holds token hashes — keep it owner-only, not world-readable on a
+    # shared/multi-user host. Best-effort (chmod is a no-op / may fail on Windows).
+    try:
+        os.chmod(parent, 0o700)
+        os.chmod(DB_PATH, 0o600)
+    except OSError:
+        pass
     conn.row_factory = sqlite3.Row
     try:
         yield conn

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -95,12 +95,14 @@ export const search = (q, params = {}, opts) =>
 // Split on both / and \ so Windows paths (C:\…\thumbnails\foo.jpg) extract the basename.
 export const thumbUrlFromPath = (thumbnailPath) =>
   thumbnailPath ? `${BASE}/thumbnails/${thumbnailPath.split(/[/\\]/).pop()}` : null
+// Append ?token= to a URL when a token is set — for WebSocket / media-asset URLs
+// that can't send an Authorization header. No-op on loopback / behind the dev
+// proxy (token unset there).
+export const appendToken = (url) =>
+  _token ? `${url}${url.includes('?') ? '&' : '?'}token=${encodeURIComponent(_token)}` : url
 // /api/stream now requires videos_read. A <video src> can't send an Authorization
 // header, so when a token is set (direct remote deployment) carry it as ?token=.
-// On loopback (token-free) and behind the dev proxy (injects the header) _token is
-// null and the URL stays clean.
-export const streamUrl = (id) =>
-  _token ? `${BASE}/api/stream/${id}?token=${encodeURIComponent(_token)}` : `${BASE}/api/stream/${id}`
+export const streamUrl = (id) => appendToken(`${BASE}/api/stream/${id}`)
 // EDL/FCPXML/SRT/VTT/CSV export download URL for a clip (optional in/out trim).
 export const exportUrl = (id, fmt) => `${BASE}/api/media/${id}/export/${fmt}`
 // Batch timeline export: lay several clips end-to-end on one timeline.

--- a/frontend/src/routes/IngestLive.svelte
+++ b/frontend/src/routes/IngestLive.svelte
@@ -26,9 +26,13 @@
   let err = ''
 
   const wsUrl = () => {
-    if (BASE) return BASE.replace(/^http/, 'ws') + '/ws/ingest'
-    const proto = location.protocol === 'https:' ? 'wss' : 'ws'
-    return `${proto}://${location.host}/ws/ingest`
+    // /ws/ingest requires ingest_write; a WebSocket can't send an Authorization
+    // header, so carry the token as ?token= when one is set (direct remote
+    // deployment). No-op on loopback / behind the dev proxy.
+    const base = BASE
+      ? BASE.replace(/^http/, 'ws') + '/ws/ingest'
+      : `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws/ingest`
+    return api.appendToken(base)
   }
 
   function pushLog(text) {

--- a/server.py
+++ b/server.py
@@ -92,6 +92,8 @@ app = FastAPI(title="Media Asset Manager API")
 _ALLOWED_ORIGINS = [
     "http://localhost:8501",
     "http://127.0.0.1:8501",
+    "http://localhost:5173",     # Vite dev server (frontend dev + ws proxy)
+    "http://127.0.0.1:5173",
     "https://tauri.localhost",   # Tauri webview
 ]
 app.add_middleware(

--- a/server.py
+++ b/server.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, field_validator
 import admin
 import chat
 import codec
+import auth
 from auth import require_scopes
 import config
 import db
@@ -33,14 +34,21 @@ import tag_quality
 
 
 # ── WebSocket connection manager ────────────────────────────────────────────
+_MAX_WS_CONNECTIONS = 32  # cap concurrent progress listeners (DoS guard)
+
+
 class IngestBroadcaster:
     """Manages WebSocket connections for ingest progress updates."""
     def __init__(self):
         self.connections: Set[WebSocket] = set()
 
-    async def connect(self, ws: WebSocket):
+    async def connect(self, ws: WebSocket) -> bool:
+        if len(self.connections) >= _MAX_WS_CONNECTIONS:
+            await ws.close(code=1013)  # try again later
+            return False
         await ws.accept()
         self.connections.add(ws)
+        return True
 
     def disconnect(self, ws: WebSocket):
         self.connections.discard(ws)
@@ -60,13 +68,14 @@ ingest_ws = IngestBroadcaster()
 db.init_db()
 
 app = FastAPI(title="Media Asset Manager API")
+_ALLOWED_ORIGINS = [
+    "http://localhost:8501",
+    "http://127.0.0.1:8501",
+    "https://tauri.localhost",   # Tauri webview
+]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:8501",
-        "http://127.0.0.1:8501",
-        "https://tauri.localhost",   # Tauri webview
-    ],
+    allow_origins=_ALLOWED_ORIGINS,
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -2150,10 +2159,39 @@ def admin_revoke_token(
 
 # ── WebSocket: Ingest Progress ───────────────────────────────────────────
 
+def _ws_authorized(ws: WebSocket, scope: str) -> bool:
+    """Authorize a WebSocket handshake. `require_scopes` (a Request-typed Depends)
+    does NOT apply to @app.websocket routes, so this is enforced manually:
+    - Origin check (CSWSH): a browser always sends Origin; reject cross-site so a
+      malicious page can't open ws:// to a loopback-trusted instance.
+    - same loopback-trust rule as HTTP (loopback peer + no forwarding header), else
+    - a `?token=` with the required scope (a browser ws can't set headers)."""
+    origin = ws.headers.get("origin")
+    if origin is not None and origin not in _ALLOWED_ORIGINS:
+        return False
+    host = ws.client.host if ws.client is not None else ""
+    if auth._trust_loopback() and host in auth._LOOPBACK_HOSTS and not auth._looks_proxied(ws):
+        return True
+    try:
+        tok = auth.resolve_raw_token((ws.query_params.get("token") or "").strip(), host)
+    except Exception:
+        return False
+    return scope in tok.get("scopes", ())
+
+
 @app.websocket("/ws/ingest")
 async def ws_ingest(ws: WebSocket):
-    """WebSocket endpoint for real-time ingest progress updates."""
-    await ingest_ws.connect(ws)
+    """WebSocket endpoint for real-time ingest progress updates.
+
+    Previously accepted ANY client (the HTTP scope-gate doesn't reach websocket
+    routes) → any LAN/tailnet client, or a malicious browser page (CSWSH), could
+    connect and stream every ingest's filenames. Now gated: Origin + ingest_write.
+    """
+    if not _ws_authorized(ws, "ingest_write"):
+        await ws.close(code=1008)  # policy violation
+        return
+    if not await ingest_ws.connect(ws):  # may refuse over the connection cap
+        return
     try:
         while True:
             await ws.receive_text()  # keep alive, client can send pings

--- a/server.py
+++ b/server.py
@@ -2189,9 +2189,17 @@ def _ws_authorized(ws: WebSocket, scope: str) -> bool:
       malicious page can't open ws:// to a loopback-trusted instance.
     - same loopback-trust rule as HTTP (loopback peer + no forwarding header), else
     - a `?token=` with the required scope (a browser ws can't set headers)."""
+    # CSWSH guard. A browser always sends Origin; accept it if it's same-origin
+    # (its authority == the request Host — the normal case for ANY deployment
+    # host/port, incl. remote + HTTPS reverse proxy) or in the static dev/Tauri
+    # allowlist. A cross-site page (different authority) is rejected. Non-browser
+    # clients (no Origin) fall through to token auth.
     origin = ws.headers.get("origin")
-    if origin is not None and origin not in _ALLOWED_ORIGINS:
-        return False
+    if origin is not None:
+        origin_authority = origin.split("://", 1)[-1]
+        host_header = ws.headers.get("host", "")
+        if origin_authority != host_header and origin not in _ALLOWED_ORIGINS:
+            return False
     host = ws.client.host if ws.client is not None else ""
     if auth._trust_loopback() and host in auth._LOOPBACK_HOSTS and not auth._looks_proxied(ws):
         return True

--- a/server.py
+++ b/server.py
@@ -67,6 +67,27 @@ ingest_ws = IngestBroadcaster()
 # ── Init ─────────────────────────────────────────────────────────────────────
 db.init_db()
 
+# Redact `?token=` from uvicorn access logs. /api/stream accepts the token as a
+# query param (a <video src> can't send a header), and uvicorn's default access
+# log records the full request line incl. query string → the raw token would be
+# written to stdout / any redirected logfile. This filter scrubs it everywhere
+# the access logger formats a request path.
+import logging as _logging
+import re as _re
+_TOKEN_QS = _re.compile(r"(token=)[^&\s\"']+")
+class _RedactTokenFilter(_logging.Filter):
+    def filter(self, record):
+        try:
+            if record.args:
+                record.args = tuple(
+                    _TOKEN_QS.sub(r"\1REDACTED", a) if isinstance(a, str) else a
+                    for a in record.args
+                )
+        except Exception:
+            pass
+        return True
+_logging.getLogger("uvicorn.access").addFilter(_RedactTokenFilter())
+
 app = FastAPI(title="Media Asset Manager API")
 _ALLOWED_ORIGINS = [
     "http://localhost:8501",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -538,6 +538,10 @@ def test_ws_ingest_requires_auth_and_scope(server_module):
     with client.websocket_connect(f"/ws/ingest?token={good_raw}",
                                   headers={"origin": "http://localhost:5173"}) as ws:
         assert ws is not None
+    # same-origin (Origin authority == Host) → connects on ANY deployment host
+    with client.websocket_connect(f"/ws/ingest?token={good_raw}",
+                                  headers={"origin": "http://testserver", "host": "testserver"}) as ws:
+        assert ws is not None
 
 
 def test_ws_ingest_loopback_trusted_without_token(server_module):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -465,3 +465,46 @@ def test_stream_accepts_token_via_query_param(server_module):
         # right scope via query → auth passes (404 because media doesn't exist,
         # crucially NOT 401/403)
         assert client.get("/api/stream/1", params={"token": good_raw}).status_code == 404
+
+
+def test_loopback_trusted_only_when_not_proxied(auth_app):
+    """Loopback trust (token-free admin) applies to a genuine local request but
+    NOT when a forwarding header is present — a reverse proxy / tailscale-serve
+    forwards from 127.0.0.1 and would otherwise be handed full admin."""
+    app, _ = auth_app
+    local = TestClient(app, client=("127.0.0.1", 12345))
+    # genuine local request, no proxy header → trusted, no token needed
+    assert local.get("/test/read").status_code == 200
+    # same loopback peer but a forwarding header → NOT trusted → 401 (no token)
+    for hdr in ("X-Forwarded-For", "X-Real-IP", "Forwarded"):
+        r = local.get("/test/read", headers={hdr: "203.0.113.9"})
+        assert r.status_code == 401, f"{hdr} should disable loopback trust"
+
+
+def test_loopback_trust_respects_env_off(auth_app, monkeypatch):
+    app, _ = auth_app
+    monkeypatch.setenv("ARKIV_TRUST_LOOPBACK", "false")
+    local = TestClient(app, client=("127.0.0.1", 12345))
+    assert local.get("/test/read").status_code == 401  # token required even local
+
+
+def test_bootstrap_rejects_weak_token(server_module, monkeypatch):
+    import admin, config
+    monkeypatch.setattr(config, "ARKIV_ADMIN_BOOTSTRAP_TOKEN", "admin", raising=False)
+    import pytest
+    with pytest.raises(ValueError, match="too weak"):
+        admin.bootstrap_admin_token_if_empty()
+
+
+def test_bootstrap_accepts_strong_token(server_module, monkeypatch):
+    import admin, auth, config, db
+    strong = "Zx9" + "k" * 40
+    monkeypatch.setattr(config, "ARKIV_ADMIN_BOOTSTRAP_TOKEN", strong, raising=False)
+    # ensure empty token table
+    with db.get_conn() as conn:
+        conn.execute("DELETE FROM access_token_scopes")
+        conn.execute("DELETE FROM access_tokens")
+    assert admin.bootstrap_admin_token_if_empty() == strong
+    with db.get_conn() as conn:
+        row = conn.execute("SELECT token_hash FROM access_tokens").fetchone()
+    assert row["token_hash"] == auth.hash_token(strong)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -508,3 +508,37 @@ def test_bootstrap_accepts_strong_token(server_module, monkeypatch):
     with db.get_conn() as conn:
         row = conn.execute("SELECT token_hash FROM access_tokens").fetchone()
     assert row["token_hash"] == auth.hash_token(strong)
+
+
+def test_ws_ingest_requires_auth_and_scope(server_module):
+    """The /ws/ingest WebSocket must reject unauthenticated / wrong-scope /
+    cross-origin handshakes (require_scopes does not apply to WS routes)."""
+    from starlette.websockets import WebSocketDisconnect as WSD
+    good_raw, _ = _make_token("ws-good", ["ingest_write"])
+    wrong_raw, _ = _make_token("ws-wrong", ["videos_read"])
+    client = TestClient(server_module.app)  # host=testclient (not loopback)
+
+    # no token → closed
+    with pytest.raises(WSD):
+        with client.websocket_connect("/ws/ingest"):
+            pass
+    # wrong scope → closed
+    with pytest.raises(WSD):
+        with client.websocket_connect(f"/ws/ingest?token={wrong_raw}"):
+            pass
+    # cross-site Origin → closed even with a good token (CSWSH guard)
+    with pytest.raises(WSD):
+        with client.websocket_connect(f"/ws/ingest?token={good_raw}",
+                                      headers={"origin": "http://evil.example"}):
+            pass
+    # correct scope, no/allowed origin → connects
+    with client.websocket_connect(f"/ws/ingest?token={good_raw}") as ws:
+        assert ws is not None
+
+
+def test_ws_ingest_loopback_trusted_without_token(server_module):
+    """A genuine loopback handshake (no forwarding header) connects token-free,
+    matching the HTTP loopback rule."""
+    client = TestClient(server_module.app, client=("127.0.0.1", 5555))
+    with client.websocket_connect("/ws/ingest") as ws:
+        assert ws is not None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -531,8 +531,12 @@ def test_ws_ingest_requires_auth_and_scope(server_module):
         with client.websocket_connect(f"/ws/ingest?token={good_raw}",
                                       headers={"origin": "http://evil.example"}):
             pass
-    # correct scope, no/allowed origin → connects
+    # correct scope, no origin → connects
     with client.websocket_connect(f"/ws/ingest?token={good_raw}") as ws:
+        assert ws is not None
+    # correct scope + allowed Vite dev origin → connects (dev proxy case)
+    with client.websocket_connect(f"/ws/ingest?token={good_raw}",
+                                  headers={"origin": "http://localhost:5173"}) as ws:
         assert ws is not None
 
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -224,3 +224,15 @@ def test_resolve_path_passes_through_inside_root_and_absolute():
     assert db.resolve_path(abs_path) == abs_path
     # Empty stays empty (idempotent)
     assert db.resolve_path("") == ""
+
+
+def test_db_file_is_owner_only(tmp_db):
+    """Token-hash DB must not be world/group-readable on POSIX."""
+    import os, stat, sys
+    if sys.platform == "win32":
+        return  # chmod semantics differ on Windows
+    db = importlib.import_module("db")
+    with db.get_conn() as conn:
+        conn.execute("SELECT 1")
+    mode = stat.S_IMODE(os.stat(db.DB_PATH).st_mode)
+    assert mode & 0o077 == 0, f"DB world/group-accessible: {oct(mode)}"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1183,3 +1183,17 @@ def test_chat_persists_capped_prompt(server_module):
     capped = ("x" * 50000)[:8000]
     assert len(capped) == 8000  # the slice the handler persists
     assert len(server.ChatRequest(prompt="x" * 50000).prompt) == 50000  # model keeps it for trim
+
+
+def test_access_log_redacts_token_query_param():
+    """uvicorn access-log filter must scrub ?token= so the raw token never lands
+    in stdout / a redirected logfile."""
+    import importlib, logging
+    server = importlib.import_module("server")
+    f = server._RedactTokenFilter()
+    rec = logging.LogRecord("uvicorn.access", logging.INFO, "", 0,
+                            '%s - "%s %s HTTP/%s" %d',
+                            ("127.0.0.1:1", "GET", "/api/stream/3?token=SECRETVALUE123", "1.1", 200), None)
+    assert f.filter(rec) is True
+    assert "SECRETVALUE123" not in (rec.args[2])
+    assert "token=REDACTED" in rec.args[2]


### PR DESCRIPTION
Second security round — targets the surfaces round 1 (the endpoint sweep) didn't cover. 4 parallel auditors on NEW surfaces (deps / WS / frontend XSS / secrets-at-rest) + the two deferred items (A crypto, C loopback). Every fix red→green tested; `codex review` ran to clean (3 rounds, fixed 6 of its findings). **247 tests pass.**

## C — the headline residual risk (loopback → admin escalation)
`ARKIV_TRUST_LOOPBACK=true` + `0.0.0.0` bind gave **full admin to any request from 127.0.0.1** — so a reverse proxy / `tailscale serve` / host-net forwarder (which connect *from* 127.0.0.1) handed every proxied remote request admin. Fix is **surgical, not a workflow change**: loopback trust now also requires **no forwarding header** (`X-Forwarded-For`/`Forwarded`/`X-Real-IP`). A genuine local request has none → still token-free (your setup unchanged); a proxied/spoofed one is rejected. Also closes the latent `--proxy-headers` spoof.

## B — new surfaces
- **WebSocket `/ws/ingest` had ZERO auth** (`require_scopes` doesn't reach `@app.websocket` routes). Any LAN/tailnet peer — or a malicious browser page (CSWSH; CORS is HTTP-only) — could connect and stream every ingest's filenames. Now: **same-origin/allowlist Origin check + `?token=` ingest_write (or genuine loopback) + connection cap**. Refactored the token core into `auth.resolve_raw_token` so HTTP and WS share identical checks.
- **`?token=` leaked into uvicorn access logs** (I added query-token streaming for `<video>` in round 1). A logging filter now scrubs `token=…` → `REDACTED`.
- **Token DB world-readable**: `.arkiv/project.db` (token hashes) now chmod 0600 (and a dir arkiv *creates* → 0700; never an existing shared parent).
- **`.env.example`** now documents `ARKIV_TRUST_LOOPBACK` (+ reverse-proxy caveat) and `ARKIV_ADMIN_BOOTSTRAP_TOKEN`.
- **Frontend XSS: audited CLEAN** (no `{@html}`, all `{expr}`-escaped, token never in DOM/localStorage).
- **Deps: 1 critical (chromadb CVE-2026-45829) but NOT reachable** — arkiv uses embedded `PersistentClient`, not the vulnerable HTTP-server + `trust_remote_code` path; no patched release exists yet. Monitor + bump when available. Everything else current.

## A
- **Weak bootstrap token**: `bootstrap_admin_token_if_empty` seeds a full-admin, any-IP token — now rejects `ARKIV_ADMIN_BOOTSTRAP_TOKEN` < 24 chars (fails loud with a generate hint).
- **hmac.compare_digest: assessed NOT applicable** — verification is a SQL lookup by SHA-256 hash (no Python secret compare), tokens are 256-bit random. Documented rather than adding security theater.

## Flagged (NOT done — rationale in commits)
- Salt/HMAC the token hash — 256-bit random ⇒ unsalted SHA-256 isn't brute-forceable; re-hashing breaks every existing token for negligible gain.
- Absolute paths in `/api/media` + health responses (dir-structure disclosure to a read-scoped/loopback client) — real but coupled to the frontend (inspector path label / open-file); needs a focused API+frontend pass, not a rushed change.
- WS broadcast is still global (every authorized listener sees every ingest's filenames) — gated to ingest_write now (fine for single-operator); per-token routing is a larger refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)