### PR TITLE
feat: Phase 11.5 resource-aware ingest pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,25 @@
 # ARKIV_HOST=0.0.0.0                    # Server bind address
 # ARKIV_PORT=8501                       # Server port
 
+# ── Resource-aware pipeline (Phase 11.5) ───────────────────
+# Backpressure: before a vision batch, ingest probes memory pressure (GPU VRAM %
+# on NVIDIA, unified-memory % on Apple Silicon) and waits while it exceeds this
+# fraction. Probe is a sensor, not a gate — if Ollama/psutil are unavailable it
+# proceeds anyway. Range (0, 1].
+# ARKIV_GPU_MEM_THRESHOLD=0.8
+#
+# Max seconds ingest will back off before proceeding regardless (never blocks
+# forever).
+# ARKIV_BACKPRESSURE_MAX_WAIT=120
+#
+# Set true to make the probe a full no-op (CI / GPU-less hosts) — ingest then
+# behaves exactly as before Phase 11.5.
+# ARKIV_PROBE_DISABLE=false
+#
+# Ollama-side parallelism for vision/whisper. Default 1 (no parallelism); tune
+# via the Phase 11.5d A/B benchmark on real hardware before raising.
+# OLLAMA_NUM_PARALLEL=1
+
 # ── Security / Auth ────────────────────────────────────────
 # Loopback trust: requests from 127.0.0.1/::1 are treated as the local owner
 # (full access, no token) UNLESS a forwarding header (X-Forwarded-For/Forwarded/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 - **Default embedding model is now `bge-m3` (1024-dim), up from `nomic-embed-text` (768-dim).** bge-m3 is multilingual (100+ languages, 8192-token context) and substantially stronger on Chinese retrieval while staying on par with nomic for English — a better default for mixed-language media libraries. **Breaking for existing indexes:** the dimension change means stored vectors are incompatible; run a full re-index (`python embed.py --rebuild` or 進階設定 → 重建向量索引) after upgrading. Override with `ARKIV_EMBED_MODEL` to keep the old model.
 
 ### Added
+- **Resource-aware ingest pipeline (Phase 11.5).** Ingest now probes machine state before a vision batch and backs off when memory is saturated — directly addressing the 427-clip stress test that lost 20 frames to a cold-start timeout and hit a 28 GB unified-memory crunch.
+  - `resource_probe.py` reports loaded Ollama models (`/api/ps`), GPU VRAM (nvidia-smi on PC), unified memory (psutil on Apple Silicon), and active-job count. It is a **sensor, not a gate**: any source failing degrades that field to `None` and never raises — a broken probe can't block ingest. `ARKIV_PROBE_DISABLE=true` makes it a full no-op.
+  - **Backpressure**: before each vision batch, ingest waits (bounded exponential backoff, `ARKIV_BACKPRESSURE_MAX_WAIT`) while memory pressure exceeds `ARKIV_GPU_MEM_THRESHOLD` (default 0.8), then warms the vision model only if it isn't already resident. Systematizes the previously ad-hoc warm-up.
+  - **`python ingest.py --queue status|cancel|retry [--job-id N]`** — a SQLite-backed job queue (no Redis/Celery) with type-derived priority.
+  - **`python ingest.py --status [--json]`** — one-shot resource + queue snapshot and the decision the next vision phase would take.
+  - New env vars: `ARKIV_GPU_MEM_THRESHOLD`, `ARKIV_BACKPRESSURE_MAX_WAIT`, `ARKIV_PROBE_DISABLE`, `OLLAMA_NUM_PARALLEL`. `psutil` added as a soft dependency.
+
+  > ⚠️ Mock-tested + verified live on Apple Silicon (probe reads real Ollama/memory). The **11.5d throughput A/B** (`OLLAMA_NUM_PARALLEL=1` vs `2`) and the **427-clip cold-start-elimination** acceptance still need a real GPU run — see `docs/phase-11.5-acceptance.md`.
 - **`POST /api/embed/rebuild`** (scope: `ingest_write`) — drops and rebuilds the ChromaDB semantic index from all media in a background subprocess. Backs the existing 進階設定 → 搜尋引擎 「重建向量索引」 button, which previously called a non-existent route (404).
 
 ### Fixed

--- a/config.py
+++ b/config.py
@@ -301,6 +301,21 @@ FILTER_WORDS = os.getenv("ARKIV_FILTER_WORDS", "")
 HOST = os.getenv("ARKIV_HOST", "0.0.0.0")
 PORT = int(os.getenv("ARKIV_PORT", "8501"))
 
+# --- Phase 11.5 resource-aware pipeline ---
+# Backpressure trigger: ingest waits when memory pressure exceeds this fraction
+# (GPU VRAM % on nvidia, unified-memory % on Apple Silicon). Clamped to (0, 1].
+try:
+    GPU_MEM_THRESHOLD = float(os.getenv("ARKIV_GPU_MEM_THRESHOLD", "0.8"))
+except ValueError:
+    GPU_MEM_THRESHOLD = 0.8
+if not (0.0 < GPU_MEM_THRESHOLD <= 1.0):
+    GPU_MEM_THRESHOLD = 0.8
+# A/B-tuned in Phase 11.5d (live GPU). Default 1 = no Ollama-side parallelism.
+try:
+    OLLAMA_NUM_PARALLEL = max(1, int(os.getenv("OLLAMA_NUM_PARALLEL", "1")))
+except ValueError:
+    OLLAMA_NUM_PARALLEL = 1
+
 def discover_projects():
     from projects import discover_projects as _discover_projects
 

--- a/db.py
+++ b/db.py
@@ -243,6 +243,25 @@ def init_db():
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_chat_msg_conv ON chat_messages(conversation_id, created_at)"
         )
+        # Phase 11.5c: SQLite-backed ingest job queue (no Redis/Celery — per
+        # roadmap 11.5c). priority is derived from type; lower runs first.
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS jobs (
+                id          INTEGER PRIMARY KEY,
+                type        TEXT NOT NULL,
+                target      TEXT,
+                priority    INTEGER NOT NULL,
+                status      TEXT NOT NULL DEFAULT 'pending',
+                created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                started_at  TEXT,
+                finished_at TEXT,
+                error       TEXT
+            )
+        """)
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_jobs_status_priority "
+            "ON jobs(status, priority, created_at)"
+        )
 
 
 def migrate_to_relative():

--- a/docs/phase-11.5-acceptance.md
+++ b/docs/phase-11.5-acceptance.md
@@ -1,0 +1,81 @@
+# Phase 11.5 — Live-GPU acceptance (deferred from overnight)
+
+The overnight run (2026-06-03, on `mini-relay`) shipped + verified the
+mock-testable core of Phase 11.5: `resource_probe.py`, the SQLite job queue,
+the probe-driven vision warm-up/backpressure wiring, and `arkiv status`. 49 new
+tests green; full suite 296 passed / 3 skipped; probe verified live against the
+mini's real Ollama.
+
+Two acceptance anchors genuinely need a **real GPU under real ingest load** and
+were intentionally left for a daytime session on the machine with the media +
+hardware (mini for Apple-Silicon, PC for NVIDIA). They cannot be honestly closed
+by mocks.
+
+---
+
+## A. 11.5d — throughput A/B (`OLLAMA_NUM_PARALLEL` 1 vs 2)
+
+**Goal**: decide the production default for `OLLAMA_NUM_PARALLEL`.
+
+**Method**
+1. Pick 10 representative clips (mix of short/long, with audio).
+2. Baseline: `OLLAMA_NUM_PARALLEL=1 python ingest.py --dir <10-clip-dir> --refresh`
+   while sampling `python ingest.py --status --json` every ~30s into a log.
+3. Repeat with `OLLAMA_NUM_PARALLEL=2` (restart Ollama so the env takes effect).
+4. Record per run: wall time, per-frame vision latency (from ingest stdout
+   `[Ns]` markers), peak `system_mem_pct` (Apple) / `gpu_mem_pct` (NVIDIA) from
+   the status samples.
+
+**Pass condition**: a filled comparison table + a one-line recommendation. If
+parallel=2 doesn't beat parallel=1 on wall time without pushing peak memory past
+the threshold, keep the default at 1.
+
+| metric | parallel=1 | parallel=2 |
+|---|---|---|
+| wall time (s) | _TODO_ | _TODO_ |
+| per-frame vision avg (s) | _TODO_ | _TODO_ |
+| peak mem % | _TODO_ | _TODO_ |
+| frames with NULL description | _TODO_ | _TODO_ |
+
+**Recommendation**: _TODO after run_
+
+---
+
+## B. Cold-start elimination (the headline risk)
+
+**Goal**: prove backpressure + warm-up removes the cold-start frame loss the
+427-clip run hit (20 frames blank).
+
+**Method**
+1. Run a vision-bearing ingest of a non-trivial batch (≥ a few dozen clips) on
+   the GPU box: `python ingest.py --dir <batch> --refresh`.
+2. After it completes:
+   `sqlite3 .arkiv/project.db "SELECT COUNT(*) FROM frames WHERE description IS NULL OR description=''"`
+
+**Pass condition**: count == 0 (no frame left undescribed by a cold-start
+timeout).
+
+**Result**: _TODO_
+
+---
+
+## C. Backpressure actually fires under contention (live)
+
+**Goal**: confirm the WAIT path triggers on a real busy GPU, not just in tests.
+
+**Method**
+1. Load the machine: start a memory-hungry model (e.g. keep `qwen2.5:14b`
+   resident) or run another ingest so memory pressure > threshold.
+2. Start a vision ingest and watch stdout for
+   `[backpressure] memory at NN% > threshold 80% — GPU busy, waiting`.
+3. Free the load → confirm it proceeds and warms up.
+
+**Pass condition**: the backpressure log line appears, then ingest proceeds once
+pressure drops (or after `ARKIV_BACKPRESSURE_MAX_WAIT`).
+
+**Result**: _TODO_
+
+---
+
+*Stub created 2026-06-03 by the overnight run. Fill in A/B/C on the next
+daytime GPU session, then flip the Phase 11.5 roadmap rows from ⏳ to ✅.*

--- a/ingest.py
+++ b/ingest.py
@@ -85,7 +85,7 @@ def _ensure_vision_ready(max_wait_s=None, _probe=None, _sleep=None):
     import resource_probe as rp
     import time as _t
 
-    probe = _probe or rp.probe
+    raw_probe = _probe or rp.probe
     sleep = _sleep or _t.sleep
     try:
         import jobs
@@ -98,14 +98,26 @@ def _ensure_vision_ready(max_wait_s=None, _probe=None, _sleep=None):
         except ValueError:
             max_wait_s = 120.0
 
+    # Belt-and-suspenders for the red line: even though rp.probe never raises,
+    # an injected probe (or a future change) might — a probe failure must never
+    # block the vision phase, so treat it as a degraded (PROCEED) reading.
+    def probe(active_jobs=None):
+        try:
+            return raw_probe(active_jobs=active_jobs)
+        except Exception as e:  # noqa: BLE001
+            r = rp._degraded_result("probe raised: {0}".format(e))
+            r["active_jobs"] = active_jobs
+            return r
+
     result = probe(active_jobs=active)
     print(f"  [probe] {rp.summary_line(result)}")
     decision, reason = rp.decide(result)
     waited, delay = 0.0, 2.0
     while decision == "WAIT" and waited < max_wait_s:
+        this_sleep = min(delay, max_wait_s - waited)  # strictly bounded by max_wait
         print(f"  [backpressure] {reason} (waited {waited:.0f}s/{max_wait_s:.0f}s)")
-        sleep(delay)
-        waited += delay
+        sleep(this_sleep)
+        waited += this_sleep
         delay = min(delay * 2, 30.0)
         result = probe(active_jobs=active)
         decision, reason = rp.decide(result)

--- a/ingest.py
+++ b/ingest.py
@@ -494,6 +494,37 @@ def process_file(path: Path, skip_vision: bool, existing: Optional[Dict] = None)
     return record
 
 
+def _run_queue_cmd(args):
+    """Phase 11.5c: `--queue status|cancel|retry`."""
+    import jobs
+
+    if args.queue == "status":
+        c = jobs.counts()
+        print("Job queue: " + "  ".join("{0}={1}".format(k, v) for k, v in c.items()))
+        active = jobs.list_jobs()
+        if not active:
+            print("  (no jobs)")
+            return
+        print("  {0:>5}  {1:<10} {2:<10} {3:<9} {4}".format("id", "type", "status", "priority", "target"))
+        for j in active:
+            print("  {0:>5}  {1:<10} {2:<10} {3:<9} {4}".format(
+                j["id"], j["type"], j["status"], j["priority"], j.get("target") or ""
+            ))
+        return
+
+    # cancel / retry need a job id
+    if not args.job_id:
+        print("--queue {0} requires --job-id N".format(args.queue))
+        sys.exit(2)
+    fn = jobs.cancel if args.queue == "cancel" else jobs.retry
+    ok = fn(args.job_id)
+    if ok:
+        print("Job {0} {1}{2}.".format(args.job_id, args.queue, "ed" if args.queue == "cancel" else "→pending"))
+    else:
+        print("Job {0}: cannot {1} (absent or wrong state).".format(args.job_id, args.queue))
+        sys.exit(1)
+
+
 def _run_vision_only(args):
     """Resume vision: only process frames with empty descriptions."""
     import time as _time
@@ -802,12 +833,15 @@ def main():
     parser.add_argument("--recursive", "-r", action="store_true", help="Recursively scan subdirectories")
     parser.add_argument("--db", default="", help="Path to SQLite DB (default: media.db next to ingest.py)")
     parser.add_argument("--no-embed", action="store_true", help="Skip building the vector index after ingest (default: auto-embed so search/chat work immediately)")
+    parser.add_argument("--queue", choices=["status", "cancel", "retry"], help="Phase 11.5c job queue: status | cancel --job-id N | retry --job-id N")
+    parser.add_argument("--job-id", type=int, default=0, help="Job id for --queue cancel/retry")
     args = parser.parse_args()
 
     # --dir validation: required only when actually ingesting
     maintenance_mode = (
         args.migrate_storage or args.migrate_relative
         or args.regenerate_proxies or args.vision_only
+        or bool(args.queue)
     )
     if not maintenance_mode and not args.dir:
         parser.error("--dir is required unless using --migrate-storage / --migrate-relative / --regenerate-proxies / --vision-only")
@@ -824,7 +858,7 @@ def main():
 
     # Phase 8.0e: pre-flight storage check before any pipeline work.
     # Skip for maintenance modes (they're the tools that fix broken state).
-    if not (args.migrate_relative or args.regenerate_proxies):
+    if not (args.migrate_relative or args.regenerate_proxies or args.queue):
         import health
         ok_pf, errors_pf = health.preflight_paths()
         if not ok_pf:
@@ -835,6 +869,10 @@ def main():
             sys.exit(4)
 
     db.init_db()
+
+    if args.queue:
+        _run_queue_cmd(args)
+        return
 
     if args.migrate_relative:
         db.migrate_to_relative()

--- a/ingest.py
+++ b/ingest.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import subprocess
 import sys
@@ -67,6 +68,52 @@ def _unload_ollama_model(model: str):
         print(f"  Unloaded {model} from VRAM")
     except Exception as e:
         print(f"  Warning: could not unload {model}: {e}")
+
+
+def _ensure_vision_ready(max_wait_s=None, _probe=None, _sleep=None):
+    """Phase 11.5b: probe-driven gate before a vision batch.
+
+    Systematizes the previously-ad-hoc warm-up: (1) bounded exponential
+    backoff while memory pressure exceeds ARKIV_GPU_MEM_THRESHOLD, then
+    (2) warm the vision model up if the probe says it isn't resident.
+
+    SENSOR, NOT GATE: a degraded probe (no Ollama / no psutil) yields a
+    PROCEED decision, so this never blocks ingest on a missing signal; and
+    after max_wait it proceeds anyway with a warning. _probe/_sleep are
+    injectable for tests. Returns the final probe dict.
+    """
+    import resource_probe as rp
+    import time as _t
+
+    probe = _probe or rp.probe
+    sleep = _sleep or _t.sleep
+    try:
+        import jobs
+        active = jobs.active_count()
+    except Exception:
+        active = None
+    if max_wait_s is None:
+        try:
+            max_wait_s = float(os.getenv("ARKIV_BACKPRESSURE_MAX_WAIT", "120"))
+        except ValueError:
+            max_wait_s = 120.0
+
+    result = probe(active_jobs=active)
+    print(f"  [probe] {rp.summary_line(result)}")
+    decision, reason = rp.decide(result)
+    waited, delay = 0.0, 2.0
+    while decision == "WAIT" and waited < max_wait_s:
+        print(f"  [backpressure] {reason} (waited {waited:.0f}s/{max_wait_s:.0f}s)")
+        sleep(delay)
+        waited += delay
+        delay = min(delay * 2, 30.0)
+        result = probe(active_jobs=active)
+        decision, reason = rp.decide(result)
+    if decision == "WAIT":
+        print(f"  [backpressure] still busy after {max_wait_s:.0f}s — proceeding anyway (sensor, not gate)")
+    if not rp.is_model_loaded(result, config.VISION_MODEL):
+        _warm_up_vision_model()
+    return result
 
 
 def _normalize_bmd_tag(value):
@@ -525,6 +572,25 @@ def _run_queue_cmd(args):
         sys.exit(1)
 
 
+def _run_status_cmd(args):
+    """Phase 11.5e: `arkiv status` — resource probe + queue depth + ETA hint."""
+    import resource_probe as rp
+    import jobs
+
+    active = jobs.active_count()
+    result = rp.probe(active_jobs=active)
+    qc = jobs.counts()
+
+    if getattr(args, "json", False):
+        print(json.dumps({"resource": result, "queue": qc}, ensure_ascii=False))
+        return
+
+    print(rp.summary_line(result))
+    print("queue: " + "  ".join("{0}={1}".format(k, v) for k, v in qc.items()))
+    decision, reason = rp.decide(result)
+    print("next vision phase would: {0} ({1})".format(decision, reason))
+
+
 def _run_vision_only(args):
     """Resume vision: only process frames with empty descriptions."""
     import time as _time
@@ -556,7 +622,7 @@ def _run_vision_only(args):
     print(f"Found {len(rows)} frames across {len(media_frames)} files\n")
 
     _unload_ollama_model("qwen2.5:14b")
-    _warm_up_vision_model()
+    _ensure_vision_ready()
 
     ok, halted = 0, False
     for vi, (mid, frames_list) in enumerate(media_frames.items(), 1):
@@ -835,13 +901,15 @@ def main():
     parser.add_argument("--no-embed", action="store_true", help="Skip building the vector index after ingest (default: auto-embed so search/chat work immediately)")
     parser.add_argument("--queue", choices=["status", "cancel", "retry"], help="Phase 11.5c job queue: status | cancel --job-id N | retry --job-id N")
     parser.add_argument("--job-id", type=int, default=0, help="Job id for --queue cancel/retry")
+    parser.add_argument("--status", action="store_true", help="Phase 11.5e: print resource + queue status (--json for machine-readable)")
+    parser.add_argument("--json", action="store_true", help="With --status: emit JSON instead of human-readable")
     args = parser.parse_args()
 
     # --dir validation: required only when actually ingesting
     maintenance_mode = (
         args.migrate_storage or args.migrate_relative
         or args.regenerate_proxies or args.vision_only
-        or bool(args.queue)
+        or bool(args.queue) or args.status
     )
     if not maintenance_mode and not args.dir:
         parser.error("--dir is required unless using --migrate-storage / --migrate-relative / --regenerate-proxies / --vision-only")
@@ -858,7 +926,7 @@ def main():
 
     # Phase 8.0e: pre-flight storage check before any pipeline work.
     # Skip for maintenance modes (they're the tools that fix broken state).
-    if not (args.migrate_relative or args.regenerate_proxies or args.queue):
+    if not (args.migrate_relative or args.regenerate_proxies or args.queue or args.status):
         import health
         ok_pf, errors_pf = health.preflight_paths()
         if not ok_pf:
@@ -872,6 +940,10 @@ def main():
 
     if args.queue:
         _run_queue_cmd(args)
+        return
+
+    if args.status:
+        _run_status_cmd(args)
         return
 
     if args.migrate_relative:
@@ -1021,7 +1093,7 @@ def main():
         print(f"\n{'─'*60}")
         print(f"Phase 2: Vision — {len(phase1_results)} files, unloading LLM to free VRAM...")
         _unload_ollama_model("qwen2.5:14b")
-        _warm_up_vision_model()
+        _ensure_vision_ready()
 
         vision_ok, vision_fail = 0, 0
         consecutive_vision_fail = 0  # halt-on-N-consecutive (Phase 6 / R6)

--- a/jobs.py
+++ b/jobs.py
@@ -1,0 +1,140 @@
+"""jobs — Phase 11.5c SQLite-backed ingest job queue.
+
+A deliberately small queue: no Redis/Celery (roadmap 11.5c). State lives in the
+``jobs`` table created by ``db.init_db()``. Used by the scheduler to serialise
+GPU-heavy work and by ``arkiv queue`` for visibility/cancel/retry.
+
+Priority is derived from job type; ``next_pending`` dequeues the lowest priority
+number first, FIFO within a tier. The roadmap orders them
+``transcode < embed < vision < whisper`` — read left-to-right as precedence, so
+transcode (cheap, unblocks proxy playback) is picked before the heavy GPU jobs.
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+import db
+
+# type -> priority (lower dequeued first). Unknown types fall to the back.
+PRIORITY = {
+    "transcode": 1,
+    "embed": 2,
+    "vision": 3,
+    "whisper": 4,
+}
+_DEFAULT_PRIORITY = 99
+
+PENDING = "pending"
+RUNNING = "running"
+DONE = "done"
+FAILED = "failed"
+CANCELLED = "cancelled"
+
+_TERMINAL = (DONE, FAILED, CANCELLED)
+
+
+def priority_for(job_type: str) -> int:
+    return PRIORITY.get(job_type, _DEFAULT_PRIORITY)
+
+
+def enqueue(job_type: str, target: Optional[str] = None) -> int:
+    """Add a pending job; returns its id."""
+    with db.get_conn() as conn:
+        cur = conn.execute(
+            "INSERT INTO jobs (type, target, priority, status) VALUES (?, ?, ?, ?)",
+            (job_type, target, priority_for(job_type), PENDING),
+        )
+        return int(cur.lastrowid)
+
+
+def next_pending() -> Optional[Dict]:
+    """Highest-precedence pending job (lowest priority number, then oldest)."""
+    with db.get_conn() as conn:
+        row = conn.execute(
+            "SELECT * FROM jobs WHERE status=? ORDER BY priority ASC, created_at ASC, id ASC LIMIT 1",
+            (PENDING,),
+        ).fetchone()
+        return dict(row) if row else None
+
+
+def mark_running(job_id: int) -> None:
+    with db.get_conn() as conn:
+        conn.execute(
+            "UPDATE jobs SET status=?, started_at=datetime('now') WHERE id=?",
+            (RUNNING, job_id),
+        )
+
+
+def mark_done(job_id: int) -> None:
+    with db.get_conn() as conn:
+        conn.execute(
+            "UPDATE jobs SET status=?, finished_at=datetime('now'), error=NULL WHERE id=?",
+            (DONE, job_id),
+        )
+
+
+def mark_failed(job_id: int, error: str = "") -> None:
+    with db.get_conn() as conn:
+        conn.execute(
+            "UPDATE jobs SET status=?, finished_at=datetime('now'), error=? WHERE id=?",
+            (FAILED, (error or "")[:2000], job_id),
+        )
+
+
+def cancel(job_id: int) -> bool:
+    """Cancel a pending/running job. Returns False if absent or terminal."""
+    with db.get_conn() as conn:
+        row = conn.execute("SELECT status FROM jobs WHERE id=?", (job_id,)).fetchone()
+        if row is None or row["status"] in _TERMINAL:
+            return False
+        conn.execute(
+            "UPDATE jobs SET status=?, finished_at=datetime('now') WHERE id=?",
+            (CANCELLED, job_id),
+        )
+        return True
+
+
+def retry(job_id: int) -> bool:
+    """Re-queue a failed/cancelled job back to pending. Returns False otherwise."""
+    with db.get_conn() as conn:
+        row = conn.execute("SELECT status FROM jobs WHERE id=?", (job_id,)).fetchone()
+        if row is None or row["status"] not in (FAILED, CANCELLED):
+            return False
+        conn.execute(
+            "UPDATE jobs SET status=?, started_at=NULL, finished_at=NULL, error=NULL WHERE id=?",
+            (PENDING, job_id),
+        )
+        return True
+
+
+def counts() -> Dict[str, int]:
+    """status -> count, with every known status present (0 if none)."""
+    base = {PENDING: 0, RUNNING: 0, DONE: 0, FAILED: 0, CANCELLED: 0}
+    with db.get_conn() as conn:
+        for row in conn.execute("SELECT status, COUNT(*) AS n FROM jobs GROUP BY status"):
+            base[row["status"]] = row["n"]
+    return base
+
+
+def active_count() -> int:
+    """Pending + running — the number `resource_probe.probe` reports as load."""
+    c = counts()
+    return c[PENDING] + c[RUNNING]
+
+
+def list_jobs(status: Optional[str] = None, limit: int = 50) -> List[Dict]:
+    limit = max(1, min(int(limit), 500))
+    with db.get_conn() as conn:
+        if status:
+            rows = conn.execute(
+                "SELECT * FROM jobs WHERE status=? ORDER BY priority ASC, created_at ASC LIMIT ?",
+                (status, limit),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM jobs ORDER BY "
+                "CASE status WHEN 'running' THEN 0 WHEN 'pending' THEN 1 ELSE 2 END, "
+                "priority ASC, created_at ASC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        return [dict(r) for r in rows]

--- a/jobs.py
+++ b/jobs.py
@@ -57,28 +57,61 @@ def next_pending() -> Optional[Dict]:
         return dict(row) if row else None
 
 
-def mark_running(job_id: int) -> None:
+def claim_next() -> Optional[Dict]:
+    """Atomically dequeue the next pending job → running.
+
+    Concurrency-safe: the UPDATE is guarded on `status='pending'`, so if a second
+    worker claimed the same row first, this one's UPDATE matches 0 rows and we
+    return None (caller retries). Prefer this over next_pending()+mark_running()
+    when more than one consumer can run.
+    """
     with db.get_conn() as conn:
-        conn.execute(
-            "UPDATE jobs SET status=?, started_at=datetime('now') WHERE id=?",
-            (RUNNING, job_id),
+        row = conn.execute(
+            "SELECT * FROM jobs WHERE status=? ORDER BY priority ASC, created_at ASC, id ASC LIMIT 1",
+            (PENDING,),
+        ).fetchone()
+        if row is None:
+            return None
+        cur = conn.execute(
+            "UPDATE jobs SET status=?, started_at=datetime('now') WHERE id=? AND status=?",
+            (RUNNING, row["id"], PENDING),
         )
+        if cur.rowcount != 1:
+            return None  # lost the race to another claimer
+        return dict(row, status=RUNNING)
 
 
-def mark_done(job_id: int) -> None:
+def mark_running(job_id: int) -> bool:
+    """pending → running. Returns False if the job wasn't pending (already
+    claimed / cancelled / terminal) — never revives a finished job."""
     with db.get_conn() as conn:
-        conn.execute(
-            "UPDATE jobs SET status=?, finished_at=datetime('now'), error=NULL WHERE id=?",
-            (DONE, job_id),
+        cur = conn.execute(
+            "UPDATE jobs SET status=?, started_at=datetime('now') WHERE id=? AND status=?",
+            (RUNNING, job_id, PENDING),
         )
+        return cur.rowcount == 1
 
 
-def mark_failed(job_id: int, error: str = "") -> None:
+def mark_done(job_id: int) -> bool:
+    """pending/running → done. Won't overwrite a cancelled/terminal job."""
     with db.get_conn() as conn:
-        conn.execute(
-            "UPDATE jobs SET status=?, finished_at=datetime('now'), error=? WHERE id=?",
-            (FAILED, (error or "")[:2000], job_id),
+        cur = conn.execute(
+            "UPDATE jobs SET status=?, finished_at=datetime('now'), error=NULL "
+            "WHERE id=? AND status IN (?, ?)",
+            (DONE, job_id, PENDING, RUNNING),
         )
+        return cur.rowcount == 1
+
+
+def mark_failed(job_id: int, error: str = "") -> bool:
+    """pending/running → failed. Won't overwrite a cancelled/terminal job."""
+    with db.get_conn() as conn:
+        cur = conn.execute(
+            "UPDATE jobs SET status=?, finished_at=datetime('now'), error=? "
+            "WHERE id=? AND status IN (?, ?)",
+            (FAILED, (error or "")[:2000], job_id, PENDING, RUNNING),
+        )
+        return cur.rowcount == 1
 
 
 def cancel(job_id: int) -> bool:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,11 @@ nanoid>=2.0.0
 pillow>=9.0
 soundfile>=0.12
 
+# Resource-aware pipeline (Phase 11.5) — soft dependency: arkiv runs without it
+# (probe degrades the memory fields to None), but installing it enables
+# backpressure and the `arkiv status` memory readout.
+psutil>=5.9
+
 # Speech pre-processing
 silero-vad>=6.0
 

--- a/resource_probe.py
+++ b/resource_probe.py
@@ -1,0 +1,239 @@
+"""resource_probe — Phase 11.5 resource-awareness layer.
+
+Reports GPU / system-memory / loaded-model / active-job state so the ingest
+pipeline can warm models up before a phase and back off when the machine is
+already saturated (the 427-clip stress test lost 20 frames to a cold-start
+timeout and hit a 28 GB unified-memory crunch).
+
+HARD RULE — this module is a *sensor*, never a *gate*. Every external call
+(Ollama HTTP, nvidia-smi, psutil) is wrapped: any failure degrades the
+corresponding field to ``None`` and is recorded in ``errors``; it must never
+raise into the ingest path. Set ``ARKIV_PROBE_DISABLE=true`` to make probe() a
+fully-degraded no-op (CI / GPU-less hosts).
+
+Backends:
+- nvidia (PC RTX): nvidia-smi gives real, separate VRAM used/total.
+- apple (M-series): unified memory — GPU and system share one pool, so the
+  backpressure signal is system memory %. Loaded-model VRAM (from Ollama
+  /api/ps ``size_vram``) is reported as ``ollama_vram_mb`` for visibility.
+"""
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import subprocess
+import urllib.request
+from typing import Dict, List, Optional, Tuple
+
+import config
+
+# psutil is a soft dependency: present in requirements.txt (mac) but probe must
+# import-time-survive its absence and just degrade the memory fields.
+try:
+    import psutil as _psutil
+except Exception:  # noqa: BLE001 — any import failure → degrade, never crash
+    _psutil = None
+
+
+def _truthy_env(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def probe_disabled() -> bool:
+    return _truthy_env("ARKIV_PROBE_DISABLE")
+
+
+def _degraded_result(reason: str) -> Dict:
+    return {
+        "degraded": True,
+        "errors": [reason],
+        "backend": "unknown",
+        "gpu_mem_used_mb": None,
+        "gpu_mem_total_mb": None,
+        "gpu_mem_pct": None,
+        "ollama_vram_mb": None,
+        "models_loaded": [],
+        "models_known": False,
+        "system_mem_used_mb": None,
+        "system_mem_total_mb": None,
+        "system_mem_pct": None,
+        "active_jobs": None,
+    }
+
+
+def _detect_backend() -> str:
+    if shutil.which("nvidia-smi"):
+        return "nvidia"
+    if platform.system() == "Darwin" and platform.machine() in ("arm64", "aarch64"):
+        return "apple"
+    return "unknown"
+
+
+def _probe_ollama(url: str, timeout: float = 3.0) -> Tuple[List[str], Optional[float]]:
+    """Return (loaded model names, summed VRAM MB) from Ollama /api/ps.
+
+    Raises on any failure — caller catches and degrades.
+    """
+    req = urllib.request.Request(url.rstrip("/") + "/api/ps")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # nosec - configured URL
+        raw = resp.read().decode("utf-8", "replace")
+    data = json.loads(raw)
+    models = data.get("models") or []
+    names = [m.get("name") or m.get("model") for m in models if (m.get("name") or m.get("model"))]
+    vram_bytes = sum((m.get("size_vram") or 0) for m in models)
+    vram_mb = round(vram_bytes / 1_000_000, 1) if vram_bytes else 0.0
+    return names, vram_mb
+
+
+def _probe_nvidia(timeout: float = 3.0) -> Tuple[float, float]:
+    """Return (used_mb, total_mb) from nvidia-smi. Raises on failure."""
+    out = subprocess.run(
+        [
+            "nvidia-smi",
+            "--query-gpu=memory.used,memory.total",
+            "--format=csv,noheader,nounits",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=True,
+    ).stdout.strip()
+    # First GPU line: "1234, 8192"
+    first = out.splitlines()[0]
+    used_str, total_str = (p.strip() for p in first.split(","))
+    return float(used_str), float(total_str)
+
+
+def _probe_memory() -> Tuple[Optional[float], Optional[float], Optional[float]]:
+    """Return (used_mb, total_mb, pct 0-1) via psutil, or (None, None, None)."""
+    if _psutil is None:
+        return None, None, None
+    vm = _psutil.virtual_memory()
+    total_mb = round(vm.total / 1_000_000, 1)
+    used_mb = round((vm.total - vm.available) / 1_000_000, 1)
+    pct = round(vm.percent / 100.0, 4)
+    return used_mb, total_mb, pct
+
+
+def probe(active_jobs: Optional[int] = None) -> Dict:
+    """Snapshot current resource state. Never raises.
+
+    ``active_jobs`` is injected by the caller (queue layer) to avoid a hard
+    import cycle with db; left None when the caller has no queue context.
+    """
+    if probe_disabled():
+        r = _degraded_result("ARKIV_PROBE_DISABLE set — probe is a no-op")
+        r["active_jobs"] = active_jobs
+        return r
+
+    errors: List[str] = []
+    backend = _detect_backend()
+
+    # --- loaded models + ollama VRAM (both backends) ---
+    models_loaded: List[str] = []
+    models_known = False
+    ollama_vram_mb: Optional[float] = None
+    try:
+        models_loaded, ollama_vram_mb = _probe_ollama(config.OLLAMA_URL)
+        models_known = True
+    except Exception as e:  # noqa: BLE001
+        errors.append("ollama /api/ps unavailable: {0}".format(e))
+
+    # --- GPU memory (nvidia only; apple has no discrete VRAM) ---
+    gpu_used_mb: Optional[float] = None
+    gpu_total_mb: Optional[float] = None
+    gpu_pct: Optional[float] = None
+    if backend == "nvidia":
+        try:
+            gpu_used_mb, gpu_total_mb = _probe_nvidia()
+            if gpu_total_mb:
+                gpu_pct = round(gpu_used_mb / gpu_total_mb, 4)
+        except Exception as e:  # noqa: BLE001
+            errors.append("nvidia-smi unavailable: {0}".format(e))
+
+    # --- system memory (psutil) ---
+    sys_used_mb, sys_total_mb, sys_pct = _probe_memory()
+    if sys_pct is None:
+        errors.append("psutil unavailable — system memory unknown")
+
+    degraded = bool(errors)
+    return {
+        "degraded": degraded,
+        "errors": errors,
+        "backend": backend,
+        "gpu_mem_used_mb": gpu_used_mb,
+        "gpu_mem_total_mb": gpu_total_mb,
+        "gpu_mem_pct": gpu_pct,
+        "ollama_vram_mb": ollama_vram_mb,
+        "models_loaded": models_loaded,
+        "models_known": models_known,
+        "system_mem_used_mb": sys_used_mb,
+        "system_mem_total_mb": sys_total_mb,
+        "system_mem_pct": sys_pct,
+        "active_jobs": active_jobs,
+    }
+
+
+def pressure_metric(result: Dict) -> Optional[float]:
+    """The 0-1 number backpressure decisions key on.
+
+    nvidia: discrete VRAM %. apple/unknown: unified-memory % (GPU shares it).
+    Returns None when no signal is available (caller must then PROCEED).
+    """
+    if result.get("backend") == "nvidia" and result.get("gpu_mem_pct") is not None:
+        return result["gpu_mem_pct"]
+    return result.get("system_mem_pct")
+
+
+def is_model_loaded(result: Dict, model: str) -> bool:
+    """True only when we positively know the model is resident in Ollama.
+
+    When model state is unknown (Ollama unreachable) returns False so the caller
+    warms up defensively rather than skipping a needed load.
+    """
+    if not result.get("models_known"):
+        return False
+    loaded = result.get("models_loaded") or []
+    # Ollama reports e.g. "qwen3-vl:8b"; tolerate bare-name configs ("qwen3-vl").
+    for name in loaded:
+        if name == model or name.split(":", 1)[0] == model.split(":", 1)[0]:
+            return True
+    return False
+
+
+def decide(result: Dict, threshold: Optional[float] = None) -> Tuple[str, str]:
+    """Return ('PROCEED'|'WAIT', human reason).
+
+    RED LINE: degraded / unknown pressure → PROCEED. Probe never blocks ingest
+    on missing signal.
+    """
+    if threshold is None:
+        threshold = config.GPU_MEM_THRESHOLD
+    p = pressure_metric(result)
+    if p is None:
+        return "PROCEED", "no memory-pressure signal (degraded) — proceeding"
+    if p > threshold:
+        return "WAIT", "memory at {0:.0%} > threshold {1:.0%} — GPU busy, waiting".format(p, threshold)
+    return "PROCEED", "memory at {0:.0%} <= threshold {1:.0%}".format(p, threshold)
+
+
+def summary_line(result: Dict) -> str:
+    """One-line human-readable status (for `arkiv status`)."""
+    backend = result.get("backend", "unknown")
+    if result.get("backend") == "nvidia" and result.get("gpu_mem_pct") is not None:
+        mem = "GPU {0:.0%} ({1:.0f}/{2:.0f}MB)".format(
+            result["gpu_mem_pct"], result["gpu_mem_used_mb"], result["gpu_mem_total_mb"]
+        )
+    elif result.get("system_mem_pct") is not None:
+        mem = "MEM {0:.0%} ({1:.0f}/{2:.0f}MB)".format(
+            result["system_mem_pct"], result["system_mem_used_mb"], result["system_mem_total_mb"]
+        )
+    else:
+        mem = "MEM unknown"
+    models = ",".join(result.get("models_loaded") or []) or "none"
+    jobs = result.get("active_jobs")
+    jobs_str = "?" if jobs is None else str(jobs)
+    flag = " [degraded]" if result.get("degraded") else ""
+    return "[{0}] {1} | models: {2} | active jobs: {3}{4}".format(backend, mem, models, jobs_str, flag)

--- a/resource_probe.py
+++ b/resource_probe.py
@@ -129,7 +129,11 @@ def probe(active_jobs: Optional[int] = None) -> Dict:
         return r
 
     errors: List[str] = []
-    backend = _detect_backend()
+    try:
+        backend = _detect_backend()
+    except Exception as e:  # noqa: BLE001 — backend detection must never escape
+        backend = "unknown"
+        errors.append("backend detection failed: {0}".format(e))
 
     # --- loaded models + ollama VRAM (both backends) ---
     models_loaded: List[str] = []
@@ -154,8 +158,12 @@ def probe(active_jobs: Optional[int] = None) -> Dict:
             errors.append("nvidia-smi unavailable: {0}".format(e))
 
     # --- system memory (psutil) ---
-    sys_used_mb, sys_total_mb, sys_pct = _probe_memory()
-    if sys_pct is None:
+    try:
+        sys_used_mb, sys_total_mb, sys_pct = _probe_memory()
+    except Exception as e:  # noqa: BLE001 — psutil reading must never escape
+        sys_used_mb = sys_total_mb = sys_pct = None
+        errors.append("psutil read failed: {0}".format(e))
+    if sys_pct is None and not any("psutil" in m for m in errors):
         errors.append("psutil unavailable — system memory unknown")
 
     degraded = bool(errors)
@@ -211,9 +219,14 @@ def decide(result: Dict, threshold: Optional[float] = None) -> Tuple[str, str]:
     """
     if threshold is None:
         threshold = config.GPU_MEM_THRESHOLD
+    # RED LINE: if ANY source failed, the picture is incomplete/untrustworthy —
+    # never WAIT on a partial reading (blocking is the dangerous action). This
+    # also avoids treating system RAM as a VRAM proxy when nvidia-smi failed.
+    if result.get("degraded"):
+        return "PROCEED", "probe degraded — proceeding (sensor, not gate)"
     p = pressure_metric(result)
     if p is None:
-        return "PROCEED", "no memory-pressure signal (degraded) — proceeding"
+        return "PROCEED", "no memory-pressure signal — proceeding"
     if p > threshold:
         return "WAIT", "memory at {0:.0%} > threshold {1:.0%} — GPU busy, waiting".format(p, threshold)
     return "PROCEED", "memory at {0:.0%} <= threshold {1:.0%}".format(p, threshold)

--- a/tests/test_ingest_resource.py
+++ b/tests/test_ingest_resource.py
@@ -69,9 +69,11 @@ def test_backs_off_then_proceeds(ingest_mod):
 def test_proceeds_after_max_wait_even_if_busy(ingest_mod):
     sleeps = []
     probe = _probe_seq({"backend": "apple", "system_mem_pct": 0.99, "models_known": True, "models_loaded": ["qwen3-vl:8b"]})
-    # max_wait small -> bounded number of backoffs, then proceed anyway
+    # max_wait small -> total backoff is STRICTLY bounded by max_wait (Codex
+    # SHOULD-FIX: clamp each sleep to the remaining budget, no overshoot).
     ingest_mod._ensure_vision_ready(max_wait_s=5, _probe=probe, _sleep=sleeps.append)
-    assert sum(sleeps) >= 5  # gave up after exceeding the budget
+    assert sum(sleeps) <= 5  # never overshoots the budget
+    assert sum(sleeps) == 5  # and uses it fully before giving up
     assert len(sleeps) <= 4  # didn't spin forever
 
 
@@ -95,6 +97,19 @@ def test_skips_warmup_when_model_loaded(ingest_mod):
     probe = _probe_seq({"backend": "apple", "system_mem_pct": 0.3, "models_known": True, "models_loaded": ["qwen3-vl:8b"]})
     ingest_mod._ensure_vision_ready(_probe=probe, _sleep=lambda s: None)
     assert ingest_mod._test_calls["warmup"] == 0
+
+
+def test_probe_that_raises_does_not_block_ingest(ingest_mod):
+    # Codex CRITICAL-3: even if the probe itself raises, the vision boundary
+    # treats it as degraded (PROCEED) and never propagates.
+    sleeps = []
+
+    def _boom(active_jobs=None):
+        raise RuntimeError("probe blew up")
+
+    ingest_mod._ensure_vision_ready(_probe=_boom, _sleep=sleeps.append)  # must not raise
+    assert sleeps == []  # degraded -> no wait
+    assert ingest_mod._test_calls["warmup"] == 1  # unknown -> defensive warm-up
 
 
 def test_probe_disable_env_makes_it_proceed(ingest_mod, monkeypatch):

--- a/tests/test_ingest_resource.py
+++ b/tests/test_ingest_resource.py
@@ -1,0 +1,107 @@
+"""Phase 11.5b — ingest probe integration (_ensure_vision_ready).
+
+Verifies the backpressure backoff + warm-up wiring with injected probe/sleep,
+and the RED LINE: a degraded/disabled probe never blocks ingest.
+"""
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def ingest_mod(tmp_db, monkeypatch):
+    # tmp_db points db.DB_PATH at a temp DB so jobs.active_count() is hermetic.
+    ingest = importlib.import_module("ingest")
+    ingest = importlib.reload(ingest)
+    # Don't fire real Ollama warm-up HTTP; just count calls.
+    calls = {"warmup": 0}
+    monkeypatch.setattr(ingest, "_warm_up_vision_model", lambda: calls.__setitem__("warmup", calls["warmup"] + 1))
+    ingest._test_calls = calls
+    return ingest
+
+
+def _full(overrides):
+    """Probe always returns the full key shape; tests merge onto that base."""
+    base = {
+        "degraded": False, "errors": [], "backend": "apple",
+        "gpu_mem_used_mb": None, "gpu_mem_total_mb": None, "gpu_mem_pct": None,
+        "ollama_vram_mb": 0.0, "models_loaded": [], "models_known": True,
+        "system_mem_used_mb": 8000.0, "system_mem_total_mb": 16000.0,
+        "system_mem_pct": 0.5, "active_jobs": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _probe_seq(*results):
+    """A probe() stub that returns each result in turn, repeating the last."""
+    seq = [_full(r) for r in results]
+
+    def _p(active_jobs=None):
+        r = seq.pop(0) if len(seq) > 1 else seq[0]
+        return dict(r, active_jobs=active_jobs)
+    return _p
+
+
+# --------------------------------------------------------------------------
+def test_proceeds_immediately_when_under_threshold(ingest_mod):
+    sleeps = []
+    probe = _probe_seq({"backend": "apple", "system_mem_pct": 0.4, "models_known": True, "models_loaded": ["qwen3-vl:8b"]})
+    ingest_mod._ensure_vision_ready(_probe=probe, _sleep=sleeps.append)
+    assert sleeps == []  # no backoff
+    assert ingest_mod._test_calls["warmup"] == 0  # model already loaded
+
+
+def test_backs_off_then_proceeds(ingest_mod):
+    sleeps = []
+    # busy, busy, then clear
+    probe = _probe_seq(
+        {"backend": "apple", "system_mem_pct": 0.95, "models_known": True, "models_loaded": ["qwen3-vl:8b"]},
+        {"backend": "apple", "system_mem_pct": 0.95, "models_known": True, "models_loaded": ["qwen3-vl:8b"]},
+        {"backend": "apple", "system_mem_pct": 0.4, "models_known": True, "models_loaded": ["qwen3-vl:8b"]},
+    )
+    ingest_mod._ensure_vision_ready(max_wait_s=120, _probe=probe, _sleep=sleeps.append)
+    assert len(sleeps) == 2  # waited twice before clearing
+    # exponential: 2s then 4s
+    assert sleeps[0] == 2.0 and sleeps[1] == 4.0
+
+
+def test_proceeds_after_max_wait_even_if_busy(ingest_mod):
+    sleeps = []
+    probe = _probe_seq({"backend": "apple", "system_mem_pct": 0.99, "models_known": True, "models_loaded": ["qwen3-vl:8b"]})
+    # max_wait small -> bounded number of backoffs, then proceed anyway
+    ingest_mod._ensure_vision_ready(max_wait_s=5, _probe=probe, _sleep=sleeps.append)
+    assert sum(sleeps) >= 5  # gave up after exceeding the budget
+    assert len(sleeps) <= 4  # didn't spin forever
+
+
+def test_degraded_probe_proceeds_and_warms_up(ingest_mod):
+    # No signal (psutil + ollama down) -> PROCEED, and warm up defensively
+    # because model state is unknown.
+    sleeps = []
+    probe = _probe_seq({"backend": "unknown", "system_mem_pct": None, "models_known": False, "models_loaded": []})
+    ingest_mod._ensure_vision_ready(_probe=probe, _sleep=sleeps.append)
+    assert sleeps == []  # degraded never waits
+    assert ingest_mod._test_calls["warmup"] == 1  # unknown -> defensive warm-up
+
+
+def test_warms_up_when_model_not_loaded(ingest_mod):
+    probe = _probe_seq({"backend": "apple", "system_mem_pct": 0.3, "models_known": True, "models_loaded": ["llama3:8b"]})
+    ingest_mod._ensure_vision_ready(_probe=probe, _sleep=lambda s: None)
+    assert ingest_mod._test_calls["warmup"] == 1
+
+
+def test_skips_warmup_when_model_loaded(ingest_mod):
+    probe = _probe_seq({"backend": "apple", "system_mem_pct": 0.3, "models_known": True, "models_loaded": ["qwen3-vl:8b"]})
+    ingest_mod._ensure_vision_ready(_probe=probe, _sleep=lambda s: None)
+    assert ingest_mod._test_calls["warmup"] == 0
+
+
+def test_probe_disable_env_makes_it_proceed(ingest_mod, monkeypatch):
+    # With the real probe under ARKIV_PROBE_DISABLE, decision is PROCEED and
+    # (models unknown) it warms up — never blocks.
+    monkeypatch.setenv("ARKIV_PROBE_DISABLE", "true")
+    sleeps = []
+    ingest_mod._ensure_vision_ready(_sleep=sleeps.append)
+    assert sleeps == []
+    assert ingest_mod._test_calls["warmup"] == 1

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -178,3 +178,70 @@ def test_list_jobs_orders_running_then_pending(jq):
     # running first regardless of priority number
     assert rows[0]["id"] == r
     assert rows[1]["id"] == p
+
+
+# --------------------------------------------------------------------------
+# atomic claim + transition guards (Codex SHOULD-FIX)
+# --------------------------------------------------------------------------
+def test_claim_next_dequeues_and_marks_running(jq):
+    jq.enqueue("whisper")
+    t = jq.enqueue("transcode")  # higher precedence
+    claimed = jq.claim_next()
+    assert claimed["id"] == t and claimed["status"] == jq.RUNNING
+    assert jq.list_jobs(status=jq.RUNNING)[0]["id"] == t
+
+
+def test_claim_next_empty_returns_none(jq):
+    assert jq.claim_next() is None
+    jq.enqueue("vision")
+    jq.claim_next()
+    # nothing pending left
+    assert jq.claim_next() is None
+
+
+def test_mark_running_guards_non_pending(jq):
+    jid = jq.enqueue("vision")
+    assert jq.mark_running(jid) is True
+    # already running -> can't re-mark
+    assert jq.mark_running(jid) is False
+    jq.mark_done(jid)
+    # done -> never revived to running
+    assert jq.mark_running(jid) is False
+    assert jq.list_jobs()[0]["status"] == jq.DONE
+
+
+def test_mark_done_cannot_overwrite_cancelled(jq):
+    jid = jq.enqueue("vision")
+    jq.cancel(jid)
+    assert jq.mark_done(jid) is False
+    assert jq.list_jobs()[0]["status"] == jq.CANCELLED
+
+
+def test_mark_failed_cannot_overwrite_cancelled(jq):
+    jid = jq.enqueue("vision")
+    jq.cancel(jid)
+    assert jq.mark_failed(jid, "x") is False
+    assert jq.list_jobs()[0]["status"] == jq.CANCELLED
+
+
+def test_concurrent_claim_only_one_wins(jq):
+    import threading
+
+    jq.enqueue("vision")  # exactly ONE pending job
+    results = []
+    lock = threading.Lock()
+
+    def worker():
+        got = jq.claim_next()
+        with lock:
+            results.append(got)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    winners = [r for r in results if r is not None]
+    assert len(winners) == 1  # exactly one worker claimed the single job
+    assert jq.counts()[jq.RUNNING] == 1

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,0 +1,180 @@
+"""Phase 11.5c — jobs queue tests (real SQLite via tmp_db fixture)."""
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def jq(tmp_db):
+    # jobs.py uses db.get_conn(); tmp_db has already pointed db.DB_PATH at tmp.
+    jobs = importlib.import_module("jobs")
+    return importlib.reload(jobs)
+
+
+# --------------------------------------------------------------------------
+# enqueue + priority
+# --------------------------------------------------------------------------
+def test_enqueue_returns_id_and_priority(jq):
+    jid = jq.enqueue("vision", target="clip.mp4")
+    rows = jq.list_jobs()
+    assert len(rows) == 1
+    assert rows[0]["id"] == jid
+    assert rows[0]["priority"] == jq.PRIORITY["vision"]
+    assert rows[0]["status"] == jq.PENDING
+    assert rows[0]["target"] == "clip.mp4"
+
+
+def test_unknown_type_goes_to_back(jq):
+    jq.enqueue("transcode")
+    weird = jq.enqueue("mystery")
+    # transcode (1) dequeues before unknown (99)
+    nxt = jq.next_pending()
+    assert nxt["type"] == "transcode"
+    assert jq.priority_for("mystery") == jq._DEFAULT_PRIORITY
+
+
+def test_next_pending_orders_by_priority_then_fifo(jq):
+    jq.enqueue("whisper")    # priority 4
+    jq.enqueue("transcode")  # priority 1  <- should come first
+    jq.enqueue("embed")      # priority 2
+    nxt = jq.next_pending()
+    assert nxt["type"] == "transcode"
+
+
+def test_next_pending_fifo_within_tier(jq):
+    a = jq.enqueue("vision", target="a")
+    b = jq.enqueue("vision", target="b")
+    nxt = jq.next_pending()
+    assert nxt["id"] == a and nxt["target"] == "a"
+    assert b  # second one still pending
+
+
+def test_next_pending_empty_returns_none(jq):
+    assert jq.next_pending() is None
+
+
+# --------------------------------------------------------------------------
+# status transitions
+# --------------------------------------------------------------------------
+def test_running_done_lifecycle(jq):
+    jid = jq.enqueue("whisper")
+    jq.mark_running(jid)
+    assert jq.list_jobs(status=jq.RUNNING)[0]["id"] == jid
+    # running job is not pending -> not dequeued
+    assert jq.next_pending() is None
+    jq.mark_done(jid)
+    c = jq.counts()
+    assert c[jq.DONE] == 1 and c[jq.RUNNING] == 0
+
+
+def test_mark_failed_records_error(jq):
+    jid = jq.enqueue("vision")
+    jq.mark_running(jid)
+    jq.mark_failed(jid, "ollama timeout")
+    row = jq.list_jobs(status=jq.FAILED)[0]
+    assert row["error"] == "ollama timeout"
+    assert row["finished_at"] is not None
+
+
+def test_mark_failed_truncates_long_error(jq):
+    jid = jq.enqueue("vision")
+    jq.mark_failed(jid, "x" * 5000)
+    row = jq.list_jobs(status=jq.FAILED)[0]
+    assert len(row["error"]) == 2000
+
+
+# --------------------------------------------------------------------------
+# cancel / retry edge cases
+# --------------------------------------------------------------------------
+def test_cancel_pending(jq):
+    jid = jq.enqueue("vision")
+    assert jq.cancel(jid) is True
+    assert jq.counts()[jq.CANCELLED] == 1
+    # cancelled job no longer dequeues
+    assert jq.next_pending() is None
+
+
+def test_cancel_running(jq):
+    jid = jq.enqueue("vision")
+    jq.mark_running(jid)
+    assert jq.cancel(jid) is True
+
+
+def test_cancel_absent_returns_false(jq):
+    assert jq.cancel(99999) is False
+
+
+def test_cannot_cancel_done(jq):
+    jid = jq.enqueue("vision")
+    jq.mark_done(jid)
+    assert jq.cancel(jid) is False
+
+
+def test_retry_failed_requeues(jq):
+    jid = jq.enqueue("vision")
+    jq.mark_running(jid)
+    jq.mark_failed(jid, "boom")
+    assert jq.retry(jid) is True
+    row = jq.list_jobs()[0]
+    assert row["status"] == jq.PENDING
+    assert row["error"] is None
+    assert row["started_at"] is None
+    # re-queued job dequeues again
+    assert jq.next_pending()["id"] == jid
+
+
+def test_retry_cancelled_requeues(jq):
+    jid = jq.enqueue("vision")
+    jq.cancel(jid)
+    assert jq.retry(jid) is True
+
+
+def test_cannot_retry_pending(jq):
+    jid = jq.enqueue("vision")
+    assert jq.retry(jid) is False
+
+
+def test_cannot_retry_done(jq):
+    jid = jq.enqueue("vision")
+    jq.mark_done(jid)
+    assert jq.retry(jid) is False
+
+
+def test_retry_absent_returns_false(jq):
+    assert jq.retry(99999) is False
+
+
+# --------------------------------------------------------------------------
+# counts / active_count
+# --------------------------------------------------------------------------
+def test_counts_has_all_statuses(jq):
+    c = jq.counts()
+    for s in (jq.PENDING, jq.RUNNING, jq.DONE, jq.FAILED, jq.CANCELLED):
+        assert s in c and c[s] == 0
+
+
+def test_active_count_pending_plus_running(jq):
+    jq.enqueue("vision")
+    r = jq.enqueue("whisper")
+    jq.mark_running(r)
+    d = jq.enqueue("embed")
+    jq.mark_done(d)
+    # 1 pending + 1 running = 2 active; done excluded
+    assert jq.active_count() == 2
+
+
+def test_list_jobs_limit_clamped(jq):
+    for _ in range(5):
+        jq.enqueue("vision")
+    assert len(jq.list_jobs(limit=2)) == 2
+    assert len(jq.list_jobs(limit=0)) == 1  # clamped to >=1
+
+
+def test_list_jobs_orders_running_then_pending(jq):
+    p = jq.enqueue("transcode")
+    r = jq.enqueue("whisper")
+    jq.mark_running(r)
+    rows = jq.list_jobs()
+    # running first regardless of priority number
+    assert rows[0]["id"] == r
+    assert rows[1]["id"] == p

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -130,6 +130,35 @@ def test_probe_psutil_missing_degrades(monkeypatch):
     assert any("psutil" in e for e in r["errors"])
 
 
+def test_probe_psutil_raises_degrades(monkeypatch):
+    # psutil present but virtual_memory() raises (Codex CRITICAL-2): must
+    # degrade, not propagate.
+    boom = types.SimpleNamespace()
+    def _raise():
+        raise RuntimeError("psutil exploded")
+    boom.virtual_memory = _raise
+    monkeypatch.setattr(rp, "_detect_backend", lambda: "apple")
+    monkeypatch.setattr(rp.urllib.request, "urlopen", _fake_urlopen({"models": []}))
+    monkeypatch.setattr(rp, "_psutil", boom)
+
+    r = rp.probe()  # must not raise
+    assert r["degraded"] is True
+    assert r["system_mem_pct"] is None
+
+
+def test_probe_backend_detection_raises_degrades(monkeypatch):
+    # _detect_backend raising must not propagate (Codex CRITICAL-2).
+    def _boom():
+        raise OSError("which failed")
+    monkeypatch.setattr(rp, "_detect_backend", _boom)
+    monkeypatch.setattr(rp.urllib.request, "urlopen", _fake_urlopen({"models": []}))
+    monkeypatch.setattr(rp, "_psutil", _fake_psutil())
+
+    r = rp.probe()
+    assert r["degraded"] is True
+    assert r["backend"] == "unknown"
+
+
 def test_probe_nvidia_smi_fails_degrades(monkeypatch):
     def _boom(timeout=3.0):
         raise FileNotFoundError("nvidia-smi")
@@ -186,12 +215,28 @@ def test_decide_proceed_when_under_threshold():
     assert decision == "PROCEED"
 
 
-def test_decide_proceed_when_degraded_red_line():
-    # No signal must never block ingest.
+def test_decide_proceed_when_no_signal():
+    # No pressure signal at all must never block ingest.
     r = {"backend": "unknown", "gpu_mem_pct": None, "system_mem_pct": None}
     decision, reason = rp.decide(r, threshold=0.8)
     assert decision == "PROCEED"
+
+
+def test_decide_degraded_with_high_pressure_proceeds():
+    # RED LINE (Codex CRITICAL-1): a degraded probe must PROCEED even when a
+    # stale/partial pressure reading is high — never WAIT on an untrustworthy
+    # picture (e.g. Ollama down but psutil reads 95%, or nvidia-smi failed).
+    r = {"degraded": True, "backend": "apple", "gpu_mem_pct": None, "system_mem_pct": 0.99}
+    decision, reason = rp.decide(r, threshold=0.8)
+    assert decision == "PROCEED"
     assert "degraded" in reason
+
+
+def test_decide_not_degraded_high_pressure_waits():
+    # Sanity: a clean (non-degraded) high reading still WAITs.
+    r = {"degraded": False, "backend": "apple", "gpu_mem_pct": None, "system_mem_pct": 0.95}
+    decision, _ = rp.decide(r, threshold=0.8)
+    assert decision == "WAIT"
 
 
 def test_decide_uses_config_default_threshold(monkeypatch):

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -1,0 +1,247 @@
+"""Phase 11.5a — resource_probe tests.
+
+All external sources (Ollama HTTP, nvidia-smi, psutil) are mocked. The central
+invariant under test: probe() degrades to None and never raises, and decide()
+PROCEEDs whenever the pressure signal is absent (probe is a sensor, not a gate).
+"""
+import io
+import json
+import types
+
+import pytest
+
+import resource_probe as rp
+
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+class _FakeResp(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        self.close()
+        return False
+
+
+def _fake_urlopen(payload):
+    def _open(req, timeout=None):
+        return _FakeResp(json.dumps(payload).encode())
+    return _open
+
+
+def _fake_psutil(percent=42.0, total=32_000_000_000, available=18_000_000_000):
+    mod = types.SimpleNamespace()
+    mod.virtual_memory = lambda: types.SimpleNamespace(
+        percent=percent, total=total, available=available
+    )
+    return mod
+
+
+@pytest.fixture(autouse=True)
+def _clear_disable(monkeypatch):
+    monkeypatch.delenv("ARKIV_PROBE_DISABLE", raising=False)
+
+
+# --------------------------------------------------------------------------
+# probe() — happy path
+# --------------------------------------------------------------------------
+def test_probe_apple_normal(monkeypatch):
+    monkeypatch.setattr(rp, "_detect_backend", lambda: "apple")
+    monkeypatch.setattr(rp.urllib.request, "urlopen", _fake_urlopen(
+        {"models": [{"name": "qwen3-vl:8b", "size_vram": 8_000_000_000}]}
+    ))
+    monkeypatch.setattr(rp, "_psutil", _fake_psutil(percent=42.0))
+
+    r = rp.probe()
+    assert r["degraded"] is False
+    assert r["backend"] == "apple"
+    assert r["models_loaded"] == ["qwen3-vl:8b"]
+    assert r["models_known"] is True
+    assert r["ollama_vram_mb"] == 8000.0
+    assert r["system_mem_pct"] == 0.42
+    # Apple has no discrete VRAM -> gpu fields stay None
+    assert r["gpu_mem_pct"] is None
+
+
+def test_probe_nvidia_normal(monkeypatch):
+    monkeypatch.setattr(rp, "_detect_backend", lambda: "nvidia")
+    monkeypatch.setattr(rp.urllib.request, "urlopen", _fake_urlopen({"models": []}))
+    monkeypatch.setattr(rp, "_probe_nvidia", lambda timeout=3.0: (4096.0, 8192.0))
+    monkeypatch.setattr(rp, "_psutil", _fake_psutil(percent=30.0))
+
+    r = rp.probe()
+    assert r["degraded"] is False
+    assert r["gpu_mem_pct"] == 0.5
+    assert r["gpu_mem_used_mb"] == 4096.0
+    assert r["models_loaded"] == []
+    assert r["models_known"] is True
+
+
+def test_probe_passes_active_jobs(monkeypatch):
+    monkeypatch.setattr(rp, "_detect_backend", lambda: "apple")
+    monkeypatch.setattr(rp.urllib.request, "urlopen", _fake_urlopen({"models": []}))
+    monkeypatch.setattr(rp, "_psutil", _fake_psutil())
+    r = rp.probe(active_jobs=3)
+    assert r["active_jobs"] == 3
+
+
+# --------------------------------------------------------------------------
+# probe() — degrade paths (RED LINE: never raise)
+# --------------------------------------------------------------------------
+def test_probe_ollama_unreachable_degrades(monkeypatch):
+    def _boom(req, timeout=None):
+        raise OSError("connection refused")
+    monkeypatch.setattr(rp, "_detect_backend", lambda: "apple")
+    monkeypatch.setattr(rp.urllib.request, "urlopen", _boom)
+    monkeypatch.setattr(rp, "_psutil", _fake_psutil())
+
+    r = rp.probe()
+    assert r["degraded"] is True
+    assert r["models_known"] is False
+    assert r["models_loaded"] == []
+    assert any("ollama" in e for e in r["errors"])
+    # but system memory still read
+    assert r["system_mem_pct"] is not None
+
+
+def test_probe_ollama_malformed_json_degrades(monkeypatch):
+    def _garbage(req, timeout=None):
+        return _FakeResp(b"<html>not json</html>")
+    monkeypatch.setattr(rp, "_detect_backend", lambda: "apple")
+    monkeypatch.setattr(rp.urllib.request, "urlopen", _garbage)
+    monkeypatch.setattr(rp, "_psutil", _fake_psutil())
+
+    r = rp.probe()
+    assert r["degraded"] is True
+    assert r["models_known"] is False
+
+
+def test_probe_psutil_missing_degrades(monkeypatch):
+    monkeypatch.setattr(rp, "_detect_backend", lambda: "apple")
+    monkeypatch.setattr(rp.urllib.request, "urlopen", _fake_urlopen({"models": []}))
+    monkeypatch.setattr(rp, "_psutil", None)
+
+    r = rp.probe()
+    assert r["degraded"] is True
+    assert r["system_mem_pct"] is None
+    assert r["system_mem_used_mb"] is None
+    assert any("psutil" in e for e in r["errors"])
+
+
+def test_probe_nvidia_smi_fails_degrades(monkeypatch):
+    def _boom(timeout=3.0):
+        raise FileNotFoundError("nvidia-smi")
+    monkeypatch.setattr(rp, "_detect_backend", lambda: "nvidia")
+    monkeypatch.setattr(rp.urllib.request, "urlopen", _fake_urlopen({"models": []}))
+    monkeypatch.setattr(rp, "_probe_nvidia", _boom)
+    monkeypatch.setattr(rp, "_psutil", _fake_psutil())
+
+    r = rp.probe()
+    assert r["degraded"] is True
+    assert r["gpu_mem_pct"] is None
+    assert any("nvidia-smi" in e for e in r["errors"])
+
+
+def test_probe_disabled_is_noop(monkeypatch):
+    monkeypatch.setenv("ARKIV_PROBE_DISABLE", "true")
+    # even if sources would work, disabled wins and nothing is called
+    monkeypatch.setattr(rp, "_detect_backend", lambda: (_ for _ in ()).throw(AssertionError("should not run")))
+    r = rp.probe(active_jobs=7)
+    assert r["degraded"] is True
+    assert r["backend"] == "unknown"
+    assert r["models_loaded"] == []
+    assert r["active_jobs"] == 7
+
+
+# --------------------------------------------------------------------------
+# pressure_metric / decide — the backpressure table
+# --------------------------------------------------------------------------
+def test_pressure_metric_nvidia_uses_gpu():
+    r = {"backend": "nvidia", "gpu_mem_pct": 0.9, "system_mem_pct": 0.2}
+    assert rp.pressure_metric(r) == 0.9
+
+
+def test_pressure_metric_apple_uses_system():
+    r = {"backend": "apple", "gpu_mem_pct": None, "system_mem_pct": 0.55}
+    assert rp.pressure_metric(r) == 0.55
+
+
+def test_pressure_metric_none_when_degraded():
+    r = {"backend": "unknown", "gpu_mem_pct": None, "system_mem_pct": None}
+    assert rp.pressure_metric(r) is None
+
+
+def test_decide_wait_when_over_threshold():
+    r = {"backend": "apple", "gpu_mem_pct": None, "system_mem_pct": 0.85}
+    decision, reason = rp.decide(r, threshold=0.8)
+    assert decision == "WAIT"
+    assert "waiting" in reason
+
+
+def test_decide_proceed_when_under_threshold():
+    r = {"backend": "apple", "gpu_mem_pct": None, "system_mem_pct": 0.5}
+    decision, _ = rp.decide(r, threshold=0.8)
+    assert decision == "PROCEED"
+
+
+def test_decide_proceed_when_degraded_red_line():
+    # No signal must never block ingest.
+    r = {"backend": "unknown", "gpu_mem_pct": None, "system_mem_pct": None}
+    decision, reason = rp.decide(r, threshold=0.8)
+    assert decision == "PROCEED"
+    assert "degraded" in reason
+
+
+def test_decide_uses_config_default_threshold(monkeypatch):
+    monkeypatch.setattr(rp.config, "GPU_MEM_THRESHOLD", 0.5)
+    r = {"backend": "apple", "system_mem_pct": 0.6}
+    decision, _ = rp.decide(r)
+    assert decision == "WAIT"
+
+
+# --------------------------------------------------------------------------
+# is_model_loaded
+# --------------------------------------------------------------------------
+def test_is_model_loaded_exact():
+    r = {"models_known": True, "models_loaded": ["qwen3-vl:8b"]}
+    assert rp.is_model_loaded(r, "qwen3-vl:8b") is True
+
+
+def test_is_model_loaded_bare_name():
+    r = {"models_known": True, "models_loaded": ["qwen3-vl:8b"]}
+    assert rp.is_model_loaded(r, "qwen3-vl") is True
+
+
+def test_is_model_loaded_absent():
+    r = {"models_known": True, "models_loaded": ["llama3:8b"]}
+    assert rp.is_model_loaded(r, "qwen3-vl:8b") is False
+
+
+def test_is_model_loaded_unknown_returns_false():
+    # Ollama unreachable -> don't claim loaded -> caller warms up defensively.
+    r = {"models_known": False, "models_loaded": []}
+    assert rp.is_model_loaded(r, "qwen3-vl:8b") is False
+
+
+# --------------------------------------------------------------------------
+# summary_line — must not crash on any shape
+# --------------------------------------------------------------------------
+def test_summary_line_degraded_does_not_crash():
+    r = rp._degraded_result("test")
+    line = rp.summary_line(r)
+    assert "degraded" in line
+    assert "unknown" in line
+
+
+def test_summary_line_nvidia():
+    r = {
+        "backend": "nvidia", "gpu_mem_pct": 0.5,
+        "gpu_mem_used_mb": 4096.0, "gpu_mem_total_mb": 8192.0,
+        "models_loaded": ["qwen3-vl:8b"], "active_jobs": 2, "degraded": False,
+    }
+    line = rp.summary_line(r)
+    assert "GPU 50%" in line
+    assert "qwen3-vl:8b" in line
+    assert "active jobs: 2" in line


### PR DESCRIPTION
## Phase 11.5 — Resource-Aware Pipeline

Makes ingest aware of GPU/memory state so it warms models up before a vision batch and backs off when the machine is saturated — directly addressing the 427-clip stress test (20 frames lost to a cold-start timeout, 28 GB unified-memory crunch).

### What landed (5 commits)
- **`resource_probe.py`** — snapshots loaded Ollama models (`/api/ps`), GPU VRAM (nvidia-smi on PC), unified memory (psutil on Apple Silicon), active-job count. **Sensor, not gate**: every source failing degrades to `None` and never raises; a degraded probe always yields PROCEED so it can't block ingest. `ARKIV_PROBE_DISABLE=true` → full no-op.
- **Backpressure + warm-up** wired into both vision sites (batch Phase 2 + `--vision-only`): bounded exponential backoff while memory > `ARKIV_GPU_MEM_THRESHOLD` (default 0.8), then warm the vision model only if not resident. Systematizes the prior ad-hoc warm-up.
- **`--queue status|cancel|retry`** — SQLite-backed job queue (no Redis/Celery), type-derived priority, atomic `claim_next()`.
- **`--status [--json]`** — resource + queue snapshot + the decision the next vision phase would take.
- New env vars: `ARKIV_GPU_MEM_THRESHOLD`, `ARKIV_BACKPRESSURE_MAX_WAIT`, `ARKIV_PROBE_DISABLE`, `OLLAMA_NUM_PARALLEL`. `psutil` added as a soft dependency.

### Verification
- **307 passed / 3 skipped** (60 new tests across `test_resource` / `test_queue` / `test_ingest_resource`).
- Verified live on Apple Silicon: probe reads real Ollama + memory; degraded probe (Ollama down) still PROCEEDs.
- **Codex review: 2 rounds, block → ship.** Round 1 found 3 CRITICAL (a `decide()` red-line hole where a degraded probe could WAIT; two unguarded raise paths) + 5 SHOULD-FIX (backoff overshoot, queue claim race, transition guards) — all fixed in `c5e875c`. Round 2: all resolved, no new issues.

### Deferred to a daytime GPU session (not faked with mocks)
Three acceptance anchors need real GPU under real load — `docs/phase-11.5-acceptance.md`:
1. 11.5d throughput A/B (`OLLAMA_NUM_PARALLEL` 1 vs 2)
2. Cold-start elimination (`frames` NULL-description count == 0 after a real batch)
3. Live backpressure firing under contention

🤖 Generated with [Claude Code](https://claude.com/claude-code)