### PR TITLE
feat: Phase 12 export.py — corpus/JSONL CLI for LoRA/RAG

### DIFF
--- a/export.py
+++ b/export.py
@@ -1,0 +1,164 @@
+"""export.py — Phase 12 corpus/JSONL export CLI.
+
+Turns an arkiv library's transcripts + vision metadata into the two formats a
+LoRA / RAG pipeline actually wants:
+
+    python export.py corpus [--lang zh] [--out corpus.txt]
+        merged plain-text corpus — transcripts only, blank-line separated, no
+        JSON residue. For continued-pretraining / LoRA.
+
+    python export.py jsonl [--lang zh] [--out chunks.jsonl]
+        one JSON object per media on its own line: {id, text, metadata}. For
+        RAG ingestion.
+
+    python export.py txt <media_id> [--out clip.txt]
+        a single clip's transcript.
+
+Reads the DB directly via db.get_conn() (same as ingest.py) so it stays free of
+the FastAPI server import. Honours --db / ARKIV_DB_PATH.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional
+
+import db
+
+
+def _frame_descriptions(frame_tags_value) -> List[str]:
+    """Pull human descriptions out of the frame_tags JSON list.
+
+    Production frame_tags is a JSON list of dicts each carrying `description`
+    (vision.py). Tolerates None / malformed / legacy shapes by returning [].
+    """
+    if not frame_tags_value:
+        return []
+    try:
+        data = json.loads(frame_tags_value)
+    except (ValueError, TypeError):
+        return []
+    if not isinstance(data, list):
+        return []
+    out = []
+    for item in data:
+        if isinstance(item, dict):
+            desc = item.get("description")
+            if isinstance(desc, str) and desc.strip():
+                out.append(desc.strip())
+    return out
+
+
+def _iter_media(conn, lang: Optional[str] = None) -> Iterator[Dict]:
+    """Yield full media rows (ordered by id), optionally filtered by language."""
+    sql = "SELECT * FROM media"
+    params: List = []
+    if lang:
+        sql += " WHERE lang = ?"
+        params.append(lang)
+    sql += " ORDER BY id"
+    for row in conn.execute(sql, params):
+        yield dict(row)
+
+
+def _tags_for(conn, media_id: int) -> List[str]:
+    rows = conn.execute(
+        "SELECT name FROM tags WHERE media_id = ? ORDER BY name", (media_id,)
+    ).fetchall()
+    return [r["name"] for r in rows]
+
+
+def build_corpus(lang: Optional[str] = None) -> str:
+    """Concatenated transcripts (blank-line separated). Plain text only."""
+    parts: List[str] = []
+    with db.get_conn() as conn:
+        for rec in _iter_media(conn, lang):
+            text = (rec.get("transcript") or "").strip()
+            if text:
+                parts.append(text)
+    return "\n\n".join(parts)
+
+
+def build_jsonl_lines(lang: Optional[str] = None) -> List[str]:
+    """One compact JSON object per media with a transcript: {id, text, metadata}."""
+    lines: List[str] = []
+    with db.get_conn() as conn:
+        for rec in _iter_media(conn, lang):
+            text = (rec.get("transcript") or "").strip()
+            if not text:
+                continue  # nothing to retrieve on
+            obj = {
+                "id": rec.get("id"),
+                "text": text,
+                "metadata": {
+                    "filename": rec.get("filename"),
+                    "lang": rec.get("lang"),
+                    "duration_s": rec.get("duration_s"),
+                    "fps": rec.get("fps"),
+                    "content_type": rec.get("content_type"),
+                    "camera_make": rec.get("camera_make"),
+                    "camera_model": rec.get("camera_model"),
+                    "rating": rec.get("rating"),
+                    "tags": _tags_for(conn, rec["id"]),
+                    "frame_descriptions": _frame_descriptions(rec.get("frame_tags")),
+                },
+            }
+            lines.append(json.dumps(obj, ensure_ascii=False))
+    return lines
+
+
+def export_txt(media_id: int) -> str:
+    rec = db.get_record_by_id(media_id)
+    if not rec:
+        raise KeyError("media id {0} not found".format(media_id))
+    return (rec.get("transcript") or "").strip()
+
+
+def _emit(content: str, out: Optional[str]) -> None:
+    if out:
+        Path(out).expanduser().write_text(content, encoding="utf-8")
+        print("Wrote {0} ({1} bytes)".format(out, len(content.encode("utf-8"))))
+    else:
+        sys.stdout.write(content)
+        if content and not content.endswith("\n"):
+            sys.stdout.write("\n")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Export arkiv transcripts/metadata for LoRA/RAG")
+    parser.add_argument("--db", default="", help="Path to SQLite DB (default: config DB_PATH)")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_corpus = sub.add_parser("corpus", help="Merged plain-text corpus (transcripts only)")
+    p_corpus.add_argument("--lang", default=None, help="Filter by language (e.g. zh)")
+    p_corpus.add_argument("--out", default=None, help="Output file (default: stdout)")
+
+    p_jsonl = sub.add_parser("jsonl", help="RAG chunks: one JSON object per media")
+    p_jsonl.add_argument("--lang", default=None, help="Filter by language (e.g. zh)")
+    p_jsonl.add_argument("--out", default=None, help="Output file (default: stdout)")
+
+    p_txt = sub.add_parser("txt", help="A single clip's transcript")
+    p_txt.add_argument("media_id", type=int)
+    p_txt.add_argument("--out", default=None, help="Output file (default: stdout)")
+
+    args = parser.parse_args(argv)
+    if args.db:
+        db.DB_PATH = Path(args.db)
+
+    if args.cmd == "corpus":
+        _emit(build_corpus(args.lang), args.out)
+    elif args.cmd == "jsonl":
+        _emit("\n".join(build_jsonl_lines(args.lang)), args.out)
+    elif args.cmd == "txt":
+        try:
+            _emit(export_txt(args.media_id), args.out)
+        except KeyError as e:
+            print(str(e), file=sys.stderr)
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -44,12 +44,22 @@ def test_corpus_lang_filter(ex, sample_record):
 
 
 def test_corpus_is_plain_text_no_json_residue(ex, sample_record):
-    # Acceptance anchor: `corpus` output must NOT parse as JSON.
-    _seed(sample_record)
+    # Acceptance anchor: `corpus` carries transcript text only — none of the
+    # exporter's JSON structure (frame_tags / metadata) leaks into it. Note a
+    # transcript may legitimately CONTAIN brace/JSON-looking spoken text; that
+    # is preserved verbatim and is not "residue" (Codex SHOULD-FIX).
+    db.upsert(sample_record(path="/m/j.mp4", lang="zh",
+                            transcript='他說 {"title":"片名"}\n下一行還在同一段。'))
     corpus = ex.build_corpus(lang="zh")
+    # JSON-looking spoken text survives untouched...
+    assert '{"title":"片名"}' in corpus
+    assert "下一行還在同一段。" in corpus
+    # ...but the exporter never dumps its own metadata structure into corpus.
+    for leaked in ("frame_tags", "frame_descriptions", '"metadata"', '"filename"'):
+        assert leaked not in corpus
+    # the corpus as a whole is plain text, not a JSON document
     with pytest.raises(ValueError):
         json.loads(corpus)
-    assert "{" not in corpus and "frame_tags" not in corpus
 
 
 def test_corpus_skips_empty_transcripts(ex, sample_record):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,152 @@
+"""Phase 12 — export.py corpus/JSONL CLI tests (real SQLite via tmp_db)."""
+import importlib
+import json
+
+import pytest
+
+import db
+
+
+@pytest.fixture
+def ex(tmp_db):
+    export = importlib.import_module("export")
+    return importlib.reload(export)
+
+
+def _seed(sample_record):
+    # 2 zh + 1 en, plus one zh with an empty transcript.
+    db.upsert(sample_record(path="/m/a.mp4", filename="a.mp4", lang="zh",
+                            transcript="第一段中文逐字稿。"))
+    db.upsert(sample_record(path="/m/b.mp4", filename="b.mp4", lang="zh",
+                            transcript="第二段中文逐字稿。"))
+    db.upsert(sample_record(path="/m/c.mp4", filename="c.mp4", lang="en",
+                            transcript="English transcript here."))
+    db.upsert(sample_record(path="/m/d.mp4", filename="d.mp4", lang="zh",
+                            transcript=""))
+
+
+# --------------------------------------------------------------------------
+# corpus
+# --------------------------------------------------------------------------
+def test_corpus_merges_transcripts_blank_line_separated(ex, sample_record):
+    _seed(sample_record)
+    corpus = ex.build_corpus()
+    assert "第一段中文逐字稿。" in corpus
+    assert "English transcript here." in corpus
+    assert "\n\n" in corpus  # blank-line separated
+
+
+def test_corpus_lang_filter(ex, sample_record):
+    _seed(sample_record)
+    zh = ex.build_corpus(lang="zh")
+    assert "第一段中文逐字稿。" in zh
+    assert "English transcript here." not in zh
+
+
+def test_corpus_is_plain_text_no_json_residue(ex, sample_record):
+    # Acceptance anchor: `corpus` output must NOT parse as JSON.
+    _seed(sample_record)
+    corpus = ex.build_corpus(lang="zh")
+    with pytest.raises(ValueError):
+        json.loads(corpus)
+    assert "{" not in corpus and "frame_tags" not in corpus
+
+
+def test_corpus_skips_empty_transcripts(ex, sample_record):
+    _seed(sample_record)
+    zh = ex.build_corpus(lang="zh")
+    # d.mp4 has empty transcript -> only the 2 non-empty zh clips
+    assert zh.count("\n\n") == 1  # 2 parts -> exactly one separator
+
+
+# --------------------------------------------------------------------------
+# jsonl
+# --------------------------------------------------------------------------
+def test_jsonl_each_line_valid_json_with_id_text_metadata(ex, sample_record):
+    # Acceptance anchor: every line is valid JSON carrying id / text / metadata.
+    _seed(sample_record)
+    lines = ex.build_jsonl_lines()
+    assert len(lines) == 3  # empty-transcript clip excluded
+    for line in lines:
+        obj = json.loads(line)  # must not raise
+        assert "id" in obj and "text" in obj and "metadata" in obj
+        assert obj["text"]
+        assert "tags" in obj["metadata"] and "frame_descriptions" in obj["metadata"]
+
+
+def test_jsonl_lang_filter_and_skip_empty(ex, sample_record):
+    _seed(sample_record)
+    zh = ex.build_jsonl_lines(lang="zh")
+    assert len(zh) == 2  # 2 non-empty zh (empty one skipped)
+    for line in zh:
+        assert json.loads(line)["metadata"]["lang"] == "zh"
+
+
+def test_jsonl_includes_tags_and_frame_descriptions(ex, sample_record):
+    db.upsert(sample_record(path="/m/x.mp4", filename="x.mp4", lang="zh",
+                            transcript="有標籤的片段。"))
+    mid = db.get_record_by_id(1)["id"]
+    db.add_tag(mid, "海邊", source="manual")
+    lines = ex.build_jsonl_lines()
+    obj = json.loads(lines[0])
+    assert "海邊" in obj["metadata"]["tags"]
+    # sample_record's frame_tags carries a description
+    assert any("描述" in d for d in obj["metadata"]["frame_descriptions"])
+
+
+def test_jsonl_ensure_ascii_false_keeps_utf8(ex, sample_record):
+    db.upsert(sample_record(path="/m/u.mp4", lang="zh", transcript="中文不要被跳脫。"))
+    line = ex.build_jsonl_lines()[0]
+    assert "中文不要被跳脫" in line  # raw UTF-8, not \uXXXX
+
+
+# --------------------------------------------------------------------------
+# _frame_descriptions robustness
+# --------------------------------------------------------------------------
+def test_frame_descriptions_handles_garbage(ex):
+    assert ex._frame_descriptions(None) == []
+    assert ex._frame_descriptions("") == []
+    assert ex._frame_descriptions("<not json>") == []
+    assert ex._frame_descriptions('{"not": "a list"}') == []
+    assert ex._frame_descriptions('[{"no_desc": 1}]') == []
+    assert ex._frame_descriptions('[{"description": "  "}]') == []  # blank stripped
+
+
+def test_frame_descriptions_extracts(ex):
+    val = json.dumps([{"description": "海灘日落"}, {"description": "人物特寫"}])
+    assert ex._frame_descriptions(val) == ["海灘日落", "人物特寫"]
+
+
+# --------------------------------------------------------------------------
+# txt + CLI
+# --------------------------------------------------------------------------
+def test_export_txt_returns_transcript(ex, sample_record):
+    db.upsert(sample_record(path="/m/t.mp4", transcript="單支逐字稿。"))
+    assert ex.export_txt(1) == "單支逐字稿。"
+
+
+def test_export_txt_missing_raises(ex):
+    with pytest.raises(KeyError):
+        ex.export_txt(99999)
+
+
+def test_cli_corpus_writes_out_file(ex, sample_record, tmp_path):
+    _seed(sample_record)
+    out = tmp_path / "corpus.txt"
+    rc = ex.main(["corpus", "--lang", "zh", "--out", str(out)])
+    assert rc == 0
+    content = out.read_text(encoding="utf-8")
+    assert "第一段中文逐字稿。" in content
+
+
+def test_cli_jsonl_writes_valid_lines(ex, sample_record, tmp_path):
+    _seed(sample_record)
+    out = tmp_path / "chunks.jsonl"
+    rc = ex.main(["jsonl", "--out", str(out)])
+    assert rc == 0
+    for line in out.read_text(encoding="utf-8").splitlines():
+        json.loads(line)
+
+
+def test_cli_txt_missing_id_returns_1(ex):
+    assert ex.main(["txt", "99999"]) == 1


### PR DESCRIPTION
## Phase 12 (core) — Export CLI

A dependency-light `export.py` (reads the DB via `db.get_conn()` like `ingest.py` — no FastAPI server import) that turns a library's transcripts + vision metadata into the two formats a LoRA/RAG pipeline wants. Feeds the "podcast 語料庫" success metric.

### Commands
- **`export.py corpus [--lang] [--out]`** — merged plain-text corpus, transcripts only, blank-line separated, no JSON residue.
- **`export.py jsonl [--lang] [--out]`** — one JSON object per media per line: `{id, text, metadata{filename,lang,duration,fps,content_type,camera,rating,tags,frame_descriptions}}`. `ensure_ascii=False` keeps Chinese readable; `json.dumps` escaping keeps the one-object-per-line invariant even when transcripts contain newlines.
- **`export.py txt <id> [--out]`** — a single clip's transcript.

### Verification
- **15 tests** (tmp_db) hitting both acceptance anchors (corpus has no exporter JSON residue; every jsonl line is valid JSON with id/text/metadata). Full suite **322 passed / 3 skipped**.
- Real smoke on the mini DB: jsonl reads C3742.MP4 with valid metadata.
- **Codex review: ship** (no CRITICAL). One SHOULD-FIX applied (an over-strict corpus test that banned brace chars — reframed so JSON-looking *spoken* text is preserved while exporter structure never leaks).

### Deferred (rest of Phase 12)
- 12.4 batch export API (`POST /api/export/batch` zip)
- 12.5 subtitle layout engine (≤14 CJK chars/line, natural breaks, bilingual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)