### PR TITLE
feat: Phase 12.5 subtitle layout engine

### DIFF
--- a/export.py
+++ b/export.py
@@ -116,6 +116,32 @@ def export_txt(media_id: int) -> str:
     return (rec.get("transcript") or "").strip()
 
 
+def export_srt(media_id: int, max_units: float = 14.0) -> str:
+    """Laid-out SRT for one clip, using the Phase 12.5 subtitle engine.
+
+    Uses segment-aligned timestamps (segments_json) when present; falls back to
+    a single full-duration cue from the transcript otherwise.
+    """
+    import subtitle
+
+    rec = db.get_record_by_id(media_id)
+    if not rec:
+        raise KeyError("media id {0} not found".format(media_id))
+    segments = []
+    seg_json = rec.get("segments_json")
+    if seg_json:
+        try:
+            segments = json.loads(seg_json)
+        except (ValueError, TypeError):
+            segments = []
+    if not segments:
+        transcript = (rec.get("transcript") or "").strip()
+        if not transcript:
+            return ""
+        segments = [{"start": 0.0, "end": rec.get("duration_s") or 0.0, "text": transcript}]
+    return subtitle.segments_to_srt(segments, max_units=max_units)
+
+
 def _emit(content: str, out: Optional[str]) -> None:
     if out:
         Path(out).expanduser().write_text(content, encoding="utf-8")
@@ -143,6 +169,11 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_txt.add_argument("media_id", type=int)
     p_txt.add_argument("--out", default=None, help="Output file (default: stdout)")
 
+    p_srt = sub.add_parser("srt", help="A single clip's laid-out SRT (Phase 12.5 engine)")
+    p_srt.add_argument("media_id", type=int)
+    p_srt.add_argument("--max-cjk", type=float, default=14.0, help="Max CJK units per line (default 14)")
+    p_srt.add_argument("--out", default=None, help="Output file (default: stdout)")
+
     args = parser.parse_args(argv)
     if args.db:
         db.DB_PATH = Path(args.db)
@@ -154,6 +185,12 @@ def main(argv: Optional[List[str]] = None) -> int:
     elif args.cmd == "txt":
         try:
             _emit(export_txt(args.media_id), args.out)
+        except KeyError as e:
+            print(str(e), file=sys.stderr)
+            return 1
+    elif args.cmd == "srt":
+        try:
+            _emit(export_srt(args.media_id, args.max_cjk), args.out)
         except KeyError as e:
             print(str(e), file=sys.stderr)
             return 1

--- a/export.py
+++ b/export.py
@@ -131,9 +131,13 @@ def export_srt(media_id: int, max_units: float = 14.0) -> str:
     seg_json = rec.get("segments_json")
     if seg_json:
         try:
-            segments = json.loads(seg_json)
+            parsed = json.loads(seg_json)
         except (ValueError, TypeError):
-            segments = []
+            parsed = None
+        # Only a list of segment dicts is usable; anything else falls back to
+        # the transcript path rather than crashing in segments_to_srt (Codex).
+        if isinstance(parsed, list):
+            segments = [s for s in parsed if isinstance(s, dict)]
     if not segments:
         transcript = (rec.get("transcript") or "").strip()
         if not transcript:

--- a/subtitle.py
+++ b/subtitle.py
@@ -1,0 +1,181 @@
+"""subtitle.py — Phase 12.5 subtitle layout engine.
+
+Re-wraps raw Whisper transcript text into broadcast-style caption lines:
+
+- line length capped in CJK "units" (default 14 — Netflix zh-Hant spec; Latin
+  chars count as 1/3 of a unit, so a line holds ~14 Chinese or ~42 Latin chars);
+- breaks at natural boundaries — CJK punctuation or spaces — and never splits a
+  Latin word or separates a number from its measure word (量詞);
+- optional bilingual cues (original on top, translation below).
+
+Pure functions, no I/O — `segments_to_srt()` ties it to Whisper segments_json.
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+# Punctuation that a line should prefer to break AFTER (kept on the upper line).
+_BREAK_AFTER = "。，、！？；：…—)）」』】》”’"
+# Latin width relative to one CJK unit (≈ Netflix 42 Latin ≈ 14 CJK).
+_LATIN_UNIT = 1.0 / 3.0
+
+
+def is_cjk(ch: str) -> bool:
+    """True for wide East-Asian glyphs (Han / Kana / fullwidth / CJK punct)."""
+    o = ord(ch)
+    return (
+        0x3000 <= o <= 0x303F      # CJK symbols & punctuation
+        or 0x3040 <= o <= 0x30FF   # Hiragana + Katakana
+        or 0x3400 <= o <= 0x4DBF   # CJK Ext-A
+        or 0x4E00 <= o <= 0x9FFF   # CJK Unified
+        or 0xF900 <= o <= 0xFAFF   # CJK compatibility
+        or 0xFF00 <= o <= 0xFFEF   # fullwidth forms
+    )
+
+
+def display_units(text: str) -> float:
+    """Width of `text` in CJK units (CJK char = 1, other = 1/3)."""
+    return sum(1.0 if is_cjk(c) else _LATIN_UNIT for c in text)
+
+
+def _atoms(text: str) -> List[str]:
+    """Split into non-breakable atoms.
+
+    An atom is a single CJK char, OR a maximal run of non-CJK non-space chars
+    (a "word" — kept whole), OR a whitespace run. Binding rule: a numeric word
+    immediately followed by a single CJK char keeps them together so a measure
+    word (`14字`, `3個`) never starts a line on its own.
+    """
+    atoms: List[str] = []
+    i, n = 0, len(text)
+    while i < n:
+        ch = text[i]
+        if ch.isspace():
+            j = i
+            while j < n and text[j].isspace():
+                j += 1
+            atoms.append(text[i:j])
+            i = j
+        elif is_cjk(ch):
+            atoms.append(ch)
+            i += 1
+        else:
+            j = i
+            while j < n and not text[j].isspace() and not is_cjk(text[j]):
+                j += 1
+            word = text[i:j]
+            # bind a trailing CJK measure word to a numeric run
+            if j < n and is_cjk(text[j]) and any(c.isdigit() for c in word):
+                word += text[j]
+                j += 1
+            atoms.append(word)
+            i = j
+    return atoms
+
+
+def wrap(text: str, max_units: float = 14.0, max_lines: Optional[int] = None) -> List[str]:
+    """Wrap `text` into lines each <= max_units, breaking at natural points.
+
+    Prefers to break right after CJK punctuation; falls back to whitespace; and
+    if a single atom already exceeds the budget it gets its own line rather than
+    being split. max_lines (None = unlimited) caps the number of returned lines —
+    extra content is merged into the last line.
+    """
+    text = " ".join(text.split())  # collapse whitespace runs to single spaces
+    if not text:
+        return []
+    atoms = _atoms(text)
+
+    lines: List[str] = []
+    cur: List[str] = []
+    cur_w = 0.0
+    last_break = -1  # index in `cur` just after a preferred break point
+
+    def flush(upto: Optional[int] = None):
+        nonlocal cur, cur_w, last_break
+        if upto is None:
+            piece = cur
+            cur = []
+        else:
+            piece = cur[:upto]
+            cur = cur[upto:]
+        lines.append("".join(piece).strip())
+        cur_w = display_units("".join(cur))
+        last_break = -1
+
+    for atom in atoms:
+        w = display_units(atom)
+        if cur and cur_w + w > max_units:
+            # over budget: break at the last preferred point if we have one,
+            # otherwise break before this atom.
+            if last_break > 0:
+                flush(last_break)
+                # re-evaluate: maybe the carried-over remainder + atom still fit
+            else:
+                flush()
+        if atom.isspace():
+            if not cur:
+                continue  # don't start a line with a space
+            cur.append(atom)
+            cur_w += w
+            last_break = len(cur)  # space is a break point
+            continue
+        cur.append(atom)
+        cur_w += w
+        if atom and atom[-1] in _BREAK_AFTER:
+            last_break = len(cur)
+    if cur:
+        flush()
+
+    lines = [ln for ln in lines if ln]
+    if max_lines is not None and len(lines) > max_lines:
+        head = lines[: max_lines - 1]
+        tail = " ".join(lines[max_lines - 1:])
+        lines = head + [tail]
+    return lines
+
+
+def _ts(seconds: float, sep: str = ",") -> str:
+    """SRT/VTT timecode HH:MM:SS,mmm."""
+    seconds = max(0.0, seconds)
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = int(seconds % 60)
+    ms = int(round((seconds % 1) * 1000))
+    if ms == 1000:  # rounding spill
+        ms = 0
+        s += 1
+    return "{0:02d}:{1:02d}:{2:02d}{3}{4:03d}".format(h, m, s, sep, ms)
+
+
+def format_cue(index: int, start: float, end: float, lines: List[str], sep: str = ",") -> str:
+    body = "\n".join(lines)
+    return "{0}\n{1} --> {2}\n{3}\n".format(index, _ts(start, sep), _ts(end, sep), body)
+
+
+def segments_to_srt(
+    segments: List[Dict],
+    max_units: float = 14.0,
+    max_lines: int = 2,
+    translate_key: Optional[str] = None,
+) -> str:
+    """Render Whisper segments to laid-out SRT.
+
+    Each segment becomes one cue; its text is wrapped to <= max_lines lines. If
+    translate_key is given and a segment carries that field, the translation is
+    wrapped and appended below the original (bilingual: original on top).
+    """
+    out: List[str] = []
+    idx = 1
+    for seg in segments:
+        text = (seg.get("text") or "").strip()
+        if not text:
+            continue
+        lines = wrap(text, max_units=max_units, max_lines=max_lines)
+        if translate_key:
+            tr = (seg.get(translate_key) or "").strip()
+            if tr:
+                lines = lines + wrap(tr, max_units=max_units, max_lines=max_lines)
+        out.append(format_cue(idx, seg.get("start", 0.0) or 0.0, seg.get("end", 0.0) or 0.0, lines))
+        idx += 1
+    return "\n".join(out)

--- a/subtitle.py
+++ b/subtitle.py
@@ -42,9 +42,10 @@ def _atoms(text: str) -> List[str]:
     """Split into non-breakable atoms.
 
     An atom is a single CJK char, OR a maximal run of non-CJK non-space chars
-    (a "word" — kept whole), OR a whitespace run. Binding rule: a numeric word
-    immediately followed by a single CJK char keeps them together so a measure
-    word (`14字`, `3個`) never starts a line on its own.
+    (a "word" — kept whole), OR a whitespace run. Digit+CJK binding: a numeric
+    word immediately followed by a single CJK char keeps them together so a
+    measure word (`14字`, `3個`) never starts a line on its own. (This binds the
+    digit run to whatever CJK char follows — usually but not strictly a 量詞.)
     """
     atoms: List[str] = []
     i, n = 0, len(text)
@@ -73,13 +74,15 @@ def _atoms(text: str) -> List[str]:
     return atoms
 
 
-def wrap(text: str, max_units: float = 14.0, max_lines: Optional[int] = None) -> List[str]:
+def wrap(text: str, max_units: float = 14.0) -> List[str]:
     """Wrap `text` into lines each <= max_units, breaking at natural points.
 
     Prefers to break right after CJK punctuation; falls back to whitespace; and
     if a single atom already exceeds the budget it gets its own line rather than
-    being split. max_lines (None = unlimited) caps the number of returned lines —
-    extra content is merged into the last line.
+    being split. Width is a HARD invariant — every returned line is <= max_units
+    (except an unbreakable atom that is itself wider). Line count is unbounded;
+    callers that need a per-cue line cap (e.g. segments_to_srt) group/time-split
+    rather than merging lines, which would break the width cap.
     """
     text = " ".join(text.split())  # collapse whitespace runs to single spaces
     if not text:
@@ -127,24 +130,20 @@ def wrap(text: str, max_units: float = 14.0, max_lines: Optional[int] = None) ->
     if cur:
         flush()
 
-    lines = [ln for ln in lines if ln]
-    if max_lines is not None and len(lines) > max_lines:
-        head = lines[: max_lines - 1]
-        tail = " ".join(lines[max_lines - 1:])
-        lines = head + [tail]
-    return lines
+    return [ln for ln in lines if ln]
 
 
 def _ts(seconds: float, sep: str = ",") -> str:
-    """SRT/VTT timecode HH:MM:SS,mmm."""
-    seconds = max(0.0, seconds)
-    h = int(seconds // 3600)
-    m = int((seconds % 3600) // 60)
-    s = int(seconds % 60)
-    ms = int(round((seconds % 1) * 1000))
-    if ms == 1000:  # rounding spill
-        ms = 0
-        s += 1
+    """SRT/VTT timecode HH:MM:SS,mmm.
+
+    Rounds to whole milliseconds via a single total-ms conversion so a value
+    like 59.9999 carries all the way up (00:01:00,000), never emitting an
+    out-of-range 00:00:60,000 (Codex CRITICAL).
+    """
+    total_ms = int(round(max(0.0, seconds) * 1000))
+    h, rem = divmod(total_ms, 3_600_000)
+    m, rem = divmod(rem, 60_000)
+    s, ms = divmod(rem, 1000)
     return "{0:02d}:{1:02d}:{2:02d}{3}{4:03d}".format(h, m, s, sep, ms)
 
 
@@ -161,9 +160,11 @@ def segments_to_srt(
 ) -> str:
     """Render Whisper segments to laid-out SRT.
 
-    Each segment becomes one cue; its text is wrapped to <= max_lines lines. If
-    translate_key is given and a segment carries that field, the translation is
-    wrapped and appended below the original (bilingual: original on top).
+    Each segment's text is wrapped to width-safe lines. A monolingual segment
+    that needs more than `max_lines` lines is split into multiple cues, its
+    time span divided proportionally — so a long segment never produces an
+    over-wide line nor a wall-of-text cue. A bilingual segment (translate_key
+    present) stays a single cue: original lines on top, translation below.
     """
     out: List[str] = []
     idx = 1
@@ -171,11 +172,25 @@ def segments_to_srt(
         text = (seg.get("text") or "").strip()
         if not text:
             continue
-        lines = wrap(text, max_units=max_units, max_lines=max_lines)
-        if translate_key:
-            tr = (seg.get(translate_key) or "").strip()
-            if tr:
-                lines = lines + wrap(tr, max_units=max_units, max_lines=max_lines)
-        out.append(format_cue(idx, seg.get("start", 0.0) or 0.0, seg.get("end", 0.0) or 0.0, lines))
-        idx += 1
+        start = float(seg.get("start", 0.0) or 0.0)
+        end = float(seg.get("end", 0.0) or 0.0)
+
+        if translate_key and (seg.get(translate_key) or "").strip():
+            lines = wrap(text, max_units) + wrap((seg.get(translate_key) or "").strip(), max_units)
+            out.append(format_cue(idx, start, end, lines))
+            idx += 1
+            continue
+
+        lines = wrap(text, max_units)
+        if not lines:
+            continue
+        cap = max(1, max_lines)
+        chunks = [lines[i:i + cap] for i in range(0, len(lines), cap)]
+        n = len(chunks)
+        span = max(0.0, end - start)
+        for ci, chunk in enumerate(chunks):
+            c_start = start + span * ci / n
+            c_end = start + span * (ci + 1) / n
+            out.append(format_cue(idx, c_start, c_end, chunk))
+            idx += 1
     return "\n".join(out)

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -1,0 +1,162 @@
+"""Phase 12.5 — subtitle layout engine tests."""
+import importlib
+import json
+
+import pytest
+
+import db
+import subtitle as sub
+
+
+# --------------------------------------------------------------------------
+# width / cjk detection
+# --------------------------------------------------------------------------
+def test_is_cjk():
+    assert sub.is_cjk("中")
+    assert sub.is_cjk("あ")
+    assert sub.is_cjk("，")  # fullwidth punct
+    assert not sub.is_cjk("a")
+    assert not sub.is_cjk("1")
+    assert not sub.is_cjk(" ")
+
+
+def test_display_units_cjk_vs_latin():
+    assert sub.display_units("中文") == pytest.approx(2.0)
+    assert sub.display_units("abc") == pytest.approx(1.0)  # 3 latin = 1 unit
+
+
+# --------------------------------------------------------------------------
+# wrap — line length cap
+# --------------------------------------------------------------------------
+def test_wrap_caps_cjk_line_length():
+    text = "一二三四五六七八九十一二三四五六七八九十"  # 20 CJK
+    lines = sub.wrap(text, max_units=14)
+    assert len(lines) == 2
+    for ln in lines:
+        assert sub.display_units(ln) <= 14
+
+
+def test_wrap_short_text_single_line():
+    assert sub.wrap("你好世界", max_units=14) == ["你好世界"]
+
+
+def test_wrap_empty():
+    assert sub.wrap("", max_units=14) == []
+    assert sub.wrap("   ", max_units=14) == []
+
+
+# --------------------------------------------------------------------------
+# natural break points
+# --------------------------------------------------------------------------
+def test_wrap_breaks_after_punctuation():
+    # Should break after the comma, not mid-clause.
+    text = "今天天氣很好，我們一起去公園散步好嗎"
+    lines = sub.wrap(text, max_units=8)
+    assert lines[0].endswith("，")
+
+
+def test_wrap_never_splits_latin_word():
+    text = "the quick brown fox jumps over lazy dog again now"
+    lines = sub.wrap(text, max_units=6)
+    rejoined = " ".join(lines).split()
+    assert "quick" in rejoined and "jumps" in rejoined
+    # no fragment of a word appears split across lines
+    for w in ("quick", "brown", "jumps"):
+        assert any(w == tok for ln in lines for tok in ln.split())
+
+
+def test_wrap_keeps_number_with_measure_word():
+    # "14字" must not break between the number and 字.
+    text = "每行最多14字才符合規範這條規則很重要喔"
+    lines = sub.wrap(text, max_units=8)
+    # find which line holds the digits; it must also hold 字
+    for ln in lines:
+        if "14" in ln:
+            assert "14字" in ln
+
+
+def test_wrap_oversized_atom_gets_own_line():
+    # A single Latin word longer than the budget shouldn't be split.
+    text = "supercalifragilisticexpialidocious yes"
+    lines = sub.wrap(text, max_units=3)
+    assert "supercalifragilisticexpialidocious" in lines
+
+
+def test_wrap_max_lines_merges_overflow():
+    text = "一二三四五六七八九十甲乙丙丁戊己庚辛壬癸"  # 20 CJK
+    lines = sub.wrap(text, max_units=5, max_lines=2)
+    assert len(lines) == 2
+
+
+# --------------------------------------------------------------------------
+# SRT rendering
+# --------------------------------------------------------------------------
+def test_ts_format():
+    assert sub._ts(0) == "00:00:00,000"
+    assert sub._ts(3661.5) == "01:01:01,500"
+
+
+def test_ts_rounding_spill():
+    # 0.9999s rounds ms to 1000 -> must carry into seconds, not emit ,1000
+    out = sub._ts(0.9999)
+    assert out == "00:00:01,000"
+
+
+def test_segments_to_srt_basic():
+    segs = [
+        {"start": 0.0, "end": 2.0, "text": "你好世界"},
+        {"start": 2.0, "end": 4.0, "text": "再見"},
+    ]
+    srt = sub.segments_to_srt(segs)
+    assert "1\n00:00:00,000 --> 00:00:02,000\n你好世界\n" in srt
+    assert "2\n00:00:02,000 --> 00:00:04,000\n再見\n" in srt
+
+
+def test_segments_to_srt_skips_empty():
+    segs = [{"start": 0, "end": 1, "text": ""}, {"start": 1, "end": 2, "text": "有字"}]
+    srt = sub.segments_to_srt(segs)
+    assert srt.count("-->") == 1  # only the non-empty cue
+
+
+def test_segments_to_srt_wraps_long_segment():
+    segs = [{"start": 0, "end": 5, "text": "一二三四五六七八九十一二三四五六七八九十"}]
+    srt = sub.segments_to_srt(segs, max_units=14)
+    # the cue body has 2 lines
+    body = srt.split("\n", 2)[2]
+    assert body.count("\n") >= 2  # at least two text lines + trailing
+
+
+def test_segments_to_srt_bilingual():
+    segs = [{"start": 0, "end": 2, "text": "你好", "translation": "Hello"}]
+    srt = sub.segments_to_srt(segs, translate_key="translation")
+    assert "你好" in srt and "Hello" in srt
+    # original above translation
+    assert srt.index("你好") < srt.index("Hello")
+
+
+# --------------------------------------------------------------------------
+# export.py srt integration
+# --------------------------------------------------------------------------
+@pytest.fixture
+def ex(tmp_db):
+    export = importlib.import_module("export")
+    return importlib.reload(export)
+
+
+def test_export_srt_uses_segments(ex, sample_record):
+    segs = json.dumps([{"start": 0.0, "end": 2.0, "text": "字幕測試一段"}])
+    db.upsert(sample_record(path="/m/s.mp4", segments_json=segs))
+    out = ex.export_srt(1)
+    assert "字幕測試一段" in out
+    assert "00:00:00,000 --> 00:00:02,000" in out
+
+
+def test_export_srt_falls_back_to_transcript(ex, sample_record):
+    db.upsert(sample_record(path="/m/n.mp4", transcript="沒有分段也要能出字幕", duration_s=3.0))
+    out = ex.export_srt(1)
+    assert "00:00:00,000 --> 00:00:03,000" in out
+
+
+def test_export_srt_missing_raises(ex):
+    with pytest.raises(KeyError):
+        ex.export_srt(99999)

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -82,10 +82,13 @@ def test_wrap_oversized_atom_gets_own_line():
     assert "supercalifragilisticexpialidocious" in lines
 
 
-def test_wrap_max_lines_merges_overflow():
+def test_wrap_width_is_hard_invariant():
+    # Codex SHOULD-FIX: every line must be <= max_units (no merge-overflow that
+    # violates the cap). Only an unbreakable atom may exceed it.
     text = "一二三四五六七八九十甲乙丙丁戊己庚辛壬癸"  # 20 CJK
-    lines = sub.wrap(text, max_units=5, max_lines=2)
-    assert len(lines) == 2
+    for mu in (3, 5, 8, 14):
+        for ln in sub.wrap(text, max_units=mu):
+            assert sub.display_units(ln) <= mu
 
 
 # --------------------------------------------------------------------------
@@ -98,8 +101,14 @@ def test_ts_format():
 
 def test_ts_rounding_spill():
     # 0.9999s rounds ms to 1000 -> must carry into seconds, not emit ,1000
-    out = sub._ts(0.9999)
-    assert out == "00:00:01,000"
+    assert sub._ts(0.9999) == "00:00:01,000"
+
+
+def test_ts_rounding_carries_to_minutes_and_hours():
+    # Codex CRITICAL: spill must carry s->m->h, never emit 00:00:60,000.
+    assert sub._ts(59.9999) == "00:01:00,000"
+    assert sub._ts(3599.9999) == "01:00:00,000"
+    assert sub._ts(3599.4) == "00:59:59,400"
 
 
 def test_segments_to_srt_basic():
@@ -118,12 +127,20 @@ def test_segments_to_srt_skips_empty():
     assert srt.count("-->") == 1  # only the non-empty cue
 
 
-def test_segments_to_srt_wraps_long_segment():
-    segs = [{"start": 0, "end": 5, "text": "一二三四五六七八九十一二三四五六七八九十"}]
-    srt = sub.segments_to_srt(segs, max_units=14)
-    # the cue body has 2 lines
-    body = srt.split("\n", 2)[2]
-    assert body.count("\n") >= 2  # at least two text lines + trailing
+def test_segments_to_srt_splits_long_segment_into_timed_cues():
+    # 40 CJK at max_units=14, max_lines=2 -> 3 lines -> 2 cues, time split.
+    segs = [{"start": 0.0, "end": 6.0,
+             "text": "一二三四五六七八九十一二三四五六七八九十甲乙丙丁戊己庚辛壬癸子丑寅卯辰巳午未"}]
+    srt = sub.segments_to_srt(segs, max_units=14, max_lines=2)
+    cue_count = srt.count("-->")
+    assert cue_count >= 2  # split into multiple timed cues
+    # cues are contiguous and within [0,6]: first starts at 0, last ends at 6
+    assert "00:00:00,000 -->" in srt
+    assert "--> 00:00:06,000" in srt
+    # every text line stays within the width cap
+    for block in srt.strip().split("\n\n"):
+        for line in block.splitlines()[2:]:
+            assert sub.display_units(line) <= 14
 
 
 def test_segments_to_srt_bilingual():
@@ -160,3 +177,21 @@ def test_export_srt_falls_back_to_transcript(ex, sample_record):
 def test_export_srt_missing_raises(ex):
     with pytest.raises(KeyError):
         ex.export_srt(99999)
+
+
+def test_export_srt_non_list_segments_falls_back(ex, sample_record):
+    # Codex SHOULD-FIX: a dict (not a list) in segments_json must not crash —
+    # fall back to the transcript path.
+    db.upsert(sample_record(path="/m/bad.mp4", segments_json='{"not":"a list"}',
+                            transcript="壞分段也要能出字幕", duration_s=2.0))
+    out = ex.export_srt(1)
+    assert "壞分段也要能出字幕" in out
+    assert "00:00:00,000 --> 00:00:02,000" in out
+
+
+def test_export_srt_segments_with_non_dict_items_filtered(ex, sample_record):
+    db.upsert(sample_record(path="/m/mix.mp4",
+                            segments_json='[{"start":0,"end":1,"text":"好"}, "garbage", 42]',
+                            transcript="fallback", duration_s=5.0))
+    out = ex.export_srt(1)
+    assert "好" in out  # the one valid dict segment is used, junk filtered


### PR DESCRIPTION
## Phase 12.5 — Subtitle layout engine

`subtitle.py` re-wraps raw Whisper text into broadcast-style captions; wired into `export.py srt <id>`.

- Line length capped in CJK units (default 14, Netflix zh-Hant; Latin = 1/3 unit). **Width is a hard invariant.**
- Breaks at natural points (CJK punctuation / spaces), never splits a Latin word, keeps a number with its measure word (`14字`).
- Long segments are **time-split into multiple proportional cues** rather than producing a wall-of-text or over-wide line.
- Optional bilingual cues (original on top, translation below).

### Verification
- **22 tests** (width invariant, punctuation/word/measure-word integrity, timecode carry, timed-cue split, bilingual, export integration). Full suite **344 passed / 3 skipped**.
- **Codex review: 1 CRITICAL + 2 SHOULD-FIX + 1 NIT, all fixed** — `_ts()` minute/hour rounding carry (was emitting invalid `00:00:60,000`); width-cap hard invariant (no merge-overflow); `export_srt` non-list `segments_json` fallback.

(Phase 12.4 batch-zip API still deferred.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)