### PR TITLE
feat: ingest CLI microtasks B3/B4/B5/B6

### DIFF
--- a/frames.py
+++ b/frames.py
@@ -42,15 +42,19 @@ def _run_ffmpeg(cmd, out_path: Optional[Path] = None) -> bool:
     return True
 
 
-def extract_thumbnail(video_path: str, duration_s: float) -> Optional[str]:
+def extract_thumbnail(video_path: str, duration_s: float, force: bool = False) -> Optional[str]:
     """
     Extract one representative frame (50% position) and save permanently
     to thumbnails/{stem}.jpg. Returns saved path or None on failure.
+
+    By default an existing non-empty poster is reused (cheap re-ingest). Pass
+    force=True to actually rebuild it (used by `ingest.py --regenerate-thumbnails`
+    after the thumbnail-rendering logic changes).
     """
     _ensure_thumbnails_dir()
     stem = Path(video_path).stem
     out = THUMBNAILS_DIR / f"{stem}.jpg"
-    if out.exists() and out.stat().st_size > 0:
+    if not force and out.exists() and out.stat().st_size > 0:
         return str(out)
 
     t = max(duration_s * 0.5, 1.0)

--- a/health.py
+++ b/health.py
@@ -331,13 +331,14 @@ def main():
     # Surface how much the derived-artifact dirs hold so an operator can spot a
     # runaway proxy/thumbnail cache. Informational (never fails).
     print("\n-- Cache dirs --")
-    try:
-        import config
-        for label, d in [
-            ("thumbnails", config.THUMBNAILS_DIR),
-            ("proxies", config.PROXIES_DIR),
-            ("chroma_db", config.CHROMA_PATH),
-        ]:
+    import config
+    for label, d in [
+        ("thumbnails", config.THUMBNAILS_DIR),
+        ("proxies", config.PROXIES_DIR),
+        ("chroma_db", config.CHROMA_PATH),
+    ]:
+        # Per-dir guard so one unreadable cache can't suppress the others.
+        try:
             p = Path(d)
             if p.exists():
                 files = [f for f in p.rglob("*") if f.is_file()]
@@ -345,8 +346,8 @@ def main():
                 check(label, True, f"({len(files)} files, {size_mb:.1f} MB)", required=False)
             else:
                 check(label, True, "(not created yet)", required=False)
-    except Exception as e:
-        check("cache dirs", False, f"({e})", required=False)
+        except Exception as e:
+            check(label, False, f"({e})", required=False)
 
     # ── Database ────────────────────────────────────────────────────────
     print("\n-- Database --")

--- a/health.py
+++ b/health.py
@@ -327,6 +327,27 @@ def main():
     except Exception as e:
         check("disk space", False, f"({e})")
 
+    # ── Cache dirs (B5) ─────────────────────────────────────────────────
+    # Surface how much the derived-artifact dirs hold so an operator can spot a
+    # runaway proxy/thumbnail cache. Informational (never fails).
+    print("\n-- Cache dirs --")
+    try:
+        import config
+        for label, d in [
+            ("thumbnails", config.THUMBNAILS_DIR),
+            ("proxies", config.PROXIES_DIR),
+            ("chroma_db", config.CHROMA_PATH),
+        ]:
+            p = Path(d)
+            if p.exists():
+                files = [f for f in p.rglob("*") if f.is_file()]
+                size_mb = sum(f.stat().st_size for f in files) / 1_000_000
+                check(label, True, f"({len(files)} files, {size_mb:.1f} MB)", required=False)
+            else:
+                check(label, True, "(not created yet)", required=False)
+    except Exception as e:
+        check("cache dirs", False, f"({e})", required=False)
+
     # ── Database ────────────────────────────────────────────────────────
     print("\n-- Database --")
     try:

--- a/ingest.py
+++ b/ingest.py
@@ -25,7 +25,11 @@ import transcribe as tr
 import vision as vis
 
 SUPPORTED = {".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts", ".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg"}
-VIDEO_EXT = {".mp4", ".mov", ".m4v", ".mts"}
+# B3: .mkv/.avi/.webm are in SUPPORTED (so they ingest into the DB) but were
+# absent here, so is_video was False for them → they silently skipped
+# thumbnail/frames/vision. ffmpeg/ffprobe handle these containers, so treat
+# them as video too. Keep VIDEO_EXT ⊆ SUPPORTED.
+VIDEO_EXT = {".mp4", ".mov", ".m4v", ".mts", ".mkv", ".avi", ".webm"}
 # Codecs needing browser-playable proxy — single source of truth in codec.py.
 PROXY_CODECS = codec.PROXY_CODECS
 logger = logging.getLogger(__name__)
@@ -736,6 +740,7 @@ def _regenerate_proxies():
         return
 
     print(f"Regenerating {len(existing)} proxies...")
+    size_before = _dir_size_bytes(proxy_dir)  # B6: report net size change
     ok, failed = 0, 0
     for idx, proxy_path in enumerate(existing, 1):
         # Proxy filename is "{media_id}_{hash}.mp4" since the path-hash fix;
@@ -770,7 +775,63 @@ def _regenerate_proxies():
         else:
             print(" [FAIL]")
             failed += 1
-    print(f"\nRegenerated: {ok}  Failed: {failed}")
+    delta = _dir_size_bytes(proxy_dir) - size_before
+    print(f"\nRegenerated: {ok}  Failed: {failed}  (size delta: {_fmt_size_delta(delta)})")
+
+
+def _dir_size_bytes(path) -> int:
+    """Total size of files directly in `path` (non-recursive is fine — proxy/
+    thumbnail dirs are flat). Missing dir → 0."""
+    p = Path(path)
+    if not p.exists():
+        return 0
+    return sum(f.stat().st_size for f in p.glob("*") if f.is_file())
+
+
+def _fmt_size_delta(delta_bytes: int) -> str:
+    sign = "+" if delta_bytes >= 0 else "-"
+    return f"{sign}{abs(delta_bytes) / 1_000_000:.1f} MB"
+
+
+def _regenerate_thumbnails():
+    """B4: rebuild the poster thumbnail for every video record (mirror of
+    --regenerate-proxies). Re-runs extract_thumbnail and updates
+    media.thumbnail_path. Frame thumbnails (which carry vision descriptions) are
+    intentionally left untouched — use --vision-only / --refresh for those."""
+    with db.get_conn() as conn:
+        rows = conn.execute("SELECT id, path, filename FROM media").fetchall()
+        records = [dict(r) for r in rows]
+    videos = [r for r in records if Path(r["path"]).suffix.lower() in VIDEO_EXT]
+    if not videos:
+        print("No video records to regenerate thumbnails for.")
+        return
+
+    print(f"Regenerating thumbnails for {len(videos)} video records...")
+    size_before = _dir_size_bytes(config.THUMBNAILS_DIR)
+    ok, failed = 0, 0
+    for idx, rec in enumerate(videos, 1):
+        src = db.resolve_path(rec["path"])
+        if not Path(src).exists():
+            print(f"  [{idx}/{len(videos)}] id={rec['id']}: source missing, skipping")
+            failed += 1
+            continue
+        meta = probe(src)
+        dur = meta.get("duration_s", 0) if meta else 0
+        print(f"  [{idx}/{len(videos)}] id={rec['id']} {rec['filename']}", end="", flush=True)
+        thumb = frm.extract_thumbnail(src, dur) if dur > 0 else None
+        if thumb:
+            with db.get_conn() as conn:
+                conn.execute(
+                    "UPDATE media SET thumbnail_path=? WHERE id=?",
+                    (db.to_relative(thumb), rec["id"]),
+                )
+            print(" [OK]")
+            ok += 1
+        else:
+            print(" [FAIL]")
+            failed += 1
+    delta = _dir_size_bytes(config.THUMBNAILS_DIR) - size_before
+    print(f"\nRegenerated: {ok}  Failed: {failed}  (size delta: {_fmt_size_delta(delta)})")
 
 
 def _migrate_storage():
@@ -904,6 +965,11 @@ def main():
         help="刪除並重建所有 HEVC/ProRes proxy（套用最新編碼設定）",
     )
     parser.add_argument(
+        "--regenerate-thumbnails",
+        action="store_true",
+        help="B4: 重建所有影片記錄的封面縮圖（不動 frame vision）",
+    )
+    parser.add_argument(
         "--migrate-storage",
         action="store_true",
         help="Phase 8.0c: 搬 legacy BASE_DIR/{media.db, thumbnails/, chroma_db/, proxies/} → BASE_DIR/.arkiv/",
@@ -920,7 +986,7 @@ def main():
     # --dir validation: required only when actually ingesting
     maintenance_mode = (
         args.migrate_storage or args.migrate_relative
-        or args.regenerate_proxies or args.vision_only
+        or args.regenerate_proxies or args.regenerate_thumbnails or args.vision_only
         or bool(args.queue) or args.status
     )
     if not maintenance_mode and not args.dir:
@@ -938,7 +1004,7 @@ def main():
 
     # Phase 8.0e: pre-flight storage check before any pipeline work.
     # Skip for maintenance modes (they're the tools that fix broken state).
-    if not (args.migrate_relative or args.regenerate_proxies or args.queue or args.status):
+    if not (args.migrate_relative or args.regenerate_proxies or args.regenerate_thumbnails or args.queue or args.status):
         import health
         ok_pf, errors_pf = health.preflight_paths()
         if not ok_pf:
@@ -964,6 +1030,10 @@ def main():
 
     if args.regenerate_proxies:
         _regenerate_proxies()
+        return
+
+    if args.regenerate_thumbnails:
+        _regenerate_thumbnails()
         return
 
     # ── Vision-only mode: patch missing vision descriptions ──────────────

--- a/ingest.py
+++ b/ingest.py
@@ -818,7 +818,7 @@ def _regenerate_thumbnails():
         meta = probe(src)
         dur = meta.get("duration_s", 0) if meta else 0
         print(f"  [{idx}/{len(videos)}] id={rec['id']} {rec['filename']}", end="", flush=True)
-        thumb = frm.extract_thumbnail(src, dur) if dur > 0 else None
+        thumb = frm.extract_thumbnail(src, dur, force=True) if dur > 0 else None
         if thumb:
             with db.get_conn() as conn:
                 conn.execute(

--- a/tests/test_ingest_microtasks.py
+++ b/tests/test_ingest_microtasks.py
@@ -54,15 +54,17 @@ def test_b4_regenerate_thumbnails_video_only(ingest_mod, sample_record, tmp_path
     monkeypatch.setattr(ingest_mod, "probe", lambda p: {"duration_s": 10.0, "fps": 30})
     fake_thumb = tmp_path / "thumb_a.jpg"; fake_thumb.write_text("t")
     calls = []
-    def _fake_extract(src, dur):
-        calls.append(src)
+    def _fake_extract(src, dur, force=False):
+        calls.append((src, force))
         return str(fake_thumb)
     monkeypatch.setattr(ingest_mod.frm, "extract_thumbnail", _fake_extract)
 
     ingest_mod._regenerate_thumbnails()
 
-    # only the video source was processed
-    assert len(calls) == 1 and calls[0].endswith("a.mp4")
+    # only the video source was processed, AND force=True so it truly rebuilds
+    # (Codex SHOULD-FIX: without force, extract_thumbnail reuses the old poster).
+    assert len(calls) == 1 and calls[0][0].endswith("a.mp4")
+    assert calls[0][1] is True, "must force=True or regeneration is a no-op"
     assert db.get_record_by_id(1)["thumbnail_path"]       # video updated
     assert not db.get_record_by_id(2)["thumbnail_path"]   # audio left alone
 
@@ -74,6 +76,20 @@ def test_b4_regenerate_thumbnails_skips_missing_source(ingest_mod, sample_record
     monkeypatch.setattr(ingest_mod.frm, "extract_thumbnail", lambda *a: called.append(1))
     ingest_mod._regenerate_thumbnails()  # must not raise
     assert called == []
+
+
+def test_b4_extract_thumbnail_force_bypasses_cache(monkeypatch, tmp_path):
+    import frames as frm
+    monkeypatch.setattr(frm, "THUMBNAILS_DIR", tmp_path)
+    monkeypatch.setattr(frm, "_ensure_thumbnails_dir", lambda: None)
+    (tmp_path / "clip.jpg").write_text("old")  # pre-existing poster
+    ran = []
+    monkeypatch.setattr(frm, "_run_ffmpeg", lambda cmd, out: ran.append(1) or True)
+
+    frm.extract_thumbnail("/x/clip.mp4", 10.0, force=False)
+    assert ran == []  # reuse — no rebuild
+    frm.extract_thumbnail("/x/clip.mp4", 10.0, force=True)
+    assert ran == [1]  # force actually re-runs ffmpeg
 
 
 def test_b4_no_videos_is_noop(ingest_mod, sample_record, monkeypatch):

--- a/tests/test_ingest_microtasks.py
+++ b/tests/test_ingest_microtasks.py
@@ -1,0 +1,83 @@
+"""Microtasks B3/B4/B6 — ingest CLI polish."""
+import importlib
+
+import pytest
+
+import db
+
+
+@pytest.fixture
+def ingest_mod(tmp_db):
+    ingest = importlib.import_module("ingest")
+    return importlib.reload(ingest)
+
+
+# --------------------------------------------------------------------------
+# B3: .mkv/.avi/.webm are treated as video (so they get thumbnail/frames/vision)
+# --------------------------------------------------------------------------
+def test_b3_video_ext_includes_mkv_avi_webm(ingest_mod):
+    for ext in (".mkv", ".avi", ".webm"):
+        assert ext in ingest_mod.VIDEO_EXT, f"{ext} should be a video ext"
+
+
+def test_b3_video_ext_subset_of_supported(ingest_mod):
+    assert ingest_mod.VIDEO_EXT <= ingest_mod.SUPPORTED
+
+
+# --------------------------------------------------------------------------
+# B6: size helpers
+# --------------------------------------------------------------------------
+def test_b6_dir_size_bytes(ingest_mod, tmp_path):
+    assert ingest_mod._dir_size_bytes(tmp_path / "missing") == 0
+    d = tmp_path / "sizedir"  # isolated — tmp_path also holds the tmp_db test.db
+    d.mkdir()
+    (d / "a.mp4").write_bytes(b"x" * 100)
+    (d / "b.mp4").write_bytes(b"y" * 50)
+    assert ingest_mod._dir_size_bytes(d) == 150
+
+
+def test_b6_fmt_size_delta(ingest_mod):
+    assert ingest_mod._fmt_size_delta(2_500_000) == "+2.5 MB"
+    assert ingest_mod._fmt_size_delta(-3_000_000) == "-3.0 MB"
+    assert ingest_mod._fmt_size_delta(0) == "+0.0 MB"
+
+
+# --------------------------------------------------------------------------
+# B4: --regenerate-thumbnails rebuilds poster for video records only
+# --------------------------------------------------------------------------
+def test_b4_regenerate_thumbnails_video_only(ingest_mod, sample_record, tmp_path, monkeypatch):
+    vid = tmp_path / "a.mp4"; vid.write_text("x")
+    aud = tmp_path / "b.mp3"; aud.write_text("x")
+    db.upsert(sample_record(path=str(vid), filename="a.mp4", ext=".mp4", thumbnail_path=None))
+    db.upsert(sample_record(path=str(aud), filename="b.mp3", ext=".mp3", thumbnail_path=None))
+
+    monkeypatch.setattr(ingest_mod, "probe", lambda p: {"duration_s": 10.0, "fps": 30})
+    fake_thumb = tmp_path / "thumb_a.jpg"; fake_thumb.write_text("t")
+    calls = []
+    def _fake_extract(src, dur):
+        calls.append(src)
+        return str(fake_thumb)
+    monkeypatch.setattr(ingest_mod.frm, "extract_thumbnail", _fake_extract)
+
+    ingest_mod._regenerate_thumbnails()
+
+    # only the video source was processed
+    assert len(calls) == 1 and calls[0].endswith("a.mp4")
+    assert db.get_record_by_id(1)["thumbnail_path"]       # video updated
+    assert not db.get_record_by_id(2)["thumbnail_path"]   # audio left alone
+
+
+def test_b4_regenerate_thumbnails_skips_missing_source(ingest_mod, sample_record, monkeypatch):
+    # path points nowhere -> skipped, no crash
+    db.upsert(sample_record(path="/nonexistent/x.mp4", filename="x.mp4", ext=".mp4"))
+    called = []
+    monkeypatch.setattr(ingest_mod.frm, "extract_thumbnail", lambda *a: called.append(1))
+    ingest_mod._regenerate_thumbnails()  # must not raise
+    assert called == []
+
+
+def test_b4_no_videos_is_noop(ingest_mod, sample_record, monkeypatch):
+    db.upsert(sample_record(path="/m/only.mp3", filename="only.mp3", ext=".mp3"))
+    monkeypatch.setattr(ingest_mod.frm, "extract_thumbnail",
+                        lambda *a: pytest.fail("should not be called"))
+    ingest_mod._regenerate_thumbnails()  # prints "No video records..." and returns


### PR DESCRIPTION
## Ingest CLI microtasks

- **B3** — add `.mkv/.avi/.webm` to `VIDEO_EXT`. They were in `SUPPORTED` (ingested into the DB) but not `VIDEO_EXT`, so they silently skipped thumbnail/frames/vision. (Proxy gen now also sees them, still guarded by `needs_proxy()` so only HEVC/ProRes actually proxy.)
- **B4** — `ingest.py --regenerate-thumbnails`: rebuilds the poster thumbnail for every video record (mirror of `--regenerate-proxies`), leaving frame vision rows untouched. Uses `extract_thumbnail(force=True)` so it genuinely rebuilds rather than reusing the cached poster.
- **B5** — `health.py` "Cache dirs" section: file count + size for thumbnails / proxies / chroma_db (informational, per-dir guarded).
- **B6** — `--regenerate-proxies` / `--regenerate-thumbnails` print the net size delta.

### Verification
- 8 tests. Full suite **367 passed / 3 skipped**. Live on mini: Cache dirs renders; B4 regenerates posters.
- **Codex review: no CRITICAL.** Fixed the one SHOULD-FIX (B4 force-rebuild) + health per-dir guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)