### PR TITLE
feat: Phase 16.1 — HMAC token hashing with dual-read

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,3 +60,10 @@
 # NOTE: /api/stream accepts the token via ?token= (a <video> tag can't send a
 # header). arkiv scrubs token= from its own access logs, but avoid persisting
 # uvicorn access logs to a shared location if you rely on query-token streaming.
+#
+# Phase 16.1 — token hash key. When set, access tokens are stored as
+# HMAC-SHA256(key, token) instead of bare SHA-256. Existing tokens keep working
+# (dual-read) and upgrade to HMAC on next use. KEEP THIS SAFE: losing it
+# invalidates every HMAC token (re-mint), same as losing the DB. Generate with:
+#   python -c "import secrets; print(secrets.token_urlsafe(32))"
+# ARKIV_TOKEN_HMAC_KEY=

--- a/admin.py
+++ b/admin.py
@@ -6,7 +6,7 @@ import json
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
-from auth import SCOPES, hash_token, new_raw_token, new_token_id
+from auth import SCOPES, preferred_hash, new_raw_token, new_token_id
 from db import get_conn
 
 
@@ -45,11 +45,12 @@ def create_token(
         expires_at = (datetime.now(timezone.utc) + timedelta(days=expires_in_days)).isoformat()
     allowed_ips_json = json.dumps(allowed_ips or ["*"])
 
+    token_hash, hash_algo = preferred_hash(raw)
     with get_conn() as conn:
         conn.execute(
-            "INSERT INTO access_tokens (id, name, description, token_hash, expires_at, allowed_ips_json) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (token_id, name, description, hash_token(raw), expires_at, allowed_ips_json),
+            "INSERT INTO access_tokens (id, name, description, token_hash, hash_algo, expires_at, allowed_ips_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (token_id, name, description, token_hash, hash_algo, expires_at, allowed_ips_json),
         )
         for scope in scopes:
             conn.execute(
@@ -129,15 +130,17 @@ def bootstrap_admin_token_if_empty() -> Optional[str]:
         )
 
     token_id = new_token_id()
+    boot_hash, boot_algo = preferred_hash(ARKIV_ADMIN_BOOTSTRAP_TOKEN)
     with get_conn() as conn:
         conn.execute(
-            "INSERT INTO access_tokens (id, name, description, token_hash, allowed_ips_json) "
-            "VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO access_tokens (id, name, description, token_hash, hash_algo, allowed_ips_json) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
             (
                 token_id,
                 "bootstrap",
                 "Admin token from ARKIV_ADMIN_BOOTSTRAP_TOKEN env (delete after creating per-machine tokens)",
-                hash_token(ARKIV_ADMIN_BOOTSTRAP_TOKEN),
+                boot_hash,
+                boot_algo,
                 '["*"]',
             ),
         )

--- a/arkiv_token.py
+++ b/arkiv_token.py
@@ -7,7 +7,7 @@ import json
 import sys
 from datetime import datetime, timedelta, timezone
 
-from auth import SCOPES, hash_token, new_raw_token, new_token_id
+from auth import SCOPES, preferred_hash, new_raw_token, new_token_id
 from db import get_conn, init_db
 
 
@@ -78,15 +78,17 @@ def cmd_create(args):
     token_id = new_token_id()
     expires_at = _expires_at(args.expires_in)
 
+    token_hash, hash_algo = preferred_hash(raw_token)
     with get_conn() as conn:
         conn.execute(
-            "INSERT INTO access_tokens (id, name, description, token_hash, expires_at, allowed_ips_json) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
+            "INSERT INTO access_tokens (id, name, description, token_hash, hash_algo, expires_at, allowed_ips_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
             (
                 token_id,
                 args.name,
                 args.description,
-                hash_token(raw_token),
+                token_hash,
+                hash_algo,
                 expires_at,
                 json.dumps(allowed_ips),
             ),

--- a/auth.py
+++ b/auth.py
@@ -158,28 +158,16 @@ def resolve_raw_token(raw: str, client_ip: str, user_agent: str = "") -> dict:
     placeholders = ",".join("?" for _ in cand_hashes)
     with get_conn() as conn:
         row = conn.execute(
-            "SELECT id, name, expires_at, allowed_ips_json, hash_algo "
+            "SELECT id, name, expires_at, allowed_ips_json, token_hash "
             "FROM access_tokens WHERE token_hash IN ({0})".format(placeholders),
             cand_hashes,
         ).fetchone()
         if not row:
             raise HTTPException(401, "Invalid token")
 
-        # Opportunistic migration: a legacy sha256 token that verifies while a
-        # server key is configured is rehashed to HMAC on this use, so the fleet
-        # drains to the stronger scheme over time. Never block auth on it.
-        try:
-            row_algo = row["hash_algo"] if "hash_algo" in row.keys() else "sha256"
-        except Exception:
-            row_algo = "sha256"
-        if config.ARKIV_TOKEN_HMAC_KEY and (row_algo or "sha256") == "sha256":
-            try:
-                conn.execute(
-                    "UPDATE access_tokens SET token_hash = ?, hash_algo = ? WHERE id = ?",
-                    (_hmac_token(raw), "hmac-sha256", row["id"]),
-                )
-            except Exception:
-                pass
+        # Which algo actually matched (derived from the matching hash, not the
+        # stored hash_algo column — robust to a corrupt column value).
+        matched_algo = next((algo for h, algo in candidates if h == row["token_hash"]), None)
 
         expires_at = row["expires_at"]
         if expires_at:
@@ -194,6 +182,21 @@ def resolve_raw_token(raw: str, client_ip: str, user_agent: str = "") -> dict:
 
         if not _check_ip_allowed(client_ip, row["allowed_ips_json"]):
             raise HTTPException(403, "Client IP not in token's allowlist")
+
+        # Opportunistic migration — ONLY after the token fully validates (Codex
+        # SHOULD-FIX: don't mutate on a request that ends up rejected). A legacy
+        # sha256 token used while a server key is set is rehashed to HMAC via a
+        # compare-and-set, so a racing request can't double-migrate. Never blocks
+        # auth.
+        if config.ARKIV_TOKEN_HMAC_KEY and matched_algo == "sha256":
+            try:
+                conn.execute(
+                    "UPDATE access_tokens SET token_hash = ?, hash_algo = ? "
+                    "WHERE id = ? AND token_hash = ? AND hash_algo = 'sha256'",
+                    (_hmac_token(raw), "hmac-sha256", row["id"], row["token_hash"]),
+                )
+            except Exception:
+                pass
 
         scope_rows = conn.execute(
             "SELECT scope FROM access_token_scopes WHERE token_id = ?",

--- a/auth.py
+++ b/auth.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 
 from fastapi import Depends, HTTPException, Request
 
+import config
 from db import get_conn
 
 try:
@@ -57,7 +58,33 @@ def _looks_proxied(request: Request) -> bool:
 
 
 def hash_token(raw):
+    """Legacy unsalted SHA-256. Kept for the dual-read transition (Phase 16.1)
+    and as the fallback when no server HMAC key is configured."""
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _hmac_token(raw):
+    import hmac as _hmac
+    return _hmac.new(
+        config.ARKIV_TOKEN_HMAC_KEY.encode("utf-8"), raw.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+
+
+def preferred_hash(raw):
+    """(hash, algo) for a NEWLY minted token: HMAC-SHA256 when a server key is
+    set (ARKIV_TOKEN_HMAC_KEY), else legacy sha256."""
+    if config.ARKIV_TOKEN_HMAC_KEY:
+        return _hmac_token(raw), "hmac-sha256"
+    return hash_token(raw), "sha256"
+
+
+def _candidate_hashes(raw):
+    """Every (hash, algo) a stored token for `raw` could be under — the dual-read
+    set. token_hash is unique so at most one matches; order is irrelevant."""
+    cands = [(hash_token(raw), "sha256")]
+    if config.ARKIV_TOKEN_HMAC_KEY:
+        cands.append((_hmac_token(raw), "hmac-sha256"))
+    return cands
 
 
 def new_token_id():
@@ -124,14 +151,35 @@ def resolve_raw_token(raw: str, client_ip: str, user_agent: str = "") -> dict:
     WebSocket path (which can't use a Request-typed Depends)."""
     if not raw:
         raise HTTPException(401, "Missing token (expected 'Authorization: Bearer <token>' or ?token=<token>)")
-    token_hash = hash_token(raw)
+    # Phase 16.1 dual-read: look the token up under every hash it could be
+    # stored as (legacy sha256 and, when a server key is set, HMAC-SHA256).
+    candidates = _candidate_hashes(raw)
+    cand_hashes = [h for h, _ in candidates]
+    placeholders = ",".join("?" for _ in cand_hashes)
     with get_conn() as conn:
         row = conn.execute(
-            "SELECT id, name, expires_at, allowed_ips_json FROM access_tokens WHERE token_hash = ?",
-            (token_hash,),
+            "SELECT id, name, expires_at, allowed_ips_json, hash_algo "
+            "FROM access_tokens WHERE token_hash IN ({0})".format(placeholders),
+            cand_hashes,
         ).fetchone()
         if not row:
             raise HTTPException(401, "Invalid token")
+
+        # Opportunistic migration: a legacy sha256 token that verifies while a
+        # server key is configured is rehashed to HMAC on this use, so the fleet
+        # drains to the stronger scheme over time. Never block auth on it.
+        try:
+            row_algo = row["hash_algo"] if "hash_algo" in row.keys() else "sha256"
+        except Exception:
+            row_algo = "sha256"
+        if config.ARKIV_TOKEN_HMAC_KEY and (row_algo or "sha256") == "sha256":
+            try:
+                conn.execute(
+                    "UPDATE access_tokens SET token_hash = ?, hash_algo = ? WHERE id = ?",
+                    (_hmac_token(raw), "hmac-sha256", row["id"]),
+                )
+            except Exception:
+                pass
 
         expires_at = row["expires_at"]
         if expires_at:

--- a/config.py
+++ b/config.py
@@ -74,6 +74,11 @@ PROXIES_DIR = _validate_writable_path(
 
 # Auth bootstrap (auth-tokens-1b handover).
 ARKIV_ADMIN_BOOTSTRAP_TOKEN = os.getenv("ARKIV_ADMIN_BOOTSTRAP_TOKEN", "").strip()
+# Phase 16.1: when set, access tokens are stored as HMAC-SHA256(key, token)
+# instead of bare SHA-256. Dual-read keeps existing sha256 tokens valid and
+# upgrades them on next use. Keep this key safe — losing it invalidates every
+# HMAC token (re-mint required), the same failure mode as losing the DB.
+ARKIV_TOKEN_HMAC_KEY = os.getenv("ARKIV_TOKEN_HMAC_KEY", "").strip()
 
 
 def proxy_path_for(media_id: int, abs_source_path: str) -> Path:

--- a/db.py
+++ b/db.py
@@ -193,6 +193,7 @@ def init_db():
                 name TEXT NOT NULL,
                 description TEXT,
                 token_hash TEXT UNIQUE NOT NULL,
+                hash_algo TEXT NOT NULL DEFAULT 'sha256',
                 expires_at TEXT,
                 allowed_ips_json TEXT NOT NULL DEFAULT '["*"]',
                 last_used_at TEXT,
@@ -201,6 +202,11 @@ def init_db():
                 created_at TEXT NOT NULL DEFAULT (datetime('now'))
             )
         """)
+        # Phase 16.1: hash_algo on pre-existing token tables (sha256 legacy).
+        try:
+            conn.execute("ALTER TABLE access_tokens ADD COLUMN hash_algo TEXT NOT NULL DEFAULT 'sha256'")
+        except Exception:
+            pass
         conn.execute("""
             CREATE TABLE IF NOT EXISTS access_token_scopes (
                 token_id TEXT NOT NULL,

--- a/docs/phase-16.1-token-hash-decision.md
+++ b/docs/phase-16.1-token-hash-decision.md
@@ -1,7 +1,10 @@
-# Phase 16.1 — Token hash salt/HMAC (decision required, not yet implemented)
+# Phase 16.1 — Token hash salt/HMAC
 
-**Status:** deferred pending an owner decision. 16.2 (relative paths in API
-responses) shipped; 16.1 is the other half of security round 3.
+**Status: IMPLEMENTED 2026-06-03** — Option A (env-var HMAC key + dual-read), the
+recommendation below, chosen by the operator. `ARKIV_TOKEN_HMAC_KEY` (when set)
+stores tokens as HMAC-SHA256; existing sha256 tokens keep working via dual-read
+and upgrade in place on next use. No flag-day. The rest of this doc is the
+original decision record.
 
 ## Current state
 

--- a/tests/test_token_hash.py
+++ b/tests/test_token_hash.py
@@ -1,0 +1,118 @@
+"""Phase 16.1 — HMAC token hash + dual-read transition."""
+import importlib
+
+import pytest
+from fastapi import HTTPException
+
+import db
+
+
+@pytest.fixture
+def mods(tmp_db):
+    config = importlib.import_module("config")
+    auth = importlib.import_module("auth")
+    admin = importlib.import_module("admin")
+    return config, auth, admin
+
+
+def _row(token_id):
+    with db.get_conn() as c:
+        return c.execute(
+            "SELECT token_hash, hash_algo FROM access_tokens WHERE id=?", (token_id,)
+        ).fetchone()
+
+
+# --------------------------------------------------------------------------
+# minting
+# --------------------------------------------------------------------------
+def test_no_key_mints_sha256(mods, monkeypatch):
+    config, auth, admin = mods
+    monkeypatch.setattr(config, "ARKIV_TOKEN_HMAC_KEY", "")
+    tok = admin.create_token(name="t", scopes=["videos_read"])
+    row = _row(tok["id"])
+    assert row["hash_algo"] == "sha256"
+    assert row["token_hash"] == auth.hash_token(tok["raw_token"])
+    assert "videos_read" in auth.resolve_raw_token(tok["raw_token"], "", "")["scopes"]
+
+
+def test_key_mints_hmac_not_bare_sha256(mods, monkeypatch):
+    config, auth, admin = mods
+    monkeypatch.setattr(config, "ARKIV_TOKEN_HMAC_KEY", "server-secret-123456")
+    tok = admin.create_token(name="t", scopes=["videos_read"])
+    raw = tok["raw_token"]
+    row = _row(tok["id"])
+    assert row["hash_algo"] == "hmac-sha256"
+    assert row["token_hash"] != auth.hash_token(raw)        # not a bare sha256
+    assert row["token_hash"] == auth._hmac_token(raw)
+    assert "videos_read" in auth.resolve_raw_token(raw, "", "")["scopes"]
+
+
+# --------------------------------------------------------------------------
+# dual-read transition (the red line: existing tokens keep working)
+# --------------------------------------------------------------------------
+def test_legacy_sha256_token_still_resolves_after_key_set(mods, monkeypatch):
+    config, auth, admin = mods
+    monkeypatch.setattr(config, "ARKIV_TOKEN_HMAC_KEY", "")     # mint legacy
+    tok = admin.create_token(name="legacy", scopes=["videos_read"])
+    raw = tok["raw_token"]
+    monkeypatch.setattr(config, "ARKIV_TOKEN_HMAC_KEY", "server-secret-123456")  # key turned on
+    # must NOT 401 — dual-read still recognises the sha256 token
+    assert "videos_read" in auth.resolve_raw_token(raw, "", "")["scopes"]
+
+
+def test_legacy_token_opportunistically_migrates_to_hmac(mods, monkeypatch):
+    config, auth, admin = mods
+    monkeypatch.setattr(config, "ARKIV_TOKEN_HMAC_KEY", "")
+    tok = admin.create_token(name="legacy", scopes=["videos_read"])
+    raw = tok["raw_token"]
+    assert _row(tok["id"])["hash_algo"] == "sha256"
+    monkeypatch.setattr(config, "ARKIV_TOKEN_HMAC_KEY", "server-secret-123456")
+    auth.resolve_raw_token(raw, "", "")            # use → rehash
+    row = _row(tok["id"])
+    assert row["hash_algo"] == "hmac-sha256"
+    assert row["token_hash"] == auth._hmac_token(raw)
+    # and it still resolves after the in-place migration
+    assert "videos_read" in auth.resolve_raw_token(raw, "", "")["scopes"]
+
+
+def test_no_migration_when_key_absent(mods, monkeypatch):
+    config, auth, admin = mods
+    monkeypatch.setattr(config, "ARKIV_TOKEN_HMAC_KEY", "")
+    tok = admin.create_token(name="legacy", scopes=["videos_read"])
+    auth.resolve_raw_token(tok["raw_token"], "", "")
+    assert _row(tok["id"])["hash_algo"] == "sha256"   # untouched without a key
+
+
+# --------------------------------------------------------------------------
+# failure modes
+# --------------------------------------------------------------------------
+def test_hmac_token_fails_if_key_lost(mods, monkeypatch):
+    # The documented tradeoff: losing the key invalidates HMAC tokens.
+    config, auth, admin = mods
+    monkeypatch.setattr(config, "ARKIV_TOKEN_HMAC_KEY", "server-secret-123456")
+    tok = admin.create_token(name="t", scopes=["videos_read"])
+    monkeypatch.setattr(config, "ARKIV_TOKEN_HMAC_KEY", "")   # key lost
+    with pytest.raises(HTTPException):
+        auth.resolve_raw_token(tok["raw_token"], "", "")
+
+
+def test_wrong_key_does_not_authenticate(mods, monkeypatch):
+    config, auth, admin = mods
+    monkeypatch.setattr(config, "ARKIV_TOKEN_HMAC_KEY", "key-A-xxxxxxxxxxxx")
+    tok = admin.create_token(name="t", scopes=["videos_read"])
+    monkeypatch.setattr(config, "ARKIV_TOKEN_HMAC_KEY", "key-B-yyyyyyyyyyyy")
+    with pytest.raises(HTTPException):
+        auth.resolve_raw_token(tok["raw_token"], "", "")
+
+
+def test_invalid_token_401(mods, monkeypatch):
+    config, auth, admin = mods
+    monkeypatch.setattr(config, "ARKIV_TOKEN_HMAC_KEY", "server-secret-123456")
+    with pytest.raises(HTTPException):
+        auth.resolve_raw_token("not-a-real-token", "", "")
+
+
+def test_empty_token_401(mods):
+    _, auth, _ = mods
+    with pytest.raises(HTTPException):
+        auth.resolve_raw_token("", "", "")

--- a/tests/test_token_hash.py
+++ b/tests/test_token_hash.py
@@ -75,6 +75,22 @@ def test_legacy_token_opportunistically_migrates_to_hmac(mods, monkeypatch):
     assert "videos_read" in auth.resolve_raw_token(raw, "", "")["scopes"]
 
 
+def test_rejected_request_does_not_migrate(mods, monkeypatch):
+    # Codex SHOULD-FIX: a token that fails validation (expired) must NOT be
+    # rehashed — migration happens only after the token fully validates.
+    config, auth, admin = mods
+    monkeypatch.setattr(config, "ARKIV_TOKEN_HMAC_KEY", "")
+    tok = admin.create_token(name="legacy", scopes=["videos_read"], expires_in_days=1)
+    raw = tok["raw_token"]
+    # force-expire the row
+    with db.get_conn() as c:
+        c.execute("UPDATE access_tokens SET expires_at='2000-01-01T00:00:00+00:00' WHERE id=?", (tok["id"],))
+    monkeypatch.setattr(config, "ARKIV_TOKEN_HMAC_KEY", "server-secret-123456")
+    with pytest.raises(HTTPException):
+        auth.resolve_raw_token(raw, "", "")
+    assert _row(tok["id"])["hash_algo"] == "sha256"  # not migrated despite key
+
+
 def test_no_migration_when_key_absent(mods, monkeypatch):
     config, auth, admin = mods
     monkeypatch.setattr(config, "ARKIV_TOKEN_HMAC_KEY", "")


### PR DESCRIPTION
## Phase 16.1 — HMAC token hashing (env-var key + dual-read)

Closes the other half of security round 3. `ARKIV_TOKEN_HMAC_KEY` (env) switches token storage from bare SHA-256 to **HMAC-SHA256(key, token)**.

- **Non-breaking (dual-read):** `resolve_raw_token` looks the token up under every candidate hash (sha256 + HMAC when keyed). Existing sha256 tokens keep authenticating; a legacy token that verifies while a key is set is rehashed to HMAC **in place, only after it fully validates** (compare-and-set, never blocks auth). New tokens mint with the preferred algo; `access_tokens` gains a `hash_algo` column.
- **Key-absent path is byte-identical to pre-16.1** sha256 behavior.
- **Tradeoff (operator-accepted):** losing the key invalidates HMAC tokens — same failure mode as losing the DB.

Decision record + the chosen option: `docs/phase-16.1-token-hash-decision.md`.

### Verification
- 10 tests: sha256 default; HMAC when keyed (not bare sha256); **legacy token resolves after key set**; opportunistic migration; rejected (expired) request does NOT migrate; no migration without key; key-lost / wrong-key / invalid / empty → 401. 33 existing auth tests unchanged. Full suite **383 passed / 3 skipped**.
- **Codex review: PASS on the red line, no CRITICAL.** SHOULD-FIX (migrate-after-validate + CAS) applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)