### PR TITLE
chore: Svelte rebuild-index button + BMD metadata edge tests + gitignore local runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,18 @@ __pycache__/
 .env
 .env.local
 *.db
+*.db-shm
+*.db-wal
 media.db
 arkiv.db
 chroma_db/
 thumbnails/
 proxies/
 waveforms/
+
+# Local project runtime data (SQLite + WAL/SHM, vector store, thumbnails, scratch)
+.arkiv/
+temp/
 
 # Benchmark artefacts — results contain private transcripts / filenames,
 # and the scripts below have hardcoded personal paths. Keep local only.

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -77,6 +77,12 @@ export const chat = (prompt, conversationId = null, opts) =>
 export const ingestWs = (path, limit = 0, opts) =>
   req('/api/ingest/ws', { method: 'POST', body: { path, limit }, ...opts })
 
+// POST /api/embed/rebuild — drop + rebuild the ChromaDB semantic index from all
+// media (runs in the background). Requires ingest_write (token-free on loopback).
+// → {message, queued}
+export const rebuildEmbedIndex = (opts) =>
+  req('/api/embed/rebuild', { method: 'POST', ...opts })
+
 // /api/media?limit&offset&projects&tag&rating  → {items, total, search}
 export const getMedia = (params = {}, opts) => req(`/api/media${qs(params)}`, opts)
 export const getMediaDetail = (id, opts) => req(`/api/media/${id}`, opts)

--- a/frontend/src/routes/IngestLive.svelte
+++ b/frontend/src/routes/IngestLive.svelte
@@ -23,6 +23,7 @@
   let complete = null // {ok, skipped, failed}
   let log = [] // [{t, text}]
   let busy = false
+  let rebuilding = false
   let err = ''
 
   const wsUrl = () => {
@@ -89,6 +90,22 @@
     }
   }
 
+  // Rebuild the semantic index — independent of the ingest WS (plain POST,
+  // background task on the server). Kept on its own flag so it never collides
+  // with the ws ingest's busy/complete lifecycle.
+  async function rebuildIndex() {
+    err = ''
+    rebuilding = true
+    try {
+      const res = await api.rebuildEmbedIndex()
+      pushLog(res.message || '重建向量索引：已排入背景')
+    } catch (e) {
+      err = e.message
+    } finally {
+      rebuilding = false
+    }
+  }
+
   onMount(connect)
   onDestroy(() => ws && ws.close())
 
@@ -122,6 +139,7 @@
             <div class="triggerrow">
               <input class="ak-input limitinput" type="number" min="0" bind:value={limit} disabled={busy} title="limit (0=all)" />
               <button class="ak-btn ak-btn--primary" on:click={trigger} disabled={busy || conn !== 'open'}>{busy ? 'running…' : 'Start ingest →'}</button>
+              <button class="ak-btn" on:click={rebuildIndex} disabled={rebuilding || busy} title="重建 ChromaDB 向量索引（背景執行）— ingest 後或換 embedding 模型後使用">{rebuilding ? '排入中…' : '重建索引'}</button>
             </div>
           </div>
         </div>

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -156,6 +156,69 @@ def test_bmd_shutter_angle_parse_fail_logs_warning(monkeypatch, caplog):
     assert any("Blackmagic-designCameraShutterAngle parse failed" in record.message for record in caplog.records)
 
 
+def test_bmd_white_balance_negative_tint():
+    """Cooling tints are negative in BMD metadata and must survive intact."""
+    import ingest
+    assert ingest._white_balance_string(5600, -10) == "5600K T-10"
+
+
+def test_bmd_white_balance_rounds_floats():
+    import ingest
+    assert ingest._white_balance_string(5603.6, 9.4) == "5604K T9"
+
+
+def test_bmd_white_balance_non_numeric_returns_none(caplog):
+    import ingest
+    with caplog.at_level("WARNING"):
+        assert ingest._white_balance_string("auto", None) is None
+    assert any(
+        "Blackmagic-designCameraWhiteBalance parse failed" in r.message for r in caplog.records
+    )
+
+
+def test_bmd_shutter_angle_non_positive_returns_none():
+    """Zero/negative angle or fps is invalid — must not divide, returns None."""
+    import ingest
+    assert ingest._shutter_angle_to_speed(0, 24) is None
+    assert ingest._shutter_angle_to_speed(-90, 24) is None
+    assert ingest._shutter_angle_to_speed(180, 0) is None
+
+
+def test_bmd_shutter_angle_near_360_and_over():
+    """Near-360 rounds to base shutter; >360° (shutter drag) is still valid."""
+    import ingest
+    assert ingest._shutter_angle_to_speed(359.0, 24) == "1/24"   # 24.07 → 24
+    assert ingest._shutter_angle_to_speed(720.0, 24) == "1/12"   # drag, no upper guard
+
+
+def test_bmd_standard_exposure_fields_win_over_bmd(monkeypatch):
+    """When a body writes standard ISO/FNumber/ShutterSpeed, those win and the
+    BMD-design fallbacks are ignored — the precedence the parser promises."""
+    import sys, os, json
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    import ingest
+
+    fake_stdout = json.dumps([{
+        "SourceFile": "mix.mov",
+        "ISO": 200, "FNumber": 4.0, "ShutterSpeed": "1/100",
+        # BMD fallbacks present but should be shadowed by the standard fields
+        "Blackmagic-designCameraIso": 640,
+        "Blackmagic-designCameraAperture": 2.8,
+        "Blackmagic-designCameraShutterAngle": 172.8,
+    }])
+
+    class _FakeProc:
+        returncode = 0
+        stdout = fake_stdout
+        stderr = ""
+
+    monkeypatch.setattr(ingest.subprocess, "run", lambda *a, **kw: _FakeProc())
+    result = ingest.exiftool_extract("mix.mov", fps=24)
+    assert result["iso"] == 200
+    assert result["aperture"] == 4.0
+    assert result["shutter_speed"] == "1/100"
+
+
 def test_bmd_metadata_roundtrips_white_balance_column(tmp_db, sample_record):
     import importlib
 


### PR DESCRIPTION
Polish bundle from the arkiv backlog — three independent, non-blocking wins.

## 1. Svelte「重建索引」button (rebuild vector index)
The backend `POST /api/embed/rebuild` existed (and the legacy `index.html` had a button) but the Svelte frontend had none.

- `api.js`: `rebuildEmbedIndex()` client function.
- Placed on **`/ingest-live`** (`IngestLive.svelte`) — the *functional* screen — next to "Start ingest →". Rebuild is a post-ingest / post-model-change maintenance action, and that screen already has the auth layer, live log, and busy/error infra. (`Settings.svelte` is a static design artboard with no functional controls — wiring a live button there would be inconsistent; a real Advanced settings screen is future work.)
- Own `rebuilding` flag so it never collides with the ingest WS `busy`/`complete` lifecycle. `npm run build` green.

## 2. BMD (Blackmagic) metadata edge-case tests — closes the stale **B10b3** todo
B10b3 was marked "待重派" but is in fact **fully implemented** in `ingest.py` (ISO/aperture fallback, `_shutter_angle_to_speed`, `_white_balance_string` Kelvin+Tint, day/night auto-tags) with tests. Added the **uncovered** edges:
- White balance: negative tint (`5600K T-10`), float rounding, non-numeric → `None` + warning.
- Shutter angle: non-positive angle/fps → `None`, near-360 rounding, >360° (shutter drag).
- **Standard ISO/FNumber/ShutterSpeed win over BMD-design fallbacks** (the precedence the parser promises).

## 3. `.gitignore` — protect the local project DB
`.arkiv/` (SQLite + WAL/SHM sidecars, ChromaDB, thumbnails) and `temp/` scratch were untracked but not ignored — `*.db-shm`/`*.db-wal` weren't covered. Now ignored so the local media DB can't be committed. (Hygiene follow-up to the recent leaked-credentials incident.)

## Tests
Full suite **381 passed, 3 skipped**.

## Not done (honest)
The original "PR #3 中文用詞微調 + mobile markdown" item targets marketing-site copy (tagline / 「介於」 / 「持有 vs 掌握」 / install 翻譯) with no clear in-repo page and no stated wording preference — deferred rather than guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)