### PR TITLE
fix(audit): 2026-06-12 pre-tag hardening — 51 findings (5 blockers + 46)

### DIFF
--- a/codec.py
+++ b/codec.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from typing import Optional
 
 from config import FFPROBE_PATH  # resolved ffprobe (handles headless Windows / WinError 448)
@@ -42,7 +43,8 @@ def probe_codec(path: str, timeout: float = 10.0) -> Optional[str]:
     if key in _codec_cache:
         return _codec_cache[key]
     cmd = [
-        FFPROBE_PATH, "-v", "quiet", "-select_streams", "v:0",
+        # audit M15: -v error (was quiet) so failure reasons reach stderr.
+        FFPROBE_PATH, "-v", "error", "-select_streams", "v:0",
         "-show_entries", "stream=codec_name", "-of", "csv=p=0", str(path),
     ]
     try:
@@ -50,10 +52,19 @@ def probe_codec(path: str, timeout: float = 10.0) -> Optional[str]:
         # output bytes (headless ingest crash), so decode explicitly.
         r = subprocess.run(cmd, capture_output=True, text=True,
                            encoding="utf-8", errors="replace", timeout=timeout)
-        codec = r.stdout.strip().strip(",").lower() or None
     except Exception:
-        codec = None
-    _codec_cache[key] = codec
+        # audit M15: transient failure (timeout / missing binary) — do NOT
+        # negative-cache, so the next call can re-probe and self-heal.
+        return None
+    # getattr: real CompletedProcess always has returncode; some test fakes don't.
+    rc = getattr(r, "returncode", 0)
+    if rc != 0:
+        # audit M15: probe error — log tail, skip caching so it can self-heal.
+        err = (getattr(r, "stderr", "") or "").strip()
+        print(f"[WARN] ffprobe rc={rc} for {path}: {err[-200:]}", file=sys.stderr)
+        return None
+    codec = r.stdout.strip().strip(",").lower() or None
+    _codec_cache[key] = codec  # audit M15: only successful probes are cached
     return codec
 
 

--- a/db.py
+++ b/db.py
@@ -11,28 +11,45 @@ from config import DB_PATH
 from contextlib import contextmanager
 
 
+# audit L14: once-only init — the parent-dir check + double chmod used to run
+# on EVERY connection, multiplying syscalls on N+1-heavy call paths. Keyed on
+# the DB path (not a plain bool) so tests / `--db` that rebind db.DB_PATH at
+# runtime still re-init for the new location.
+_init_done_for: Optional[str] = None
+
+
 @contextmanager
 def get_conn():
-    # Ensure the DB's parent dir exists. On a fresh clone the .arkiv/ data dir
-    # doesn't exist yet, and server.py calls init_db() at import → sqlite would
-    # raise "unable to open database file". Covers every DB-opening path
-    # (server / ingest / embed / tests), not just server startup.
-    parent = Path(DB_PATH).expanduser().parent
-    if parent and not parent.exists():
-        parent.mkdir(parents=True, exist_ok=True)
-        # Only tighten a dir WE just created — never an existing (possibly shared)
-        # parent, which could strip access from unrelated files.
+    global _init_done_for
+    first_open = _init_done_for != str(DB_PATH)
+    if first_open:
+        # Ensure the DB's parent dir exists. On a fresh clone the .arkiv/ data dir
+        # doesn't exist yet, and server.py calls init_db() at import → sqlite would
+        # raise "unable to open database file". Covers every DB-opening path
+        # (server / ingest / embed / tests), not just server startup.
+        parent = Path(DB_PATH).expanduser().parent
+        if parent and not parent.exists():
+            parent.mkdir(parents=True, exist_ok=True)
+            # Only tighten a dir WE just created — never an existing (possibly shared)
+            # parent, which could strip access from unrelated files.
+            try:
+                os.chmod(parent, 0o700)
+            except OSError:
+                pass
+    conn = sqlite3.connect(DB_PATH, timeout=30)
+    # audit M6: SQLite ships with foreign_keys OFF per-connection, so every
+    # ON DELETE CASCADE in the schema was dead — revoking a token or deleting
+    # media left orphan child rows. init_db() clears pre-existing orphans via
+    # foreign_key_check before enforcement can bite on legacy data.
+    conn.execute("PRAGMA foreign_keys=ON")
+    if first_open:
+        # Our own token-hash DB file — keep it owner-only on shared hosts.
+        # Best-effort (no-op / may fail on Windows).
         try:
-            os.chmod(parent, 0o700)
+            os.chmod(DB_PATH, 0o600)
         except OSError:
             pass
-    conn = sqlite3.connect(DB_PATH, timeout=30)
-    # Our own token-hash DB file — keep it owner-only on shared hosts.
-    # Best-effort (no-op / may fail on Windows).
-    try:
-        os.chmod(DB_PATH, 0o600)
-    except OSError:
-        pass
+        _init_done_for = str(DB_PATH)
     conn.row_factory = sqlite3.Row
     try:
         yield conn
@@ -80,6 +97,20 @@ def resolve_path(rel_path: str) -> str:
             f"DB rel_path 解析後逃出 PROJECT_ROOT 邊界：{rel_path!r} → {joined!s}"
         )
     return str(joined)
+
+
+def _add_column_if_missing(conn, table: str, col: str, typ: str):
+    """ALTER TABLE ... ADD COLUMN that only swallows the expected
+    "duplicate column name" error.
+
+    audit L10: the old bare `except Exception: pass` here also ate
+    database-locked / disk-I/O errors, silently skipping schema migrations —
+    those must surface, only the idempotent re-run case is benign."""
+    try:
+        conn.execute(f"ALTER TABLE {table} ADD COLUMN {col} {typ}")
+    except sqlite3.OperationalError as e:
+        if "duplicate column" not in str(e).lower():
+            raise
 
 
 def init_db():
@@ -171,10 +202,7 @@ def init_db():
             # re-probe the whole library each ingest (H1).
             ("codec", "TEXT"),
         ]:
-            try:
-                conn.execute(f"ALTER TABLE media ADD COLUMN {col} {typ}")
-            except Exception:
-                pass
+            _add_column_if_missing(conn, "media", col, typ)  # audit L10
         for col, typ in [
             ("content_type", "TEXT"),
             ("focus_score", "INTEGER"),
@@ -186,10 +214,7 @@ def init_db():
             ("edit_position", "TEXT"),
             ("edit_reason", "TEXT"),
         ]:
-            try:
-                conn.execute(f"ALTER TABLE frames ADD COLUMN {col} {typ}")
-            except Exception:
-                pass
+            _add_column_if_missing(conn, "frames", col, typ)  # audit L10
         conn.execute("""
             CREATE TABLE IF NOT EXISTS access_tokens (
                 id TEXT PRIMARY KEY,
@@ -206,10 +231,9 @@ def init_db():
             )
         """)
         # Phase 16.1: hash_algo on pre-existing token tables (sha256 legacy).
-        try:
-            conn.execute("ALTER TABLE access_tokens ADD COLUMN hash_algo TEXT NOT NULL DEFAULT 'sha256'")
-        except Exception:
-            pass
+        _add_column_if_missing(  # audit L10
+            conn, "access_tokens", "hash_algo", "TEXT NOT NULL DEFAULT 'sha256'"
+        )
         conn.execute("""
             CREATE TABLE IF NOT EXISTS access_token_scopes (
                 token_id TEXT NOT NULL,
@@ -271,12 +295,37 @@ def init_db():
             "CREATE INDEX IF NOT EXISTS idx_jobs_status_priority "
             "ON jobs(status, priority, created_at)"
         )
+        # audit M6: PRAGMA foreign_keys was never enabled before, so orphan
+        # child rows accumulated (e.g. scopes of revoked tokens, tags/frames of
+        # deleted media). Clear them once here so the now-active enforcement in
+        # get_conn() doesn't start failing writes against legacy inconsistency.
+        _known_child_tables = {"tags", "frames", "access_token_scopes", "chat_messages"}
+        try:
+            violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+        except sqlite3.Error:
+            violations = []
+        removed = 0
+        for v in violations:
+            tbl, rowid = v[0], v[1]
+            # Only touch tables we know are pure child rows — never auto-delete
+            # from anything unexpected.
+            if tbl in _known_child_tables and rowid is not None:
+                conn.execute(
+                    "DELETE FROM {0} WHERE rowid=?".format(tbl), (rowid,)
+                )
+                removed += 1
+        if removed:
+            print(
+                "[init_db] foreign_key_check: removed {0} orphan child row(s)"
+                " left from pre-enforcement era (audit M6)".format(removed)
+            )
 
 
 def migrate_to_relative():
     """Convert DB path fields from absolute to relative paths."""
     media_count = 0
     frame_count = 0
+    merged_count = 0
     with get_conn() as conn:
         rows = conn.execute("SELECT id, path, thumbnail_path FROM media").fetchall()
         for row in rows:
@@ -289,8 +338,29 @@ def migrate_to_relative():
                         (new_path, new_thumb, row["id"]),
                     )
                     media_count += 1
-                except sqlite3.IntegrityError as exc:
-                    print(f"[migrate] warning: media id={row['id']} skipped due to UNIQUE conflict: {exc}")
+                except sqlite3.IntegrityError:
+                    # audit H5: another row already holds the relative form
+                    # (abs/rel duplicate pair — upsert's ON CONFLICT(path) never
+                    # fires across the two forms). Merge instead of skip: move
+                    # over child rows the survivor doesn't already have, then
+                    # drop the duplicate. UPDATE OR IGNORE skips children that
+                    # would violate UNIQUE(media_id, frame_index/name) — the
+                    # survivor's own copy wins there.
+                    survivor = conn.execute(
+                        "SELECT id FROM media WHERE path=? AND id<>?",
+                        (new_path, row["id"]),
+                    ).fetchone()
+                    if survivor is None:
+                        print(f"[migrate] warning: media id={row['id']} UNIQUE conflict without locatable survivor — skipped")
+                        continue
+                    sid = survivor["id"]
+                    conn.execute("UPDATE OR IGNORE frames SET media_id=? WHERE media_id=?", (sid, row["id"]))
+                    conn.execute("DELETE FROM frames WHERE media_id=?", (row["id"],))
+                    conn.execute("UPDATE OR IGNORE tags SET media_id=? WHERE media_id=?", (sid, row["id"]))
+                    conn.execute("DELETE FROM tags WHERE media_id=?", (row["id"],))
+                    conn.execute("DELETE FROM media WHERE id=?", (row["id"],))
+                    merged_count += 1
+                    print(f"[migrate] merged duplicate media id={row['id']} into id={sid} ({new_path})")
         frame_rows = conn.execute(
             "SELECT id, thumbnail_path FROM frames WHERE thumbnail_path IS NOT NULL"
         ).fetchall()
@@ -307,6 +377,8 @@ def migrate_to_relative():
             media_count, len(rows), frame_count, len(frame_rows)
         )
     )
+    if merged_count:
+        print("[migrate] 另合併 {0} 組 abs/rel 重複 row（audit H5）。".format(merged_count))
 
 
 def is_processed(path: str) -> bool:
@@ -357,6 +429,29 @@ def upsert(record: dict, _conn=None):
     else:
         with get_conn() as conn:
             conn.execute(sql, list(safe.values()))
+
+
+def update_media_by_id(media_id: int, record: dict, _conn=None):
+    """UPDATE an existing media row by id (column-subset, same key filter as
+    upsert).
+
+    audit H5: refresh used to go through upsert's ON CONFLICT(path), which
+    never fires when the stored path is absolute and the incoming one relative
+    (or vice versa) — silently INSERTing a duplicate row that frames/tags then
+    attached to arbitrarily. Callers that already resolved the row id (via
+    abs-OR-rel lookup) update in place instead, which also normalizes a legacy
+    absolute path to the incoming relative form."""
+    safe = {k: v for k, v in record.items() if k in _ALLOWED_COLS}
+    if not safe:
+        return
+    sets = ", ".join(f"{k}=?" for k in safe)
+    sql = f"UPDATE media SET {sets} WHERE id=?"
+    params = list(safe.values()) + [media_id]
+    if _conn is not None:
+        _conn.execute(sql, params)
+    else:
+        with get_conn() as conn:
+            conn.execute(sql, params)
 
 
 # ── Lightweight queries (Phase 4) ────────────────────────────────────────────

--- a/db.py
+++ b/db.py
@@ -613,13 +613,20 @@ def upsert_frame(
             _do(conn)
 
 
-def get_frames(media_id: int) -> List[Dict]:
-    with get_conn() as conn:
-        rows = conn.execute(
+def get_frames(media_id: int, _conn=None) -> List[Dict]:
+    def _do(c):
+        rows = c.execute(
             "SELECT * FROM frames WHERE media_id = ? ORDER BY frame_index",
             (media_id,),
         ).fetchall()
         return [dict(r) for r in rows]
+    # _conn lets a caller read frames inside its own open write txn — without it
+    # a second connection can't see the txn's uncommitted UPDATEs (stale read,
+    # audit M1) and on SQLite would block on the writer lock (audit C1).
+    if _conn is not None:
+        return _do(_conn)
+    with get_conn() as conn:
+        return _do(conn)
 
 
 def delete_frames(media_id: int, _conn=None):

--- a/embed.py
+++ b/embed.py
@@ -16,10 +16,36 @@ import db
 import vectordb as vdb
 
 
-def get_all_records() -> list[dict]:
+# audit H12: after this many consecutive per-record failures, assume a systemic
+# outage (Ollama/Chroma down) and stop early instead of burning through the
+# whole library printing the same error.
+FAIL_FAST_CONSECUTIVE = 10
+
+
+def get_all_media_ids() -> list[int]:
+    """IDs only — reconcile/diff doesn't need the heavy transcript/JSON columns
+    (audit M25)."""
     with db.get_conn() as conn:
-        rows = conn.execute("SELECT * FROM media ORDER BY id").fetchall()
-        return [dict(r) for r in rows]
+        rows = conn.execute("SELECT id FROM media ORDER BY id").fetchall()
+        return [r[0] for r in rows]
+
+
+def get_records_by_ids(ids: list[int]) -> list[dict]:
+    """Fetch full rows only for the records that actually need (re)embedding
+    (audit M25). Chunked IN-queries to stay under SQLite's variable limit."""
+    if not ids:
+        return []
+    records: list[dict] = []
+    with db.get_conn() as conn:
+        for i in range(0, len(ids), 500):
+            batch = ids[i:i + 500]
+            placeholders = ",".join("?" * len(batch))
+            rows = conn.execute(
+                f"SELECT * FROM media WHERE id IN ({placeholders}) ORDER BY id",
+                batch,
+            ).fetchall()
+            records.extend(dict(r) for r in rows)
+    return records
 
 
 def get_indexed_media_ids(col) -> set[str]:
@@ -28,12 +54,22 @@ def get_indexed_media_ids(col) -> set[str]:
     return {m["media_id"] for m in result["metadatas"]}
 
 
-def run_embed(rebuild: bool = False, force_ids=None, prune: bool = True):
+def run_embed(rebuild: bool = False, force_ids=None, prune: bool = True) -> dict:
+    """Embed pending records. Returns stats {"ok": n, "errors": n, "aborted": bool}
+    so the CLI can map failures to exit codes (audit H12) without sys.exit()-ing
+    out from under the in-process caller in ingest.py.
+
+    Raises vdb.EmbeddingDimensionMismatch instead of exiting: the CLI converts it
+    to exit 2, while ingest's per-call ``except Exception`` catches and reports it
+    (previously sys.exit(1) here killed the whole ingest process).
+    """
     print(f"{'Rebuilding' if rebuild else 'Updating'} vector index...")
     col = vdb.get_collection(reset=rebuild)
 
-    records = get_all_records()
-    if not records:
+    # audit M25: reconcile only needs ids — don't load every transcript /
+    # words_json / frame_tags column for the whole library on each run.
+    all_ids = get_all_media_ids()
+    if not all_ids:
         print("No records in SQLite. Run ingest.py first.")
         sys.exit(1)
 
@@ -43,7 +79,7 @@ def run_embed(rebuild: bool = False, force_ids=None, prune: bool = True):
     # Reconcile: drop Chroma entries whose media_id no longer exists in SQLite,
     # so deleted clips stop surfacing in search (H5).
     if prune and not rebuild:
-        db_ids = {str(r["id"]) for r in records}
+        db_ids = {str(i) for i in all_ids}
         orphans = indexed_ids - db_ids
         for oid in orphans:
             vdb.delete_media(col, oid)
@@ -52,34 +88,56 @@ def run_embed(rebuild: bool = False, force_ids=None, prune: bool = True):
 
     # Re-embed anything not yet indexed PLUS any caller-forced ids (e.g. records
     # re-processed by `ingest --refresh`, which are already indexed but stale).
-    to_process = [
-        r for r in records
-        if str(r["id"]) not in indexed_ids or str(r["id"]) in force_ids
+    to_process_ids = [
+        mid for mid in all_ids
+        if str(mid) not in indexed_ids or str(mid) in force_ids
     ]
 
-    print(f"Total records: {len(records)} | Already indexed: {len(indexed_ids)} | To process: {len(to_process)}")
+    print(f"Total records: {len(all_ids)} | Already indexed: {len(indexed_ids)} | To process: {len(to_process_ids)}")
 
-    if not to_process:
+    if not to_process_ids:
         print("Index is up to date.")
-        return
+        return {"ok": 0, "errors": 0, "aborted": False}
+
+    # audit M25: full rows fetched only for the work set.
+    to_process = get_records_by_ids(to_process_ids)
 
     total_chunks = 0
+    ok = 0
+    errors = 0          # audit H12: count failures instead of printing-and-forgetting
+    consecutive = 0
+    aborted = False
     for i, rec in enumerate(to_process, 1):
         print(f"[{i}/{len(to_process)}] {rec['filename']}", end="", flush=True)
         try:
             n = vdb.upsert_record(col, rec)
             total_chunks += n
+            ok += 1
+            consecutive = 0
             print(f" -> {n} chunk(s) OK")
-        except vdb.EmbeddingDimensionMismatch as e:
-            # Whole index is incompatible — every row will fail, so stop loud
-            # instead of printing a per-row error for the entire library.
-            print(f"\n[ABORT] {e}")
-            sys.exit(1)
+        except vdb.EmbeddingDimensionMismatch:
+            # Whole index is incompatible — every row will fail. Propagate so the
+            # caller decides (CLI: exit 2; ingest: caught + reported, ingest itself
+            # keeps its own exit status).
+            print()
+            raise
         except Exception as e:
+            errors += 1
+            consecutive += 1
             print(f" [ERROR: {e}]")
+            if consecutive >= FAIL_FAST_CONSECUTIVE:
+                # audit H12: N identical-class failures in a row ≈ Ollama/Chroma
+                # outage; stop early instead of failing the whole library one by one.
+                remaining = len(to_process) - i
+                print(f"\n[ABORT] {consecutive} consecutive failures — embedding backend "
+                      f"likely down; stopping early ({remaining} record(s) not attempted).")
+                aborted = True
+                break
 
-    print(f"\nDone. {total_chunks} total chunks in collection '{vdb.COLLECTION_NAME}'.")
+    status = "Done." if not errors else f"Done with {errors} error(s) ({ok} ok)."
+    print(f"\n{status} {total_chunks} total chunks in collection '{vdb.COLLECTION_NAME}'.")
     print(f"ChromaDB path: {vdb.CHROMA_PATH}")
+    return {"ok": ok, "errors": errors, "aborted": aborted}
 
 
 def run_search(query: str):
@@ -100,7 +158,15 @@ def main():
     parser.add_argument("--search", metavar="QUERY", help="Quick semantic search test after build")
     args = parser.parse_args()
 
-    run_embed(rebuild=args.rebuild)
+    # audit H12: real exit codes — all-failed exit 2, partial failure exit 1
+    # (mirrors ingest Phase 8.0e), instead of "Done." + exit 0 with Ollama down.
+    try:
+        stats = run_embed(rebuild=args.rebuild)
+    except vdb.EmbeddingDimensionMismatch as e:
+        print(f"[ABORT] {e}")
+        sys.exit(2)
+    if stats["errors"]:
+        sys.exit(2 if stats["ok"] == 0 else 1)
 
     if args.search:
         print()

--- a/embed.py
+++ b/embed.py
@@ -11,6 +11,7 @@ Usage:
 from __future__ import annotations
 import argparse
 import sys
+from typing import Dict, List
 
 import db
 import vectordb as vdb
@@ -22,7 +23,7 @@ import vectordb as vdb
 FAIL_FAST_CONSECUTIVE = 10
 
 
-def get_all_media_ids() -> list[int]:
+def get_all_media_ids() -> List[int]:
     """IDs only — reconcile/diff doesn't need the heavy transcript/JSON columns
     (audit M25)."""
     with db.get_conn() as conn:
@@ -30,12 +31,12 @@ def get_all_media_ids() -> list[int]:
         return [r[0] for r in rows]
 
 
-def get_records_by_ids(ids: list[int]) -> list[dict]:
+def get_records_by_ids(ids: List[int]) -> List[Dict]:
     """Fetch full rows only for the records that actually need (re)embedding
     (audit M25). Chunked IN-queries to stay under SQLite's variable limit."""
     if not ids:
         return []
-    records: list[dict] = []
+    records: List[Dict] = []
     with db.get_conn() as conn:
         for i in range(0, len(ids), 500):
             batch = ids[i:i + 500]

--- a/federation.py
+++ b/federation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import sqlite3
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 from dataclasses import dataclass, field
@@ -16,6 +17,61 @@ from projects import ProjectMeta
 
 
 LOGGER = logging.getLogger(__name__)
+
+# audit M10: shared bounded executor — the previous per-request ThreadPoolExecutor
+# + shutdown(wait=False) abandoned workers hung on stale NAS mounts with no global
+# bound, so threads/SQLite connections/Chroma Systems accumulated per request.
+# A single module-level pool caps total concurrency for the whole process.
+_EXECUTOR_MAX_WORKERS = 8
+_EXECUTOR_LOCK = threading.Lock()
+_EXECUTOR: Optional[ThreadPoolExecutor] = None
+
+
+def _shared_executor() -> ThreadPoolExecutor:
+    global _EXECUTOR
+    if _EXECUTOR is None:
+        with _EXECUTOR_LOCK:
+            if _EXECUTOR is None:
+                _EXECUTOR = ThreadPoolExecutor(
+                    max_workers=_EXECUTOR_MAX_WORKERS,
+                    thread_name_prefix="arkiv-fed",
+                )
+    return _EXECUTOR
+
+
+# audit M10: negative cache for timed-out projects — a project that just timed
+# out is skipped for a short TTL so a stalled mount can't pin the bounded pool's
+# workers on every federated query. Self-heals after the TTL.
+_TIMEOUT_NEG_TTL_S = 60.0
+_TIMEOUT_NEG_LOCK = threading.Lock()
+_timeout_neg_cache: Dict[str, float] = {}  # key -> monotonic expiry
+
+
+def _neg_cache_key(project: ProjectMeta) -> str:
+    return str(_project_root(project).resolve(strict=False)).casefold()
+
+
+def _neg_cached(project: ProjectMeta) -> bool:
+    key = _neg_cache_key(project)
+    with _TIMEOUT_NEG_LOCK:
+        expiry = _timeout_neg_cache.get(key)
+        if expiry is None:
+            return False
+        if time.monotonic() >= expiry:
+            del _timeout_neg_cache[key]
+            return False
+        return True
+
+
+def _neg_mark(project: ProjectMeta) -> None:
+    with _TIMEOUT_NEG_LOCK:
+        _timeout_neg_cache[_neg_cache_key(project)] = time.monotonic() + _TIMEOUT_NEG_TTL_S
+
+
+def _neg_clear() -> None:
+    """Drop the timeout negative cache (used by tests)."""
+    with _TIMEOUT_NEG_LOCK:
+        _timeout_neg_cache.clear()
 
 
 def embed_query(query: str):
@@ -320,16 +376,26 @@ def search_all_projects(
         q_embed = None
 
     merged: Dict[Tuple[str, str], Dict[str, Any]] = {}
-    # Manual executor (not a `with` block): the context manager's __exit__ calls
-    # shutdown(wait=True), which blocks until every worker returns — so a worker
-    # hung on a stale NAS mount would make this function hang for far longer than
-    # `timeout`, despite the per-future timeout below. We instead bound total
-    # wall-clock with a shared deadline and abandon stragglers via
-    # shutdown(wait=False, cancel_futures=True).
-    executor = ThreadPoolExecutor(max_workers=min(len(projects), 8))
+    # audit M10: shared module-level bounded executor (see _shared_executor) —
+    # total wall-clock is still bounded by the deadline below; stragglers keep
+    # their worker until they return, but the pool caps process-wide leakage and
+    # the timeout negative cache stops re-feeding stalled mounts.
+    executor = _shared_executor()
+    futures: List[Tuple[ProjectMeta, Any]] = []
     try:
-        futures = []
         for project in projects:
+            if _neg_cached(project):  # audit M10: skip recently-timed-out project
+                LOGGER.warning(
+                    "project %s skipped: recent timeout (negative cache)", project.name)
+                response["projects_failed"] += 1
+                response["errors"].append({
+                    "project_name": project.name,
+                    "project_path": str(project.path),
+                    "error": "skipped: recent timeout (retry in <{0:.0f}s)".format(
+                        _TIMEOUT_NEG_TTL_S),
+                    "stage": "negative_cache",
+                })
+                continue
             futures.append((project, executor.submit(
                 query_single_project,
                 project,
@@ -348,6 +414,7 @@ def search_all_projects(
                 result = future.result(timeout=remaining)
             except FuturesTimeoutError:
                 LOGGER.warning("project query timeout for %s after %ss", project.name, timeout)
+                _neg_mark(project)  # audit M10: back off this project for a TTL
                 response["projects_failed"] += 1
                 response["errors"].append({
                     "project_name": project.name,
@@ -373,8 +440,10 @@ def search_all_projects(
                 if existing is None or float(item.get("score", 0)) > float(existing.get("score", 0)):
                     merged[key] = item
     finally:
-        # Do not wait on stragglers; cancel anything not yet started.
-        executor.shutdown(wait=False, cancel_futures=True)
+        # audit M10: shared executor — never shut it down per request; just
+        # cancel anything still queued (no-op for done/running futures).
+        for _project, future in futures:
+            future.cancel()
 
     items = sorted(
         merged.values(),

--- a/frames.py
+++ b/frames.py
@@ -46,12 +46,26 @@ def _ensure_thumbnails_dir() -> None:
     THUMBNAILS_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def _run_ffmpeg(cmd, out_path: Optional[Path] = None) -> bool:
+def _run_ffmpeg(cmd, out_path: Optional[Path] = None, timeout: float = 60) -> bool:
     """Strict ffmpeg success: returncode == 0 AND out_path (if given)
     is a non-zero-size file. 0-byte file from ffmpeg-exit-0-but-failed
     is treated as fail (avoids registering empty frames as valid)."""
-    result = subprocess.run(cmd, capture_output=True)
+    try:
+        # Single-frame extraction must not hang forever on a corrupt file —
+        # an unbounded ffmpeg here wedged whole Phase 1 batches (audit H6).
+        result = subprocess.run(cmd, capture_output=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        # audit H6: timeout → fail loud; drop any partial output so a torn
+        # jpg isn't reused as "already_ok" on the next pass
+        print(f"  [frames] ffmpeg timed out (>{int(timeout)}s), skipping frame", flush=True)
+        if out_path is not None:
+            out_path.unlink(missing_ok=True)
+        return False
     if result.returncode != 0:
+        # audit M18: failures used to be silently dropped — clips ended up
+        # permanently frameless with zero diagnostics
+        err = (result.stderr or b"").decode("utf-8", "replace").strip()
+        print(f"  [frames] ffmpeg failed rc={result.returncode}: {err[-300:] or '(no stderr)'}", flush=True)
         return False
     if out_path is not None:
         if not out_path.exists() or out_path.stat().st_size == 0:
@@ -111,6 +125,10 @@ def extract_frames(video_path: str, duration_s: float, fps: float) -> List[Dict]
         if not results:
             results = _extract_fixed_persistent(video_path, duration_s, fps, stem, n_frames=n_frames)
 
+    if not results:
+        # audit M18: a video ending up with zero frames used to look like [OK]
+        # — leave at least one trace in the log
+        print(f"  [frames] WARNING: extracted 0 frames for {video_path}", flush=True)
     return results
 
 
@@ -156,8 +174,22 @@ def _extract_scene_persistent(
         "-vf", "select='gt(scene,0.3)',showinfo",
         "-vsync", "vfr", "-f", "null", "-"
     ]
-    proc = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
+    # Full-file scene-detect pass scales with clip length — bound it so one
+    # bad file can't hang the whole batch; timeout falls back to fixed frames
+    # via the caller (audit H6).
+    scene_timeout = max(120.0, duration_s * 2)
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=scene_timeout,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"  [frames] scene-detect timed out (>{int(scene_timeout)}s), falling back to fixed frames", flush=True)  # audit H6
+        return []
     if proc.returncode != 0:
+        # audit M18: surface why scene detection failed instead of silent []
+        err = (proc.stderr or "").strip()
+        print(f"  [frames] scene-detect failed rc={proc.returncode}: {err[-300:] or '(no stderr)'}", flush=True)
         return []
 
     # Parse timestamps from showinfo output

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -99,8 +99,11 @@ export const search = (q, params = {}, opts) =>
 // per-id route. /api/media items carry `thumbnail_path` (absolute fs path);
 // derive the served URL from its basename. Verified: /thumbnails/C3742.jpg → 200.
 // Split on both / and \ so Windows paths (C:\…\thumbnails\foo.jpg) extract the basename.
+// /thumbnails now requires videos_read (audit M12). An <img src> can't send an
+// Authorization header, so carry the token as ?token= when set — no-op on loopback
+// (token unset), same as streamUrl(). Without this, remote token deployments 401.
 export const thumbUrlFromPath = (thumbnailPath) =>
-  thumbnailPath ? `${BASE}/thumbnails/${thumbnailPath.split(/[/\\]/).pop()}` : null
+  thumbnailPath ? appendToken(`${BASE}/thumbnails/${thumbnailPath.split(/[/\\]/).pop()}`) : null
 // Append ?token= to a URL when a token is set — for WebSocket / media-asset URLs
 // that can't send an Authorization header. No-op on loopback / behind the dev
 // proxy (token unset there).

--- a/index.html
+++ b/index.html
@@ -1396,7 +1396,7 @@ async function doChangeLang(id, lang) {
     });
     hideIngestModal();
     if (r.ok) { await tauriMessage('轉錄完成'); await fetchDetail(id); renderInspector(); }
-    else { const d = await r.json().catch(()=>({})); await tauriMessage('轉錄失敗: ' + (d.error || r.status)); }
+    else { const d = await r.json().catch(()=>({})); await tauriMessage('轉錄失敗: ' + (d.detail || d.error || ('HTTP ' + r.status))); }
   } catch(e) { hideIngestModal(); await tauriMessage('錯誤: ' + e.message); }
 }
 
@@ -1441,7 +1441,8 @@ async function doReIngest(id) {
         await tauriMessage('Re-ingest 失敗：\n' + (data.stderr || data.error || ''));
       }
     } else {
-      await tauriMessage('Re-ingest 失敗: HTTP ' + r.status);
+      const d = await r.json().catch(()=>({}));
+      await tauriMessage('Re-ingest 失敗：\n' + (d.stderr || d.detail || d.error || ('HTTP ' + r.status)));
     }
   } catch(e) { hideIngestModal(); await tauriMessage('Re-ingest 錯誤：' + e.message); }
 }

--- a/ingest.py
+++ b/ingest.py
@@ -58,7 +58,9 @@ def _warm_up_vision_model():
             data=payload,
             headers={"Content-Type": "application/json"},
         )
-        urllib.request.urlopen(req, timeout=180)
+        # audit L3: close the response socket instead of leaking the fd to GC
+        with urllib.request.urlopen(req, timeout=180):
+            pass
         print(" ready")
     except Exception as e:
         print(f" warning: {e}")
@@ -74,7 +76,9 @@ def _unload_ollama_model(model: str):
             data=payload,
             headers={"Content-Type": "application/json"},
         )
-        urllib.request.urlopen(req, timeout=30)
+        # audit L3: close the response socket instead of leaking the fd to GC
+        with urllib.request.urlopen(req, timeout=30):
+            pass
         print(f"  Unloaded {model} from VRAM")
     except Exception as e:
         print(f"  Warning: could not unload {model}: {e}")
@@ -287,8 +291,15 @@ def probe(path: str) -> Optional[Dict]:
     }
 
 
+# audit H11: once-only banner flag — a missing exiftool binary used to be
+# swallowed per-file by a bare except, leaving the whole library's camera
+# metadata silently NULL with zero signal.
+_exiftool_missing_warned = False
+
+
 def exiftool_extract(path: str, fps: Optional[float] = None) -> dict:
     """Extract EXIF metadata via exiftool -json. Returns dict of 12 fields."""
+    global _exiftool_missing_warned
     cmd = [
         config.EXIFTOOL_PATH, "-json",
         "-Make", "-Model", "-LensModel",
@@ -316,16 +327,27 @@ def exiftool_extract(path: str, fps: Optional[float] = None) -> dict:
         "-n",  # numeric output for GPS
         path,
     ]
+    # audit H11: split the old bare `except Exception: return {}` so failures
+    # are loud — metadata still degrades gracefully to {}, but with a cause.
     try:
         r = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8",
                            errors="replace", timeout=30)
         if r.returncode != 0:
+            print("\n    [exiftool rc={0}] {1}".format(
+                r.returncode, (r.stderr or "").strip()[:200]))
             return {}
         data = json.loads(r.stdout)
         if not data:
             return {}
         d = data[0]
-    except Exception:
+    except FileNotFoundError:
+        if not _exiftool_missing_warned:
+            _exiftool_missing_warned = True
+            print("\n    [exiftool not found: {0} — camera metadata will be NULL"
+                  " for this run]".format(config.EXIFTOOL_PATH))
+        return {}
+    except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError) as e:
+        print("\n    [exiftool failed: {0}: {1}]".format(type(e).__name__, e))
         return {}
 
     # Parse focal length (may be "50 mm" or numeric)
@@ -1096,7 +1118,10 @@ def main():
     tr.warm_up_ollama()
     print("")
 
-    media_dir = Path(args.dir)
+    # audit M7: a relative --dir (e.g. `--dir clips`) used to flow cwd-relative
+    # paths into the DB — a third path form besides abs/rel-to-PROJECT_ROOT,
+    # breaking dedupe and resolve_path. Canonicalize before any DB interaction.
+    media_dir = Path(args.dir).expanduser().resolve()
     if not media_dir.exists():
         print(f"Error: {media_dir} does not exist")
         sys.exit(1)
@@ -1116,9 +1141,20 @@ def main():
         )
 
     total = len(files)
+
+    # audit M26: load the known-path set ONCE for the whole batch —
+    # db.is_processed() opens a fresh connection per file, so a 5000-file dir
+    # cost 5000+ connections just to build a skip set. Same abs-OR-rel
+    # semantics as is_processed.
+    with db.get_conn() as conn:
+        _known_paths = {r[0] for r in conn.execute("SELECT path FROM media").fetchall()}
+
+    def _is_known(p) -> bool:
+        return str(p) in _known_paths or db.to_relative(str(p)) in _known_paths
+
     if args.limit and not args.refresh:
         # Filter out already-processed files before applying limit
-        new_files = [f for f in files if not db.is_processed(str(f))]
+        new_files = [f for f in files if not _is_known(f)]
         skipped_count = total - len(new_files)
         files = new_files[:args.limit]
         print(f"Found {total} media files ({skipped_count} already indexed). Processing {len(files)}...\n")
@@ -1143,7 +1179,7 @@ def main():
     phase1_results = {}  # path -> (record, frames)
 
     for i, f in enumerate(files, 1):
-        already = db.is_processed(str(f))
+        already = _is_known(f)  # audit M26: set lookup, not a per-file connection
         if already and not args.refresh:
             print(f"[{i}/{len(files)}] SKIP {f.name}")
             skipped += 1
@@ -1173,8 +1209,19 @@ def main():
                 # Phase 2, but it's the ONLY tag write for audio/no-vision clips.
                 auto_tags = record.get("_auto_tags") or []
                 with db.get_conn() as conn:
-                    db.upsert(record, _conn=conn)
+                    # audit H5: resolve the existing row id FIRST (the lookup
+                    # matches abs OR rel form) and UPDATE in place. upsert's
+                    # ON CONFLICT(path) never fires across abs↔rel forms, so a
+                    # refresh of a legacy absolute-path row used to INSERT a
+                    # duplicate row that frames/tags then attached to
+                    # arbitrarily (observed in prod). Updating by id also
+                    # normalizes the stored path to the relative form.
                     mid = _get_media_id_for_path(f, _conn=conn)
+                    if mid:
+                        db.update_media_by_id(mid, record, _conn=conn)
+                    else:
+                        db.upsert(record, _conn=conn)
+                        mid = _get_media_id_for_path(f, _conn=conn)
                     if mid:
                         if existing is not None:
                             refreshed_ids.add(mid)
@@ -1281,9 +1328,14 @@ def main():
                     print(f"{'!'*60}\n")
                     break
 
-                # Update DB: frames + media.frame_tags
+                # Update DB: frames + media.frame_tags + auto tags.
+                # audit L2: the frame/media UPDATEs and the tag clear+rewrite
+                # used to live in TWO separate transactions — a crash between
+                # them left frame_tags and the tags table permanently
+                # inconsistent with no resume path. Everything for one clip now
+                # commits atomically in a single transaction.
                 with db.get_conn() as conn:
-                    mid = _get_media_id_for_path(Path(fpath))
+                    mid = _get_media_id_for_path(Path(fpath), _conn=conn)
                     if mid:
                         for fd in video_frames:
                             conn.execute(
@@ -1311,23 +1363,20 @@ def main():
                                 )
                             )
                         frame_tags_json = vis.frames_to_json(frame_results)
+                        # audit M2: COALESCE so a free-text vision fallback
+                        # (all frames score=None → scores empty) preserves the
+                        # prior editability_score instead of nulling it on
+                        # refresh — same semantics as _run_vision_only.
                         conn.execute(
-                            "UPDATE media SET frame_tags=?, editability_score=? WHERE id=?",
+                            "UPDATE media SET frame_tags=?, editability_score=COALESCE(?, editability_score) WHERE id=?",
                             (frame_tags_json, max(scores) if scores else None, mid),
                         )
-
-                v_elapsed = _time.time() - v_start
-                print(f" [{v_elapsed:.1f}s] [OK]")
-                vision_ok += 1
-                consecutive_vision_fail = 0  # reset streak on success
-                # Write auto tags from vision. Clear + rewrite happen in ONE
-                # transaction reached only on vision success: a refresh that
-                # fails vision never clears, so old searchable tags survive
-                # (Codex review P2). BMD tags (added in Phase 1) are cleared by
-                # this too, so re-apply them here.
-                with db.get_conn() as conn:
-                    mid = _get_media_id_for_path(Path(fpath))
-                    if mid:
+                        # Write auto tags from vision. Clear + rewrite happen in
+                        # ONE transaction reached only on vision success: a
+                        # refresh that fails vision never clears, so old
+                        # searchable tags survive (Codex review P2). BMD tags
+                        # (added in Phase 1) are cleared by this too, so
+                        # re-apply them here.
                         db.delete_auto_tags(mid, _conn=conn)
                         for tag_name in (record.get("_auto_tags") or []):
                             db.add_tag(mid, tag_name, source="auto", _conn=conn)
@@ -1336,6 +1385,11 @@ def main():
                                 tag_name = tag_name.strip()
                                 if tag_name and tag_name != "```":
                                     db.add_tag(mid, tag_name, source="auto", _conn=conn)
+
+                v_elapsed = _time.time() - v_start
+                print(f" [{v_elapsed:.1f}s] [OK]")
+                vision_ok += 1
+                consecutive_vision_fail = 0  # reset streak on success
             except Exception as e:
                 print(f" [ERROR: {e}]")
                 vision_fail += 1

--- a/jobs.py
+++ b/jobs.py
@@ -115,29 +115,33 @@ def mark_failed(job_id: int, error: str = "") -> bool:
 
 
 def cancel(job_id: int) -> bool:
-    """Cancel a pending/running job. Returns False if absent or terminal."""
+    """Cancel a pending/running job. Returns False if absent or terminal.
+
+    audit L1: single status-guarded UPDATE (no check-then-write race) — a job
+    that goes terminal between read and write can no longer be flipped to
+    cancelled; rowcount is the truth.
+    """
     with db.get_conn() as conn:
-        row = conn.execute("SELECT status FROM jobs WHERE id=?", (job_id,)).fetchone()
-        if row is None or row["status"] in _TERMINAL:
-            return False
-        conn.execute(
-            "UPDATE jobs SET status=?, finished_at=datetime('now') WHERE id=?",
-            (CANCELLED, job_id),
+        cur = conn.execute(
+            "UPDATE jobs SET status=?, finished_at=datetime('now') "
+            "WHERE id=? AND status IN (?, ?)",
+            (CANCELLED, job_id, PENDING, RUNNING),
         )
-        return True
+        return cur.rowcount == 1
 
 
 def retry(job_id: int) -> bool:
-    """Re-queue a failed/cancelled job back to pending. Returns False otherwise."""
+    """Re-queue a failed/cancelled job back to pending. Returns False otherwise.
+
+    audit L1: single status-guarded UPDATE, same rationale as cancel().
+    """
     with db.get_conn() as conn:
-        row = conn.execute("SELECT status FROM jobs WHERE id=?", (job_id,)).fetchone()
-        if row is None or row["status"] not in (FAILED, CANCELLED):
-            return False
-        conn.execute(
-            "UPDATE jobs SET status=?, started_at=NULL, finished_at=NULL, error=NULL WHERE id=?",
-            (PENDING, job_id),
+        cur = conn.execute(
+            "UPDATE jobs SET status=?, started_at=NULL, finished_at=NULL, error=NULL "
+            "WHERE id=? AND status IN (?, ?)",
+            (PENDING, job_id, FAILED, CANCELLED),
         )
-        return True
+        return cur.rowcount == 1
 
 
 def counts() -> Dict[str, int]:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -18,12 +18,16 @@ Run:  python mcp_server.py            # stdio MCP server
 from __future__ import annotations
 
 import json
+import logging
 import os
 from typing import Any, Dict, List, Optional
 
 import db
 import vectordb as vdb
 from mcp.server.fastmcp import FastMCP
+
+# Logging goes to stderr (never stdout — stdout is the MCP stdio channel).
+LOGGER = logging.getLogger(__name__)
 
 mcp = FastMCP("arkiv")
 
@@ -87,8 +91,17 @@ def _tag_names(media_id: int) -> List[str]:
 
 
 # ── impl (unit-testable; no MCP/stdio coupling) ───────────────────────────────
-def search_media_impl(query: str, limit: int = 20) -> List[Dict[str, Any]]:
-    """Semantic search with SQL text fallback. Returns lightweight records."""
+def search_media_impl(
+    query: str,
+    limit: int = 20,
+    _warnings: Optional[List[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Semantic search with SQL text fallback. Returns lightweight records.
+
+    ``_warnings``: optional out-param list; degraded-search messages (e.g.
+    embedding dimension mismatch) are appended so the tool layer can surface
+    them without changing this function's list return contract (audit M17).
+    """
     query = (query or "").strip()
     if not query:
         return []
@@ -115,8 +128,16 @@ def search_media_impl(query: str, limit: int = 20) -> List[Dict[str, Any]]:
             enriched.append(item)
             if len(enriched) >= limit:
                 break
+    # audit M17: split the dim-mismatch branch out of the blanket except — log
+    # it and surface a degraded hint (mirrors server.py's search_degraded fix)
+    # instead of silently SQL-degrading. SQL fallback still runs below.
+    except vdb.EmbeddingDimensionMismatch as exc:
+        LOGGER.warning("mcp semantic search degraded: %s", exc)
+        if _warnings is not None:
+            _warnings.append(str(exc))
+        enriched, seen = [], set()
     except Exception:
-        # Vector index unavailable/empty/dim-mismatch — degrade to SQL.
+        # Vector index unavailable/empty — degrade to SQL.
         enriched, seen = [], set()
 
     # 2. SQL text fallback (filename / transcript) when semantic found nothing.
@@ -205,8 +226,15 @@ def search_media(query: str, limit: int = 20) -> str:
     Semantic search over transcripts + vision tags, falling back to
     filename/transcript text match. Returns a JSON list of lightweight records:
     {id, filename, path, score, excerpt, tags, lang, duration_s}.
+    If semantic search is degraded (e.g. embedding index needs a rebuild), the
+    response is instead {items, search_degraded: true, warning}.
     """
-    return _j(search_media_impl(query, limit))
+    # audit M17: surface degraded-search hint instead of silently falling back.
+    warnings: List[str] = []
+    items = search_media_impl(query, limit, _warnings=warnings)
+    if warnings:
+        return _j({"items": items, "search_degraded": True, "warning": warnings[0]})
+    return _j(items)
 
 
 @mcp.tool()

--- a/server.py
+++ b/server.py
@@ -33,6 +33,28 @@ import smart_collections
 import tag_quality
 
 
+# ── Ingest single-flight guard ───────────────────────────────────────────────
+# One guard for ALL ingest entry points (REST /api/ingest, reingest, WS) so two
+# full pipelines can't run at once → DB-lock contention + double whisper + OOM on a
+# 16GB box (audit H3). threading.Lock because REST runs in the threadpool while the
+# WS variant runs on the event loop.
+import threading as _threading
+_ingest_lock = _threading.Lock()
+_ingest_active = False
+
+def _acquire_ingest_slot() -> bool:
+    global _ingest_active
+    with _ingest_lock:
+        if _ingest_active:
+            return False
+        _ingest_active = True
+        return True
+
+def _release_ingest_slot() -> None:
+    global _ingest_active
+    with _ingest_lock:
+        _ingest_active = False
+
 # ── WebSocket connection manager ────────────────────────────────────────────
 _MAX_WS_CONNECTIONS = 32  # cap concurrent progress listeners (DoS guard)
 
@@ -55,7 +77,9 @@ class IngestBroadcaster:
 
     async def broadcast(self, data: dict):
         dead = set()
-        for ws in self.connections:
+        # snapshot: send_json awaits, so a concurrent connect/disconnect mutating
+        # the live set mid-iteration would raise "Set changed size" (audit H9).
+        for ws in list(self.connections):
             try:
                 await ws.send_json(data)
             except Exception:
@@ -1252,7 +1276,9 @@ class MetadataCsvExportRequest(BaseModel):
 @app.post("/api/export/metadata-csv-to")
 def export_metadata_csv_to(
     body: MetadataCsvExportRequest,
-    _tok: dict = Depends(require_scopes("media_read")),
+    # writes a file to a caller-chosen local path — gate on write, not read, so a
+    # read-only token can't drop files in the operator's home dir (audit H10).
+    _tok: dict = Depends(require_scopes("videos_write")),
 ):
     """Tauri WKWebView path: server writes CSV directly to user-picked dest.
 
@@ -1365,6 +1391,8 @@ def ingest_media(
     cmd = [sys.executable, str(ROOT / "ingest.py"), "--dir", str(target)]
     if body.limit > 0:
         cmd += ["--limit", str(body.limit)]
+    if not _acquire_ingest_slot():  # audit H3
+        raise HTTPException(409, "已有匯入任務進行中，請稍候")
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=1800, cwd=str(ROOT))
         return {
@@ -1374,6 +1402,8 @@ def ingest_media(
         }
     except subprocess.TimeoutExpired:
         return {"ok": False, "error": "匯入逾時（>30 分鐘）"}
+    finally:
+        _release_ingest_slot()
 
 
 # ── Re-transcribe ─────────────────────────────────────────────────────────────
@@ -1413,20 +1443,27 @@ def retranscribe_media(
     try:
         import transcribe as tr
         text, lang, segments, words = tr.transcribe(media_path, language=body.language)
-        with db.get_conn() as conn:
-            conn.execute(
-                "UPDATE media SET transcript=?, lang=?, segments_json=?, words_json=? WHERE id=?",
-                (
-                    text,
-                    body.language,
-                    json.dumps(segments, ensure_ascii=False) if segments else None,
-                    json.dumps(words, ensure_ascii=False) if words else None,
-                    media_id,
-                )
-            )
-        return {"ok": True, "transcript_length": len(text), "language": body.language}
     except Exception as e:
-        raise HTTPException(500, str(e))
+        # Extraction/transcription failed — leave the existing transcript untouched
+        # rather than blanking it (audit H1/H2).
+        raise HTTPException(500, "retranscribe 失敗：{0}".format(e))
+    # An empty result means "no speech"; for a clip that already has a transcript
+    # that's almost always a regression (transient decode failure), not intent —
+    # refuse to overwrite a good transcript with nothing (audit H1).
+    if not (text or "").strip() and (rec.get("transcript") or "").strip():
+        raise HTTPException(422, "transcribe 回空，拒絕覆寫既有逐字稿（可能是音訊擷取失敗）")
+    with db.get_conn() as conn:
+        conn.execute(
+            "UPDATE media SET transcript=?, lang=?, segments_json=?, words_json=? WHERE id=?",
+            (
+                text,
+                lang or body.language,  # store the detected language, not just the hint
+                json.dumps(segments, ensure_ascii=False) if segments else None,
+                json.dumps(words, ensure_ascii=False) if words else None,
+                media_id,
+            )
+        )
+    return {"ok": True, "transcript_length": len(text), "language": lang or body.language}
 
 
 @app.post("/api/media/{media_id}/retry-vision")
@@ -1499,19 +1536,22 @@ def retry_vision(
                 for tag_name in vr.get("tags", []):
                     tag_name = tag_name.strip()
                     if tag_name and tag_name != "```":
-                        db.add_tag(media_id, tag_name, source="auto")
+                        # _conn=conn: add_tag must reuse the open write txn, else it
+                        # opens a 2nd connection that deadlocks on our own writer lock
+                        # (audit C1 — 30s wait then the whole patch rolls back / 500).
+                        db.add_tag(media_id, tag_name, source="auto", _conn=conn)
                 patched += 1
-        # Update legacy frame_tags
-        all_frames = db.get_frames(media_id)
+        # Update legacy frame_tags. Read frames through the SAME conn so we see the
+        # UPDATEs just written above, not a stale pre-txn snapshot (audit M1).
+        all_frames = db.get_frames(media_id, _conn=conn)
         frame_tags = [{"description": f.get("description", ""), "tags": f.get("tags", "").split(",") if f.get("tags") else []} for f in all_frames]
         frame_tags_json = json.dumps(frame_tags, ensure_ascii=False)
-        editability_score = None
-        for frame in all_frames:
-            if frame.get("focus_score") is not None:
-                editability_score = db.compute_editability(frame)
-                break
+        # max over all scored frames (not the first), and leave the prior score
+        # untouched when nothing scored rather than nulling it (audit M1).
+        scores = [db.compute_editability(fr) for fr in all_frames if fr.get("focus_score") is not None]
+        editability_score = max(scores) if scores else None
         conn.execute(
-            "UPDATE media SET frame_tags=?, editability_score=? WHERE id=?",
+            "UPDATE media SET frame_tags=?, editability_score=COALESCE(?, editability_score) WHERE id=?",
             (frame_tags_json, editability_score, media_id),
         )
 
@@ -1537,10 +1577,14 @@ def reingest_media(
     if not Path(media_path).exists():
         raise HTTPException(400, f"找不到媒體檔案：{media_path}")
     import subprocess, sys
+    if not _acquire_ingest_slot():  # audit H3 — don't run concurrently with another ingest
+        raise HTTPException(409, "已有匯入任務進行中，請稍候")
     try:
+        # Single-file mode (ingest.py handles a file path as --dir). The old
+        # `--dir <parent> --limit 1` re-processed the alphabetically-first file of
+        # the folder, not this media — silently refreshing the WRONG row (audit H4).
         result = subprocess.run(
-            [sys.executable, str(ROOT / "ingest.py"), "--dir", str(Path(media_path).parent),
-             "--limit", "1", "--refresh"],
+            [sys.executable, str(ROOT / "ingest.py"), "--dir", media_path, "--refresh"],
             capture_output=True, text=True, timeout=600, cwd=str(ROOT)
         )
         return {
@@ -1552,6 +1596,8 @@ def reingest_media(
         return {"ok": False, "error": "重新處理逾時（>10 分鐘）"}
     except Exception as e:
         raise HTTPException(500, str(e))
+    finally:
+        _release_ingest_slot()
 
 
 # ── Cache Management ──────────────────────────────────────────────────────────
@@ -2032,7 +2078,8 @@ class ExportToRequest(BaseModel):
 def export_to_file(
     media_id: int,
     body: ExportToRequest,
-    _tok: dict = Depends(require_scopes("media_read")),
+    # writes a file to a caller-chosen local path → require write scope (audit H10).
+    _tok: dict = Depends(require_scopes("videos_write")),
 ):
     """Export and write directly to a local path (for Tauri native save dialog).
 
@@ -2364,13 +2411,9 @@ async def ws_ingest(ws: WebSocket):
 # held or the task can be GC'd mid-run and its exceptions silently dropped; the
 # flag also serializes ingests so concurrent runs don't hammer the same SQLite DB.
 _ingest_ws_tasks: set = set()
-_ingest_ws_active = False
-
-
 def _on_ingest_ws_done(task: "asyncio.Task") -> None:
-    global _ingest_ws_active
     _ingest_ws_tasks.discard(task)
-    _ingest_ws_active = False
+    _release_ingest_slot()  # audit H3 — shared single-flight guard
     try:
         exc = task.exception()
     except asyncio.CancelledError:
@@ -2475,14 +2518,12 @@ async def ingest_media_ws(
     could drive the ingest pipeline over an arbitrary directory (Codex-class
     finding from the overnight audit).
     """
-    global _ingest_ws_active
     target = Path(body.path).expanduser().resolve()
     if not target.is_dir():
         raise HTTPException(400, f"路徑不是有效的目錄：{body.path}")
     _assert_ingest_path_safe(target)
-    if _ingest_ws_active:
+    if not _acquire_ingest_slot():  # audit H3 — shared single-flight with REST ingest/reingest
         raise HTTPException(409, "已有匯入進行中，請等待完成後再試")
-    _ingest_ws_active = True
     task = asyncio.create_task(_run_ingest_with_ws(target, body.limit))
     _ingest_ws_tasks.add(task)
     task.add_done_callback(_on_ingest_ws_done)

--- a/server.py
+++ b/server.py
@@ -12,12 +12,11 @@ import json
 import os
 import urllib.request
 from pathlib import Path
-from typing import List, Literal, Optional, Set
+from typing import Any, List, Literal, Optional, Set
 
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Query, Request, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
-from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, field_validator
 
 import admin
@@ -55,6 +54,19 @@ def _release_ingest_slot() -> None:
     with _ingest_lock:
         _ingest_active = False
 
+# audit M9 (partial): vision.VISION_MODEL is module-global, so two concurrent
+# retry-vision calls could interleave their save/swap/restore and permanently
+# pin the fallback model as "primary" (silent quality degradation). Serializing
+# the swap window removes the race; the full fix (pass the model as a
+# describe_frames parameter) needs a vision.py signature change.
+_vision_fallback_lock = _threading.Lock()
+
+# audit M8: single-flight for the embed rebuild — double-clicking the rebuild
+# button used to launch N concurrent drop+rebuild subprocesses over the same
+# Chroma collection.
+_embed_rebuild_lock = _threading.Lock()
+_embed_rebuild_active = False
+
 # ── WebSocket connection manager ────────────────────────────────────────────
 _MAX_WS_CONNECTIONS = 32  # cap concurrent progress listeners (DoS guard)
 
@@ -69,6 +81,11 @@ class IngestBroadcaster:
             await ws.close(code=1013)  # try again later
             return False
         await ws.accept()
+        # audit L6: re-check after the await — concurrent handshakes can all pass
+        # the pre-accept check before any of them is added to the set (TOCTOU).
+        if len(self.connections) >= _MAX_WS_CONNECTIONS:
+            await ws.close(code=1013)
+            return False
         self.connections.add(ws)
         return True
 
@@ -129,13 +146,37 @@ app.add_middleware(
 
 ROOT = Path(__file__).parent
 
-# Serve thumbnails as static files (create dir if missing so mount always works).
-# Honor ARKIV_THUMBNAILS_DIR (via config.THUMBNAILS_DIR) instead of hardcoding
-# ROOT / "thumbnails" — otherwise any deployment that points thumbnails elsewhere
-# (test rig, docker, worktree QA) silently 404s every /thumbnails/*.jpg.
+# Serve thumbnails through an AUTHED route (create dir if missing so it always
+# works). Honor ARKIV_THUMBNAILS_DIR (via config.THUMBNAILS_DIR) instead of
+# hardcoding ROOT / "thumbnails" — otherwise any deployment that points
+# thumbnails elsewhere (test rig, docker, worktree QA) silently 404s every
+# /thumbnails/*.jpg.
 thumbs_dir = config.THUMBNAILS_DIR
 thumbs_dir.mkdir(parents=True, exist_ok=True)
-app.mount("/thumbnails", StaticFiles(directory=str(thumbs_dir)), name="thumbnails")
+
+
+# audit M12: thumbnails were a StaticFiles mount, which bypasses the auth
+# dependency entirely — any unauthenticated client could pull every scene
+# thumbnail. Serve via an authed route instead: loopback trust still covers the
+# local UI token-free; a remote client needs a videos_read token.
+@app.get("/thumbnails/{name}")
+def serve_thumbnail(
+    name: str,
+    _tok: dict = Depends(require_scopes("videos_read")),
+):
+    # basename + containment check: no separators (an encoded %2F decodes into
+    # the path param), no hidden/dot names, and the resolved path must stay
+    # inside the thumbnails dir (symlink defense).
+    if "/" in name or "\\" in name or name.startswith("."):
+        raise HTTPException(404, "not found")
+    try:
+        resolved = (thumbs_dir / name).resolve()
+        resolved.relative_to(thumbs_dir.resolve())
+    except (OSError, ValueError):
+        raise HTTPException(404, "not found")
+    if not resolved.is_file():
+        raise HTTPException(404, "not found")
+    return FileResponse(str(resolved))
 
 
 def _basename_safe(value: str) -> str:
@@ -245,6 +286,23 @@ class ProjectCreate(BaseModel):
     name: str
     path: str
     tags: Optional[List[str]] = None
+
+    # audit M21: empty / control-char / separator-bearing names were accepted —
+    # a name containing '/' can be created but never DELETEd (the path param
+    # can't match it), and unbounded names bloat the registry.
+    @field_validator("name")
+    @classmethod
+    def _clean_project_name(cls, v: str) -> str:
+        cleaned = " ".join(
+            "".join(c for c in (v or "") if c == " " or (ord(c) >= 0x20 and c != "\x7f")).split()
+        )
+        if not cleaned:
+            raise ValueError("project name must not be empty")
+        if len(cleaned) > 100:
+            raise ValueError("project name too long (max 100)")
+        if "/" in cleaned or "\\" in cleaned:
+            raise ValueError("project name must not contain path separators")
+        return cleaned
 
 
 class CreateTokenRequest(BaseModel):
@@ -448,11 +506,13 @@ def list_chat_conversations(
 @app.get("/api/search/all")
 def search_all(
     q: str = Query(..., alias="q"),
-    limit: int = 50,
-    per_project_limit: int = 20,
+    # audit H13: declarative bounds — limit=-1 silently truncated, and
+    # timeout=999999 parked a threadpool worker on a stalled peer for hours.
+    limit: int = Query(50, ge=1, le=500),
+    per_project_limit: int = Query(20, ge=1, le=100),
     projects: Optional[str] = None,
     tag: Optional[str] = None,
-    timeout: float = 10.0,
+    timeout: float = Query(10.0, gt=0.0, le=30.0),
     no_fallback_sql: bool = False,
     _tok: dict = Depends(require_scopes("videos_read")),
 ):
@@ -523,6 +583,14 @@ def add_project(
     body: ProjectCreate,
     _tok: dict = Depends(require_scopes("projects_write")),
 ):
+    # audit M21: registry add_project silently REPLACES an existing entry of the
+    # same name — surface the collision as 409 instead of overwriting.
+    try:
+        existing = {p.name for p in project_registry.list_registry_projects()}
+    except project_registry.RegistryError as exc:
+        raise HTTPException(status_code=500, detail="project registry unreadable: {0}".format(exc))
+    if body.name in existing:
+        raise HTTPException(status_code=409, detail="project name already exists: {0}".format(body.name))
     try:
         project = project_registry.add_project(body.name, body.path, body.tags or [])
     except project_registry.RegistryError as exc:
@@ -581,14 +649,20 @@ def media_position(
         filters["media_type"] = media_type
     where, params = db._build_filter_clause(**filters)
     order = db.SORT_MAP.get(sort, "id")
+    # audit L12: single window-function query instead of fetching the whole view
+    # into Python; and a clip NOT in the current view now says so explicitly
+    # (in_view=false) instead of a fake offset 0 that is indistinguishable from
+    # genuinely being first. offset stays 0 in that case so the existing UI
+    # fallback (jump to page 0) keeps working.
     with db.get_conn() as conn:
-        rows = conn.execute(
-            f"SELECT id FROM media WHERE {where} ORDER BY {order}", params
-        ).fetchall()
-        for idx, row in enumerate(rows):
-            if row["id"] == media_id:
-                return {"id": media_id, "offset": idx}
-    return {"id": media_id, "offset": 0}
+        row = conn.execute(
+            f"SELECT pos FROM (SELECT id, ROW_NUMBER() OVER (ORDER BY {order}) - 1 AS pos "
+            f"FROM media WHERE {where}) ranked WHERE id = ?",
+            (*params, media_id),
+        ).fetchone()
+    if row is None:
+        return {"id": media_id, "offset": 0, "in_view": False}
+    return {"id": media_id, "offset": row["pos"], "in_view": True}
 
 
 @app.get("/api/media/pool")
@@ -619,6 +693,49 @@ def media_pool(
     return {"items": items, "total": len(items)}
 
 
+# audit H14: ext buckets mirror db._build_filter_clause's media_type sets so the
+# search branch applies the SAME filter the SQL (non-search) path does.
+_VIDEO_EXTS = frozenset({".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts"})
+_AUDIO_EXTS = frozenset({".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg"})
+
+
+def _get_tags_bulk(media_ids) -> dict:
+    """audit H15: tags for many media ids in ONE query — the per-row db.get_tags
+    loop opened a fresh SQLite connection per record (501 connections for a
+    500-row page). Returns {media_id: [tag dicts]} matching db.get_tags shape."""
+    out = {int(m): [] for m in media_ids}
+    if not out:
+        return out
+    ids = list(out.keys())
+    placeholders = ",".join("?" * len(ids))
+    with db.get_conn() as conn:
+        rows = conn.execute(
+            "SELECT id, media_id, name, source FROM tags "
+            "WHERE media_id IN ({0}) ORDER BY name".format(placeholders),
+            ids,
+        ).fetchall()
+    for r in rows:
+        out[r["media_id"]].append({"id": r["id"], "name": r["name"], "source": r["source"]})
+    return out
+
+
+def _get_light_records_by_ids(media_ids) -> list:
+    """audit H16: LIGHT_COLS records for many ids in ONE query, preserving input
+    order. The semantic-search path did a per-hit SELECT * (words_json /
+    segments_json — tens of MB across a page) plus one connection per hit."""
+    ids = [int(m) for m in media_ids]
+    if not ids:
+        return []
+    placeholders = ",".join("?" * len(ids))
+    with db.get_conn() as conn:
+        rows = conn.execute(
+            f"SELECT {db.LIGHT_COLS} FROM media WHERE id IN ({placeholders})",
+            ids,
+        ).fetchall()
+    by_id = {r["id"]: dict(r) for r in rows}
+    return [by_id[i] for i in ids if i in by_id]
+
+
 @app.get("/api/media")
 def list_media(
     offset: int = 0,
@@ -639,6 +756,11 @@ def list_media(
         enriched = []
         search_warning = None
         import vectordb as vdb
+        # audit M19: search used to ignore `offset` entirely (page 2 == page 1).
+        # Collect up to offset+limit matches, then slice the requested page.
+        # Capped so a huge ?offset can't inflate n_results / SQL LIMIT (audit
+        # H13-class DoS); search hits past 2000 are noise anyway.
+        needed = min(offset + limit, 2000)
 
         def _passes_filters(rec: dict) -> bool:
             # Applied to the ENRICHED record (which has real lang/rating), not the
@@ -652,73 +774,115 @@ def list_media(
                 return False
             if rating and rating != "unrated" and rv != rating:
                 return False
+            # audit H14: media_type was silently ignored on the search branch
+            # (?q=...&media_type=video still returned audio). Mirror the SQL
+            # path's ext buckets.
+            ext = (rec.get("ext") or "").lower()
+            if media_type == "video" and ext not in _VIDEO_EXTS:
+                return False
+            if media_type == "audio" and ext not in _AUDIO_EXTS:
+                return False
             return True
 
         # Try semantic search first (requires vectordb with embeddings)
         try:
-            raw = vdb.search(q, n_results=limit * 3)
+            raw = vdb.search(q, n_results=needed * 3)
             seen = set()
+            ordered_ids = []
+            hit_by_id = {}
             for r in raw:
                 mid = int(r["media_id"])
                 if mid in seen:
                     continue
                 seen.add(mid)
-                rec = db.get_record_by_id(mid)
-                if not rec or not _passes_filters(rec):
+                ordered_ids.append(mid)
+                hit_by_id[mid] = r
+            # audit H16: one batched LIGHT_COLS fetch instead of per-hit SELECT *
+            for rec in _get_light_records_by_ids(ordered_ids):
+                if not _passes_filters(rec):
                     continue
                 _resolve_record(rec)
-                rec["score"] = r.get("score", 0)
-                rec["excerpt"] = r.get("excerpt", "")
-                rec["tags"] = db.get_tags(mid)
+                hit = hit_by_id[rec["id"]]
+                rec["score"] = hit.get("score", 0)
+                rec["excerpt"] = hit.get("excerpt", "")
                 enriched.append(rec)
-                if len(enriched) >= limit:
+                if len(enriched) >= needed:
                     break
         except vdb.EmbeddingDimensionMismatch as exc:
             # Don't silently SQL-degrade a dim mismatch — log it and surface a hint
             # so the operator knows semantic search is off until they rebuild.
             _logging.getLogger(__name__).warning("semantic search degraded: %s", exc)
             search_warning = str(exc)
-        except Exception:
-            pass
+        except Exception as exc:
+            # audit L8: was a bare `except: pass` — Ollama being down degraded to
+            # SQL search with zero signal anywhere. Log + flag the degradation.
+            _logging.getLogger(__name__).warning(
+                "semantic search failed, falling back to SQL: %s", exc
+            )
+            search_warning = "semantic search unavailable (SQL fallback used)"
 
         # Fallback: SQL text search (filename, transcript, tags) — same lang/rating
         # filter applied so a degraded search still honors the active filters.
         if not enriched:
             seen_ids = set()
             like = f"%{q}%"
+            # audit H17: push the active filters into WHERE and bound the scan —
+            # the old query LIKE-scanned the whole table, built every matching
+            # record, then threw away everything past `limit`.
+            filter_sql = ""
+            filter_params: list = []
+            if lang:
+                filter_sql += " AND lang = ?"
+                filter_params.append(lang)
+            if rating == "unrated":
+                filter_sql += " AND rating IS NULL"
+            elif rating:
+                filter_sql += " AND rating = ?"
+                filter_params.append(rating)
+            if media_type == "video":
+                filter_sql += " AND ext IN ({0})".format(",".join("?" * len(_VIDEO_EXTS)))
+                filter_params.extend(sorted(_VIDEO_EXTS))
+            elif media_type == "audio":
+                filter_sql += " AND ext IN ({0})".format(",".join("?" * len(_AUDIO_EXTS)))
+                filter_params.extend(sorted(_AUDIO_EXTS))
             with db.get_conn() as conn:
                 rows = conn.execute(
                     f"SELECT {db.LIGHT_COLS} FROM media "
-                    "WHERE filename LIKE ? OR transcript LIKE ? "
-                    "ORDER BY id",
-                    (like, like),
+                    "WHERE (filename LIKE ? OR transcript LIKE ?)" + filter_sql +
+                    " ORDER BY id LIMIT ?",
+                    (like, like, *filter_params, needed),
                 ).fetchall()
                 for r in rows:
                     rec = dict(r)
-                    if not _passes_filters(rec):
-                        continue
                     _resolve_record(rec)
-                    rec["tags"] = db.get_tags(rec["id"])
                     enriched.append(rec)
                     seen_ids.add(rec["id"])
 
-                # Also search by tag name
-                tag_rows = conn.execute(
-                    "SELECT DISTINCT media_id FROM tags WHERE name LIKE ?",
-                    (like,),
-                ).fetchall()
-                for tr in tag_rows:
-                    mid = tr["media_id"]
-                    if mid in seen_ids:
+            # Also search by tag name (bounded — audit H17)
+            if len(enriched) < needed:
+                with db.get_conn() as conn:
+                    tag_rows = conn.execute(
+                        "SELECT DISTINCT media_id FROM tags WHERE name LIKE ? LIMIT ?",
+                        (like, needed * 3),
+                    ).fetchall()
+                tag_ids = [tr["media_id"] for tr in tag_rows if tr["media_id"] not in seen_ids]
+                for rec in _get_light_records_by_ids(tag_ids):
+                    if not _passes_filters(rec):
                         continue
-                    rec = db.get_record_by_id(mid)
-                    if rec and _passes_filters(rec):
-                        _resolve_record(rec)
-                        rec["tags"] = db.get_tags(mid)
-                        enriched.append(rec)
-                        seen_ids.add(mid)
+                    _resolve_record(rec)
+                    enriched.append(rec)
+                    seen_ids.add(rec["id"])
+                    if len(enriched) >= needed:
+                        break
 
-        resp = {"items": enriched[:limit], "total": len(enriched), "search": True}
+        # audit M19: slice the requested page; total = bounded match count (the
+        # same "items seen so far" semantic for both search sub-paths).
+        items = enriched[offset:offset + limit]
+        # audit H15: one bulk tag query for the returned page only
+        tags_by_id = _get_tags_bulk([rec["id"] for rec in items])
+        for rec in items:
+            rec["tags"] = tags_by_id.get(rec["id"], [])
+        resp = {"items": items, "total": len(enriched), "search": True}
         if search_warning:
             resp["search_degraded"] = True
             resp["warning"] = search_warning
@@ -735,10 +899,12 @@ def list_media(
     records, total = db.get_media_filtered(
         offset=offset, limit=limit, sort=sort, **filters,
     )
-    # Attach tags to each record
+    # Attach tags to each record — one bulk query for the page instead of one
+    # SQLite connection per row (audit H15).
+    tags_by_id = _get_tags_bulk([rec["id"] for rec in records])
     for rec in records:
         _resolve_record(rec)
-        rec["tags"] = db.get_tags(rec["id"])
+        rec["tags"] = tags_by_id.get(rec["id"], [])
 
     return {"items": records, "total": total, "search": False}
 
@@ -806,7 +972,12 @@ def get_media_waveform(
         raise HTTPException(500, "波形計算失敗")
     payload = {"media_id": media_id, "bins": bins, "peaks": peaks}
     try:
-        cache_path.write_text(json.dumps(payload), encoding="utf-8")
+        # audit L5: atomic write (tmp + os.replace) — a direct write_text could
+        # leave a concurrent reader a torn/partial JSON. pid-suffixed tmp name so
+        # two concurrent writers don't tear each other's tmp file either.
+        tmp_path = cache_path.with_name("{0}.{1}.tmp".format(cache_path.name, os.getpid()))
+        tmp_path.write_text(json.dumps(payload), encoding="utf-8")
+        os.replace(tmp_path, cache_path)
     except Exception:
         pass
     return payload
@@ -891,12 +1062,32 @@ def update_rating(
     body: RatingUpdate,
     _tok: dict = Depends(require_scopes("videos_write")),
 ):
-    """Set or clear rating for a media asset."""
+    """Set or clear rating for a media asset.
+
+    PATCH semantics (audit M20): a field OMITTED from the body is left
+    untouched; an explicit null clears it. PATCH {rating:'good'} used to
+    silently wipe the stored note (PUT semantics in a PATCH endpoint).
+    """
     rec = db.get_record_by_id(media_id)
     if not rec:
         raise HTTPException(404, "找不到")
-    db.set_rating(media_id, body.rating, body.note)
-    return {"ok": True, "rating": body.rating, "note": body.note}
+    provided = body.model_fields_set  # audit M20: omitted vs explicit-null
+    sets, params = [], []
+    if "rating" in provided:
+        sets.append("rating = ?")
+        params.append(body.rating)
+    if "note" in provided:
+        sets.append("rating_note = ?")
+        params.append(body.note)
+    if sets:
+        with db.get_conn() as conn:
+            conn.execute(
+                "UPDATE media SET {0} WHERE id = ?".format(", ".join(sets)),
+                (*params, media_id),
+            )
+    new_rating = body.rating if "rating" in provided else rec.get("rating")
+    new_note = body.note if "note" in provided else rec.get("rating_note")
+    return {"ok": True, "rating": new_rating, "note": new_note}
 
 
 @app.get("/api/media/{media_id}/tags")
@@ -975,7 +1166,16 @@ def list_collections(
     defs = smart_collections.DEFAULT_COLLECTIONS
     buckets = {c.key: {"key": c.key, "title": c.title, "category": c.category, "items": []} for c in defs}
 
-    for rec in db.get_all_records():
+    # audit L13: classify reads only these columns (frame_tags + media-level
+    # aggregates + gps + duration/audio) — get_all_records() was SELECT *,
+    # hauling words_json/segments_json/transcript for the entire library.
+    with db.get_conn() as conn:
+        rows = conn.execute(
+            "SELECT id, filename, thumbnail_path, duration_s, has_audio, "
+            "frame_tags, content_type, atmosphere, energy, gps_lat, gps_lon "
+            "FROM media ORDER BY id"
+        ).fetchall()
+    for rec in (dict(r) for r in rows):
         for hit in smart_collections.classify(rec, defs):
             buckets[hit["key"]]["items"].append({
                 "id": rec["id"],
@@ -1395,13 +1595,19 @@ def ingest_media(
         raise HTTPException(409, "已有匯入任務進行中，請稍候")
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=1800, cwd=str(ROOT))
-        return {
+        payload = {
             "ok": result.returncode == 0,
             "stdout": result.stdout[-2000:] if result.stdout else "",
             "stderr": result.stderr[-1000:] if result.stderr else "",
         }
+        if result.returncode != 0:
+            # audit L11: failures used to come back HTTP 200 + ok:false — keep
+            # the body shape for the UI but surface the failure as a 5xx so
+            # status-code monitors see it.
+            return JSONResponse(status_code=500, content=payload)
+        return payload
     except subprocess.TimeoutExpired:
-        return {"ok": False, "error": "匯入逾時（>30 分鐘）"}
+        raise HTTPException(504, "匯入逾時（>30 分鐘）")  # audit L11: was 200 + ok:false
     finally:
         _release_ingest_slot()
 
@@ -1410,6 +1616,17 @@ def ingest_media(
 
 class RetranscribeRequest(BaseModel):
     language: str = "zh"
+
+    # audit M23: an arbitrary string used to flow straight into whisper → 500
+    # with raw str(e) leaked to the client + a polluted lang column on partial
+    # writes. Accept ISO-639-shaped codes only (whisper's set is 2-3 letters).
+    @field_validator("language")
+    @classmethod
+    def _check_language(cls, v: str) -> str:
+        v = (v or "").strip().lower()
+        if not _re.fullmatch(r"[a-z]{2,3}", v):
+            raise ValueError("language must be a 2-3 letter ISO-639 code (e.g. 'zh', 'en')")
+        return v
 
 @app.get("/api/media/{media_id}/remotion-props")
 def get_remotion_props(
@@ -1491,16 +1708,20 @@ def retry_vision(
     # Phase 2: fallback to lighter model for failed frames
     if failed:
         fallback_model = "moondream2:latest"
-        original_model = vis.VISION_MODEL
-        try:
-            vis.VISION_MODEL = fallback_model
-            retry_paths = [frame_paths[i] for i in failed]
-            retry_results = vis.describe_frames(retry_paths)
-            for idx, retry_r in zip(failed, retry_results):
-                if retry_r.get("description") and not retry_r.get("error"):
-                    results[idx] = retry_r
-        finally:
-            vis.VISION_MODEL = original_model
+        # audit M9: hold the lock across save/swap/restore so a concurrent
+        # retry-vision can't snapshot the fallback as "original" and restore it
+        # as the permanent primary model.
+        with _vision_fallback_lock:
+            original_model = vis.VISION_MODEL
+            try:
+                vis.VISION_MODEL = fallback_model
+                retry_paths = [frame_paths[i] for i in failed]
+                retry_results = vis.describe_frames(retry_paths)
+                for idx, retry_r in zip(failed, retry_results):
+                    if retry_r.get("description") and not retry_r.get("error"):
+                        results[idx] = retry_r
+            finally:
+                vis.VISION_MODEL = original_model
 
     # Write results to DB
     patched = 0
@@ -1587,13 +1808,20 @@ def reingest_media(
             [sys.executable, str(ROOT / "ingest.py"), "--dir", media_path, "--refresh"],
             capture_output=True, text=True, timeout=600, cwd=str(ROOT)
         )
-        return {
+        payload = {
             "ok": result.returncode == 0,
             "stdout": result.stdout[-1000:] if result.stdout else "",
             "stderr": result.stderr[-500:] if result.stderr else "",
         }
+        if result.returncode != 0:
+            # audit L11: same error-schema unification as /api/ingest — failure
+            # is a 5xx with the diagnostic body, not 200 + ok:false.
+            return JSONResponse(status_code=500, content=payload)
+        return payload
     except subprocess.TimeoutExpired:
-        return {"ok": False, "error": "重新處理逾時（>10 分鐘）"}
+        raise HTTPException(504, "重新處理逾時（>10 分鐘）")  # audit L11
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(500, str(e))
     finally:
@@ -2442,7 +2670,10 @@ async def _run_ingest_with_ws(target: Path, limit: int):
     # child's write, stalls the stdout read loop, and `proc.wait()` hangs forever.
     proc = await asyncio.create_subprocess_exec(
         *cmd, stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.STDOUT, cwd=str(ROOT)
+        stderr=asyncio.subprocess.STDOUT, cwd=str(ROOT),
+        # audit M3: a single stdout line beyond the default 64KB reader limit
+        # raises inside the read loop; give pathological log lines 1MB headroom.
+        limit=2 ** 20,
     )
 
     ok, skipped, failed = 0, 0, 0
@@ -2452,47 +2683,56 @@ async def _run_ingest_with_ws(target: Path, limit: int):
     file_re = re.compile(r"\[(\d+)/(\d+)\]\s+(SKIP\s+)?(.+?)\s+>")
     done_re = re.compile(r"\[(\d+)/(\d+)\]\s+(.+?)\s+.+\[OK\]")
 
-    async for line in proc.stdout:
-        text = line.decode("utf-8", errors="replace").strip()
-        if not text:
-            continue
-        print(f"[ingest-ws] {text}", flush=True)
+    # audit M3: if the read loop dies (oversized line, task cancel, broadcast
+    # error) nobody drains stdout — the child wedges forever on a full pipe
+    # while the done-callback frees the single-flight slot, allowing a second
+    # concurrent ingest. Always kill the subprocess on the way out.
+    try:
+        async for line in proc.stdout:
+            text = line.decode("utf-8", errors="replace").strip()
+            if not text:
+                continue
+            print(f"[ingest-ws] {text}", flush=True)
 
-        # Parse progress lines like "[1/3] FX30.5365.MP4 >probe >whisper..."
-        m = file_re.match(text)
-        if m:
-            idx, total, skip, fname = m.group(1), m.group(2), m.group(3), m.group(4)
-            last_total = max(last_total, int(total))
-            if skip:
-                skipped += 1
+            # Parse progress lines like "[1/3] FX30.5365.MP4 >probe >whisper..."
+            m = file_re.match(text)
+            if m:
+                idx, total, skip, fname = m.group(1), m.group(2), m.group(3), m.group(4)
+                last_total = max(last_total, int(total))
+                if skip:
+                    skipped += 1
+                    await ingest_ws.broadcast({
+                        "type": "file", "index": int(idx), "total": int(total),
+                        "filename": fname.strip(), "status": "skipped"
+                    })
+                else:
+                    await ingest_ws.broadcast({
+                        "type": "file", "index": int(idx), "total": int(total),
+                        "filename": fname.strip(), "status": "transcribing"
+                    })
+
+            # Parse completion "[OK]"
+            d = done_re.match(text)
+            if d:
+                ok += 1
+                last_total = max(last_total, int(d.group(2)))
                 await ingest_ws.broadcast({
-                    "type": "file", "index": int(idx), "total": int(total),
-                    "filename": fname.strip(), "status": "skipped"
-                })
-            else:
-                await ingest_ws.broadcast({
-                    "type": "file", "index": int(idx), "total": int(total),
-                    "filename": fname.strip(), "status": "transcribing"
+                    "type": "file", "index": int(d.group(1)), "total": int(d.group(2)),
+                    "filename": d.group(3).strip(), "status": "done"
                 })
 
-        # Parse completion "[OK]"
-        d = done_re.match(text)
-        if d:
-            ok += 1
-            last_total = max(last_total, int(d.group(2)))
-            await ingest_ws.broadcast({
-                "type": "file", "index": int(d.group(1)), "total": int(d.group(2)),
-                "filename": d.group(3).strip(), "status": "done"
-            })
+            # Parse "Found N media files"
+            if text.startswith("Found "):
+                fm = re.search(r"Processing (\d+)", text)
+                if fm:
+                    last_total = max(last_total, int(fm.group(1)))
+                    await ingest_ws.broadcast({"type": "start", "total": int(fm.group(1))})
 
-        # Parse "Found N media files"
-        if text.startswith("Found "):
-            fm = re.search(r"Processing (\d+)", text)
-            if fm:
-                last_total = max(last_total, int(fm.group(1)))
-                await ingest_ws.broadcast({"type": "start", "total": int(fm.group(1))})
-
-    await proc.wait()
+        await proc.wait()
+    finally:
+        if proc.returncode is None:  # audit M3: loop exited abnormally — reap child
+            proc.kill()
+            await proc.wait()
     # Derive failed from the observed total (not `limit`, which is 0 for "all"
     # and overstates when it exceeds the real file count) and surface the exit
     # code so a nonzero ingest result (e.g. vision halt) is visible to the UI.
@@ -2604,7 +2844,20 @@ def stream_media(media_id: int, _tok: dict = Depends(require_scopes("videos_read
     # 「需先建 proxy」的引導 + POST /api/proxy/build 觸發背景生成。
     # tri-state: NEEDED → 409；NOT_NEEDED / UNKNOWN（ffprobe 失敗、binary 缺、
     # NAS unreachable）→ fall through，維持送原檔的舊 fallback 行為。
-    if codec.needs_proxy(str(file_path)) == codec.NEEDED:
+    # audit M24: use the codec persisted at ingest instead of re-running ffprobe
+    # on EVERY playback; only probe when the column is NULL (legacy rows) and
+    # backfill so the next play is probe-free. None (probe failed / audio-only)
+    # keeps the UNKNOWN fall-through behavior.
+    stored_codec = (rec.get("codec") or "").strip().lower() or None
+    if stored_codec is None:
+        stored_codec = codec.probe_codec(str(file_path))
+        if stored_codec:
+            try:
+                with db.get_conn() as conn:
+                    conn.execute("UPDATE media SET codec=? WHERE id=?", (stored_codec, media_id))
+            except Exception:
+                pass  # backfill is best-effort; playback must not fail on it
+    if stored_codec and stored_codec in codec.PROXY_CODECS:
         return JSONResponse(
             status_code=409,
             content={
@@ -2630,6 +2883,24 @@ def stream_media(media_id: int, _tok: dict = Depends(require_scopes("videos_read
 
 # PROXY_CODECS lives in codec.py — single source of truth.
 
+def _assert_same_site(request: Request) -> None:
+    """audit M14: the no-body POSTs below are CORS 'simple requests' — a
+    malicious page can fire them cross-site WITHOUT a preflight, and
+    loopback-trust then authorizes them (whole-library rebuild / proxy-build
+    DoS). Browsers attach Sec-Fetch-Site and/or Origin on cross-site POSTs;
+    non-browser clients (curl, scripts) send neither and pass through."""
+    sfs = request.headers.get("sec-fetch-site")
+    if sfs and sfs not in ("same-origin", "same-site", "none"):
+        raise HTTPException(403, "cross-site request rejected")
+    origin = request.headers.get("origin")
+    if not origin:
+        return  # non-browser client
+    if origin in _ALLOWED_ORIGINS:
+        return
+    if origin != "null" and origin.split("://", 1)[-1] == request.headers.get("host", ""):
+        return  # same-origin for whatever host/port this deployment uses
+    raise HTTPException(403, "cross-site request rejected")
+
 @app.get("/api/proxy/status")
 def proxy_status(_tok: dict = Depends(require_scopes("videos_read"))):
     """Check proxy status for all media files."""
@@ -2646,8 +2917,9 @@ def proxy_status(_tok: dict = Depends(require_scopes("videos_read"))):
 
 
 @app.post("/api/proxy/build")
-def proxy_build(background_tasks: BackgroundTasks, _tok: dict = Depends(require_scopes("ingest_write"))):
+def proxy_build(request: Request, background_tasks: BackgroundTasks, _tok: dict = Depends(require_scopes("ingest_write"))):
     """Queue proxy generation for all HEVC/ProRes files without proxy."""
+    _assert_same_site(request)  # audit M14
     proxy_dir = config.PROXIES_DIR
     proxy_dir.mkdir(parents=True, exist_ok=True)
     with db.get_conn() as conn:
@@ -2663,9 +2935,10 @@ def proxy_build(background_tasks: BackgroundTasks, _tok: dict = Depends(require_
 
 
 @app.post("/api/proxy/build/{media_id}")
-def proxy_build_one(media_id: int, background_tasks: BackgroundTasks, _tok: dict = Depends(require_scopes("ingest_write"))):
+def proxy_build_one(media_id: int, request: Request, background_tasks: BackgroundTasks, _tok: dict = Depends(require_scopes("ingest_write"))):
     """Per-id proxy build — surface 自 7.7g 409 「生成 proxy」按鈕，使用者點到
     哪個 HEVC 就只建那個，避免 build all 整庫拖時間。"""
+    _assert_same_site(request)  # audit M14
     proxy_dir = config.PROXIES_DIR
     proxy_dir.mkdir(parents=True, exist_ok=True)
     rec = db.get_record_by_id(media_id)
@@ -2697,13 +2970,19 @@ def _build_proxies(items: list):
 
 
 @app.post("/api/embed/rebuild")
-def embed_rebuild(background_tasks: BackgroundTasks, _tok: dict = Depends(require_scopes("ingest_write"))):
+def embed_rebuild(request: Request, background_tasks: BackgroundTasks, _tok: dict = Depends(require_scopes("ingest_write"))):
     """Drop + rebuild the ChromaDB semantic index from all media.
     Wired to 進階設定 → 搜尋引擎 → 「重建向量索引」button."""
+    _assert_same_site(request)  # audit M14
+    global _embed_rebuild_active
     with db.get_conn() as conn:
         total = conn.execute("SELECT count(*) FROM media").fetchone()[0]
     if not total:
         return {"message": "尚無素材可建立索引", "queued": 0}
+    with _embed_rebuild_lock:  # audit M8: refuse concurrent rebuilds
+        if _embed_rebuild_active:
+            raise HTTPException(409, "向量索引重建已在進行中，請稍候")
+        _embed_rebuild_active = True
     background_tasks.add_task(_rebuild_embeddings)
     return {"message": f"開始重建向量索引（{total} 筆素材，背景執行）", "queued": total}
 
@@ -2712,12 +2991,16 @@ def _rebuild_embeddings():
     """Background task: full embedding rebuild via subprocess. Runs embed.py in a
     child process to isolate its sys.exit() guard and use sys.executable per the
     platform Python-concurrency rule (not in-process — sys.exit would kill server)."""
+    global _embed_rebuild_active
     import subprocess
     import sys
     try:
         subprocess.run([sys.executable, str(ROOT / "embed.py"), "--rebuild"], check=False)
     except Exception as e:
         print(f"[embed] rebuild failed: {e}")
+    finally:
+        with _embed_rebuild_lock:  # audit M8: always free the single-flight slot
+            _embed_rebuild_active = False
 
 
 # ── Serve Frontend ───────────────────────────────────────────────────────────
@@ -2729,9 +3012,14 @@ def _load_index() -> str:
         return index.read_text(encoding="utf-8")
     return "<h1>arkiv</h1><p>index.html not found</p>"
 
+class OpenFileRequest(BaseModel):  # audit M22: malformed JSON → clean 422, not a raw 500
+    path: str
+    reveal: bool = False
+
+
 @app.post("/api/open-file")
-async def open_file(
-    request: __import__('starlette.requests', fromlist=['Request']).Request,
+def open_file(
+    body: OpenFileRequest,
     _tok: dict = Depends(require_scopes("videos_write")),
 ):
     """Open file in OS default app or reveal in file manager. Only allows known media files from DB.
@@ -2741,9 +3029,8 @@ async def open_file(
     read-only browse token is correctly refused.
     """
     import subprocess, platform
-    body = await request.json()
-    file_path = body.get("path", "")
-    reveal = body.get("reveal", False)
+    file_path = body.path
+    reveal = body.reveal
     # Validate: only allow paths that exist in our database
     if not db.is_processed(file_path):
         raise HTTPException(403, "只能開啟已索引的媒體檔案")
@@ -2768,8 +3055,16 @@ async def open_file(
     return {"ok": True}
 
 
+class ClientLogRequest(BaseModel):
+    # audit M22: the model's job is turning malformed JSON into a 422 instead of
+    # a raw 500. Fields stay Any (the WebView occasionally logs non-string
+    # payloads); the handler stringifies + sanitizes as before.
+    level: Any = "info"
+    msg: Any = ""
+
+
 @app.post("/api/client-log")
-async def client_log(request: __import__('starlette.requests', fromlist=['Request']).Request):
+def client_log(body: ClientLogRequest):
     """Receive client-side logs (errors, info) and print to server terminal.
 
     Stays unauthenticated (the WebView logs diagnostics, sometimes before a token
@@ -2778,9 +3073,8 @@ async def client_log(request: __import__('starlette.requests', fromlist=['Reques
     caller can't forge log lines or corrupt the operator's terminal, and lengths
     are capped so it can't be used to fill a redirected logfile.
     """
-    body = await request.json()
-    level = _log_safe(str(body.get("level", "info")).upper(), 16)
-    msg = _log_safe(str(body.get("msg", "")), 2000)
+    level = _log_safe(str(body.level if body.level is not None else "info").upper(), 16)
+    msg = _log_safe(str(body.msg if body.msg is not None else ""), 2000)
     print(f"[WebView {level}] {msg}", flush=True)
     return {"ok": True}
 

--- a/tests/test_audit_20260612.py
+++ b/tests/test_audit_20260612.py
@@ -1,0 +1,118 @@
+"""Regression tests for the 2026-06-12 audit fix batch (blockers).
+
+Each test pins a behaviour that was broken before the fixes so a future change
+can't silently reintroduce it. See references/management/2026-06-12 audit report.
+"""
+import importlib
+import subprocess
+import types
+
+import pytest
+
+
+def _media_id(db, rec):
+    with db.get_conn() as c:
+        row = c.execute(
+            "SELECT id FROM media WHERE path=? OR path=?",
+            (rec["path"], db.to_relative(rec["path"])),
+        ).fetchone()
+    return row[0]
+
+
+# ── H2: _to_wav raises (not silent empty) when ffmpeg audio extract fails ───────
+def test_h2_to_wav_raises_on_ffmpeg_failure(monkeypatch):
+    tr = importlib.import_module("transcribe")
+    monkeypatch.setattr(
+        tr.subprocess, "run",
+        lambda *a, **k: types.SimpleNamespace(returncode=1, stderr=b"boom"),
+    )
+    # A failed extraction must raise, not return None (which masqueraded as
+    # "no speech" and silently blanked the transcript).
+    with pytest.raises(RuntimeError):
+        tr._to_wav("/whatever.mp4")
+
+
+# ── H3: ingest single-flight — a second concurrent ingest is rejected ───────────
+def test_h3_ingest_slot_single_flight(server_module):
+    assert server_module._acquire_ingest_slot() is True
+    assert server_module._acquire_ingest_slot() is False, "2nd ingest must be rejected"
+    server_module._release_ingest_slot()
+    assert server_module._acquire_ingest_slot() is True
+    server_module._release_ingest_slot()
+
+
+# ── H1: retranscribe refuses to overwrite a good transcript with an empty result ─
+def test_h1_retranscribe_refuses_empty_overwrite(
+    fastapi_client, server_module, sample_record, monkeypatch
+):
+    import db
+    rec = sample_record()
+    rec["transcript"] = "原本就有的逐字稿"
+    rec["lang"] = "zh"
+    db.upsert(rec)
+    mid = _media_id(db, rec)
+
+    import transcribe as tr
+    monkeypatch.setattr(tr, "transcribe", lambda *a, **k: ("", "", [], []))
+    monkeypatch.setattr(server_module, "_resolve_media_path", lambda p: __file__)
+
+    r = fastapi_client.post("/api/media/%d/retranscribe" % mid, json={"language": "zh"})
+    assert r.status_code == 422
+    with db.get_conn() as c:
+        kept = c.execute("SELECT transcript FROM media WHERE id=?", (mid,)).fetchone()[0]
+    assert kept == "原本就有的逐字稿", "empty retranscribe must not blank a good transcript"
+
+
+# ── H4: reingest targets the exact media file, not the folder's first file ──────
+def test_h4_reingest_targets_single_file(
+    fastapi_client, server_module, sample_record, monkeypatch
+):
+    import db
+    rec = sample_record()
+    db.upsert(rec)
+    mid = _media_id(db, rec)
+    monkeypatch.setattr(server_module, "_resolve_media_path", lambda p: __file__)
+
+    captured = {}
+
+    def fake_run(cmd, *a, **k):
+        captured["cmd"] = cmd
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    r = fastapi_client.post("/api/media/%d/reingest" % mid)
+    assert r.status_code == 200
+    cmd = captured["cmd"]
+    assert __file__ in cmd, "must reingest the exact media path"
+    assert "--limit" not in cmd, "must not use --limit (would pick the folder's first file)"
+
+
+# ── C1: retry-vision completes (no self-deadlock) and persists tags ─────────────
+def test_c1_retry_vision_no_deadlock_persists_tags(
+    fastapi_client, server_module, sample_record, monkeypatch
+):
+    import db
+    rec = sample_record()
+    db.upsert(rec)
+    mid = _media_id(db, rec)
+    db.upsert_frame(mid, 0, 0.0, thumbnail_path="t.jpg", description="")  # empty → retried
+
+    import vision as vis
+    monkeypatch.setattr(
+        vis, "describe_frames",
+        lambda paths: [{"description": "一隻貓", "tags": ["貓", "室內"], "focus_score": 80}],
+    )
+    monkeypatch.setattr(server_module, "_resolve_media_path", lambda p: p)
+
+    r = fastapi_client.post("/api/media/%d/retry-vision" % mid)
+    assert r.status_code == 200, r.text
+    assert r.json()["patched"] == 1
+    with db.get_conn() as c:
+        desc = c.execute(
+            "SELECT description FROM frames WHERE media_id=? AND frame_index=0", (mid,)
+        ).fetchone()[0]
+        tags = [row[0] for row in c.execute(
+            "SELECT name FROM tags WHERE media_id=?", (mid,)
+        ).fetchall()]
+    assert desc == "一隻貓"
+    assert "貓" in tags, "tags must persist (add_tag with _conn must not deadlock)"

--- a/transcribe.py
+++ b/transcribe.py
@@ -547,9 +547,21 @@ def _to_wav(media_path: str):
         "-loglevel", "error",
         out, "-y"
     ]
-    r = subprocess.run(cmd, capture_output=True)
-    if r.returncode != 0 or not Path(out).exists():
-        return None
+    # duration-unaware files can hang ffmpeg — bound it so a single bad file can't
+    # wedge the whole whisper phase (audit H7).
+    try:
+        r = subprocess.run(cmd, capture_output=True, timeout=900)
+    except subprocess.TimeoutExpired:
+        Path(out).unlink(missing_ok=True)
+        raise RuntimeError("ffmpeg audio extract timed out (>900s): {0}".format(media_path))
+    if r.returncode != 0 or not Path(out).exists() or Path(out).stat().st_size == 0:
+        Path(out).unlink(missing_ok=True)  # don't leak the temp wav on failure (H7)
+        err = (r.stderr or b"").decode("utf-8", "replace").strip()
+        err = err[-300:] if err else "(no stderr)"
+        # A failed extraction must NOT masquerade as "no speech" (returning empty
+        # made ingest record an empty transcript forever and retranscribe overwrite
+        # a good one — audit H1/H2). Raise so the caller counts it a real failure.
+        raise RuntimeError("ffmpeg audio extract failed rc={0}: {1}".format(r.returncode, err))
     return out
 
 

--- a/transcribe.py
+++ b/transcribe.py
@@ -5,6 +5,7 @@ import json
 import os
 import subprocess
 import tempfile
+import threading
 import platform
 from pathlib import Path
 
@@ -123,6 +124,7 @@ def _optional_option(opts, key, value):
         opts[key] = value
 
 _whisper_loaded = False
+_warm_up_lock = threading.Lock()  # audit L7: guard lazy model load against concurrent callers
 _fw_model = None  # faster-whisper model instance
 _whisperx_model = None  # WhisperX model instance
 _vad_model = None  # Silero VAD model instance
@@ -161,7 +163,11 @@ def _vad_filter(wav_path: str, sample_rate: int = 16000):
     speech = np.concatenate(chunks)
 
     _fd, out = tempfile.mkstemp(suffix=".wav"); os.close(_fd)
-    sf.write(out, speech, sample_rate)
+    try:
+        sf.write(out, speech, sample_rate)
+    except Exception:
+        Path(out).unlink(missing_ok=True)  # audit L4: don't leak the temp wav on write failure
+        raise
     kept = len(speech) / max(len(audio), 1)
     print(f"  [VAD] kept {kept:.0%} of audio ({len(stamps)} segments)", flush=True)
     return out
@@ -173,35 +179,41 @@ def warm_up():
     if _whisper_loaded:
         return
 
-    if _USE_MLX:
-        import mlx_whisper
-        import numpy as np
-        _fd, silence = tempfile.mkstemp(suffix=".wav"); os.close(_fd)
-        try:
-            subprocess.run([
-                FFMPEG_PATH, "-f", "lavfi", "-i", "anullsrc=r=16000:cl=mono",
-                "-t", "1", "-loglevel", "error", silence, "-y"
-            ], capture_output=True)
-            mlx_whisper.transcribe(silence, path_or_hf_repo=WHISPER_MODEL, language="zh")
-        except Exception:
-            pass
-        finally:
-            Path(silence).unlink(missing_ok=True)
-    elif _non_mac_backend() == "whisperx":
-        import whisperx
-        _whisperx_model = whisperx.load_model(
-            WHISPER_MODEL,
-            "cuda",
-            compute_type="float16",
-        )
-        print("  [whisperx on cuda]", flush=True)
-    else:
-        from faster_whisper import WhisperModel
-        _fw_model = WhisperModel(WHISPER_MODEL, device="cuda", compute_type="float16")
-        print("  [faster-whisper on cuda]", flush=True)
+    # audit L7: double-checked locking — concurrent retranscribe requests used
+    # to both pass the flag check and load the model twice (RAM spike).
+    with _warm_up_lock:
+        if _whisper_loaded:
+            return
 
-    _whisper_loaded = True
-    print("  [whisper model loaded]", flush=True)
+        if _USE_MLX:
+            import mlx_whisper
+            import numpy as np
+            _fd, silence = tempfile.mkstemp(suffix=".wav"); os.close(_fd)
+            try:
+                subprocess.run([
+                    FFMPEG_PATH, "-f", "lavfi", "-i", "anullsrc=r=16000:cl=mono",
+                    "-t", "1", "-loglevel", "error", silence, "-y"
+                ], capture_output=True)
+                mlx_whisper.transcribe(silence, path_or_hf_repo=WHISPER_MODEL, language="zh")
+            except Exception:
+                pass
+            finally:
+                Path(silence).unlink(missing_ok=True)
+        elif _non_mac_backend() == "whisperx":
+            import whisperx
+            _whisperx_model = whisperx.load_model(
+                WHISPER_MODEL,
+                "cuda",
+                compute_type="float16",
+            )
+            print("  [whisperx on cuda]", flush=True)
+        else:
+            from faster_whisper import WhisperModel
+            _fw_model = WhisperModel(WHISPER_MODEL, device="cuda", compute_type="float16")
+            print("  [faster-whisper on cuda]", flush=True)
+
+        _whisper_loaded = True
+        print("  [whisper model loaded]", flush=True)
 
 
 def transcribe(media_path: str, language=None) -> tuple:

--- a/vectordb.py
+++ b/vectordb.py
@@ -5,6 +5,7 @@ Vector DB module — ChromaDB + Ollama bge-m3 (multilingual, default)
 import json
 import logging
 import re
+import threading
 import requests
 from typing import Any, Dict, List, Optional
 
@@ -56,7 +57,50 @@ def _reraise_dim_error(exc: Exception) -> None:
 
 # ── Embedding ────────────────────────────────────────────────────────────────
 
+# audit M27: reuse one TCP connection for embedding calls instead of a bare
+# requests.post per chunk (connection setup dominated rebuild wall-clock time).
+_EMBED_SESSION = requests.Session()
+# None = unprobed; False = this Ollama has no batch /api/embed (pre-0.1.32) —
+# don't re-probe a 404 on every record.
+_BATCH_EMBED_SUPPORTED: Optional[bool] = None
+
+
 def embed_batch(texts: List[str]) -> List[List[float]]:
+    """Embed many texts in ONE Ollama ``/api/embed`` call (batch ``input``) over a
+    shared Session (audit M27). Falls back to per-text ``embed()`` when the batch
+    endpoint is unavailable (older Ollama) or returns an unexpected shape.
+
+    Single-text calls delegate straight to ``embed()`` — no batch win there, and
+    it keeps the module-level ``embed`` the single seam tests monkeypatch."""
+    global _BATCH_EMBED_SUPPORTED
+    if not texts:
+        return []
+    if len(texts) == 1 or _BATCH_EMBED_SUPPORTED is False:
+        return [embed(t) for t in texts]
+
+    truncated = [t[:EMBED_MAX_CHARS] for t in texts]
+    try:
+        resp = _EMBED_SESSION.post(
+            f"{OLLAMA_URL}/api/embed",
+            json={"model": EMBED_MODEL, "input": truncated},
+            timeout=max(30, 5 * len(truncated)),
+        )
+        if resp.status_code == 404:
+            _BATCH_EMBED_SUPPORTED = False
+        else:
+            resp.raise_for_status()
+            vectors = resp.json().get("embeddings")
+            if (isinstance(vectors, list) and len(vectors) == len(truncated)
+                    and all(isinstance(v, list) and v for v in vectors)):
+                _BATCH_EMBED_SUPPORTED = True
+                return vectors
+            # Responded but with a shape we don't trust — stop using it.
+            _BATCH_EMBED_SUPPORTED = False
+            _LOGGER.warning("/api/embed returned unexpected shape; falling back to per-text embeds")
+    except requests.RequestException:
+        # Transient (timeout / connection refused): don't mark unsupported —
+        # fall back for this call only; per-text embed surfaces the real error.
+        pass
     return [embed(t) for t in texts]
 
 
@@ -139,21 +183,29 @@ def _assert_collection_compatible(col) -> None:
             )
 
 
+# audit M11: chromadb's PersistentClient/get_or_create_collection is a
+# check-then-create on shared on-disk state — concurrent callers (FastAPI
+# threadpool workers, federation, embed rebuild) can race it and leak System
+# instances. Serialize client + collection acquisition behind one lock.
+_CHROMA_LOCK = threading.Lock()
+
+
 def get_collection(reset: bool = False):
-    client = chromadb.PersistentClient(path=str(CHROMA_PATH))
-    if reset:
-        try:
-            client.delete_collection(COLLECTION_NAME)
-        except Exception:
-            pass
-    col = client.get_or_create_collection(
-        COLLECTION_NAME,
-        # Stamp the embedding model + dim so a later model change is detected and
-        # fails loud instead of throwing a raw chromadb dimension error. On an
-        # EXISTING collection chromadb ignores these extra metadata keys (verified
-        # on 1.5.x), so the stamp only lands when the collection is created/reset.
-        metadata={"hnsw:space": "cosine", "embed_model": EMBED_MODEL, "embed_dim": EMBED_DIM},
-    )
+    with _CHROMA_LOCK:  # audit M11
+        client = chromadb.PersistentClient(path=str(CHROMA_PATH))
+        if reset:
+            try:
+                client.delete_collection(COLLECTION_NAME)
+            except Exception:
+                pass
+        col = client.get_or_create_collection(
+            COLLECTION_NAME,
+            # Stamp the embedding model + dim so a later model change is detected and
+            # fails loud instead of throwing a raw chromadb dimension error. On an
+            # EXISTING collection chromadb ignores these extra metadata keys (verified
+            # on 1.5.x), so the stamp only lands when the collection is created/reset.
+            metadata={"hnsw:space": "cosine", "embed_model": EMBED_MODEL, "embed_dim": EMBED_DIM},
+        )
     _assert_collection_compatible(col)
     return col
 
@@ -233,11 +285,12 @@ def upsert_record(col, record: dict) -> int:
 
     if transcript:
         chunks = chunk_text(transcript)
-        for i, chunk in enumerate(chunks):
+        vectors = embed_batch(chunks)  # audit M27: one HTTP call for all chunks
+        for i, (chunk, vec) in enumerate(zip(chunks, vectors)):
             doc_id = f"{media_id}_t{i}"
             ids.append(doc_id)
             documents.append(chunk)
-            embeddings.append(embed(chunk))
+            embeddings.append(vec)
             metadatas.append({**meta_base, "chunk_type": "transcript", "chunk_idx": i})
     else:
         # No transcript — embed frame tags / filename only

--- a/watch.py
+++ b/watch.py
@@ -10,11 +10,13 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import os
+import signal
 import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import List, Set
+from typing import List, Sequence, Set
 
 MEDIA_EXTS = {
     ".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts",  # video
@@ -37,14 +39,57 @@ def find_new_files(watch_dir: Path, known: Set[str]) -> List[Path]:
     return sorted(new)
 
 
+def run_tree(cmd: Sequence[str], timeout: float) -> subprocess.CompletedProcess:
+    """subprocess.run-like wrapper that kills the *whole process tree* on timeout.
+
+    audit H8: plain subprocess.run(timeout=...) only kills the direct child;
+    grandchildren (ffmpeg/whisper spawned by ingest.py) become orphans and keep
+    running — and on Windows they hold the stdout/stderr pipes open, so
+    communicate() hangs forever. POSIX: new session + killpg. Windows:
+    taskkill /T /F (needs verification on PC — cannot be exercised on mac).
+    """
+    kwargs = {}
+    if os.name == "posix":
+        kwargs["start_new_session"] = True
+    else:
+        kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    proc = subprocess.Popen(
+        list(cmd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        **kwargs,
+    )
+    try:
+        out, err = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        if os.name == "posix":
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                proc.kill()
+        else:
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                capture_output=True,
+            )
+            proc.kill()  # belt-and-suspenders if taskkill failed
+        # Tree is dead, so draining the pipes terminates promptly; bound it anyway.
+        try:
+            out, err = proc.communicate(timeout=10)
+        except Exception:
+            out, err = "", ""
+        raise subprocess.TimeoutExpired(list(cmd), timeout, output=out, stderr=err)
+    return subprocess.CompletedProcess(list(cmd), proc.returncode, out, err)
+
+
 def ingest_file(filepath: Path) -> bool:
     """Run ingest.py on a single file."""
     script = Path(__file__).parent / "ingest.py"
     try:
-        result = subprocess.run(
+        # audit H8: use run_tree so a timeout reaps ffmpeg/whisper grandchildren too
+        result = run_tree(
             [sys.executable, str(script), "--dir", str(filepath)],
-            capture_output=True,
-            text=True,
             timeout=600,  # 10 min per file
         )
         if result.returncode == 0:
@@ -83,8 +128,11 @@ def main():
             rows = conn.execute("SELECT path FROM media").fetchall()
             known = {db.resolve_path(r["path"]) for r in rows}
         print(f"  {len(known)} files already in DB")
-    except Exception:
-        pass
+    except Exception as e:
+        # audit L9: don't swallow DB load failure silently — without `known`
+        # the watcher re-ingests everything it sees; warn loudly up front.
+        print(f"  WARN: could not load known files from DB ({e.__class__.__name__}: {e}); "
+              f"starting with empty set — already-ingested files may be re-processed")
 
     while True:
         new_files = find_new_files(watch_dir, known)


### PR DESCRIPTION
## 來源
2026-06-12 multi-agent 硬化審計（207 agents / 8.2M tokens，報告：hevin-ai-os `references/management/2026-06-12_arkiv-pretag-hardening-audit.md`）找到 57 條 confirmed。本 PR 修 51 條。

## Batch 1 — 5 blockers + regression tests（`7274771`）
**這 5 條原本讓 v0.8.0 tag NO-GO，現已解除：**
- **C1+M1** retry-vision 自我死鎖 + stale read（`add_tag`/`get_frames` 傳 `_conn` + editability max+COALESCE）
- **H1+H2** transcript 銷毀鏈（`_to_wav` 失敗改 raise+診斷+timeout+暫存清理；retranscribe 拒空覆寫+存偵測 lang）
- **H3** ingest 互斥（REST `/api/ingest` + reingest + WS 統一 `threading.Lock` single-flight，衝突 409）
- **H4** reingest 改單檔模式（不再 refresh 目錄字母序第一個檔）
- **H9** broadcast `list()` 快照；**H10** export-to scope `media_read`→`videos_write`
- ➕ `tests/test_audit_20260612.py` 5 條 regression

## Batch 2-4 — 46 findings by-file 平行修復（`5112549`）
6-agent workflow 套審計 proposed_fix，**471 pass / 0 regression**：
- **server.py**: H13-H17（clamp/filter/N+1+payload+SQL LIMIT）/ M3 ws finally / M8-M9 guard/lock / M12 thumbnails auth / M14 CSRF / M19-M24 contract / L5/L6/L8/L11-L13
- **ingest+db**: H5 abs-rel UPDATE-by-id + migrate 合併 / H11 exiftool loud / M2/M6 FK / M7/M26 / L2/L10/L14
- **transcribe+frames**: H6 ffmpeg timeout / M18 診斷 / L4/L7
- **embed+vectordb**: H12 exit code / M11 chroma lock+API / M25/M27 session+batch
- **federation/codec/jobs/mcp**: M10 bounded executor / M15 / L1 / M17
- **watch**: H8 run_tree process-group

## ⚠️ 17 條 needs_verification（請 Hevin 特別留意行為變更）
- **M6** `PRAGMA foreign_keys=ON` + init_db orphan 清理 → 真實 DB 首次 init 會清 pre-enforcement orphan，請看清理輸出
- **M12** /thumbnails 改 auth → **本地 loopback UI 不受影響，但遠端 token-auth 瀏覽器 `<img>` 無法帶 header 會 401**（遠端縮圖場景受限）
- **M14** CSRF `_assert_same_site` → 反向代理若改寫 Host 可能誤擋
- **M19-M21** 契約變更：搜尋 total 改 bounded count / PATCH rating 不再清 note / ProjectCreate 撞名 409（原靜默覆蓋）
- **H5** abs/rel 去重：殘餘 edge（DB 已存 abs+rel 雙 row 時 Phase-1 可能撞 UNIQUE → loud fail，靠 `--migrate-relative` 清）
- **H8** watch run_tree 的 **Windows taskkill 路徑無法在 mac 實測，需 PC 驗證**

## 狀態
- ✅ 471 pass / 5 skip（466 + 5 新 regression）
- 🔄 Codex(GPT-5) 獨立 read-only audit 進行中，findings 會補 commit
- 跳過 6 條（report 判 v0.8.1：大型效能 refactor 等）

## Tag 建議
5 個 blocker 全解除 → **conditional GO**（待 Codex audit 收斂 + Hevin review needs_verification 行為變更）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)