### PR TITLE
feat(ingest): 360 格式白名單 — .insv / .360

### DIFF
--- a/frontend/src/routes/MainStates.svelte
+++ b/frontend/src/routes/MainStates.svelte
@@ -163,7 +163,7 @@
           </div>
           <div class="supported">
             <Mono dim style="font-size:10.5px;letter-spacing:0.08em;">SUPPORTED</Mono>
-            <Mono dim style="font-size:10.5px;">.mov · .mp4 · .mxf · .braw · .r3d · .wav · .flac</Mono>
+            <Mono dim style="font-size:10.5px;">.mov · .mp4 · .insv · .360 · .mxf · .braw · .r3d · .wav · .flac</Mono>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -419,7 +419,7 @@ function showLimitModal(total, newCount) {
     document.getElementById('limitInput').onkeydown = (e) => { if(e.key==='Enter') document.getElementById('limitOk').click(); };
   });
 }
-var VIDEO_EXT = ['.mp4','.mov','.m4v','.mts'];
+var VIDEO_EXT = ['.mp4','.mov','.m4v','.mts','.insv','.360'];
 var AUDIO_EXT = ['.wav','.mp3','.m4a','.aac'];
 
 var gridCols = 4;

--- a/ingest.py
+++ b/ingest.py
@@ -25,12 +25,19 @@ import frames as frm
 import transcribe as tr
 import vision as vis
 
-SUPPORTED = {".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts", ".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg"}
+SUPPORTED = {".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts",
+             ".insv", ".360",  # 360 rigs (Insta360 / GoPro Max) — see VIDEO_EXT note
+             ".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg"}
 # B3: .mkv/.avi/.webm are in SUPPORTED (so they ingest into the DB) but were
 # absent here, so is_video was False for them → they silently skipped
 # thumbnail/frames/vision. ffmpeg/ffprobe handle these containers, so treat
 # them as video too. Keep VIDEO_EXT ⊆ SUPPORTED.
-VIDEO_EXT = {".mp4", ".mov", ".m4v", ".mts", ".mkv", ".avi", ".webm"}
+# 360 formats: .insv (Insta360) / .360 (GoPro Max) are HEVC-in-MOV/MP4 — ffmpeg
+# probes + extracts frames fine (.insv verified 2026-06-12: dual 2880×2880 HEVC
+# fisheye + AAC, thumbnail decodes). Frames land as raw fisheye, which is exactly
+# what we want indexed (VLM still describes them). Competitor StoryCube shows the
+# same files as UNKNOWN — see case-study storycube-asus-gopro-20260612.
+VIDEO_EXT = {".mp4", ".mov", ".m4v", ".mts", ".mkv", ".avi", ".webm", ".insv", ".360"}
 # Codecs needing browser-playable proxy — single source of truth in codec.py.
 PROXY_CODECS = codec.PROXY_CODECS
 logger = logging.getLogger(__name__)

--- a/server.py
+++ b/server.py
@@ -695,7 +695,7 @@ def media_pool(
 
 # audit H14: ext buckets mirror db._build_filter_clause's media_type sets so the
 # search branch applies the SAME filter the SQL (non-search) path does.
-_VIDEO_EXTS = frozenset({".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts"})
+_VIDEO_EXTS = frozenset({".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts", ".insv", ".360"})
 _AUDIO_EXTS = frozenset({".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg"})
 
 
@@ -1510,7 +1510,7 @@ class IngestRequest(BaseModel):
 class ScanRequest(BaseModel):
     path: str
 
-MEDIA_EXTS = {".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts", ".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg"}
+MEDIA_EXTS = {".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts", ".insv", ".360", ".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg"}
 
 def _allowed_ingest_roots() -> list:
     """Approved roots for ingest scan / ingest endpoints.

--- a/tests/test_ingest_microtasks.py
+++ b/tests/test_ingest_microtasks.py
@@ -25,6 +25,18 @@ def test_b3_video_ext_subset_of_supported(ingest_mod):
 
 
 # --------------------------------------------------------------------------
+# 360 rigs: .insv (Insta360) / .360 (GoPro Max) are HEVC-in-MOV/MP4 — ffmpeg
+# probes + extracts frames. Verified 2026-06-12 on a real .insv (dual 2880×2880
+# HEVC fisheye + AAC, thumbnail decodes). Competitor StoryCube shows the same
+# files as UNKNOWN; arkiv must treat them as first-class video.
+# --------------------------------------------------------------------------
+def test_360_formats_are_video(ingest_mod):
+    for ext in (".insv", ".360"):
+        assert ext in ingest_mod.VIDEO_EXT, f"{ext} should be a video ext"
+        assert ext in ingest_mod.SUPPORTED, f"{ext} should be ingestible"
+
+
+# --------------------------------------------------------------------------
 # B6: size helpers
 # --------------------------------------------------------------------------
 def test_b6_dir_size_bytes(ingest_mod, tmp_path):

--- a/watch.py
+++ b/watch.py
@@ -20,6 +20,7 @@ from typing import List, Sequence, Set
 
 MEDIA_EXTS = {
     ".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts",  # video
+    ".insv", ".360",  # 360 rigs (Insta360 / GoPro Max)
     ".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg",  # audio
 }
 


### PR DESCRIPTION
## 摘要
Insta360 `.insv` 與 GoPro Max `.360` 納入 video/media 白名單。底層皆 HEVC-in-MOV/MP4，ffmpeg 完整 probe + 抽 frame，但原本不在白名單 → `is_video=False`，silently 跳過 thumbnail/frames/vision（與 B3 的 .mkv/.avi/.webm 同類缺口）。

## 實測佐證（2026-06-12）
- Hevin Insta360 `.insv`：mov 容器、雙 2880×2880 HEVC 魚眼 + AAC，`ffmpeg -map 0:0` 抽 640×640 縮圖乾淨解碼 ✅
- 同批 Sony FX30 XAVC：`parse_xavc_sidecar()` 讀出 Sony / ILME-FX30 / E 17-70mm
- 競品 StoryCube 對**同檔**顯示 UNKNOWN → 見 case-study `storycube-asus-gopro-20260612`

## 改動
- `SUPPORTED` + `VIDEO_EXT` (ingest.py)
- `_VIDEO_EXTS` + `MEDIA_EXTS` (server.py)
- `MEDIA_EXTS` (watch.py)
- `VIDEO_EXT` (index.html) + SUPPORTED 顯示串 (MainStates.svelte)
- `test_360_formats_are_video`

`.insp`（Insta360 靜態照片）未納入 — arkiv 無 image pipeline。

## 測試
472 passed / 5 skip（本機 3.12）

🤖 Generated with [Claude Code](https://claude.com/claude-code)