### PR TITLE
docs(readme): 支援格式補 360 + Sony sidecar metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,9 @@ Yes — the native Python install is the primary workflow. Docker is optional fo
 
 **Q: What file formats are supported?**
 Video: `.mp4`, `.mov`, `.mkv`, `.avi`, `.webm`, `.m4v`, `.mts`
+360: `.insv` (Insta360), `.360` (GoPro Max) — indexed as raw fisheye
 Audio: `.wav`, `.mp3`, `.m4a`, `.aac`, `.flac`, `.ogg`
+Camera metadata (make/model/lens/timecode) is read from embedded EXIF **and** Sony XAVC NRT sidecar XML — so FX30/FX-series footage keeps its identity.
 
 ## Smoke Test
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -335,7 +335,9 @@ Invoke-RestMethod "http://localhost:8501/api/media?q=關鍵字&limit=5"
 
 **Q：支援哪些檔案格式？**
 影片：`.mp4`、`.mov`、`.mkv`、`.avi`、`.webm`、`.m4v`、`.mts`
+360：`.insv`（Insta360）、`.360`（GoPro Max）— 以魚眼原狀索引
 音訊：`.wav`、`.mp3`、`.m4a`、`.aac`、`.flac`、`.ogg`
+相機 metadata（機型/鏡頭/timecode）同時讀內嵌 EXIF **與** Sony XAVC NRT sidecar XML — FX30／FX 系列素材機型不會掉。
 
 ## 冒煙測試
 


### PR DESCRIPTION
## 摘要
README 中英雙版 FAQ「支援哪些格式」補上：
- **360**：`.insv`（Insta360）/ `.360`（GoPro Max）— 魚眼原狀索引
- 相機 metadata 同時讀內嵌 EXIF **與** Sony XAVC NRT sidecar XML（FX30/FX 系列機型不會掉）

對齊 PR #45（`.insv/.360` 白名單）已 merge 的實作。docs-only。

🤖 Generated with [Claude Code](https://claude.com/claude-code)