### PR TITLE
feat(vision): frame-failure tolerance — --max-failures / --skip-failed (closes #48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## Unreleased
+
+### Added
+- **Vision frame-failure tolerance (`--max-failures` / `--skip-failed`, issue #48).** The vision phase used to halt the entire run on the first frame that failed both the primary and fallback model — fine interactively, but a single transient Ollama hiccup killed a 481-frame overnight run. `--max-failures N` tolerates N cumulative failed frames before halting (N=0, the default, keeps the historical zero-tolerance behaviour). `--skip-failed` never halts on individual frame failures — it leaves them with an empty description (so a later `--vision-only` retries exactly those frames) and prints a report at the end. A consecutive-failure guard (whole files producing nothing) still halts fast under either flag, so a real Ollama outage can't spin all night. Successful frames are now committed even on a file that later triggers a halt (no lost work). `--vision-only` and the main Phase-2 loop share one describe→fallback→tolerance path. Tests in `tests/test_vision_tolerance.py`.
+
 ## v0.8.1 - 2026-06-12
 
 ### Added

--- a/ingest.py
+++ b/ingest.py
@@ -682,6 +682,62 @@ def _run_status_cmd(args):
     print("next vision phase would: {0} ({1})".format(decision, reason))
 
 
+# issue #48: vision failure tolerance. A frame is "failed" when both the primary
+# and fallback model leave its description empty. Historically a single failed
+# frame halted the whole run (zero-tolerance) — fine interactively, fragile for a
+# 481-frame overnight run where one transient Ollama hiccup kills the night.
+#   --max-failures N : tolerate N cumulative failed frames, halt once exceeded
+#                      (N=0, the default, preserves the historical behaviour).
+#   --skip-failed    : never halt on frame failures; leave them empty (so a later
+#                      --vision-only re-picks them) and report the list at the end.
+# A consecutive-failure guard fires regardless of the above: this many frames
+# failing in a row (whole files producing nothing) means Ollama is down, so we
+# halt fast instead of spinning all night writing the same error.
+_VISION_CONSECUTIVE_HALT = 20
+
+
+def _describe_frames_with_fallback(frame_paths):
+    """Primary vision model, then minicpm-v fallback for any failed frame.
+
+    Returns (frame_results, still_failed_indices). Shared by --vision-only and the
+    main Phase-2 loop so both get identical describe → fallback → tolerance logic.
+    """
+    frame_results = vis.describe_frames(frame_paths)
+    failed_indices = [i for i, vr in enumerate(frame_results) if vr.get("error") or not vr.get("description")]
+    if failed_indices:
+        print(f" [Phase 1: {len(failed_indices)} failed, trying fallback]", end="", flush=True)
+        fallback_model = "minicpm-v:latest"
+        original_model = vis.VISION_MODEL
+        try:
+            vis.VISION_MODEL = fallback_model
+            retry_results = vis.describe_frames([frame_paths[i] for i in failed_indices])
+            for idx, retry_r in zip(failed_indices, retry_results):
+                if retry_r.get("description") and not retry_r.get("error"):
+                    frame_results[idx] = retry_r
+        finally:
+            vis.VISION_MODEL = original_model
+    still_failed = [i for i, vr in enumerate(frame_results) if vr.get("error") or not vr.get("description")]
+    return frame_results, still_failed
+
+
+def _vision_halt_decision(file_failed, file_total, total_failed, consecutive_failed,
+                          max_failures, skip_failed):
+    """Decide whether to halt after a file with `file_failed`/`file_total` still-failing
+    frames. Returns (should_halt, reason); reason is "" when continuing.
+
+    Order matters: the consecutive-failure guard is checked first and ignores the
+    tolerance flags — an Ollama outage must stop an unattended run even under
+    --skip-failed.
+    """
+    if consecutive_failed >= _VISION_CONSECUTIVE_HALT:
+        return True, "{0} consecutive frame failures — Ollama likely down / model crash".format(consecutive_failed)
+    if skip_failed:
+        return False, ""
+    if total_failed > max_failures:
+        return True, "{0} failed frame(s) exceeded --max-failures={1}".format(total_failed, max_failures)
+    return False, ""
+
+
 def _run_vision_only(args):
     """Resume vision: only process frames with empty descriptions."""
     import time as _time
@@ -715,7 +771,11 @@ def _run_vision_only(args):
     _unload_ollama_model("qwen2.5:14b")
     _ensure_vision_ready()
 
+    max_failures = getattr(args, "max_failures", 0) or 0
+    skip_failed = getattr(args, "skip_failed", False)
     ok, halted = 0, False
+    total_failed, consecutive_failed = 0, 0
+    failed_files = []  # (fname, failed_count, frame_count) for the end-of-run report
     for vi, (mid, frames_list) in enumerate(media_frames.items(), 1):
         fname = frames_list[0]["filename"]
         frame_paths = [db.resolve_path(f["thumbnail_path"]) for f in frames_list]
@@ -723,38 +783,11 @@ def _run_vision_only(args):
         print(f"[{vi}/{len(media_frames)}] {fname} ({len(frame_paths)} frames) >vision", end="", flush=True)
         v_start = _time.time()
 
-        # Phase 1: primary vision model
-        frame_results = vis.describe_frames(frame_paths)
-        failed_indices = [i for i, vr in enumerate(frame_results) if vr.get("error") or not vr.get("description")]
+        frame_results, still_failed_idx = _describe_frames_with_fallback(frame_paths)
 
-        # Phase 2: fallback model for failed frames
-        if failed_indices:
-            print(f" [Phase 1: {len(failed_indices)} failed, trying fallback]", end="", flush=True)
-            fallback_model = "minicpm-v:latest"
-            original_model = vis.VISION_MODEL
-            try:
-                vis.VISION_MODEL = fallback_model
-                retry_paths = [frame_paths[i] for i in failed_indices]
-                retry_results = vis.describe_frames(retry_paths)
-                for idx, retry_r in zip(failed_indices, retry_results):
-                    if retry_r.get("description") and not retry_r.get("error"):
-                        frame_results[idx] = retry_r
-            finally:
-                vis.VISION_MODEL = original_model
-
-        # Check if still failing after both phases
-        still_failed = sum(1 for vr in frame_results if vr.get("error") or not vr.get("description"))
-        if still_failed:
-            remaining = len(media_frames) - vi
-            print(f"\n\n{'!'*60}")
-            print(f"VISION HALTED: {still_failed}/{len(frame_paths)} frames failed on {fname} (both models)")
-            print(f"  Completed: {ok}  |  Remaining: {remaining}")
-            print(f"  Fix Ollama, then re-run: py -3.12 ingest.py --dir {args.dir} --vision-only")
-            print(f"{'!'*60}\n")
-            halted = True
-            break
-
-        # Write to DB
+        # Commit now — successful frames get descriptions; failed frames keep their
+        # empty description (so a later --vision-only re-picks exactly them). Work is
+        # never lost, even on a file we may halt after.
         with db.get_conn() as conn:
             for f_info, vr in zip(frames_list, frame_results):
                 desc = vr.get("description", "")
@@ -799,11 +832,41 @@ def _run_vision_only(args):
                 )
 
         v_elapsed = _time.time() - v_start
-        print(f" [{v_elapsed:.1f}s] [OK]")
-        ok += 1
+        n_failed = len(still_failed_idx)
+        if n_failed:
+            total_failed += n_failed
+            # Only a *whole* file producing nothing counts toward the Ollama-down
+            # streak; a partial failure (some frames succeeded) resets it.
+            consecutive_failed = consecutive_failed + n_failed if n_failed == len(frame_paths) else 0
+            failed_files.append((fname, n_failed, len(frame_paths)))
+            print(f" [{v_elapsed:.1f}s] [{n_failed}/{len(frame_paths)} FAILED]")
+            should_halt, reason = _vision_halt_decision(
+                n_failed, len(frame_paths), total_failed, consecutive_failed, max_failures, skip_failed)
+            if should_halt:
+                remaining = len(media_frames) - vi
+                print(f"\n\n{'!'*60}")
+                print(f"VISION HALTED: {reason}")
+                print(f"  Completed: {ok}  |  Remaining: {remaining}  |  Failed frames: {total_failed}")
+                print(f"  Fix Ollama, then resume: py -3.12 ingest.py --vision-only")
+                print(f"  (skip persistent failures: add --skip-failed)")
+                print(f"{'!'*60}\n")
+                halted = True
+                break
+        else:
+            consecutive_failed = 0
+            print(f" [{v_elapsed:.1f}s] [OK]")
+            ok += 1
 
+    if failed_files:
+        total = sum(n for _, n, _ in failed_files)
+        print(f"\n⚠ {total} frame(s) across {len(failed_files)} file(s) left empty (re-run --vision-only to retry just those):")
+        for fn, n, tot in failed_files[:20]:
+            print(f"    {fn}: {n}/{tot}")
+        if len(failed_files) > 20:
+            print(f"    … and {len(failed_files) - 20} more file(s)")
     if not halted:
-        print(f"\nVision-only done. {ok} files patched.")
+        suffix = f", {len(failed_files)} with skipped frames." if failed_files else "."
+        print(f"\nVision-only done. {ok} file(s) fully patched{suffix}")
     return halted
 
 
@@ -1030,6 +1093,8 @@ def main():
     parser.add_argument("--skip-vision", action="store_true", help="Skip llava frame description")
     parser.add_argument("--refresh", action="store_true", help="Re-process already-indexed files (thumbnail + vision)")
     parser.add_argument("--vision-only", action="store_true", help="Only run vision on frames with empty descriptions (resume after halt)")
+    parser.add_argument("--max-failures", type=int, default=0, metavar="N", help="issue #48: tolerate N cumulative failed frames before halting vision (0=halt on first, the default). Failed frames are left empty for a later --vision-only retry.")
+    parser.add_argument("--skip-failed", action="store_true", help="issue #48: never halt on individual frame vision failures — skip them (left empty for retry), report at end. Recommended for large unattended/overnight runs. A whole-Ollama outage still halts fast.")
     parser.add_argument(
         "--migrate-relative",
         action="store_true",
@@ -1280,8 +1345,14 @@ def main():
     # Initialized unconditionally so the exit-code logic can read them even when
     # Phase 2 doesn't run (was a fragile locals().get("vision_fail", 0) hack).
     vision_ok = vision_fail = 0
-    consecutive_vision_fail = 0  # halt-on-N-consecutive (Phase 6 / R6)
+    consecutive_vision_fail = 0  # halt-on-N-consecutive whole-file EXCEPTIONS (Phase 6 / R6)
     vision_halted = False
+    # issue #48: frame-failure tolerance (see _vision_halt_decision). Default 0 /
+    # False = historical zero-tolerance halt.
+    max_failures = getattr(args, "max_failures", 0) or 0
+    skip_failed = getattr(args, "skip_failed", False)
+    total_failed, consecutive_empty_frames = 0, 0
+    vision_failed_files = []  # (fname, failed_count, frame_count)
     if phase1_results:
         print(f"\n{'─'*60}")
         print(f"Phase 2: Vision — {len(phase1_results)} files, unloading LLM to free VRAM...")
@@ -1297,43 +1368,8 @@ def main():
             v_start = _time.time()
             try:
                 frame_paths = [db.resolve_path(fd["thumbnail_path"]) for fd in video_frames]
-                # Phase 2a: primary vision model
-                frame_results = vis.describe_frames(frame_paths)
-                failed_indices = [i for i, vr in enumerate(frame_results) if vr.get("error") or not vr.get("description")]
-
-                # Phase 2b: fallback model for failed frames
-                if failed_indices:
-                    print(f" [Phase 2a: {len(failed_indices)} failed, trying fallback]", end="", flush=True)
-                    fallback_model = "minicpm-v:latest"
-                    original_model = vis.VISION_MODEL
-                    try:
-                        vis.VISION_MODEL = fallback_model
-                        retry_paths = [frame_paths[i] for i in failed_indices]
-                        retry_results = vis.describe_frames(retry_paths)
-                        for idx, retry_r in zip(failed_indices, retry_results):
-                            if retry_r.get("description") and not retry_r.get("error"):
-                                frame_results[idx] = retry_r
-                    finally:
-                        vis.VISION_MODEL = original_model
-
+                frame_results, still_failed_idx = _describe_frames_with_fallback(frame_paths)
                 scores = _apply_vision_to_frame_data(video_frames, frame_results)
-
-                # Vision fail after both phases → halt
-                still_failed = sum(1 for vr in frame_results if vr.get("error") or not vr.get("description"))
-                if still_failed:
-                    # Count the halt as a failure so the exit code is nonzero —
-                    # otherwise a halt on the first file left vision_fail=0 →
-                    # implicit exit 0, hiding a fully-unindexed library from cron.
-                    vision_fail += 1
-                    vision_halted = True
-                    remaining = len(phase1_results) - vi
-                    print(f"\n\n{'!'*60}")
-                    print(f"VISION HALTED: {still_failed}/{len(video_frames)} frames failed on {fname} (both models)")
-                    print(f"  Completed: {vision_ok}  |  Remaining: {remaining}")
-                    print(f"  Fix Ollama, then resume with:")
-                    print(f"    py -3.12 ingest.py --dir <path> --vision-only")
-                    print(f"{'!'*60}\n")
-                    break
 
                 # Update DB: frames + media.frame_tags + auto tags.
                 # audit L2: the frame/media UPDATEs and the tag clear+rewrite
@@ -1394,16 +1430,45 @@ def main():
                                     db.add_tag(mid, tag_name, source="auto", _conn=conn)
 
                 v_elapsed = _time.time() - v_start
-                print(f" [{v_elapsed:.1f}s] [OK]")
-                vision_ok += 1
-                consecutive_vision_fail = 0  # reset streak on success
+                consecutive_vision_fail = 0  # reset EXCEPTION streak: file processed without raising
+                n_failed = len(still_failed_idx)
+                if n_failed:
+                    # issue #48: some frames still empty after both models. The
+                    # successful frames were already committed above; the failed
+                    # ones keep empty descriptions so a later --vision-only retries
+                    # exactly them. Tolerate / halt per the policy.
+                    # NOT counted in vision_fail: that drives sys.exit(1) (line ~1600),
+                    # and a tolerated/skipped frame must leave the exit code 0 when the
+                    # run completes — matching --vision-only (where only a halt exits 1).
+                    # vision_fail stays reserved for whole-file EXCEPTIONS below.
+                    total_failed += n_failed
+                    consecutive_empty_frames = consecutive_empty_frames + n_failed if n_failed == len(video_frames) else 0
+                    vision_failed_files.append((fname, n_failed, len(video_frames)))
+                    print(f" [{v_elapsed:.1f}s] [{n_failed}/{len(video_frames)} FAILED]")
+                    should_halt, reason = _vision_halt_decision(
+                        n_failed, len(video_frames), total_failed, consecutive_empty_frames, max_failures, skip_failed)
+                    if should_halt:
+                        vision_halted = True
+                        remaining = len(phase1_results) - vi
+                        print(f"\n\n{'!'*60}")
+                        print(f"VISION HALTED: {reason}")
+                        print(f"  Completed: {vision_ok}  |  Remaining: {remaining}  |  Failed frames: {total_failed}")
+                        print(f"  Fix Ollama, then resume: py -3.12 ingest.py --vision-only")
+                        print(f"  (skip persistent failures: add --skip-failed)")
+                        print(f"{'!'*60}\n")
+                        break
+                else:
+                    consecutive_empty_frames = 0
+                    print(f" [{v_elapsed:.1f}s] [OK]")
+                    vision_ok += 1
             except Exception as e:
                 print(f" [ERROR: {e}]")
                 vision_fail += 1
                 consecutive_vision_fail += 1
-                # Halt on consecutive failures (likely Ollama disconnect / model crash).
-                # Symmetric with still_failed halt above — don't burn through every file
-                # writing the same error 200 times.
+                # Halt on consecutive whole-file EXCEPTIONS (likely Ollama disconnect
+                # / model crash). Distinct from the empty-description streak above —
+                # this is describe_frames itself raising. Don't burn through every
+                # file writing the same error 200 times.
                 if consecutive_vision_fail >= 3:
                     vision_halted = True
                     remaining = len(phase1_results) - vi
@@ -1415,7 +1480,15 @@ def main():
                     print(f"{'!'*60}\n")
                     break
 
-        print(f"Vision done. OK={vision_ok}  fail={vision_fail}")
+        if vision_failed_files and not vision_halted:
+            total = sum(n for _, n, _ in vision_failed_files)
+            print(f"\n⚠ {total} frame(s) across {len(vision_failed_files)} file(s) left empty (re-run --vision-only to retry):")
+            for fn, n, tot in vision_failed_files[:20]:
+                print(f"    {fn}: {n}/{tot}")
+            if len(vision_failed_files) > 20:
+                print(f"    … and {len(vision_failed_files) - 20} more file(s)")
+        skipped_frames = sum(n for _, n, _ in vision_failed_files)
+        print(f"Vision done. OK={vision_ok}  exceptions={vision_fail}  skipped_frames={skipped_frames}")
     elif need_vision and ok == 0 and failed > 0:
         # Phase 1 全 fail → Phase 2 沒檔可跑（不是「沒新檔」是「上游全炸」）
         print(f"\nPhase 2 skipped: phase 1 had {failed}/{len(files)} failures, no frames to process.")

--- a/tests/test_vision_tolerance.py
+++ b/tests/test_vision_tolerance.py
@@ -1,0 +1,154 @@
+"""Tests for issue #48 — vision frame-failure tolerance.
+
+The vision phase used to halt the entire run on the first frame that failed both
+the primary and fallback model (zero-tolerance). For a 481-frame overnight run a
+single transient Ollama hiccup killed the night. `--max-failures N` / `--skip-failed`
+add tolerance while a consecutive-failure guard preserves fail-fast on a real outage.
+"""
+import importlib
+import types
+
+import pytest
+
+
+# ── Policy unit tests: _vision_halt_decision ────────────────────────────────
+@pytest.fixture
+def ing():
+    return importlib.import_module("ingest")
+
+
+def _decide(ing, total, consecutive, max_failures=0, skip_failed=False, file_failed=1, file_total=1):
+    return ing._vision_halt_decision(file_failed, file_total, total, consecutive, max_failures, skip_failed)
+
+
+def test_default_zero_tolerance_halts_on_first_failure(ing):
+    halt, reason = _decide(ing, total=1, consecutive=1, max_failures=0)
+    assert halt is True
+    assert "max-failures=0" in reason
+
+
+def test_max_failures_tolerates_up_to_n_then_halts(ing):
+    assert _decide(ing, total=3, consecutive=1, max_failures=3)[0] is False  # at the limit → continue
+    assert _decide(ing, total=4, consecutive=1, max_failures=3)[0] is True   # over the limit → halt
+
+
+def test_skip_failed_never_halts_on_frame_failures(ing):
+    halt, _ = _decide(ing, total=999, consecutive=1, skip_failed=True)
+    assert halt is False
+
+
+def test_consecutive_guard_fires_at_threshold(ing):
+    k = ing._VISION_CONSECUTIVE_HALT
+    assert _decide(ing, total=k, consecutive=k - 1, max_failures=10_000)[0] is False
+    halt, reason = _decide(ing, total=k, consecutive=k, max_failures=10_000)
+    assert halt is True
+    assert "consecutive" in reason
+
+
+def test_consecutive_guard_overrides_skip_failed(ing):
+    # An Ollama outage must stop even an explicit --skip-failed run.
+    k = ing._VISION_CONSECUTIVE_HALT
+    halt, reason = _decide(ing, total=k, consecutive=k, skip_failed=True)
+    assert halt is True
+    assert "consecutive" in reason
+
+
+# ── _describe_frames_with_fallback ──────────────────────────────────────────
+def _install_fake_vision(ing, monkeypatch):
+    """describe_frames mock keyed on path tokens. Reads vis.VISION_MODEL so the
+    fallback pass can rescue a TFAIL (transient) frame but not a PFAIL one."""
+    def fake(paths):
+        out = []
+        for p in paths:
+            ps = str(p)
+            is_fallback = "minicpm" in (ing.vis.VISION_MODEL or "")
+            if "PFAIL" in ps:
+                out.append({"description": ""})                       # both models fail
+            elif "TFAIL" in ps and not is_fallback:
+                out.append({"description": ""})                       # primary fails
+            else:
+                out.append({"description": "desc:" + ps, "tags": ["t"]})
+        return out
+    monkeypatch.setattr(ing.vis, "describe_frames", fake)
+
+
+def test_fallback_rescues_transient_not_persistent(ing, monkeypatch):
+    _install_fake_vision(ing, monkeypatch)
+    results, still_failed = ing._describe_frames_with_fallback(
+        ["ok_0.jpg", "TFAIL_1.jpg", "PFAIL_2.jpg"])
+    assert still_failed == [2]                       # only the persistent one remains failed
+    assert results[0]["description"].startswith("desc:")
+    assert results[1]["description"].startswith("desc:")  # transient rescued by fallback
+    assert not results[2].get("description")
+
+
+# ── Integration: _run_vision_only tolerance + resumability ──────────────────
+@pytest.fixture
+def vision_db(tmp_db, monkeypatch):
+    """A DB with one media + N frames (empty descriptions, thumbnail set) plus the
+    Ollama-touching helpers stubbed out. Returns (ing, db, mid, make_frames)."""
+    ing = importlib.import_module("ingest")
+    db = importlib.import_module("db")
+    monkeypatch.setattr(ing, "_unload_ollama_model", lambda *a, **k: None)
+    monkeypatch.setattr(ing, "_ensure_vision_ready", lambda *a, **k: None)
+    _install_fake_vision(ing, monkeypatch)
+
+    def make(thumb_names):
+        db.upsert({"path": "clip.mp4", "filename": "clip.mp4", "ext": ".mp4"})
+        with db.get_conn() as c:
+            mid = c.execute("SELECT id FROM media WHERE path=?", ("clip.mp4",)).fetchone()["id"]
+        for i, name in enumerate(thumb_names):
+            db.upsert_frame(mid, i, float(i), thumbnail_path=name, description="")
+        return mid
+    return ing, db, make
+
+
+def _args(**kw):
+    base = {"max_failures": 0, "skip_failed": False, "dir": None}
+    base.update(kw)
+    return types.SimpleNamespace(**base)
+
+
+def _desc_count(db, mid):
+    with db.get_conn() as c:
+        done = c.execute("SELECT COUNT(*) AS n FROM frames WHERE media_id=? AND description<>''", (mid,)).fetchone()["n"]
+        empty = c.execute("SELECT COUNT(*) AS n FROM frames WHERE media_id=? AND (description IS NULL OR description='')", (mid,)).fetchone()["n"]
+    return done, empty
+
+
+def test_default_halts_on_persistent_failure(vision_db):
+    ing, db, make = vision_db
+    mid = make(["ok_0.jpg", "PFAIL_1.jpg", "ok_2.jpg"])
+    halted = ing._run_vision_only(_args())          # default zero-tolerance
+    assert halted is True
+
+
+def test_skip_failed_completes_and_leaves_failures_empty(vision_db):
+    ing, db, make = vision_db
+    mid = make(["ok_0.jpg", "PFAIL_1.jpg", "ok_2.jpg", "PFAIL_3.jpg"])
+    halted = ing._run_vision_only(_args(skip_failed=True))
+    assert halted is False                          # never halts on frame failures
+    done, empty = _desc_count(db, mid)
+    assert done == 2                                # the two ok frames described
+    assert empty == 2                               # the two PFAIL frames left empty → resumable
+
+
+def test_skip_failed_resumable_picks_up_only_failed(vision_db):
+    """After a skip-failed run, the failed frames still satisfy the --vision-only
+    'empty description' query — i.e. a re-run retries exactly them."""
+    ing, db, make = vision_db
+    mid = make(["ok_0.jpg", "PFAIL_1.jpg"])
+    ing._run_vision_only(_args(skip_failed=True))
+    with db.get_conn() as c:
+        resumable = c.execute(
+            "SELECT frame_index FROM frames WHERE media_id=? AND (description IS NULL OR description='') "
+            "AND thumbnail_path IS NOT NULL", (mid,)).fetchall()
+    assert [r["frame_index"] for r in resumable] == [1]   # only the PFAIL frame
+
+
+def test_max_failures_tolerates_then_halts(vision_db):
+    ing, db, make = vision_db
+    # 3 persistent failures across one file; max_failures=2 → exceeded → halt.
+    mid = make(["PFAIL_0.jpg", "PFAIL_1.jpg", "PFAIL_2.jpg"])
+    halted = ing._run_vision_only(_args(max_failures=2))
+    assert halted is True


### PR DESCRIPTION
## 摘要
Closes #48. Vision phase 的 zero-tolerance halt（單一 frame 主+備兩家失敗即停整個 run）對大語料 overnight 太脆——這次 ingest53 481-frame 補跑就 halt 在 153/481（2 個 transient 失敗），靠外部 orchestrator 繞過。本 PR 內建容忍。

## 行為
| flag | 行為 |
|---|---|
| (default `--max-failures 0`) | 歷史零容忍：第一個失敗就 halt + exit 1 |
| `--max-failures N` | 容忍 N 個累計失敗 frame，超過才 halt |
| `--skip-failed` | 永不因單 frame 失敗 halt;失敗 frame 留空（`--vision-only` 之後重試)、結束列清單 |
| consecutive guard（恆開） | 整檔全空連續 ≥20 frame = Ollama down → 快速 halt（即使 `--skip-failed`),保留 fail-fast |

## 關鍵正確性
- 失敗 frame **留空 description、絕不寫 sentinel** → 真正 resumable（`--vision-only` 的「empty description」查詢精準撈回）
- 成功 frame **即使在會 halt 的檔也先 commit** → 不丟工作
- 容忍/skip 的失敗 **exit code 維持 0**（只有 halt 才 exit 1),`--vision-only` 與主 Phase-2 一致
- `--vision-only` 與主 Phase-2 統一走 `_describe_frames_with_fallback` + `_vision_halt_decision`(原本重複且 halt 邏輯歧異)

## 測試
- 10 條新測（policy 5 + fallback 1 + 整合/resumability 4）
- 全套 **488 pass / 5 skip**
- **Codex(GPT-5) read-only 審查:CLEAN**

🤖 Generated with [Claude Code](https://claude.com/claude-code)