### PR TITLE
feat(offload): DIT card-watcher — --watch auto-offload on insert (DIT wrapper ②)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 ## Unreleased
 
+### Added
+- **DIT card-watcher (`offload.py --watch`).** Waits for a camera card to mount, then auto-offloads it — copy + hash-verify + MHL, **never deletes the source** — with the `--organize` naming policy. A card is a newly-mounted volume with a `DCIM/` folder or media files; only NEW inserts trigger (already-plugged disks at startup are the baseline and ignored), and a removed→reinserted card re-triggers. One failed offload is logged and the watch loop survives. The "insert → it just copies" half of the Gate replacement, paired with the `--organize` folder policy. Requires at least one `--dst`. Tests in `tests/test_offload_card_watch.py`.
+
 ### Fixed
 - **`--refresh` now actually re-extracts thumbnails + frames (issue #53).** It used to re-run vision/embed but reuse cached frame thumbnails (the `already_ok` check skipped extraction whenever a file existed), so a change to the extraction logic itself — e.g. the Phase 8.3b 360 reproject — never re-applied to already-ingested clips; they kept their stale raw-fisheye frames. `--refresh` now threads `force=True` down to frame/thumbnail extraction. Re-extraction is atomic (ffmpeg writes a temp sibling, `os.replace` onto the canonical file only on success), so a forced re-extract that times out / fails can't destroy the prior good thumbnail while the DB still points at it. Non-refresh ingest still reuses existing thumbnails (cheap re-ingest, unchanged).
 

--- a/offload.py
+++ b/offload.py
@@ -8,6 +8,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 import unicodedata
 from datetime import datetime, timezone
 from pathlib import Path
@@ -528,10 +529,143 @@ def run_offload(src, dsts, hash_algo=DEFAULT_HASH, include_heic=False, resume=No
     return exit_code, summary, state_path
 
 
+# ── card-watcher (DIT wrapper ②) ────────────────────────────────────────────
+# `--watch --dst X [--organize T]` waits for a camera card to mount, then offloads
+# it automatically (copy + hash-verify + MHL, never deletes the source) with the ①
+# naming policy. The engine layer's "insert → it just copies" half of the Gate
+# replacement. A card is a freshly-mounted volume with a DCIM/ folder or media files;
+# only NEW mounts (vs the baseline at start) trigger, so already-plugged disks don't.
+_CARD_MEDIA_EXTS = {
+    ".mp4", ".mov", ".m4v", ".mts", ".mxf", ".avi", ".insv", ".360",  # video
+    ".braw", ".r3d", ".ari",                                          # cinema raw
+    ".jpg", ".jpeg", ".heic", ".dng", ".arw", ".cr2", ".cr3", ".nef", ".raf",  # stills
+    ".wav", ".aif", ".aiff",                                          # audio
+}
+
+
+def _looks_like_card(mountpoint):
+    """True if a mountpoint looks like a camera card: the universal DCIM/ folder, or
+    media files in a shallow scan. Never raises."""
+    try:
+        if os.path.isdir(os.path.join(mountpoint, "DCIM")):
+            return True
+        scanned = 0
+        for entry in os.scandir(mountpoint):
+            if entry.is_file(follow_symlinks=False) and \
+               os.path.splitext(entry.name)[1].lower() in _CARD_MEDIA_EXTS:
+                return True
+            scanned += 1
+            if scanned > 200:  # shallow — don't walk a huge disk root
+                break
+    except OSError:
+        return False
+    return False
+
+
+def _media_volumes(_partitions=None):
+    """Currently-mounted volumes that look like camera cards. `_partitions` is an
+    injection point for tests; defaults to psutil.disk_partitions()."""
+    parts = _partitions
+    if parts is None:
+        try:
+            import psutil
+            parts = [p.mountpoint for p in psutil.disk_partitions(all=False)]
+        except Exception:
+            return set()
+    out = set()
+    for mp in parts:
+        # skip the obvious system roots; cards mount under /Volumes (mac), a drive
+        # letter (Windows), or /media|/mnt (Linux) — the new-mount diff also guards this
+        if not mp or mp in ("/",) or os.path.normpath(mp) == os.path.normpath(os.path.expanduser("~")):
+            continue
+        if os.path.isdir(mp) and _looks_like_card(mp):
+            out.add(os.path.normpath(mp))
+    return out
+
+
+def _all_mounts(_partitions=None):
+    """All current mountpoints (no card filter), normpath'd. Test seam via _partitions."""
+    parts = _partitions
+    if parts is None:
+        try:
+            import psutil
+            parts = [p.mountpoint for p in psutil.disk_partitions(all=False)]
+        except Exception:
+            return set()
+    return {os.path.normpath(p) for p in parts if p}
+
+
+def run_card_watch(dsts, organize=None, interval=3.0, hash_algo=DEFAULT_HASH,
+                   include_heic=False, retry_limit=DEFAULT_RETRY_LIMIT, verify=True,
+                   emit_mhl=True, once=False, _loops=None, _list_fn=None, _mounts_fn=None):
+    """Poll for newly-appeared camera cards and offload each to ``dsts`` with the ①
+    naming policy. Returns the list of (volume, exit_code) handled (for tests).
+    Copy-only — never touches the source card. `once`/`_loops`/`_list_fn`/`_mounts_fn`
+    are test seams.
+
+    A volume is offloaded once per continuous mount: ``handled`` is pruned by the RAW
+    mount set (not the card-detection result), so a transient _looks_like_card() miss
+    on a still-plugged card can't re-trigger an offload (Codex). Only an unplug→replug
+    (the path leaving the raw mount set) re-arms it."""
+    if not dsts:
+        raise ValueError("--watch requires at least one --dst")
+    if organize:
+        _validate_organize_template(organize)
+    list_fn = _list_fn or _media_volumes
+    mounts_fn = _mounts_fn or _all_mounts
+    # Baseline: every volume mounted at startup is ignored — only new inserts trigger.
+    handled = set(mounts_fn())
+    print("Watching for camera cards… dst={0} organize={1} (already-mounted ignored)".format(
+        list(dsts), organize or "mirror"))
+    results = []
+    i = 0
+    while True:
+        try:
+            raw = set(mounts_fn())
+            cards = set(list_fn())
+        except Exception as exc:
+            print("[card-watch] volume scan error: {0}".format(exc))
+            raw, cards = set(), set()
+        if not raw:
+            # A real system always has at least one mount ("/"), so an empty raw set
+            # means the probe transiently failed (or raised above). Treat it as "no
+            # information": keep `handled` intact and skip this cycle, rather than
+            # pruning everything and re-offloading still-mounted cards (Codex).
+            i += 1
+            if once or (_loops is not None and i >= _loops):
+                break
+            time.sleep(interval)
+            continue
+        handled &= raw  # forget unmounted volumes → a replug re-arms; a flicker does not
+        for vol in sorted(cards - handled):
+            print("\n[card-watch] detected card: {0} → offloading (copy + verify + MHL)".format(vol))
+            handled.add(vol)  # mark before running so a slow offload can't double-fire
+            try:
+                code, _summary, _sp = run_offload(
+                    vol, dsts, hash_algo=hash_algo, include_heic=include_heic,
+                    retry_limit=retry_limit, verify=verify, emit_mhl=emit_mhl,
+                    organize=organize)
+                print("[card-watch] {0} done (exit {1})".format(vol, code))
+                results.append((vol, code))
+            except Exception as exc:
+                print("[card-watch] offload failed for {0}: {1}".format(vol, exc))
+                results.append((vol, 1))
+        i += 1
+        if once or (_loops is not None and i >= _loops):
+            break
+        time.sleep(interval)
+    return results
+
+
 def build_parser():
     parser = argparse.ArgumentParser(description="arkiv offload")
-    parser.add_argument("--src", required=True)
+    parser.add_argument("--src", default=None, help="Source card / directory (required unless --watch)")
     parser.add_argument("--dst", action="append", required=True)
+    parser.add_argument("--watch", action="store_true",
+                        help="DIT wrapper ②: wait for a camera card to mount, then auto-offload it "
+                             "(copy + verify + MHL, never deletes the source) with --organize. "
+                             "Already-mounted volumes are ignored; only new inserts trigger.")
+    parser.add_argument("--interval", type=float, default=3.0, help="--watch poll seconds (default 3)")
     parser.add_argument("--hash", dest="hash_algo", default="xxh3", choices=["xxh3", "md5", "sha1", "sha256"])
     parser.add_argument("--no-verify", action="store_true")
     parser.add_argument("--no-mhl", action="store_true")
@@ -553,6 +687,22 @@ def build_parser():
 def main(argv=None):
     parser = build_parser()
     args = parser.parse_args(argv)
+    if args.watch:
+        try:
+            run_card_watch(
+                args.dst, organize=args.organize, interval=args.interval,
+                hash_algo=args.hash_algo, include_heic=args.include_heic,
+                retry_limit=args.retry_limit, verify=not args.no_verify,
+                emit_mhl=not args.no_mhl)
+        except ValueError as exc:
+            print(str(exc))
+            return 4
+        except KeyboardInterrupt:
+            print("\n[card-watch] stopped")
+        return 0
+    if not args.src:
+        print("--src is required (or use --watch)")
+        return 4
     try:
         code, summary, state_path = run_offload(
             args.src,

--- a/tests/test_offload_card_watch.py
+++ b/tests/test_offload_card_watch.py
@@ -1,0 +1,133 @@
+"""Tests for the DIT card-watcher — offload.py --watch (DIT wrapper ②).
+
+`--watch --dst X [--organize T]` waits for a camera card to mount and auto-offloads
+it (copy + verify + MHL, never deletes the source) with the ① naming policy. Only
+NEW inserts trigger; already-mounted volumes are ignored.
+"""
+import importlib
+import os
+
+import pytest
+
+offload = importlib.import_module("offload")
+
+
+# ── _looks_like_card ────────────────────────────────────────────────────────
+def test_looks_like_card_dcim(tmp_path):
+    (tmp_path / "DCIM").mkdir()
+    assert offload._looks_like_card(str(tmp_path)) is True
+
+
+def test_looks_like_card_media_file(tmp_path):
+    (tmp_path / "C0001.MP4").write_bytes(b"x")
+    assert offload._looks_like_card(str(tmp_path)) is True
+
+
+def test_looks_like_card_no_media_is_false(tmp_path):
+    (tmp_path / "readme.txt").write_text("hi")
+    assert offload._looks_like_card(str(tmp_path)) is False
+
+
+def test_looks_like_card_missing_path_is_false():
+    assert offload._looks_like_card("/no/such/mount") is False
+
+
+# ── _media_volumes (injected partition list) ────────────────────────────────
+def test_media_volumes_filters_system_and_non_cards(tmp_path):
+    card = tmp_path / "CARD"; (card / "DCIM").mkdir(parents=True)
+    plain = tmp_path / "PLAIN"; plain.mkdir()
+    vols = offload._media_volumes(_partitions=[str(card), str(plain), "/"])
+    assert os.path.normpath(str(card)) in vols
+    assert os.path.normpath(str(plain)) not in vols   # no DCIM / media
+    assert "/" not in vols                            # system root skipped
+
+
+# ── run_card_watch ──────────────────────────────────────────────────────────
+def _seq(*states):
+    it = iter(states)
+    return lambda: next(it)
+
+
+# Real systems always have at least "/" mounted; a card coexists with it. (An
+# *empty* raw set means the probe failed, not "everything unplugged".)
+_SYS = "/"
+
+
+def test_watch_offloads_new_card(monkeypatch):
+    calls = []
+    monkeypatch.setattr(offload, "run_offload",
+                        lambda vol, dsts, **kw: (calls.append((vol, dsts, kw)), (0, {}, "s"))[1])
+    handled = offload.run_card_watch(
+        ["/dst"], organize="{date}/{camera}", once=True,
+        _mounts_fn=_seq({_SYS}, {_SYS, "/Volumes/CARD"}),  # baseline system-only → CARD mounts
+        _list_fn=_seq({"/Volumes/CARD"}))                  # …and is card-like
+    assert len(calls) == 1
+    vol, dsts, kw = calls[0]
+    assert vol == "/Volumes/CARD"
+    assert dsts == ["/dst"]
+    assert kw["organize"] == "{date}/{camera}"     # ① naming policy threaded through
+    assert handled == [("/Volumes/CARD", 0)]
+
+
+def test_watch_ignores_already_mounted(monkeypatch):
+    calls = []
+    monkeypatch.setattr(offload, "run_offload", lambda *a, **k: (calls.append(1), (0, {}, "s"))[1])
+    offload.run_card_watch(
+        ["/dst"], once=True,
+        _mounts_fn=_seq({_SYS, "/Volumes/CARD"}, {_SYS, "/Volumes/CARD"}),  # mounted at baseline
+        _list_fn=_seq({"/Volumes/CARD"}))
+    assert calls == []                                # baseline card NOT offloaded
+
+
+def test_watch_flicker_does_not_reoffload(monkeypatch):
+    # Codex: a still-mounted card that transiently fails _looks_like_card must NOT
+    # re-offload. handled is pruned by RAW mounts, not the card-detection result.
+    calls = []
+    monkeypatch.setattr(offload, "run_offload", lambda *a, **k: (calls.append(1), (0, {}, "s"))[1])
+    offload.run_card_watch(
+        ["/dst"], interval=0, _loops=2,
+        _mounts_fn=_seq({_SYS}, {_SYS, "/Volumes/CARD"}, {_SYS, "/Volumes/CARD"}),  # stays mounted
+        _list_fn=_seq({"/Volumes/CARD"}, set()))                       # card-like, then flickers off
+    assert len(calls) == 1                            # offloaded once, not twice
+
+
+def test_watch_replug_reoffloads(monkeypatch):
+    calls = []
+    monkeypatch.setattr(offload, "run_offload", lambda *a, **k: (calls.append(1), (0, {}, "s"))[1])
+    offload.run_card_watch(
+        ["/dst"], interval=0, _loops=3,
+        _mounts_fn=_seq({_SYS}, {_SYS, "/Volumes/CARD"}, {_SYS}, {_SYS, "/Volumes/CARD"}),  # plug/unplug/replug
+        _list_fn=_seq({"/Volumes/CARD"}, set(), {"/Volumes/CARD"}))
+    assert len(calls) == 2                            # unplug→replug re-arms → second offload
+
+
+def test_watch_empty_raw_does_not_reoffload(monkeypatch):
+    # Codex edge: a transient EMPTY raw-mount probe must not clear `handled` and
+    # re-offload a still-mounted card. Empty raw → skip the cycle.
+    calls = []
+    monkeypatch.setattr(offload, "run_offload", lambda *a, **k: (calls.append(1), (0, {}, "s"))[1])
+    offload.run_card_watch(
+        ["/dst"], interval=0, _loops=2,
+        _mounts_fn=_seq({_SYS, "/Volumes/CARD"}, set(), {_SYS, "/Volumes/CARD"}),  # card handled, then probe blips empty
+        _list_fn=_seq({"/Volumes/CARD"}, {"/Volumes/CARD"}))
+    assert calls == []                                # baseline-handled card never re-offloaded
+
+
+def test_watch_offload_failure_is_recorded_not_fatal(monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError("copy failed")
+    monkeypatch.setattr(offload, "run_offload", boom)
+    handled = offload.run_card_watch(
+        ["/dst"], once=True,
+        _mounts_fn=_seq({_SYS}, {_SYS, "/Volumes/CARD"}), _list_fn=_seq({"/Volumes/CARD"}))
+    assert handled == [("/Volumes/CARD", 1)]          # failure recorded, didn't crash the loop
+
+
+def test_watch_requires_dst():
+    with pytest.raises(ValueError, match="dst"):
+        offload.run_card_watch([], once=True, _list_fn=lambda: set())
+
+
+def test_watch_validates_organize_template():
+    with pytest.raises(ValueError):
+        offload.run_card_watch(["/dst"], organize="no-tokens", once=True, _list_fn=lambda: set())


### PR DESCRIPTION
## 摘要
DIT wrapper ②（引擎層最後一塊）。`offload.py --watch --dst X [--organize T]` 等卡掛載 → 自動 offload（copy + hash 校驗 + MHL，**永不刪源**）+ ① naming policy。「插卡 → 自動複製」這半,配 ① 的資料夾 policy = Gate 替代品的引擎層完成。

## 行為與安全
- 卡 = 新掛載且有 `DCIM/` 或媒體檔的卷;**只新插觸發**（開機已掛的是 baseline,忽略）
- `handled` 用 **raw mount set** 追蹤+修剪（非 card-detection 結果）→ 卡還插著時偵測 flicker **不重觸發**;只有拔→插重觸發
- **只複製不刪源**（run_offload 語意);單卡失敗只記錄、loop 存活
- 需 ≥1 `--dst`;`--src` 改 optional（非 watch 仍必填）

## 品質
- 13 測（偵測 + 新插 + baseline 忽略 + flicker + replug + empty-raw guard + 失敗隔離）+ 全套 **537 pass**
- **Codex 審抓 2 bug**（偵測 flicker 重 offload / empty raw 清空 state）→ 全修 + 回歸測試鎖住
- 真 psutil 路徑驗（無卡回 set()、系統卷正確過濾）

🤖 Generated with [Claude Code](https://claude.com/claude-code)