### PR TITLE
feat(dit): DIT Offload UI — /dit control panel (preview + run)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 
 ### Added
+- **DIT Offload UI (`/dit`).** A working control panel for the DIT engine: type a source card, destination(s), and an `--organize` template, hit **Preview** to see the exact source→destination layout (read-only, no copy), then **Run** to offload (copy + hash-verify + ascMHL, never deletes the source). New endpoints `POST /api/offload/preview` (pure layout via `offload.preview_layout()`) and `POST /api/offload` (subprocess, mirrors `/api/ingest`; state file scoped to the project's `.arkiv`, not the install dir); page served at `GET /dit`. Verified end-to-end (preview layout + real copy + MHL manifest). Tests in `tests/test_dit_offload_ui.py` + `tests/test_offload_organize.py`. (v1 runs the offload as a blocking request; live progress streaming is a follow-up.)
 - **DIT card-watcher (`offload.py --watch`).** Waits for a camera card to mount, then auto-offloads it — copy + hash-verify + MHL, **never deletes the source** — with the `--organize` naming policy. A card is a newly-mounted volume with a `DCIM/` folder or media files; only NEW inserts trigger (already-plugged disks at startup are the baseline and ignored), and a removed→reinserted card re-triggers. One failed offload is logged and the watch loop survives. The "insert → it just copies" half of the Gate replacement, paired with the `--organize` folder policy. Requires at least one `--dst`. Tests in `tests/test_offload_card_watch.py`.
 
 ### Fixed

--- a/dit-offload.html
+++ b/dit-offload.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>arkiv · DIT Offload</title>
+<style>
+  :root{
+    --bg:#0a0a0c; --surface:#141418; --surface2:#1b1b20; --line:#2a2a31;
+    --text:#e8e8ea; --dim:#8a8a93; --cyan:#18b6dc; --ok:#3ecf8e; --err:#e5604d;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--text);
+    font-family:Inter,-apple-system,"Segoe UI",system-ui,sans-serif;font-size:14px;line-height:1.5}
+  .mono{font-family:"JetBrains Mono",ui-monospace,Menlo,Consolas,monospace}
+  header{padding:22px 28px;border-bottom:1px solid var(--line);display:flex;align-items:baseline;gap:14px}
+  header h1{font-family:"Archivo Black",Inter,sans-serif;font-weight:900;font-size:19px;margin:0;letter-spacing:-.01em}
+  header .sub{color:var(--dim);font-size:12px;letter-spacing:.06em;text-transform:uppercase}
+  main{max-width:1080px;margin:0 auto;padding:28px}
+  .card{background:var(--surface);border:1px solid var(--line);border-radius:10px;padding:22px;margin-bottom:20px}
+  label{display:block;color:var(--dim);font-size:11px;letter-spacing:.08em;text-transform:uppercase;margin:0 0 6px}
+  input[type=text]{width:100%;background:var(--surface2);border:1px solid var(--line);color:var(--text);
+    border-radius:7px;padding:10px 12px;font-size:13px;font-family:"JetBrains Mono",monospace}
+  input[type=text]:focus{outline:none;border-color:var(--cyan)}
+  .row{display:flex;gap:14px;flex-wrap:wrap;margin-bottom:14px}
+  .row > div{flex:1;min-width:240px}
+  .dsts{display:flex;flex-direction:column;gap:8px}
+  .dst-line{display:flex;gap:8px}
+  .chk{display:flex;align-items:center;gap:8px;color:var(--dim);font-size:13px;text-transform:none;letter-spacing:0}
+  button{font-family:Inter,sans-serif;font-size:13px;font-weight:600;border-radius:7px;padding:10px 18px;
+    border:1px solid var(--line);background:var(--surface2);color:var(--text);cursor:pointer}
+  button:hover{border-color:var(--cyan)}
+  button.primary{background:var(--cyan);border-color:var(--cyan);color:#062028}
+  button.ghost{padding:8px 12px}
+  button:disabled{opacity:.45;cursor:not-allowed}
+  .actions{display:flex;gap:12px;align-items:center;margin-top:6px}
+  .hint{color:var(--dim);font-size:12px;margin-top:10px}
+  table{width:100%;border-collapse:collapse;font-size:12.5px}
+  th{text-align:left;color:var(--dim);font-weight:600;font-size:11px;letter-spacing:.06em;text-transform:uppercase;
+    padding:8px 10px;border-bottom:1px solid var(--line)}
+  td{padding:7px 10px;border-bottom:1px solid var(--surface2);vertical-align:top}
+  td.rel{color:var(--cyan)}
+  .arrow{color:var(--dim);padding:0 4px}
+  .status{font-size:13px;margin-top:12px;min-height:20px}
+  .status.ok{color:var(--ok)} .status.err{color:var(--err)} .status.run{color:var(--cyan)}
+  pre{background:var(--surface2);border:1px solid var(--line);border-radius:7px;padding:12px;
+    font-size:11.5px;overflow:auto;max-height:280px;white-space:pre-wrap;color:var(--dim)}
+  .meta{color:var(--dim);font-size:12px;margin:0 0 12px}
+  .pill{display:inline-block;border:1px solid var(--line);border-radius:999px;padding:2px 10px;font-size:11px;color:var(--dim)}
+</style>
+</head>
+<body>
+<header>
+  <h1>arkiv · DIT OFFLOAD</h1>
+  <span class="sub">card → backup · copy + verify + ascMHL · never deletes source</span>
+</header>
+<main>
+  <div class="card">
+    <div class="row">
+      <div>
+        <label>Source 來源卡 / 資料夾</label>
+        <input id="src" type="text" placeholder="/Volumes/CARD  或  /Users/you/footage" spellcheck="false">
+      </div>
+      <div>
+        <label>Organize template（資料夾規則,留空=鏡射原結構）</label>
+        <input id="organize" type="text" placeholder="{date}/{camera}/{reel}" spellcheck="false">
+      </div>
+    </div>
+    <div class="row">
+      <div>
+        <label>Destinations 目的地（一鍵多備份）</label>
+        <div class="dsts" id="dsts">
+          <div class="dst-line"><input type="text" class="dst" placeholder="/Volumes/Backup1" spellcheck="false"><button class="ghost" onclick="addDst()">+</button></div>
+        </div>
+      </div>
+      <div style="flex:0 0 220px">
+        <label>選項</label>
+        <label class="chk"><input type="checkbox" id="heic"> include .heic</label>
+      </div>
+    </div>
+    <div class="actions">
+      <button class="primary" id="previewBtn" onclick="doPreview()">Preview 預覽排版</button>
+      <button id="runBtn" onclick="doRun()" disabled>Run Offload 執行轉存</button>
+      <span class="pill mono">tokens: {date} {camera} {reel} {stem} {ext}</span>
+    </div>
+    <div class="hint">Preview 只讀不複製（顯示每個檔的目的端路徑）。Run 才真的複製 + xxh3 校驗 + 產 ascMHL,<b>絕不刪來源卡</b>。</div>
+    <div class="status" id="status"></div>
+  </div>
+
+  <div class="card" id="layoutCard" style="display:none">
+    <p class="meta mono" id="layoutMeta"></p>
+    <div style="max-height:420px;overflow:auto">
+      <table><thead><tr><th>Source</th><th></th><th>→ Destination (rel)</th><th>MB</th></tr></thead>
+      <tbody id="layoutBody"></tbody></table>
+    </div>
+  </div>
+
+  <div class="card" id="resultCard" style="display:none">
+    <p class="meta">Offload 輸出</p>
+    <pre id="resultOut"></pre>
+  </div>
+</main>
+
+<script>
+function $(id){return document.getElementById(id)}
+function addDst(){
+  const wrap=$('dsts');
+  const line=document.createElement('div'); line.className='dst-line';
+  line.innerHTML='<input type="text" class="dst" placeholder="/Volumes/Backup2" spellcheck="false"><button class="ghost" onclick="this.parentNode.remove()">−</button>';
+  wrap.appendChild(line);
+}
+function dsts(){return [...document.querySelectorAll('.dst')].map(i=>i.value.trim()).filter(Boolean)}
+function setStatus(msg,cls){const s=$('status');s.textContent=msg;s.className='status '+(cls||'')}
+function esc(s){return String(s).replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]))}
+
+async function doPreview(){
+  const src=$('src').value.trim();
+  if(!src){setStatus('請先填來源路徑','err');return}
+  setStatus('預覽中…','run'); $('previewBtn').disabled=true;
+  try{
+    const r=await fetch('/api/offload/preview',{method:'POST',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({src,organize:$('organize').value.trim()||null,include_heic:$('heic').checked})});
+    const d=await r.json();
+    if(!r.ok){setStatus(d.detail||'預覽失敗','err');return}
+    renderLayout(d);
+    setStatus(d.count+' 個檔案 · '+(d.organize?('organize: '+d.organize):'鏡射原結構'),'ok');
+    $('runBtn').disabled = dsts().length===0;
+    if(dsts().length===0) setStatus(d.count+' 個檔案。填一個目的地才能執行。','ok');
+  }catch(e){setStatus('錯誤: '+e,'err')}
+  finally{$('previewBtn').disabled=false}
+}
+
+function renderLayout(d){
+  $('layoutCard').style.display='block';
+  $('layoutMeta').textContent=d.src+'  ('+d.count+' files'+(d.count>=200?', 截斷顯示前 200':'')+')';
+  const b=$('layoutBody'); b.innerHTML='';
+  for(const f of d.files){
+    const name=f.source.split(/[\\/]/).pop();
+    b.insertAdjacentHTML('beforeend',
+      '<tr><td class="mono">'+esc(name)+'</td><td class="arrow">→</td><td class="rel mono">'+esc(f.rel)+'</td><td class="mono">'+(f.size_mb??'')+'</td></tr>');
+  }
+}
+
+async function doRun(){
+  const src=$('src').value.trim(); const dst=dsts();
+  if(!src||dst.length===0){setStatus('需要來源 + 至少一個目的地','err');return}
+  if(!confirm('開始轉存 '+src+'\n→ '+dst.join('\n→ ')+'\n\n(複製 + 校驗 + MHL,不刪來源)')) return;
+  setStatus('轉存中…（複製 + 校驗,可能要數分鐘）','run'); $('runBtn').disabled=true; $('previewBtn').disabled=true;
+  try{
+    const r=await fetch('/api/offload',{method:'POST',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({src,dst,organize:$('organize').value.trim()||null,include_heic:$('heic').checked})});
+    const d=await r.json();
+    $('resultCard').style.display='block';
+    $('resultOut').textContent=(d.stdout||'')+(d.stderr?('\n--- stderr ---\n'+d.stderr):'');
+    setStatus(d.ok?('✓ 轉存完成 (exit '+d.code+')'):('✗ 轉存失敗 (exit '+(d.code??'?')+')'), d.ok?'ok':'err');
+  }catch(e){setStatus('錯誤: '+e,'err')}
+  finally{$('runBtn').disabled=false; $('previewBtn').disabled=false}
+}
+</script>
+</body>
+</html>

--- a/offload.py
+++ b/offload.py
@@ -153,6 +153,33 @@ def _organize_relpath(src_file, template, meta):
     return (folder + "/" + name) if folder else name
 
 
+def preview_layout(src, organize=None, include_heic=False, limit=0):
+    """Return a layout preview without copying anything — powers the DIT Offload UI.
+
+    Result: {"src": <root>, "count": N, "organize": template|None,
+             "files": [{"source": abs, "rel": dest-relpath, "size_mb": f}, ...]}.
+    For --organize each rel is the camera-metadata folder path; otherwise the mirror
+    of the source tree. Pure / read-only (no copy, no state file)."""
+    if organize:
+        _validate_organize_template(organize)
+    src_root = Path(src).expanduser().resolve(strict=False)
+    if not src_root.exists():
+        raise FileNotFoundError("source missing: {0}".format(src_root))
+    files = _collect_sources(src_root, include_heic=include_heic)
+    if limit and limit > 0:
+        files = files[:limit]
+    out = []
+    for f in files:
+        rel = (_organize_relpath(f, organize, _probe_camera_meta(f)) if organize
+               else _normalize_relpath(f, src_root))
+        try:
+            size_mb = round(f.stat().st_size / 1048576, 1)
+        except OSError:
+            size_mb = None
+        out.append({"source": str(f), "rel": rel, "size_mb": size_mb})
+    return {"src": str(src_root), "count": len(out), "organize": organize or None, "files": out}
+
+
 def _validate_organize_template(template):
     if not any(("{" + tok + "}") in template for tok in _ORGANIZE_TOKENS):
         raise ValueError(

--- a/server.py
+++ b/server.py
@@ -1612,6 +1612,98 @@ def ingest_media(
         _release_ingest_slot()
 
 
+# ── DIT Offload (card → backup) — powers the /dit UI ─────────────────────────
+
+class OffloadPreviewRequest(BaseModel):
+    src: str
+    organize: Optional[str] = None
+    include_heic: bool = False
+    limit: int = 200  # cap the preview; a full card can be hundreds of files
+
+
+class OffloadRequest(BaseModel):
+    src: str
+    dst: List[str]
+    organize: Optional[str] = None
+    include_heic: bool = False
+
+
+@app.post("/api/offload/preview")
+def offload_preview(
+    body: OffloadPreviewRequest,
+    _tok: dict = Depends(require_scopes("videos_write")),
+):
+    """Read-only layout preview for the DIT Offload UI — shows source→dest mapping
+    under the --organize template without copying anything."""
+    import offload as _offload
+    src = Path(body.src).expanduser().resolve()
+    if not src.exists():
+        raise HTTPException(400, "來源路徑不存在")
+    # Clamp the limit server-side: it's client-controlled and a 0 / negative / huge
+    # value would otherwise disable the cap and force full enumeration + exiftool +
+    # a giant JSON on a large card (Codex). Always (0, 200].
+    safe_limit = body.limit if 0 < body.limit <= 200 else 200
+    try:
+        return _offload.preview_layout(
+            str(src), organize=body.organize, include_heic=body.include_heic,
+            limit=safe_limit)
+    except ValueError as exc:  # bad --organize template
+        raise HTTPException(400, str(exc))
+    except FileNotFoundError as exc:
+        raise HTTPException(400, str(exc))
+
+
+@app.post("/api/offload")
+def offload_run(
+    body: OffloadRequest,
+    _tok: dict = Depends(require_scopes("videos_write")),
+):
+    """Run a DIT offload (copy + hash-verify + MHL, never deletes source) with the
+    --organize naming policy. Mirrors /api/ingest's subprocess pattern. Source/dest
+    are arbitrary by design (card → backup drives); gated by videos_write (loopback
+    is token-free, a remote read token is refused)."""
+    import subprocess, sys
+    src = Path(body.src).expanduser().resolve()
+    if not src.exists():
+        raise HTTPException(400, "來源路徑不存在")
+    if not body.dst:
+        raise HTTPException(400, "至少需要一個目的地 (dst)")
+    cmd = [sys.executable, str(ROOT / "offload.py"), "--src", str(src), "--progress", "json"]
+    for d in body.dst:
+        cmd += ["--dst", d]
+    if body.organize:
+        cmd += ["--organize", body.organize]
+    if body.include_heic:
+        cmd += ["--include-heic"]
+    # offload writes offload-state.json into its cwd; keep that out of the install
+    # ROOT (it would dirty the repo / install dir on every UI run). Use the
+    # project's .arkiv dir so the state is scoped + resumable per project.
+    state_cwd = config.THUMBNAILS_DIR.parent
+    state_cwd.mkdir(parents=True, exist_ok=True)
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=3600, cwd=str(state_cwd))
+        payload = {
+            "ok": result.returncode == 0,
+            "code": result.returncode,
+            "stdout": result.stdout[-4000:] if result.stdout else "",
+            "stderr": result.stderr[-1000:] if result.stderr else "",
+        }
+        if result.returncode != 0:
+            return JSONResponse(status_code=500, content=payload)
+        return payload
+    except subprocess.TimeoutExpired:
+        raise HTTPException(504, "轉存逾時（>60 分鐘）")
+
+
+@app.get("/dit", response_class=HTMLResponse)
+def serve_dit():
+    """DIT Offload control panel (separate from the main search UI)."""
+    page = ROOT / "dit-offload.html"
+    if page.exists():
+        return page.read_text(encoding="utf-8")
+    return "<h1>arkiv DIT</h1><p>dit-offload.html not found</p>"
+
+
 # ── Re-transcribe ─────────────────────────────────────────────────────────────
 
 class RetranscribeRequest(BaseModel):

--- a/tests/test_dit_offload_ui.py
+++ b/tests/test_dit_offload_ui.py
@@ -1,0 +1,76 @@
+"""Tests for the DIT Offload UI endpoints (server.py) — /api/offload/preview,
+/api/offload, and the /dit page. The functional 'working UI' for the DIT engine.
+"""
+
+
+def test_offload_preview_mirror(fastapi_client, tmp_path):
+    # source is a dedicated subdir so the fixture's test.db (in tmp_path root) isn't
+    # seen by _collect_sources (which copies *everything*, not just media).
+    card = tmp_path / "card"; (card / "DCIM").mkdir(parents=True)
+    (card / "DCIM" / "C0001.MP4").write_bytes(b"x" * 100)
+    (card / "DCIM" / "C0002.MP4").write_bytes(b"y" * 50)
+    r = fastapi_client.post("/api/offload/preview", json={"src": str(card)})
+    assert r.status_code == 200
+    d = r.json()
+    assert d["count"] == 2
+    assert d["organize"] is None
+    rels = {f["rel"] for f in d["files"]}
+    assert rels == {"DCIM/C0001.MP4", "DCIM/C0002.MP4"}
+
+
+def test_offload_preview_organize(fastapi_client, tmp_path, monkeypatch):
+    import offload
+    monkeypatch.setattr(offload, "_probe_camera_meta",
+                        lambda f: {"date": "2026-03-09", "camera": "Sony FX30", "reel": "A001"})
+    card = tmp_path / "card"; card.mkdir()
+    (card / "C0001.MP4").write_bytes(b"x")
+    r = fastapi_client.post("/api/offload/preview",
+                            json={"src": str(card), "organize": "{date}/{camera}/{reel}"})
+    assert r.status_code == 200
+    assert r.json()["files"][0]["rel"] == "2026-03-09/Sony FX30/A001/C0001.MP4"
+
+
+def test_offload_preview_missing_src_400(fastapi_client, tmp_path):
+    r = fastapi_client.post("/api/offload/preview", json={"src": str(tmp_path / "nope")})
+    assert r.status_code == 400
+
+
+def test_offload_preview_bad_template_400(fastapi_client, tmp_path):
+    (tmp_path / "C0001.MP4").write_bytes(b"x")
+    r = fastapi_client.post("/api/offload/preview",
+                            json={"src": str(tmp_path), "organize": "no-tokens"})
+    assert r.status_code == 400
+
+
+def test_offload_run_missing_src_400(fastapi_client, tmp_path):
+    r = fastapi_client.post("/api/offload", json={"src": str(tmp_path / "nope"), "dst": ["/x"]})
+    assert r.status_code == 400
+
+
+def test_offload_run_empty_dst_400(fastapi_client, tmp_path):
+    (tmp_path / "C0001.MP4").write_bytes(b"x")
+    r = fastapi_client.post("/api/offload", json={"src": str(tmp_path), "dst": []})
+    assert r.status_code == 400
+
+
+def test_dit_page_served(fastapi_client):
+    r = fastapi_client.get("/dit")
+    assert r.status_code == 200
+    assert "DIT OFFLOAD" in r.text
+    assert "/api/offload/preview" in r.text  # the page actually wires the endpoint
+
+
+def test_offload_preview_limit_clamped(fastapi_client, tmp_path):
+    # Codex: client-controlled limit must be clamped (0 / negative / huge → cap 200),
+    # never disabling the cap. 3 files; valid limit slices, limit=0 falls back to cap.
+    card = tmp_path / "card"; card.mkdir()
+    for i in range(3):
+        (card / f"C{i}.MP4").write_bytes(b"x")
+    assert fastapi_client.post("/api/offload/preview",
+                               json={"src": str(card), "limit": 2}).json()["count"] == 2
+    # limit=0 must NOT mean "no slicing / 0 files" — it falls back to the 200 cap
+    assert fastapi_client.post("/api/offload/preview",
+                               json={"src": str(card), "limit": 0}).json()["count"] == 3
+    # an absurd value is capped, not honored verbatim (still returns the 3 real files)
+    assert fastapi_client.post("/api/offload/preview",
+                               json={"src": str(card), "limit": 99999}).json()["count"] == 3

--- a/tests/test_offload_organize.py
+++ b/tests/test_offload_organize.py
@@ -191,3 +191,40 @@ def test_run_offload_without_organize_mirrors_source(tmp_path):
     offload.run_offload(str(src), [str(dst)], emit_mhl=False, progress="json",
                         resume=str(tmp_path / "state.json"))
     assert (dst / "DCIM" / "C0001.MP4").read_bytes() == b"hi"   # mirror layout unchanged
+
+
+# ── preview_layout (powers the DIT Offload UI) ──────────────────────────────
+def test_preview_layout_mirror(tmp_path):
+    (tmp_path / "DCIM").mkdir()
+    (tmp_path / "DCIM" / "C0001.MP4").write_bytes(b"x" * 100)
+    p = offload.preview_layout(str(tmp_path))
+    assert p["count"] == 1
+    assert p["organize"] is None
+    assert p["files"][0]["rel"] == "DCIM/C0001.MP4"
+    assert p["files"][0]["size_mb"] is not None
+
+
+def test_preview_layout_organize(monkeypatch, tmp_path):
+    monkeypatch.setattr(offload, "_probe_camera_meta",
+                        lambda f: {"date": "2026-03-09", "camera": "Sony FX30", "reel": "A001"})
+    (tmp_path / "C0001.MP4").write_bytes(b"x")
+    p = offload.preview_layout(str(tmp_path), organize="{date}/{camera}/{reel}")
+    assert p["files"][0]["rel"] == "2026-03-09/Sony FX30/A001/C0001.MP4"
+
+
+def test_preview_layout_bad_template_raises(tmp_path):
+    (tmp_path / "C0001.MP4").write_bytes(b"x")
+    with pytest.raises(ValueError):
+        offload.preview_layout(str(tmp_path), organize="no-tokens")
+
+
+def test_preview_layout_missing_src(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        offload.preview_layout(str(tmp_path / "nope"))
+
+
+def test_preview_layout_limit(tmp_path):
+    for i in range(5):
+        (tmp_path / f"C{i}.MP4").write_bytes(b"x")
+    p = offload.preview_layout(str(tmp_path), limit=2)
+    assert len(p["files"]) == 2


### PR DESCRIPTION
## 摘要
DIT 引擎（①naming ②card-watch ④白名單）的「能動的 UI」。`/dit` 控制台：輸入來源卡 + 目的地 + `--organize` template → **Preview** 看每個檔的目的端路徑（唯讀不複製）→ **Run** 真轉存（複製 + xxh3 校驗 + ascMHL，**絕不刪來源**）。

## 內容
- `offload.preview_layout()`：純唯讀 layout 預覽（source→rel 映射）
- `POST /api/offload/preview`：真實 layout;client limit 端點 clamp 到 (0,200]（防 0/巨大值繞 cap → 全枚舉）
- `POST /api/offload`：subprocess 跑 offload.py（mirror /api/ingest）;src/dst/organize 走 argv 無注入;state 落 project `.arkiv` 不污染 install 目錄
- `GET /dit`：服務 `dit-offload.html`（vanilla JS、loopback 免 token、arkiv dark editorial 風格、全值 esc()/textContent 防 XSS）

## 品質
- **端到端真實驗證**（啟 server：/dit 服務 → preview 真 layout → /api/offload 真複製 2 檔到 organize 路徑 + ascMHL manifest）
- 8 端點測 + 5 preview_layout 測 + 全套 **550 pass**
- **Codex 審 CLEAN**（除 limit cap → 已修 + 測試鎖住）

## Follow-up
- run 目前 blocking request（同 /api/ingest）;live progress streaming + 接進 Svelte frontend 是下一步

🤖 Generated with [Claude Code](https://claude.com/claude-code)