### PR TITLE
feat(ui): default landing = live product (+ 360 route note)

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -18,7 +18,8 @@
 
   // Routes are added per overnight segment.
   const routes = {
-    '/': Home,
+    '/': MainLive, // g1 — default landing = live product (was Home token-proof scaffold)
+    '/home': Home, // design scaffold kept for reference (was '/')
     '/live': Live, // B1 — live API proof (reads running backend)
     '/main-live': MainLive, // B1 — main grid wired to live data
     '/ingest-live': IngestLive, // B1+ — ingest progress wired to live ws
@@ -33,7 +34,7 @@
     '/settings': Settings, // seg 7 — settings modal
     '/flows': Flows, // seg 8 — round-3 flows
     '/edge': Edge, // seg 9 — round-4 edge
-    // (insta360 — excluded, gated on 8.3a POC)
+    // 360 (.insv/.360): ingest reproject shipped (Phase 8.3b) — no dedicated SPA viewer route yet
   }
 </script>
 


### PR DESCRIPTION
Review-driven change from the UI architecture audit.

- **g1 — default landing = product**: `/` now routes to `MainLive` (the live grid wired to real data) instead of `Home` (the token-proof scaffold). `Home` moved to `/home` as a design reference. Opening arkiv now lands on the working product, not the design-proof page.
- **g5 — stale note**: `App.svelte:36` updated — 360 (`.insv`/`.360`) ingest reproject shipped (Phase 8.3b); no dedicated SPA viewer route yet (was "excluded, gated on 8.3a POC").

Part of the review-driven UI mock→live construction plan (S0). Follow-up segments S1–S4 bring live routes up to the mock design spec and fold `/dit` into the SPA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)