### PR TITLE
feat(api): surface ingest engine options on /api/ingest (S1a brick 1)

### DIFF
--- a/server.py
+++ b/server.py
@@ -1506,6 +1506,36 @@ def export_metadata_csv_to(
 class IngestRequest(BaseModel):
     path: str
     limit: int = 0
+    # ingest.py engine options, surfaced so the redesign's ingest setup dialog
+    # (docs/design/redesign-2026 op-01) has a real backend to bind to. Each
+    # defaults to the pre-existing behaviour, so existing callers are unchanged.
+    skip_vision: bool = False
+    refresh: bool = False
+    recursive: bool = False
+    max_failures: int = 0
+    skip_failed: bool = False
+    no_embed: bool = False
+
+
+def _ingest_cmd_opts(body: "IngestRequest") -> list:
+    """Translate IngestRequest options into ingest.py CLI flags. Shared by the
+    REST (/api/ingest) and WebSocket (/api/ingest/ws) triggers so the two never
+    drift. --dir / --limit stay with the callers; this is only the extra knobs."""
+    opts: list = []
+    if body.skip_vision:
+        opts.append("--skip-vision")
+    if body.refresh:
+        opts.append("--refresh")
+    if body.recursive:
+        opts.append("--recursive")
+    if body.max_failures and body.max_failures > 0:
+        opts += ["--max-failures", str(int(body.max_failures))]
+    if body.skip_failed:
+        opts.append("--skip-failed")
+    if body.no_embed:
+        opts.append("--no-embed")
+    return opts
+
 
 class ScanRequest(BaseModel):
     path: str
@@ -1591,6 +1621,7 @@ def ingest_media(
     cmd = [sys.executable, str(ROOT / "ingest.py"), "--dir", str(target)]
     if body.limit > 0:
         cmd += ["--limit", str(body.limit)]
+    cmd += _ingest_cmd_opts(body)
     if not _acquire_ingest_slot():  # audit H3
         raise HTTPException(409, "已有匯入任務進行中，請稍候")
     try:
@@ -2772,13 +2803,15 @@ def _on_ingest_ws_done(task: "asyncio.Task") -> None:
         )
 
 
-async def _run_ingest_with_ws(target: Path, limit: int):
+async def _run_ingest_with_ws(target: Path, limit: int, opts: Optional[list] = None):
     """Run ingest as a single subprocess, parse stdout for progress."""
     import re, sys
 
     cmd = [sys.executable, str(ROOT / "ingest.py"), "--dir", str(target)]
     if limit > 0:
         cmd += ["--limit", str(limit)]
+    if opts:
+        cmd += opts
 
     await ingest_ws.broadcast({"type": "start", "total": limit or 0})
 
@@ -2881,7 +2914,7 @@ async def ingest_media_ws(
     _assert_ingest_path_safe(target)
     if not _acquire_ingest_slot():  # audit H3 — shared single-flight with REST ingest/reingest
         raise HTTPException(409, "已有匯入進行中，請等待完成後再試")
-    task = asyncio.create_task(_run_ingest_with_ws(target, body.limit))
+    task = asyncio.create_task(_run_ingest_with_ws(target, body.limit, _ingest_cmd_opts(body)))
     _ingest_ws_tasks.add(task)
     task.add_done_callback(_on_ingest_ws_done)
     return {"ok": True, "message": "已開始匯入 — 連線 /ws/ingest 取得進度"}

--- a/tests/test_ingest_options.py
+++ b/tests/test_ingest_options.py
@@ -1,0 +1,34 @@
+"""S1a — ingest engine options surfaced through the API (server._ingest_cmd_opts).
+
+The redesign's ingest setup dialog (docs/design/redesign-2026 op-01) exposes
+transcribe/vision knobs; these must translate to the real ingest.py CLI flags,
+shared by the REST and WebSocket triggers so they never drift.
+"""
+import server
+
+
+def test_defaults_emit_no_extra_flags():
+    # an unconfigured ingest must behave exactly as before (only --dir/--limit,
+    # which the callers add — this helper returns just the extra knobs)
+    assert server._ingest_cmd_opts(server.IngestRequest(path="/x")) == []
+
+
+def test_each_option_maps_to_its_flag():
+    body = server.IngestRequest(
+        path="/x", skip_vision=True, refresh=True, recursive=True,
+        max_failures=20, skip_failed=True, no_embed=True,
+    )
+    opts = server._ingest_cmd_opts(body)
+    assert "--skip-vision" in opts
+    assert "--refresh" in opts
+    assert "--recursive" in opts
+    assert opts[opts.index("--max-failures") + 1] == "20"  # value follows the flag
+    assert "--skip-failed" in opts
+    assert "--no-embed" in opts
+
+
+def test_zero_max_failures_omits_flag():
+    # 0 = the engine default (halt on first failure); must NOT emit the flag
+    assert "--max-failures" not in server._ingest_cmd_opts(
+        server.IngestRequest(path="/x", max_failures=0)
+    )


### PR DESCRIPTION
First build brick of the UI mock→live plan **S1** (ingest), targeting the redesign SSOT's ingest setup dialog (`docs/design/redesign-2026` op-01).

op-01 exposes transcribe/vision knobs, but `/api/ingest` only accepted `{path, limit}` — the engine (`ingest.py`) could already do more than the API allowed.

### Change
- `IngestRequest` gains `skip_vision` / `refresh` / `recursive` / `max_failures` / `skip_failed` / `no_embed`. All default to prior behaviour → existing callers unchanged.
- `_ingest_cmd_opts()` maps them to `ingest.py` CLI flags, **shared by the REST (`/api/ingest`) and WebSocket (`/api/ingest/ws`) triggers** so the two never drift.

### Not yet exposed (later S1 bricks)
Whisper/vision model pickers, language set, tag pool, frames-per-scene, and the copy strategy / destination / conflict half (that's `offload.py`'s domain — op-01 unifies offload + ingest config).

### Tests
`tests/test_ingest_options.py` — defaults emit nothing, each option maps to its flag, `max_failures=0` omitted. Full suite **557 passed / 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)