### PR TITLE
feat(api): /api/ingest/scan returns a MANIFEST summary (S1a brick 2)

### DIFF
--- a/server.py
+++ b/server.py
@@ -1541,6 +1541,28 @@ class ScanRequest(BaseModel):
     path: str
 
 MEDIA_EXTS = {".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts", ".insv", ".360", ".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg"}
+VIDEO_EXTS = {".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts", ".insv", ".360"}
+AUDIO_EXTS = {".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg"}
+assert VIDEO_EXTS | AUDIO_EXTS == MEDIA_EXTS  # the two must partition MEDIA_EXTS
+# camera raw / stills the ingest pipeline does not process — surfaced in the scan
+# manifest as "skipped" so the redesign's setup dialog (op-01) can show what will
+# not be ingested (e.g. a card of .mov clips + .crw stills).
+UNSUPPORTED_STILL_EXTS = {".crw", ".cr2", ".cr3", ".arw", ".nef", ".dng",
+                          ".raf", ".orf", ".rw2", ".heic", ".heif", ".tif", ".tiff"}
+
+
+def _build_scan_manifest(files: list, unsupp: dict) -> dict:
+    """Aggregate a scanned file list into op-01's MANIFEST panel: counts + sizes
+    by category (video / audio) plus the unsupported-stills skip count."""
+    def cat(exts: set) -> dict:
+        sub = [f for f in files if Path(f["name"]).suffix.lower() in exts]
+        return {"count": len(sub), "size_mb": round(sum(f["size_mb"] for f in sub), 1)}
+    return {
+        "video": cat(VIDEO_EXTS),
+        "audio": cat(AUDIO_EXTS),
+        "unsupported": {"count": sum(unsupp.values()), "by_ext": dict(sorted(unsupp.items()))},
+        "total_size_mb": round(sum(f["size_mb"] for f in files), 1),
+    }
 
 def _allowed_ingest_roots() -> list:
     """Approved roots for ingest scan / ingest endpoints.
@@ -1601,11 +1623,22 @@ def scan_media(
         raise HTTPException(400, "路徑不是有效的目錄")
     _assert_ingest_path_safe(target)
     files = []
+    unsupp: dict = {}  # ext -> count, for the MANIFEST "skipped" line
     for f in sorted(target.rglob("*")):
-        if f.suffix.lower() in MEDIA_EXTS:
+        if not f.is_file():
+            continue
+        ext = f.suffix.lower()
+        if ext in MEDIA_EXTS:
             already = db.is_processed(str(f)) if hasattr(db, 'is_processed') else False
             files.append({"name": f.name, "size_mb": round(f.stat().st_size / 1048576, 1), "path": str(f), "already": already})
-    return {"total": len(files), "new": sum(1 for f in files if not f["already"]), "files": files}
+        elif ext in UNSUPPORTED_STILL_EXTS:
+            unsupp[ext] = unsupp.get(ext, 0) + 1
+    return {
+        "total": len(files),
+        "new": sum(1 for f in files if not f["already"]),
+        "manifest": _build_scan_manifest(files, unsupp),
+        "files": files,
+    }
 
 @app.post("/api/ingest")
 def ingest_media(

--- a/tests/test_scan_manifest.py
+++ b/tests/test_scan_manifest.py
@@ -1,0 +1,32 @@
+"""S1a — /api/ingest/scan returns op-01's MANIFEST panel (counts + sizes by
+category + unsupported-stills skip count). Pure aggregation over the scan."""
+
+
+def test_scan_manifest_categorizes_and_sizes(fastapi_client, tmp_path):
+    card = tmp_path / "card"; (card / "DCIM").mkdir(parents=True)
+    (card / "DCIM" / "A001.MP4").write_bytes(b"v" * (2 * 1048576))   # 2 MB video
+    (card / "DCIM" / "A002.MOV").write_bytes(b"v" * (1 * 1048576))   # 1 MB video
+    (card / "DCIM" / "VOICE.WAV").write_bytes(b"a" * (1048576 // 2)) # 0.5 MB audio
+    (card / "DCIM" / "STILL.CRW").write_bytes(b"r" * 100)            # unsupported raw still
+    (card / "DCIM" / "STILL2.crw").write_bytes(b"r" * 100)           # case-insensitive
+    (card / "DCIM" / "notes.txt").write_bytes(b"x")                  # neither media nor still — ignored
+
+    r = fastapi_client.post("/api/ingest/scan", json={"src": str(card), "path": str(card)})
+    assert r.status_code == 200
+    m = r.json()["manifest"]
+
+    assert m["video"]["count"] == 2
+    assert m["video"]["size_mb"] == 3.0
+    assert m["audio"]["count"] == 1
+    assert m["audio"]["size_mb"] == 0.5
+    assert m["unsupported"]["count"] == 2          # both .crw / .CRW, .txt excluded
+    assert m["unsupported"]["by_ext"] == {".crw": 2}
+    assert m["total_size_mb"] == 3.5               # video+audio only, stills not counted
+
+
+def test_scan_manifest_empty_dir(fastapi_client, tmp_path):
+    d = tmp_path / "empty"; d.mkdir()
+    m = fastapi_client.post("/api/ingest/scan", json={"path": str(d)}).json()["manifest"]
+    assert m["video"]["count"] == 0 and m["audio"]["count"] == 0
+    assert m["unsupported"]["count"] == 0
+    assert m["total_size_mb"] == 0


### PR DESCRIPTION
Second S1a brick toward the redesign's ingest setup dialog (`docs/design/redesign-2026` op-01), whose **MANIFEST** panel shows video/audio counts + sizes and an unsupported-stills skip count. `/api/ingest/scan` previously returned only a flat file list — no backend for that panel.

### Change
- `VIDEO_EXTS` / `AUDIO_EXTS` partition `MEDIA_EXTS` (asserted at import).
- `UNSUPPORTED_STILL_EXTS` — camera raw / stills the pipeline won't process (`.crw/.cr2/.arw/.nef/.dng/...`), counted so the dialog can show "N skipped".
- `scan_media` now returns `manifest{ video, audio, unsupported, total_size_mb }` (pure aggregation + an `is_file()` guard on the walk).

### Tests
`tests/test_scan_manifest.py` — categorize + size, case-insensitive ext, `.txt` excluded, stills excluded from total, empty dir. Full suite **559 passed / 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)