### PR TITLE
feat(ui): wire per-stage progress into IngestLive — S1b

### DIFF
--- a/frontend/src/routes/IngestLive.svelte
+++ b/frontend/src/routes/IngestLive.svelte
@@ -1,9 +1,10 @@
-<!-- B1+ — ingest progress wired to the live backend.
+<!-- B1+ / S1b — ingest progress wired to the live backend.
      Connects ws://…/ws/ingest, triggers POST /api/ingest/ws, renders the real
-     broadcast stream. The ws protocol only provides per-file status
-     (transcribing/done/skipped) + start/complete — NOT the per-stage
-     probe/transcribe/tag columns or GPU metrics the mock screen mocks. So this
-     is an honest subset: real queue + real progress, no faked sub-stages. -->
+     broadcast stream. Since S1a brick 3 the protocol carries real per-stage
+     events ({type:"stage", stage, index, counts}, stage ∈ probe/transcribe/
+     thumbnail/frames/vision) on top of per-file start/done/skipped + start/
+     complete — so the queue shows each file's live stage + a real aggregate
+     stage breakdown. No faked sub-stages: every segment is a backend event. -->
 <script>
   import { onMount, onDestroy } from 'svelte'
   import * as api from '../lib/api.js'
@@ -19,8 +20,15 @@
   let path = ''
   let limit = 3
   let total = 0
-  let files = {} // index → {filename, status}
+  let files = {} // index → {filename, status, stage}
+  let stageCounts = {} // aggregate per-stage tally from the backend (counts dict)
   let complete = null // {ok, skipped, failed}
+
+  // Canonical pipeline order (matches ingest.py _stage calls). probe→frames run
+  // in phase 1 (file ends "done"); vision streams in a second phase-2 pass, so a
+  // file can receive a vision event after it already read "done" — handled below.
+  const STAGES = ['probe', 'transcribe', 'thumbnail', 'frames', 'vision']
+  const stageLabel = { probe: 'PROBE', transcribe: 'WHISPER', thumbnail: 'THUMB', frames: 'FRAMES', vision: 'VISION' }
   let log = [] // [{t, text}]
   let busy = false
   let rebuilding = false
@@ -58,12 +66,24 @@
       if (msg.type === 'start') {
         total = msg.total || 0
         files = {}
+        stageCounts = {}
         complete = null
         pushLog(`start · ${total} files`)
       } else if (msg.type === 'file') {
-        files[msg.index] = { filename: msg.filename, status: msg.status }
+        // Preserve any stage already recorded for this file (e.g. a vision event
+        // can land after the "done" file event in phase 2 — don't clobber it).
+        const prev = files[msg.index] || {}
+        files[msg.index] = { ...prev, filename: msg.filename, status: msg.status }
         files = files // trigger reactivity
         pushLog(`[${msg.index}/${msg.total}] ${msg.filename} · ${msg.status}`)
+      } else if (msg.type === 'stage') {
+        // Per-stage event (S1a brick 3): attribute to the in-flight file by index
+        // and refresh the aggregate tally the backend keeps for us.
+        const prev = files[msg.index] || { filename: msg.filename, status: 'transcribing' }
+        files[msg.index] = { ...prev, filename: prev.filename || msg.filename, stage: msg.stage }
+        files = files // trigger reactivity
+        if (msg.counts) stageCounts = msg.counts
+        pushLog(`[${msg.index}/${msg.total}] ${msg.filename} >${msg.stage}`)
       } else if (msg.type === 'complete') {
         complete = { ok: msg.ok, skipped: msg.skipped, failed: msg.failed }
         busy = false
@@ -77,6 +97,7 @@
     err = ''
     busy = true
     files = {}
+    stageCounts = {}
     complete = null
     try {
       // Through the authenticated API layer (adds the Bearer token when set) —
@@ -114,7 +135,24 @@
     .sort((a, b) => a.index - b.index)
   $: doneCount = rows.filter((r) => r.status === 'done').length
   $: pct = total ? Math.round((doneCount / total) * 100) : 0
+  // The aggregate stage breakdown strip — only stages the backend has reported.
+  $: stageStrip = STAGES.filter((s) => stageCounts[s]).map((s) => ({ s, n: stageCounts[s] }))
   const statusText = { transcribing: 'RUN', done: 'OK', skipped: 'SKIP' }
+
+  // Reached index in the canonical pipeline for a row: -1 (none) up to 4 (vision).
+  // A "done" file (phase 1 complete) has cleared probe→frames even if its last
+  // event was an earlier stage; vision only lights up once its own event lands.
+  function reached(r) {
+    let idx = r.stage ? STAGES.indexOf(r.stage) : -1
+    if (r.status === 'done' && idx < 3) idx = 3 // probe..frames done in phase 1
+    return idx
+  }
+  function badge(r) {
+    if (r.status === 'done') return 'OK'
+    if (r.status === 'skipped') return 'SKIP'
+    if (r.stage) return stageLabel[r.stage] || r.stage.toUpperCase()
+    return statusText[r.status] || r.status
+  }
 </script>
 
 <div class="artboard" data-theme={theme}>
@@ -145,6 +183,13 @@
         </div>
         {#if err}<Mono style="font-size:11px;color:var(--cyan);">{err}</Mono>{/if}
         <div class="aggbar"><div class="aggfill" style="width:{pct}%;"></div></div>
+        {#if stageStrip.length}
+          <div class="stagestrip">
+            {#each stageStrip as { s, n }}
+              <span class="stagechip"><span class="sname">{stageLabel[s]}</span><span class="snum">{n}</span></span>
+            {/each}
+          </div>
+        {/if}
       </div>
 
       <div class="queue">
@@ -159,7 +204,14 @@
             <div class="qrow" class:done={r.status === 'done'}>
               <Mono dim style="font-size:10px;flex:0 0 36px;">{r.index}/{total}</Mono>
               <Mono style="font-size:11.5px;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{r.filename}</Mono>
-              <span class="stage {r.status}">{statusText[r.status] || r.status}</span>
+              {#if r.status !== 'skipped'}
+                <div class="pipe" title={STAGES.join(' → ')}>
+                  {#each STAGES as st, si}
+                    <span class="seg" class:fill={si <= reached(r)} class:active={r.stage === st && r.status !== 'done'} title={stageLabel[st]}></span>
+                  {/each}
+                </div>
+              {/if}
+              <span class="stage {r.status}" class:running={r.status === 'transcribing'}>{badge(r)}</span>
             </div>
           {/each}
         {/if}
@@ -199,13 +251,22 @@
   .limitinput { width: 70px; font-size: 12px; }
   .aggbar { height: 4px; background: var(--surface-3); position: relative; margin-top: 22px; }
   .aggfill { position: absolute; left: 0; top: 0; bottom: 0; background: var(--cyan); transition: width 0.2s; }
+  .stagestrip { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 12px; }
+  .stagechip { display: inline-flex; align-items: center; gap: 6px; font-family: var(--ak-mono); font-size: 9.5px; letter-spacing: 0.08em; padding: 2px 7px; border: 1px solid var(--rule); color: var(--quiet); }
+  .stagechip .sname { color: var(--ink-2); }
+  .stagechip .snum { color: var(--cyan); font-weight: 700; }
   .queue { flex: 1; padding: 14px 40px 20px; overflow: auto; }
   .qhead { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 12px; }
   .empty { padding: 30px 0; }
   .qrow { display: flex; align-items: center; gap: 12px; padding: 7px 0; border-bottom: 1px solid var(--rule); }
   .qrow.done { opacity: 0.6; }
-  .stage { font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.08em; padding: 2px 6px; border: 1px solid var(--rule); color: var(--quiet); }
-  .stage.transcribing { color: var(--cyan); border-color: var(--cyan); font-weight: 700; }
+  .pipe { display: flex; gap: 3px; flex: 0 0 auto; }
+  .seg { width: 14px; height: 4px; background: var(--surface-3); transition: background 0.2s; }
+  .seg.fill { background: var(--ink-2); }
+  .seg.active { background: var(--cyan); animation: segpulse 1s ease-in-out infinite; }
+  @keyframes segpulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+  .stage { font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.08em; padding: 2px 6px; border: 1px solid var(--rule); color: var(--quiet); flex: 0 0 auto; min-width: 52px; text-align: center; }
+  .stage.running { color: var(--cyan); border-color: var(--cyan); font-weight: 700; }
   .stage.done { color: var(--ink); border-color: var(--ink); font-weight: 600; }
   .stage.skipped { color: var(--quiet); border-style: dashed; }
   .right { display: flex; flex-direction: column; min-height: 0; overflow: hidden; }


### PR DESCRIPTION
## What

IngestLive ignored the `type:"stage"` events that S1a brick 3 (#66) added to `/ws/ingest` — it rendered only per-file `start`/`done`/`skipped`. This wires them in (plan S1b — frontend consumes the new events).

- **Per-row pipeline** — each queue row shows a 5-segment pipeline (`probe → transcribe → thumbnail → frames → vision`) lit by real stage events; the in-flight segment pulses cyan.
- **Live badge** — shows the current stage while running (WHISPER/THUMB/…), `OK`/`SKIP` on terminal status.
- **Aggregate strip** — hero shows the backend's running per-stage tally (the `counts` dict).
- **No faked sub-stages** — every segment maps to a backend event. `vision` streams in a phase-2 pass *after* `phase1_done`, so its event merges via `{...prev}` without clobbering the earlier `done` file event.

## Verification

- `npm run build` ✓
- Real `/ws/ingest` e2e (generated tiny.mp4, `skip_vision`): stage events `probe→transcribe→thumbnail→frames` each carrying `index`/`filename`/`counts`, file `transcribing→done`, aggregate `counts {probe:1,transcribe:1,thumbnail:1,frames:1}`, `complete` ok=1.

## Scope notes

- Setup dialog (op-01 mock) is a separate route `/ingest-setup` (#65) — unchanged.
- brick 4 (model picker / language / tag pool) still deferred (not yet CLI args in ingest.py).
- THROUGHPUT/ETA not surfaced — backend doesn't emit them yet, so the UI doesn't fake them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)