### PR TITLE
feat(ui): real disk usage in the sidebar Storage footer — S3

### DIFF
--- a/frontend/src/lib/PoolSidebar.svelte
+++ b/frontend/src/lib/PoolSidebar.svelte
@@ -10,6 +10,7 @@
   export let onTag = null // (name) => void; live tag-click → filter
   export let liveCollections = null // [{key,title,count,items}]; null → section hidden
   export let onCollection = null // (collection) => void; click → filter to members
+  export let liveStorage = null // {pct, used_gb, total_gb} from /api/stats.disk; null → mock placeholder
 
   const MOCK_POOLS = [
     ['All media', 247],
@@ -21,6 +22,11 @@
   $: projects = liveProjects ?? PROJECTS
   $: pools = livePools ?? MOCK_POOLS
   $: tags = liveTags ?? TAGS
+  // Storage footer: real disk usage when wired (live), else the design placeholder.
+  const gb = (n) => (n >= 1000 ? `${(n / 1000).toFixed(1)} TB` : `${Math.round(n)} GB`)
+  $: storage = liveStorage
+    ? { pct: liveStorage.pct, label: `${gb(liveStorage.used_gb)} · ${gb(liveStorage.total_gb)} · disk` }
+    : { pct: 40, label: '4.8 TB · 12 TB · NAS' }
 </script>
 
 <aside class="pool">
@@ -83,10 +89,10 @@
   <section class="storage">
     <div class="strow">
       <Eyebrow>Storage</Eyebrow>
-      <Mono dim style="font-size:10px;">40%</Mono>
+      <Mono dim style="font-size:10px;">{storage.pct}%</Mono>
     </div>
-    <div class="bar"><div class="barfill"></div></div>
-    <Mono dim style="font-size:10.5px;margin-top:5px;letter-spacing:0.02em;">4.8 TB · 12 TB · NAS</Mono>
+    <div class="bar"><div class="barfill" style="width:{storage.pct}%;"></div></div>
+    <Mono dim style="font-size:10.5px;margin-top:5px;letter-spacing:0.02em;">{storage.label}</Mono>
   </section>
 </aside>
 
@@ -125,5 +131,5 @@
   .storage { border-top: 1px solid var(--rule); padding-top: 12px; }
   .strow { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 6px; }
   .bar { height: 2px; background: var(--surface-3); position: relative; }
-  .barfill { position: absolute; left: 0; top: 0; bottom: 0; width: 40%; background: var(--ink); }
+  .barfill { position: absolute; left: 0; top: 0; bottom: 0; background: var(--ink); transition: width 0.2s; }
 </style>

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -133,6 +133,8 @@
       ]
     : null
   $: liveProjects = stats ? [{ id: 'msr', name: '明燒肉', count: stats.total, active: true }] : null
+  // real disk usage for the sidebar Storage footer (replaces the mock placeholder)
+  $: liveStorage = stats?.disk ?? null
   // tag click → search that tag
   function onTagClick(name) {
     query = name
@@ -290,7 +292,7 @@
 <div class="artboard" data-theme={theme}>
   <TopBar />
   <div class="body">
-    <PoolSidebar {liveProjects} {livePools} {liveTags} {liveCollections} onTag={onTagClick} onCollection={onCollectionClick} />
+    <PoolSidebar {liveProjects} {livePools} {liveTags} {liveCollections} {liveStorage} onTag={onTagClick} onCollection={onCollectionClick} />
 
     <main class="center">
       <div class="toolrow">

--- a/server.py
+++ b/server.py
@@ -1128,6 +1128,19 @@ def get_stats(
     """Aggregate stats for dashboard."""
     stats = db.get_stats()
     stats["rating"] = db.get_rating_stats()
+    # Real disk usage of the volume holding the arkiv data — feeds the sidebar's
+    # Storage footer (was a hardcoded "4.8 TB · 12 TB · 40%" placeholder). Best
+    # effort: a stat() failure (e.g. path vanished) must not 500 the dashboard.
+    try:
+        import shutil
+        du = shutil.disk_usage(config.DB_PATH.parent if config.DB_PATH else ROOT)
+        stats["disk"] = {
+            "used_gb": round(du.used / 1e9, 1),
+            "total_gb": round(du.total / 1e9, 1),
+            "pct": round(du.used / du.total * 100) if du.total else 0,
+        }
+    except Exception:
+        stats["disk"] = None
     # Screen quality-defect tags here too (Codex review P2) — index.html and any
     # stats-driven cloud read top_tags. Over-fetch then filter so we still get 10
     # real tags even if some of the top entries were noise.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -118,6 +118,12 @@ def test_tag_stats_and_tag_catalog_endpoints(fastapi_client, sample_record):
     assert stats_data["total"] == 2
     assert stats_data["langs"] == {"en": 1, "zh": 1}
     assert stats_data["top_tags"][0]["name"] == "精選"
+    # real disk usage feeds the sidebar Storage footer (S3 — replaced a hardcoded
+    # placeholder). Best-effort, so it's either a well-formed dict or None.
+    disk = stats_data["disk"]
+    assert disk is None or (
+        disk["total_gb"] > 0 and 0 <= disk["pct"] <= 100 and disk["used_gb"] >= 0
+    )
 
     tags = fastapi_client.get("/api/tags")
     assert tags.status_code == 200


### PR DESCRIPTION
## What

The `PoolSidebar` Storage footer was **hardcoded** ("4.8 TB · 12 TB · NAS · 40%") and, since the component is shared, the **live** main view rendered those fake numbers — an evidence-discipline violation. Make it real.

- `/api/stats` returns `disk` usage of the volume holding the arkiv data (`shutil.disk_usage` on `DB_PATH`'s parent), best-effort: a stat failure → `null`, never 500s the dashboard.
- `PoolSidebar` gains a `liveStorage` prop — real `{used_gb, total_gb, pct}` when wired, else the design placeholder (mock screens stay byte-identical). GB→TB formatting.
- `MainLive` passes `stats.disk`.

S3 is otherwise a no-op: MainLive was already at parity with the `/main` mock — this was the one piece showing fabricated data.

## Verification

- Live footer renders `46% · 227 GB · 494 GB · disk`.
- `npm run build` green; `pytest` 564 passed / 5 skipped (+ a disk-shape assertion on `/api/stats`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)