### PR TITLE
feat(ui): DIT offload route in the SPA (/offload) — S4

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -16,6 +16,7 @@
   import IngestSetup from './routes/IngestSetup.svelte'
   import ChatLive from './routes/ChatLive.svelte'
   import SearchLive from './routes/SearchLive.svelte'
+  import Offload from './routes/Offload.svelte'
 
   // Routes are added per overnight segment.
   const routes = {
@@ -25,6 +26,7 @@
     '/main-live': MainLive, // B1 — main grid wired to live data
     '/ingest-setup': IngestSetup, // S1b — ingest setup dialog (redesign op-01), wired to scan manifest + ingest options
     '/ingest-live': IngestLive, // B1+ — ingest progress wired to live ws
+    '/offload': Offload, // S4 — DIT offload (card → backup), ported from the /dit island into the SPA
     '/chat-live': ChatLive, // E2 — chat wired to live /api/chat
     '/search-live': SearchLive, // search wired to live /api/media?q=
     '/gallery': Gallery, // seg 1 — shared-primitive gallery

--- a/frontend/src/lib/TopBar.svelte
+++ b/frontend/src/lib/TopBar.svelte
@@ -1,5 +1,6 @@
 <!-- Top bar: logo · search · all-projects toggle · actions. crossProject is bindable. -->
 <script>
+  import { push } from 'svelte-spa-router'
   import ArkivLogo from './ArkivLogo.svelte'
   import Mono from './Mono.svelte'
   export let crossProject = false
@@ -24,7 +25,8 @@
   </div>
 
   <div class="actions">
-    <button class="ak-btn ak-btn--primary">+ Ingest</button>
+    <button class="ak-btn ak-btn--primary" on:click={() => push('/ingest-setup')}>+ Ingest</button>
+    <button class="ak-btn" on:click={() => push('/offload')} title="DIT offload · card → backup">DIT</button>
     <button class="ak-btn">EDL</button>
     <button class="ak-btn">FCPXML</button>
     <div class="vrule"></div>

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -91,6 +91,30 @@ export const ingestWs = (path, limit = 0, options = {}, opts) =>
 export const rebuildEmbedIndex = (opts) =>
   req('/api/embed/rebuild', { method: 'POST', ...opts })
 
+// ---- DIT offload (card → backup) ----
+// POST /api/offload/preview {src, organize?, include_heic?, limit?} → read-only
+// layout {src, count, organize, files:[{source, rel, size_mb}]}. videos_write.
+export const offloadPreview = (body, opts) =>
+  req('/api/offload/preview', { method: 'POST', body, ...opts })
+
+// POST /api/offload {src, dst:[…], organize?, include_heic?} → ndjson stream of
+// {type:"dst_start"|"file"|"done", …}. req() can't stream, so return the raw
+// Response for the caller to read line-by-line; auth header attached when set
+// (token-free on loopback). Throws ApiError on a non-OK status (e.g. bad path).
+export async function offloadRun(body, { signal } = {}) {
+  const headers = { 'Content-Type': 'application/json' }
+  if (_token) headers['Authorization'] = `Bearer ${_token}`
+  const res = await fetch(`${BASE}/api/offload`, {
+    method: 'POST', headers, body: JSON.stringify(body), signal,
+  })
+  if (!res.ok) {
+    let detail = null
+    try { detail = await res.json() } catch { /* non-json */ }
+    throw new ApiError(res.status, '/api/offload', detail)
+  }
+  return res
+}
+
 // /api/media?limit&offset&projects&tag&rating  → {items, total, search}
 export const getMedia = (params = {}, opts) => req(`/api/media${qs(params)}`, opts)
 export const getMediaDetail = (id, opts) => req(`/api/media/${id}`, opts)

--- a/frontend/src/routes/IngestSetup.svelte
+++ b/frontend/src/routes/IngestSetup.svelte
@@ -9,6 +9,7 @@
      shown as disabled "picker pending" rows, never faked. Everything enabled here
      is fully wired to a real endpoint. -->
 <script>
+  import { onMount } from 'svelte'
   import { push } from 'svelte-spa-router'
   import * as api from '../lib/api.js'
   import ArkivLogo from '../lib/ArkivLogo.svelte'
@@ -48,6 +49,16 @@
       push('/ingest-live')
     } catch (e) { err = e.message; starting = false }
   }
+
+  // 2-phase DIT handoff: /offload sends the completed destination here as
+  // #/ingest-setup?src=<path> so the user can ingest what they just offloaded.
+  onMount(() => {
+    const h = window.location.hash
+    const qi = h.indexOf('?')
+    if (qi === -1) return
+    const src = new URLSearchParams(h.slice(qi + 1)).get('src')
+    if (src) { path = src; scan() }
+  })
 
   const TOGGLES = [
     ['skip_vision', 'Skip vision', '跳過 AI 視覺標註（只轉錄）'],

--- a/frontend/src/routes/Offload.svelte
+++ b/frontend/src/routes/Offload.svelte
@@ -1,0 +1,281 @@
+<!-- S4 — DIT Offload, ported into the SPA (was the standalone /dit island:
+     dit-offload.html, which couldn't @fontsource-bundle, had inline-only tokens,
+     and lived outside the router). This route uses app.css tokens + the shared
+     primitives, so it inherits dual-theme + bundled faces for free.
+
+     Built to the LOCKED interaction draft (plan §DIT, 2026-06-15):
+       1. Human gate — Preview (read-only layout) must run first; Run is the
+          explicit second click. No auto-run.
+       2. offload ↔ ingest is two phases — offload (copy + xxh3 verify + ascMHL)
+          completes on its own, then offers "接著 ingest →" handing the destination
+          to /ingest-setup. Not one button to the end.
+       3. Error red is the sanctioned exception — copy/checksum failures get a red
+          signal (data-safety); every other state stays the brutalist B&W (+ cyan
+          for in-progress). Reverses PR #59's pure-mono rule for failures only.
+
+     Safety: offload.py copies + verifies, NEVER deletes the source. -->
+<script>
+  import { push } from 'svelte-spa-router'
+  import * as api from '../lib/api.js'
+  import ArkivLogo from '../lib/ArkivLogo.svelte'
+  import Mono from '../lib/Mono.svelte'
+  import Eyebrow from '../lib/Eyebrow.svelte'
+
+  let src = ''
+  let organize = ''
+  let dsts = [''] // one or more backup destinations (one-click multi-backup)
+  let includeHeic = false
+
+  let phase = 'idle' // idle | previewing | preview | running | done
+  let preview = null // {src, count, organize, files:[{source, rel, size_mb}]}
+  let err = ''
+
+  // run progress
+  let curDst = ''
+  let pTotal = 0
+  let pDone = 0
+  let pFailed = 0
+  let recent = [] // [{name, status}] — last handful of files, failed flagged
+  let summary = null // {dst: {verified_files, failed_files, mhl_path, status}}
+  let doneCode = null
+
+  $: liveDsts = dsts.map((d) => d.trim()).filter(Boolean)
+  $: canRun = phase === 'preview' && liveDsts.length > 0
+  $: pct = pTotal ? Math.min(100, Math.round((pDone / pTotal) * 100)) : 0
+  $: anyFailed = summary ? Object.values(summary).some((s) => s.failed_files > 0) || doneCode !== 0 : false
+  const base = (p) => String(p).split(/[\\/]/).pop()
+
+  function addDst() { dsts = [...dsts, ''] }
+  function removeDst(i) { dsts = dsts.filter((_, j) => j !== i); if (!dsts.length) dsts = [''] }
+
+  async function doPreview() {
+    if (!src.trim()) { err = '請先填來源路徑'; return }
+    err = ''; phase = 'previewing'; preview = null
+    try {
+      preview = await api.offloadPreview({
+        src: src.trim(), organize: organize.trim() || null, include_heic: includeHeic,
+      })
+      phase = 'preview'
+    } catch (e) {
+      err = e.body?.detail || e.message
+      phase = 'idle'
+    }
+  }
+
+  async function doRun() {
+    if (!canRun) return
+    err = ''; phase = 'running'
+    curDst = ''; pTotal = 0; pDone = 0; pFailed = 0; recent = []; summary = null; doneCode = null
+    try {
+      const res = await api.offloadRun({
+        src: src.trim(), dst: liveDsts,
+        organize: organize.trim() || null, include_heic: includeHeic,
+      })
+      const reader = res.body.getReader()
+      const dec = new TextDecoder()
+      let buf = ''
+      for (;;) {
+        const { value, done } = await reader.read()
+        if (done) break
+        buf += dec.decode(value, { stream: true })
+        let nl
+        while ((nl = buf.indexOf('\n')) >= 0) {
+          const line = buf.slice(0, nl).trim(); buf = buf.slice(nl + 1)
+          if (!line) continue
+          let ev; try { ev = JSON.parse(line) } catch { continue }
+          if (ev.type === 'dst_start') {
+            curDst = ev.dst; pTotal = ev.total; pDone = 0; pFailed = 0
+          } else if (ev.type === 'file') {
+            pDone++
+            if (ev.status === 'failed') pFailed++
+            recent = [{ name: ev.name, status: ev.status }, ...recent].slice(0, 8)
+          } else if (ev.type === 'done') {
+            doneCode = ev.code
+            summary = ev.summary || {}
+            phase = 'done'
+          }
+        }
+      }
+      if (phase !== 'done') { phase = 'done'; doneCode = doneCode ?? 1 }
+    } catch (e) {
+      err = e.body?.detail || e.message
+      phase = 'done'; doneCode = doneCode ?? 1
+    }
+  }
+
+  // 2-phase handoff — ingest the first destination we just offloaded.
+  function ingestNext() {
+    const target = (summary && Object.keys(summary)[0]) || liveDsts[0]
+    if (target) push(`/ingest-setup?src=${encodeURIComponent(target)}`)
+  }
+</script>
+
+<div class="artboard" data-theme="dark">
+  <div class="topbar">
+    <ArkivLogo size={16} />
+    <Mono dim style="font-size:10px;">v0.9.2</Mono>
+    <div class="grow"></div>
+    <Mono dim style="font-size:11px;">dit · offload</Mono>
+  </div>
+
+  <div class="dialog">
+    <div class="dhead">
+      <Eyebrow>DIT · card → backup</Eyebrow>
+      <div class="ak-display title">Offload{preview ? ` · ${preview.count} files` : ''}</div>
+      <button class="esc" on:click={() => push('/')}>ESC · CANCEL</button>
+    </div>
+
+    <div class="body">
+      <!-- LEFT — config -->
+      <div class="col">
+        <div class="field">
+          <Eyebrow>Source · card / folder</Eyebrow>
+          <div class="srcrow">
+            <input class="ak-input" placeholder="/Volumes/CARD/DCIM  或  ~/footage" bind:value={src} spellcheck="false" on:keydown={(e) => e.key === 'Enter' && doPreview()} />
+            <button class="ak-btn" on:click={doPreview} disabled={phase === 'previewing' || phase === 'running'}>{phase === 'previewing' ? 'reading…' : 'Preview'}</button>
+          </div>
+        </div>
+
+        <div class="field">
+          <Eyebrow>Organize template · 留空=鏡射原結構</Eyebrow>
+          <input class="ak-input" placeholder="{'{date}/{camera}/{reel}'}" bind:value={organize} spellcheck="false" disabled={phase === 'running'} />
+          <Mono dim style="font-size:9.5px;">tokens · {'{date} {camera} {reel} {stem} {ext}'}</Mono>
+        </div>
+
+        <div class="field">
+          <Eyebrow>Destinations · one-click multi-backup</Eyebrow>
+          {#each dsts as d, i}
+            <div class="dstrow">
+              <input class="ak-input" placeholder={`/Volumes/Backup${i + 1}`} bind:value={dsts[i]} spellcheck="false" disabled={phase === 'running'} />
+              {#if i === dsts.length - 1}
+                <button class="seg" on:click={addDst} disabled={phase === 'running'} title="add destination">+</button>
+              {:else}
+                <button class="seg" on:click={() => removeDst(i)} disabled={phase === 'running'} title="remove">−</button>
+              {/if}
+            </div>
+          {/each}
+        </div>
+
+        <div class="field">
+          <Eyebrow>Options</Eyebrow>
+          <div class="optrow">
+            <button class="seg" class:on={includeHeic} on:click={() => includeHeic = !includeHeic} disabled={phase === 'running'}>{includeHeic ? 'ON' : 'OFF'}</button>
+            <div class="optlabel"><span>Include .heic</span><Mono dim style="font-size:10px;">連同 .heic 靜照一起轉存</Mono></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- RIGHT — preview / progress / result -->
+      <div class="col out">
+        {#if phase === 'idle' || phase === 'previewing'}
+          <Eyebrow>Layout preview</Eyebrow>
+          <div class="empty"><Mono dim>{phase === 'previewing' ? '讀取中…' : '填來源後按 Preview（只讀、不複製）'}</Mono></div>
+        {:else if phase === 'preview'}
+          <Eyebrow>Layout · {preview.organize ? `organize ${preview.organize}` : '鏡射原結構'}</Eyebrow>
+          <Mono dim style="font-size:10px;">{base(preview.src)} · {preview.count} files{preview.count >= 200 ? ' · 顯示前 200' : ''}</Mono>
+          <div class="rowsbox">
+            {#each preview.files as f}
+              <div class="prow">
+                <Mono style="font-size:10.5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{base(f.source)}</Mono>
+                <span class="arr">→</span>
+                <Mono dim style="font-size:10.5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{f.rel}</Mono>
+                <Mono dim style="font-size:10px;">{f.size_mb ?? '—'}</Mono>
+              </div>
+            {/each}
+          </div>
+        {:else}
+          <!-- running / done -->
+          <Eyebrow>{phase === 'running' ? 'Copying · verify + MHL' : (anyFailed ? 'Offload — failed' : 'Offload — complete')}</Eyebrow>
+          {#if curDst}<Mono dim style="font-size:10px;">→ {curDst}</Mono>{/if}
+          <div class="bar"><div class="barfill" class:fail={anyFailed} style="width:{phase === 'done' ? 100 : pct}%;"></div></div>
+          <Mono dim style="font-size:10.5px;">{pDone}{pTotal ? `/${pTotal}` : ''} files{pFailed ? ` · ${pFailed} failed` : ''}</Mono>
+
+          <div class="rowsbox">
+            {#each recent as r}
+              <div class="prow file" class:fail={r.status === 'failed'}>
+                <Mono style="font-size:10.5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{r.name}</Mono>
+                <span class="st {r.status}">{r.status === 'failed' ? 'FAIL' : r.status === 'skipped' ? 'SKIP' : 'OK'}</span>
+              </div>
+            {/each}
+          </div>
+
+          {#if phase === 'done' && summary}
+            <div class="summary">
+              {#each Object.entries(summary) as [dst, s]}
+                <div class="srow" class:fail={s.failed_files > 0}>
+                  <Mono style="font-size:10.5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{base(dst)}</Mono>
+                  <Mono dim style="font-size:10px;">{s.verified_files} ok{s.failed_files ? ` · ${s.failed_files} fail` : ''}{s.mhl_path ? ' · MHL' : ''}</Mono>
+                </div>
+              {/each}
+            </div>
+          {/if}
+        {/if}
+
+        <div class="noticebox">
+          <Mono dim style="font-size:10px;">◇ Copy + xxh3 verify + ascMHL. Never deletes the source card.</Mono>
+        </div>
+      </div>
+    </div>
+
+    <div class="footer">
+      {#if err}<Mono style="font-size:11px;" class="errtext">{err}</Mono>
+      {:else if phase === 'done'}<Mono style="font-size:11px;" class={anyFailed ? 'errtext' : ''}>{anyFailed ? `✗ 轉存有失敗 (exit ${doneCode})` : `✓ 轉存完成 (exit ${doneCode})`}</Mono>{/if}
+      <div class="grow"></div>
+      {#if phase === 'done' && !anyFailed}
+        <button class="ak-btn" on:click={ingestNext}>接著 ingest →</button>
+      {/if}
+      <button class="ak-btn" on:click={() => push('/')}>{phase === 'done' ? 'Done' : 'Cancel'}</button>
+      <button class="ak-btn ak-btn--primary" on:click={doRun} disabled={!canRun}>{phase === 'running' ? 'copying…' : 'Run offload →'}</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  /* error red — the LOCKED exception to the B&W palette, failures only */
+  .artboard { --danger: #e0563a; width: 1400px; height: 900px; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 1fr; overflow: hidden; margin: 0 auto; }
+  .grow { flex: 1; }
+  .topbar { display: flex; align-items: center; border-bottom: 1px solid var(--rule); padding: 0 16px; gap: 16px; }
+
+  .dialog { margin: 40px auto; width: 1080px; border: 1px solid var(--rule-hi); background: var(--surface); display: grid; grid-template-rows: auto 1fr auto; min-height: 0; max-height: calc(900px - 80px); }
+  .dhead { display: flex; align-items: baseline; gap: 20px; padding: 22px 28px; border-bottom: 1px solid var(--rule); }
+  .title { font-size: 28px; letter-spacing: -0.03em; line-height: 1; }
+  .esc { margin-left: auto; font-family: var(--ak-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--quiet); background: none; border: none; cursor: pointer; }
+  .esc:hover { color: var(--ink); }
+
+  .body { display: grid; grid-template-columns: 1fr 360px; min-height: 0; overflow: hidden; }
+  .col { padding: 24px 28px; display: flex; flex-direction: column; gap: 22px; overflow: auto; }
+  .out { border-left: 1px solid var(--rule); gap: 10px; }
+
+  .field { display: flex; flex-direction: column; gap: 8px; }
+  .srcrow { display: flex; gap: 10px; align-items: flex-end; }
+  .dstrow { display: flex; gap: 8px; align-items: center; }
+
+  .optrow { display: flex; align-items: center; gap: 14px; }
+  .optlabel { display: flex; flex-direction: column; gap: 1px; font-size: 12px; }
+  .seg { font-family: var(--ak-mono); font-size: 11px; letter-spacing: 0.08em; width: 46px; flex: 0 0 46px; padding: 6px 0; border: 1px solid var(--rule-hi); background: transparent; color: var(--quiet); cursor: pointer; text-align: center; }
+  .seg.on { background: var(--invert); color: var(--invert-ink); border-color: var(--invert); font-weight: 700; }
+  .seg:disabled { opacity: 0.4; cursor: not-allowed; }
+
+  .empty { padding: 24px 0; }
+  .rowsbox { flex: 1; min-height: 0; overflow: auto; border-top: 1px solid var(--rule); margin-top: 2px; }
+  .prow { display: grid; grid-template-columns: 1fr auto 1.1fr auto; gap: 8px; align-items: baseline; padding: 4px 0; border-bottom: 1px solid var(--surface-2); }
+  .prow.file { grid-template-columns: 1fr auto; }
+  .arr { color: var(--quiet); font-family: var(--ak-mono); font-size: 10px; }
+  .st { font-family: var(--ak-mono); font-size: 9.5px; letter-spacing: 0.06em; padding: 1px 6px; border: 1px solid var(--rule); color: var(--quiet); }
+  .st.verified { color: var(--ink); border-color: var(--ink); }
+  .st.skipped { color: var(--quiet); border-style: dashed; }
+  .st.failed { color: var(--danger); border-color: var(--danger); font-weight: 700; }
+  .prow.fail :global(*) { color: var(--danger); }
+
+  .bar { height: 6px; background: var(--surface-2); position: relative; margin-top: 4px; }
+  .barfill { position: absolute; left: 0; top: 0; bottom: 0; background: var(--cyan); transition: width 0.2s; }
+  .barfill.fail { background: var(--danger); }
+
+  .summary { border-top: 1px solid var(--rule); padding-top: 8px; display: flex; flex-direction: column; gap: 4px; }
+  .srow { display: flex; justify-content: space-between; align-items: baseline; gap: 10px; }
+  .srow.fail :global(*) { color: var(--danger); }
+  .noticebox { margin-top: auto; border: 1px dashed var(--rule-hi); padding: 10px 12px; line-height: 1.5; }
+
+  .footer { display: flex; align-items: center; gap: 12px; padding: 16px 28px; border-top: 1px solid var(--rule); }
+  .footer :global(.errtext) { color: var(--danger); }
+</style>


### PR DESCRIPTION
## What

Port the standalone `/dit` island (`dit-offload.html` — inline-only tokens, no `@fontsource`, outside the router) into a real Svelte route. Using `app.css` + the shared primitives, `/offload` inherits dual-theme + bundled faces (the island's three gaps). The old `/dit` page stays for now (S-Cleanup downgrades the mock/island routes; `test_dit_offload_ui.py` still covers it).

## LOCKED interaction draft (plan §DIT, 2026-06-15)

- **Human gate** — Preview (read-only layout) runs first; Run is the explicit second click; no auto-run.
- **Two-phase offload→ingest** — offload (copy + xxh3 verify + ascMHL) finishes on its own, then offers **接著 ingest →** handing the destination to `/ingest-setup` (new `?src=` seed prefills + scans it).
- **Error red** — the sanctioned exception to the B&W palette: copy/checksum failures get a red signal (`--danger`); every other state stays brutalist B&W (+ cyan for in-progress).

## Plumbing

- `api.js`: `offloadPreview` (via `req`) + `offloadRun` (returns the raw `Response` so the caller streams the ndjson; auth header attached when set).
- `TopBar`: a **DIT** entry → `/offload`; **+ Ingest** now navigates to `/ingest-setup`.

## Verification

End-to-end (4 clips → BACKUP1): preview 4 files → verified×4 → done exit 0, **real copies + ascMHL written, source card intact** (never deleted); **接著 ingest →** navigates to `#/ingest-setup?src=<dst>` with the path prefilled. `npm run build` green; `pytest` 564 passed / 5 skipped.

Follows #70 (S3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)