### PR TITLE
chore(ui): namespace design mock routes under /_design/* — S-Cleanup

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -19,9 +19,14 @@
   import Offload from './routes/Offload.svelte'
 
   // Routes are added per overnight segment.
+  //
+  // S-Cleanup (2026-06-15): the live product owns the bare paths; the original
+  // Claude-design mock artboards are kept as a design reference under /_design/*
+  // (NOT deleted — see plan S-Cleanup). They have no inbound links (verified), so
+  // namespacing them just stops "two sets coexisting, told apart by memory".
   const routes = {
+    // ── live product ────────────────────────────────────────────────────────
     '/': MainLive, // g1 — default landing = live product (was Home token-proof scaffold)
-    '/home': Home, // design scaffold kept for reference (was '/')
     '/live': Live, // B1 — live API proof (reads running backend)
     '/main-live': MainLive, // B1 — main grid wired to live data
     '/ingest-setup': IngestSetup, // S1b — ingest setup dialog (redesign op-01), wired to scan manifest + ingest options
@@ -29,15 +34,18 @@
     '/offload': Offload, // S4 — DIT offload (card → backup), ported from the /dit island into the SPA
     '/chat-live': ChatLive, // E2 — chat wired to live /api/chat
     '/search-live': SearchLive, // search wired to live /api/media?q=
-    '/gallery': Gallery, // seg 1 — shared-primitive gallery
-    '/main': MainDark, // seg 2 — hero (interactive)
-    '/states': MainStates, // seg 3 — state variants
-    '/inspector': InspectorFull, // seg 4 — inspector full
-    '/search': Search, // seg 5 — cross-project search
-    '/ingest': Ingest, // seg 6 — ingest progress
-    '/settings': Settings, // seg 7 — settings modal
-    '/flows': Flows, // seg 8 — round-3 flows
-    '/edge': Edge, // seg 9 — round-4 edge
+
+    // ── design reference (Claude-design mock artboards; not the product) ──────
+    '/_design/home': Home, // design scaffold kept for reference (was '/')
+    '/_design/gallery': Gallery, // seg 1 — shared-primitive gallery
+    '/_design/main': MainDark, // seg 2 — hero (interactive)
+    '/_design/states': MainStates, // seg 3 — state variants
+    '/_design/inspector': InspectorFull, // seg 4 — inspector full
+    '/_design/search': Search, // seg 5 — cross-project search
+    '/_design/ingest': Ingest, // seg 6 — ingest progress
+    '/_design/settings': Settings, // seg 7 — settings modal
+    '/_design/flows': Flows, // seg 8 — round-3 flows
+    '/_design/edge': Edge, // seg 9 — round-4 edge
     // 360 (.insv/.360): ingest reproject shipped (Phase 8.3b) — no dedicated SPA viewer route yet
   }
 </script>


### PR DESCRIPTION
## What

Now that the live product covers S1–S4, the original Claude-design mock artboards (seg 1–9 + the Home scaffold) move from bare paths to `/_design/*`, so the product owns `/main`, `/search`, `/ingest`, etc. and the two sets no longer coexist "told apart by memory" (plan S-Cleanup). They are **kept, not deleted** — design reference.

| was | now |
|---|---|
| `/home /gallery /main /states /inspector /search /ingest /settings /flows /edge` | `/_design/{home,gallery,main,states,inspector,search,ingest,settings,flows,edge}` |

`/live` stays (it's a live API proof, not a mock).

## Safe

The mock routes have **zero inbound links** — every `#/…` and `push()` target in the app is a live route (verified by grep), so nothing breaks.

## Verification

`/_design/main` and `/_design/flows` render; the old `/main` no longer resolves; `npm run build` green.

Completes the mock→live construction plan (follows #67/#68 S1, #69 S2, #70 S3, #71 S4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)