### PR TITLE
feat(ingest): whisper preset + language pickers — S1a brick 4 (transcribe slice)

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -76,6 +76,10 @@ export const chat = (prompt, conversationId = null, opts) =>
 export const scanMedia = (path, opts) =>
   req('/api/ingest/scan', { method: 'POST', body: { path }, ...opts })
 
+// GET /api/ingest/engines (brick 4) — real transcription picker options:
+// {whisper_modes:[{mode,name}], default_mode, languages:[{code,label}]}.
+export const getIngestEngines = (opts) => req('/api/ingest/engines', opts)
+
 // POST /api/ingest/ws {path, limit, …options} — trigger ingest with WS progress.
 // `options` forwards the engine flags the setup dialog exposes (skip_vision,
 // refresh, recursive, max_failures, skip_failed, no_embed); omitted keys keep

--- a/frontend/src/routes/IngestSetup.svelte
+++ b/frontend/src/routes/IngestSetup.svelte
@@ -22,6 +22,11 @@
   // engine flags surfaced by S1a brick 1
   let opts = { skip_vision: false, refresh: false, recursive: false, skip_failed: false, no_embed: false }
   let maxFailures = 0
+  // brick 4 — real transcription pickers, options from /api/ingest/engines.
+  // '' = use the backend default (no flag sent), so unchanged callers stay default.
+  let engines = null
+  let whisperGuard = '' // '' = default preset; else mode int as string
+  let language = ''     // '' = auto-detect; else whisper code
 
   let manifest = null      // {video,audio,unsupported,total_size_mb}
   let total = 0, fresh = 0
@@ -45,6 +50,8 @@
     try {
       const body = { ...opts }
       if (maxFailures > 0) body.max_failures = Number(maxFailures)
+      if (whisperGuard !== '') body.whisper_guard = Number(whisperGuard)
+      if (language !== '') body.language = language
       await api.ingestWs(path.trim(), Number(limit) || 0, body)
       // hand off to the live progress route (the WS is already broadcasting)
       push('/ingest-live')
@@ -53,7 +60,8 @@
 
   // 2-phase DIT handoff: /offload sends the completed destination here as
   // #/ingest-setup?src=<path> so the user can ingest what they just offloaded.
-  onMount(() => {
+  onMount(async () => {
+    try { engines = await api.getIngestEngines() } catch (e) { /* picker falls back to default-only */ }
     const h = window.location.hash
     const qi = h.indexOf('?')
     if (qi === -1) return
@@ -114,12 +122,33 @@
           </div>
         </div>
 
-        <!-- design sections with no backend picker yet — shown, not faked -->
-        <div class="field deferred">
+        <!-- brick 4 — real transcription pickers (options from /api/ingest/engines) -->
+        <div class="field">
           <Eyebrow>Transcribe · whisper</Eyebrow>
-          <div class="pendrow"><Mono dim>model · languages · skip-if</Mono><span class="pend">picker pending · brick 4</span></div>
+          <div class="optrow">
+            <select class="ak-input sel" bind:value={whisperGuard} title="transcription quality preset">
+              <option value="">Default{engines ? ` (${(engines.whisper_modes.find((m) => m.mode === engines.default_mode) || {}).name})` : ''}</option>
+              {#each (engines?.whisper_modes ?? []) as m}
+                <option value={String(m.mode)}>{m.name}</option>
+              {/each}
+            </select>
+            <div class="optlabel"><span>Model · quality</span><Mono dim style="font-size:10px;">whisper guard preset（0 快 → 4 最準，預設 4）</Mono></div>
+          </div>
+          <div class="optrow">
+            <select class="ak-input sel" bind:value={language} title="force transcription language">
+              <option value="">Auto-detect</option>
+              {#each (engines?.languages ?? []) as l}
+                <option value={l.code}>{l.label} · {l.code}</option>
+              {/each}
+            </select>
+            <div class="optlabel"><span>Language</span><Mono dim style="font-size:10px;">強制語言（留 Auto = 自動偵測 / 預設提示）</Mono></div>
+          </div>
+        </div>
+
+        <!-- vision pickers still have no backend (model list / tag pool) — shown, not faked -->
+        <div class="field deferred">
           <Eyebrow>Vision tagging · ollama</Eyebrow>
-          <div class="pendrow"><Mono dim>model · tag pool · frames</Mono><span class="pend">picker pending · brick 4</span></div>
+          <div class="pendrow"><Mono dim>model · tag pool · frames</Mono><span class="pend">picker pending · brick 4b</span></div>
         </div>
       </div>
 
@@ -170,6 +199,8 @@
   .field { display: flex; flex-direction: column; gap: 10px; }
   .srcrow { display: flex; gap: 10px; align-items: flex-end; }
   .num { width: 80px; flex: 0 0 80px; }
+  .sel { flex: 0 0 196px; width: 196px; font-size: 11.5px; font-family: var(--ak-mono); background: transparent; color: var(--ink); border: 1px solid var(--rule-hi); border-radius: 0; padding: 6px 8px; cursor: pointer; }
+  .sel:focus { outline: none; border-color: var(--ink); }
 
   .optrow { display: flex; align-items: center; gap: 14px; }
   .optlabel { display: flex; flex-direction: column; gap: 1px; font-size: 12px; }

--- a/ingest.py
+++ b/ingest.py
@@ -50,6 +50,10 @@ logger = logging.getLogger(__name__)
 # existing human output (and its parsers) is unchanged.
 _STAGE_EVENTS = os.environ.get("ARKIV_STAGE_EVENTS") == "1"
 
+# brick 4: per-run whisper language override (None = auto-detect / guard-layer
+# hint, the default). Set from --language in main(), read at the transcribe call.
+_LANGUAGE_OVERRIDE = None
+
 
 def _emit_progress(obj: Dict) -> None:
     """One JSON progress event on its own flushed line (sentinel-prefixed). No-op
@@ -605,7 +609,7 @@ def process_file(path: Path, skip_vision: bool, existing: Optional[Dict] = None,
     # Audio transcription (skip on refresh — reuse existing)
     if meta["has_audio"] and not existing:
         _stage("whisper", "transcribe")
-        text, lang, segments, words = tr.transcribe(str(path))
+        text, lang, segments, words = tr.transcribe(str(path), language=_LANGUAGE_OVERRIDE)
         record["transcript"] = text if text is not None else ""
         record["lang"] = lang or None
         if segments:
@@ -1140,6 +1144,8 @@ def main():
         action="store_true",
         help="Phase 8.0c: 搬 legacy BASE_DIR/{media.db, thumbnails/, chroma_db/, proxies/} → BASE_DIR/.arkiv/",
     )
+    parser.add_argument("--whisper-guard", type=int, default=None, metavar="MODE", help="brick 4: transcription quality preset 0-4 (0 baseline … 4 +LLM polish, the default). Omit = config default / ARKIV_WHISPER_GUARD_LAYERS env.")
+    parser.add_argument("--language", default=None, metavar="LANG", help="brick 4: force whisper language code (zh/en/ja/ko); omit = auto-detect / preset hint.")
     parser.add_argument("--recursive", "-r", action="store_true", help="Recursively scan subdirectories")
     parser.add_argument("--db", default="", help="Path to SQLite DB (default: media.db next to ingest.py)")
     parser.add_argument("--no-embed", action="store_true", help="Skip building the vector index after ingest (default: auto-embed so search/chat work immediately)")
@@ -1148,6 +1154,15 @@ def main():
     parser.add_argument("--status", action="store_true", help="Phase 11.5e: print resource + queue status (--json for machine-readable)")
     parser.add_argument("--json", action="store_true", help="With --status: emit JSON instead of human-readable")
     args = parser.parse_args()
+
+    # brick 4: apply the per-run whisper preset + language override before any
+    # transcription. Guard-mode resolution keeps its env-wins precedence (an
+    # ARKIV_WHISPER_GUARD_LAYERS env still overrides the flag, as in the
+    # transcribe CLI); language is a direct override read at the transcribe call.
+    if args.whisper_guard is not None:
+        tr._apply_whisper_guard_mode(tr._resolve_whisper_guard_mode(args.whisper_guard))
+    global _LANGUAGE_OVERRIDE
+    _LANGUAGE_OVERRIDE = args.language or None
 
     # --dir validation: required only when actually ingesting
     maintenance_mode = (

--- a/server.py
+++ b/server.py
@@ -1528,6 +1528,21 @@ class IngestRequest(BaseModel):
     max_failures: int = 0
     skip_failed: bool = False
     no_embed: bool = False
+    # brick 4: transcription engine knobs. whisper_guard = quality preset 0-4
+    # (None = default); language = forced whisper code (zh/en/ja/ko, None = auto).
+    whisper_guard: Optional[int] = None
+    language: Optional[str] = None
+
+
+# brick 4 — whisper language codes the setup picker offers (whisper supports many
+# more; this is the curated UI set). Omit / None = auto-detect or the preset hint.
+_INGEST_LANGUAGES = [
+    {"code": "zh", "label": "中文"},
+    {"code": "en", "label": "English"},
+    {"code": "ja", "label": "日本語"},
+    {"code": "ko", "label": "한국어"},
+]
+_INGEST_LANGUAGE_CODES = {lang["code"] for lang in _INGEST_LANGUAGES}
 
 
 def _ingest_cmd_opts(body: "IngestRequest") -> list:
@@ -1547,6 +1562,11 @@ def _ingest_cmd_opts(body: "IngestRequest") -> list:
         opts.append("--skip-failed")
     if body.no_embed:
         opts.append("--no-embed")
+    # brick 4 — only emit when explicitly set (and valid) so defaults stay untouched.
+    if body.whisper_guard is not None and body.whisper_guard in config.WHISPER_GUARD_LAYERS:
+        opts += ["--whisper-guard", str(int(body.whisper_guard))]
+    if body.language and body.language in _INGEST_LANGUAGE_CODES:
+        opts += ["--language", body.language]
     return opts
 
 
@@ -1623,6 +1643,25 @@ def _assert_ingest_path_safe(target: Path) -> None:
         403,
         f"ingest 路徑必須在批准的目錄底下：{[str(r) for r in roots]} (override via ARKIV_INGEST_ROOTS env)",
     )
+
+
+@app.get("/api/ingest/engines")
+def ingest_engines(
+    _tok: dict = Depends(require_scopes("videos_read")),
+):
+    """brick 4 — real options for the setup dialog's transcription pickers, so the
+    UI is driven by backend truth (config.WHISPER_GUARD_LAYERS) instead of a
+    hardcoded list that would drift. whisper_modes = quality presets 0-4;
+    languages = the curated forced-language set (None/omit = auto-detect)."""
+    modes = [
+        {"mode": k, "name": config.WHISPER_GUARD_LAYERS[k].get("name", str(k))}
+        for k in sorted(config.WHISPER_GUARD_LAYERS)
+    ]
+    return {
+        "whisper_modes": modes,
+        "default_mode": config.WHISPER_GUARD_DEFAULT_MODE,
+        "languages": _INGEST_LANGUAGES,
+    }
 
 
 @app.post("/api/ingest/scan")

--- a/tests/test_ingest_options.py
+++ b/tests/test_ingest_options.py
@@ -32,3 +32,35 @@ def test_zero_max_failures_omits_flag():
     assert "--max-failures" not in server._ingest_cmd_opts(
         server.IngestRequest(path="/x", max_failures=0)
     )
+
+
+# ── brick 4: whisper guard preset + language ──────────────────────────────────
+
+def test_brick4_whisper_guard_and_language_map_to_flags():
+    body = server.IngestRequest(path="/x", whisper_guard=2, language="zh")
+    opts = server._ingest_cmd_opts(body)
+    assert opts[opts.index("--whisper-guard") + 1] == "2"
+    assert opts[opts.index("--language") + 1] == "zh"
+
+
+def test_brick4_defaults_omit_flags():
+    # None preset + None language = unchanged engine behaviour, no flags
+    opts = server._ingest_cmd_opts(server.IngestRequest(path="/x"))
+    assert "--whisper-guard" not in opts and "--language" not in opts
+
+
+def test_brick4_invalid_values_dropped():
+    # an out-of-range preset / unknown language code must not reach the CLI
+    opts = server._ingest_cmd_opts(
+        server.IngestRequest(path="/x", whisper_guard=99, language="xx")
+    )
+    assert "--whisper-guard" not in opts and "--language" not in opts
+
+
+def test_brick4_engines_endpoint_shape(fastapi_client):
+    r = fastapi_client.get("/api/ingest/engines")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["default_mode"] in {m["mode"] for m in data["whisper_modes"]}
+    assert data["whisper_modes"] and all("name" in m for m in data["whisper_modes"])
+    assert {lang["code"] for lang in data["languages"]} >= {"zh", "en"}


### PR DESCRIPTION
## What

The setup dialog's "Transcribe · whisper · picker pending · brick 4" row is now **real, end-to-end**.

- **ingest.py**: `--whisper-guard MODE` (quality preset 0–4) applies via the existing transcribe guard resolver; `--language LANG` forces the whisper code (`transcribe()` already accepts `language`). Both default to `None` → unchanged behaviour.
- **server.py**: `IngestRequest` gains `whisper_guard`/`language`; `_ingest_cmd_opts` emits the flags only when set **and valid** (out-of-range preset / unknown code dropped, never reaching the CLI). New **GET `/api/ingest/engines`** returns the real presets + curated languages from `config.WHISPER_GUARD_LAYERS` so the picker can't drift.
- **IngestSetup.svelte**: two real selects (model·quality + language) driven by `/api/ingest/engines`; `""` = backend default (no flag sent), so the existing flow is unchanged.

## Honest scope

The **vision row** (model · tag pool · frames) stays `picker pending · brick 4b` — vision-model needs an ollama model-list source, and "tag pool" isn't a real backend concept (the VLM emits free-vocab tags). Faking either would violate the evidence discipline.

## Verification

- `pytest` **568 passed / 5 skipped** (+4 brick-4: valid→flags, defaults→none, invalid→dropped, engines endpoint shape).
- `npm run build` green; live `/api/ingest/engines` returns 5 presets + 4 langs; IngestSetup selects are backend-driven; guard-apply path sets mode 2 → zh hint.

Follows the UI mock→live plan (S1a brick 1–3 + S1b shipped). Unblocks one of the two "picker pending" rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)