### PR TITLE
feat(ui): Svelte cutover Tier 1 — wire 5 backend-parity gaps (#78)

### DIFF
--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -24,6 +24,11 @@
   export let tags = null
   export let onAddTag = null // (name) => void
   export let onRemoveTag = null // (name) => void
+  // Live re-processing. onReprocess = async (action, opts) => {ok, message};
+  // action ∈ 'retranscribe' | 'retry-vision' | 'reingest'. null → no block (mock).
+  export let onReprocess = null
+  export let languages = null // [{code,label}] for the retranscribe picker
+  export let mediaLang = null // current clip language → default selection
   let imgFailed = false
   let tagInput = ''
   function submitTag() {
@@ -32,6 +37,33 @@
     onAddTag(v)
     tagInput = ''
   }
+  // reprocess local state, reset when the selected clip changes
+  let reBusy = null // action currently running, or null
+  let reMsg = ''
+  let reLang = 'zh'
+  let lastMediaId = null
+  $: if (media && media.id !== lastMediaId) {
+    lastMediaId = media.id
+    reBusy = null
+    reMsg = ''
+    reLang = mediaLang || 'zh'
+  }
+  async function doReprocess(action) {
+    if (!onReprocess || reBusy) return
+    reBusy = action
+    reMsg = ''
+    try {
+      const opts = action === 'retranscribe' ? { language: reLang || 'zh' } : {}
+      const r = await onReprocess(action, opts)
+      reMsg = (r && r.message) || '完成'
+    } catch (e) {
+      reMsg = `失敗: ${(e && e.message) || e}`
+    } finally {
+      reBusy = null
+    }
+  }
+  const RE_LANGS = [{ code: 'zh', label: '中文' }, { code: 'en', label: 'English' }]
+  $: langOpts = languages && languages.length ? languages : RE_LANGS
   const EXPORT_FMTS = ['edl', 'fcpxml', 'srt']
 
   const MOCK_TRANSCRIPT = [
@@ -179,6 +211,31 @@
     </div>
   {/if}
 
+  {#if onReprocess}
+    <div class="block reproc">
+      <Eyebrow style="margin-bottom:8px;">Reprocess</Eyebrow>
+      <div class="reprow">
+        <select class="ak-input relang" bind:value={reLang} disabled={!!reBusy} title="重新轉錄語言">
+          {#each langOpts as l}
+            <option value={l.code}>{l.label || l.code}</option>
+          {/each}
+        </select>
+        <button class="ak-btn rebtn" disabled={!!reBusy} on:click={() => doReprocess('retranscribe')}>
+          {reBusy === 'retranscribe' ? '轉錄中…' : '重轉錄'}
+        </button>
+      </div>
+      <div class="reprow">
+        <button class="ak-btn rebtn" disabled={!!reBusy} on:click={() => doReprocess('retry-vision')}>
+          {reBusy === 'retry-vision' ? '分析中…' : '重試視覺'}
+        </button>
+        <button class="ak-btn rebtn" disabled={!!reBusy} on:click={() => doReprocess('reingest')}>
+          {reBusy === 'reingest' ? '重建中…' : '完整重建'}
+        </button>
+      </div>
+      {#if reMsg}<Mono dim style="font-size:10px;line-height:1.45;display:block;">{reMsg}</Mono>{/if}
+    </div>
+  {/if}
+
   <div class="rate">
     <Eyebrow>Rate</Eyebrow>
     <div class="ratebtns">
@@ -254,6 +311,12 @@
   .tagadd { display: flex; gap: 6px; margin-top: 8px; }
   .taginput { flex: 1; font-size: 11px; padding: 5px 8px; }
   .tagaddbtn { flex: 0 0 auto; padding: 5px 10px; }
+  /* reprocess */
+  .reproc { display: flex; flex-direction: column; gap: 6px; }
+  .reprow { display: flex; gap: 6px; }
+  .relang { flex: 0 0 auto; font-size: 11px; padding: 5px 6px; }
+  .rebtn { flex: 1; font-size: 10px; }
+  .rebtn:disabled { opacity: 0.5; cursor: default; }
   .rate { padding: 14px 18px; display: flex; flex-direction: column; gap: 10px; }
   .ratebtns { display: flex; gap: 4px; }
   .ratebtn {

--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -19,7 +19,19 @@
   // (fmt) => void; triggers an authenticated download for this clip. When set,
   // the export buttons become live; null → mock screens keep the inert buttons.
   export let onExport = null
+  // Live tag editing. tags = [{id,name,source}] → renders the editable Tags block;
+  // null → no block (mock screens unchanged). onAddTag/onRemoveTag wire the writes.
+  export let tags = null
+  export let onAddTag = null // (name) => void
+  export let onRemoveTag = null // (name) => void
   let imgFailed = false
+  let tagInput = ''
+  function submitTag() {
+    const v = tagInput.trim()
+    if (!v || !onAddTag) return
+    onAddTag(v)
+    tagInput = ''
+  }
   const EXPORT_FMTS = ['edl', 'fcpxml', 'srt']
 
   const MOCK_TRANSCRIPT = [
@@ -70,6 +82,31 @@
       <Mono dim>SIZE</Mono><Mono>{media.size} · {media.dur}</Mono>
     </div>
   </div>
+
+  {#if tags}
+    <div class="block">
+      <Eyebrow style="margin-bottom:8px;">Tags</Eyebrow>
+      <div class="tagrow">
+        {#each tags as t (t.name)}
+          <span class="tagchip" class:auto={t.source === 'auto'}>
+            <span class="tagname">{t.name}</span>
+            {#if onRemoveTag}
+              <button class="tagx" title="移除標籤" on:click={() => onRemoveTag(t.name)}>×</button>
+            {/if}
+          </span>
+        {/each}
+        {#if tags.length === 0}
+          <Mono dim style="font-size:10.5px;">（無標籤）</Mono>
+        {/if}
+      </div>
+      {#if onAddTag}
+        <form class="tagadd" on:submit|preventDefault={submitTag}>
+          <input class="ak-input taginput" placeholder="加標籤…" bind:value={tagInput} />
+          <button class="ak-btn tagaddbtn" type="submit" disabled={!tagInput.trim()}>＋</button>
+        </form>
+      {/if}
+    </div>
+  {/if}
 
   <div class="block">
     <div class="blockhead">
@@ -199,6 +236,24 @@
   .line { display: flex; gap: 10px; }
   .ttext { color: var(--ink); }
   .ttext.hl { border-bottom: 1px solid var(--invert); padding-bottom: 1px; }
+  /* tags */
+  .tagrow { display: flex; flex-wrap: wrap; gap: 5px; }
+  .tagchip {
+    display: inline-flex; align-items: center; gap: 4px;
+    font-family: var(--ak-mono); font-size: 10px; letter-spacing: 0.03em;
+    padding: 2px 4px 2px 7px; border: 1px solid var(--rule-hi); color: var(--ink);
+    background: var(--surface-2);
+  }
+  .tagchip.auto { border-style: dashed; border-color: var(--rule); color: var(--ink-2); }
+  .tagchip .tagname { white-space: nowrap; }
+  .tagx {
+    appearance: none; background: transparent; border: none; cursor: pointer;
+    color: var(--ink-2); font-size: 13px; line-height: 1; padding: 0 2px;
+  }
+  .tagx:hover { color: var(--cyan); }
+  .tagadd { display: flex; gap: 6px; margin-top: 8px; }
+  .taginput { flex: 1; font-size: 11px; padding: 5px 8px; }
+  .tagaddbtn { flex: 0 0 auto; padding: 5px 10px; }
   .rate { padding: 14px 18px; display: flex; flex-direction: column; gap: 10px; }
   .ratebtns { display: flex; gap: 4px; }
   .ratebtn {

--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -232,6 +232,11 @@
           {reBusy === 'reingest' ? '重建中…' : '完整重建'}
         </button>
       </div>
+      <div class="reprow">
+        <button class="ak-btn rebtn" disabled={!!reBusy} on:click={() => doReprocess('proxy')}>
+          {reBusy === 'proxy' ? '排入中…' : '建立 proxy'}
+        </button>
+      </div>
       {#if reMsg}<Mono dim style="font-size:10px;line-height:1.45;display:block;">{reMsg}</Mono>{/if}
     </div>
   {/if}

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -221,4 +221,16 @@ export const retryVision = (id, opts) =>
 export const reingest = (id, opts) =>
   req(`/api/media/${id}/reingest`, { method: 'POST', ...opts })
 
+// ---- editing proxies ----
+// GET /api/proxy/status → {total, proxied, size_mb}
+export const getProxyStatus = (opts) => req('/api/proxy/status', opts)
+// POST /api/proxy/build → {message, queued}. Queues proxy generation for every
+// HEVC/ProRes without one; runs in the BACKGROUND (returns immediately, no
+// completion signal — re-poll getProxyStatus). Requires ingest_write.
+export const buildProxies = (opts) => req('/api/proxy/build', { method: 'POST', ...opts })
+// POST /api/proxy/build/{id} → {message, queued, media_id, filename?}. Builds
+// just one clip's proxy in the background.
+export const buildProxyOne = (id, opts) =>
+  req(`/api/proxy/build/${id}`, { method: 'POST', ...opts })
+
 export { ApiError }

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -186,6 +186,10 @@ export async function downloadFile(path, filename) {
 export const exportPath = (id, fmt) => `/api/media/${id}/export/${fmt}`
 export const exportTimelinePath = (ids, fmt) =>
   `/api/export/timeline/${fmt}?ids=${ids.join(',')}`
+// DaVinci Resolve metadata CSV (File → Import Metadata from CSV). ids optional
+// (CSV of media ids) → batch-scoped; omitted/empty → whole library.
+export const metadataCsvPath = (ids = null) =>
+  `/api/export/metadata-csv${ids && ids.length ? `?ids=${ids.join(',')}` : ''}`
 
 // ---- writes ----
 // note: backend PATCH writes BOTH rating + rating_note, so an omitted note

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -70,6 +70,15 @@ export const getCollections = (opts) => req('/api/collections', opts)
 export const chat = (prompt, conversationId = null, opts) =>
   req('/api/chat', { method: 'POST', body: { prompt, conversation_id: conversationId }, ...opts })
 
+// Chat history. Requires chat_read (token-free on loopback; remote sees only its
+// own conversations).
+// GET /api/chat/conversations?limit → {conversations:[{id,title,project_scope_json,created_at,updated_at}]}
+export const listConversations = (limit = 50, opts) =>
+  req(`/api/chat/conversations${qs({ limit })}`, opts)
+// GET /api/chat/history/{id}?limit → {conversation:{…}, messages:[{role,content,intent,scene_ids_json,…}]}
+export const getChatHistory = (id, limit = 200, opts) =>
+  req(`/api/chat/history/${id}${qs({ limit })}`, opts)
+
 // POST /api/ingest/scan {path} — quick scan, no processing. Returns
 // {total, new, manifest:{video,audio,unsupported,total_size_mb}, files:[…]}.
 // Powers the setup dialog's MANIFEST panel. Requires ingest_write.

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -193,4 +193,15 @@ export const exportTimelinePath = (ids, fmt) =>
 export const setRating = (id, rating, note = null, opts) =>
   req(`/api/media/${id}/rating`, { method: 'PATCH', body: { rating, note }, ...opts })
 
+// ---- tag editing ----
+// POST /api/media/{id}/tags {name, source:'manual'} → {ok, tags:[{id,name,source}]}
+// Backend forces source='manual' for user-added tags (only vision mints 'auto').
+// Requires videos_write (token-free on loopback). Returns the full updated tag list.
+export const addTag = (id, name, opts) =>
+  req(`/api/media/${id}/tags`, { method: 'POST', body: { name }, ...opts })
+// DELETE /api/media/{id}/tags/{name} → {ok, tags:[...]}. Removes by name (any
+// source). encodeURIComponent so spaces / CJK tag names survive the path.
+export const removeTag = (id, name, opts) =>
+  req(`/api/media/${id}/tags/${encodeURIComponent(name)}`, { method: 'DELETE', ...opts })
+
 export { ApiError }

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -204,4 +204,17 @@ export const addTag = (id, name, opts) =>
 export const removeTag = (id, name, opts) =>
   req(`/api/media/${id}/tags/${encodeURIComponent(name)}`, { method: 'DELETE', ...opts })
 
+// ---- per-clip re-processing (all SYNCHRONOUS — the request blocks until done,
+// so callers must show a busy state; reingest can run up to ~10 min) ----
+// POST /api/media/{id}/retranscribe {language} → {ok, transcript_length, language}
+export const retranscribe = (id, language = 'zh', opts) =>
+  req(`/api/media/${id}/retranscribe`, { method: 'POST', body: { language }, ...opts })
+// POST /api/media/{id}/retry-vision → {ok, patched, still_empty, total_frames, message?}
+export const retryVision = (id, opts) =>
+  req(`/api/media/${id}/retry-vision`, { method: 'POST', ...opts })
+// POST /api/media/{id}/reingest → {ok, stdout, stderr}. 409 if an ingest is
+// already running (single-flight guard); 504 on the 10-min server timeout.
+export const reingest = (id, opts) =>
+  req(`/api/media/${id}/reingest`, { method: 'POST', ...opts })
+
 export { ApiError }

--- a/frontend/src/routes/ChatLive.svelte
+++ b/frontend/src/routes/ChatLive.svelte
@@ -18,6 +18,52 @@
   let err = ''
   let mediaById = new Map() // id → {filename, thumb} for scene resolution
   let scroller
+  let conversations = [] // [{id, title, updated_at, …}] — past chats (newest first)
+
+  const fmtTime = (s) => (s || '').slice(5, 16).replace('T', ' ')
+  const parseSceneIds = (json) => {
+    if (!json) return []
+    try { const v = JSON.parse(json); return Array.isArray(v) ? v : [] } catch { return [] }
+  }
+
+  async function loadConversations() {
+    try {
+      const r = await api.listConversations()
+      conversations = r.conversations || []
+    } catch (e) { /* non-fatal — history sidebar just stays empty */ }
+  }
+
+  // Restore a past conversation: rebuild the thread from stored messages,
+  // resolving each assistant turn's scene_ids back to thumbnails. Sets convId
+  // so the next prompt continues this conversation.
+  async function openConversation(id) {
+    if (busy) return
+    err = ''
+    try {
+      const r = await api.getChatHistory(id)
+      convId = (r.conversation && r.conversation.id) || id
+      const rebuilt = []
+      for (const m of r.messages || []) {
+        if (m.role === 'user') {
+          rebuilt.push({ role: 'user', text: m.content })
+        } else {
+          const scenes = await resolveScenes(parseSceneIds(m.scene_ids_json))
+          rebuilt.push({ role: 'assistant', text: m.content || '', intent: m.intent, scenes })
+        }
+      }
+      messages = rebuilt
+      scrollDown()
+    } catch (e) {
+      err = e.status === 404 ? '找不到這個對話' : e.message
+    }
+  }
+
+  function newChat() {
+    if (busy) return
+    convId = null
+    messages = []
+    err = ''
+  }
 
   // Honest phrasing — chat finds candidate clips, it does NOT cut a final video.
   const suggestions = ['找生肉切割的鏡頭', '找店內空景的畫面', '哪些素材有餐廳']
@@ -86,9 +132,12 @@
     messages = [...messages, { role: 'user', text: prompt }]
     busy = true
     scrollDown()
+    const wasNew = convId == null
     try {
       const r = await api.chat(prompt, convId)
       convId = r.conversation_id || convId
+      // a brand-new conversation now exists server-side → refresh the sidebar
+      if (wasNew) loadConversations()
       const scenes = await resolveScenes(r.scene_ids)
       messages = [
         ...messages,
@@ -115,7 +164,7 @@
     }
   }
 
-  onMount(loadMediaIndex)
+  onMount(() => { loadMediaIndex(); loadConversations() })
 </script>
 
 <div class="artboard" data-theme={theme}>
@@ -127,6 +176,25 @@
   </div>
 
   <div class="body">
+    <aside class="convs">
+      <div class="convhead">
+        <Eyebrow>對話紀錄</Eyebrow>
+        <button class="ak-btn newchat" on:click={newChat} disabled={busy}>＋ 新對話</button>
+      </div>
+      <div class="convlist">
+        {#each conversations as c (c.id)}
+          <button class="convitem" class:active={c.id === convId} on:click={() => openConversation(c.id)} disabled={busy}>
+            <span class="convtitle">{c.title || '未命名對話'}</span>
+            <Mono dim style="font-size:9px;letter-spacing:0.04em;">{fmtTime(c.updated_at)}</Mono>
+          </button>
+        {/each}
+        {#if conversations.length === 0}
+          <Mono dim style="font-size:10.5px;padding:8px 2px;display:block;">尚無紀錄</Mono>
+        {/if}
+      </div>
+    </aside>
+
+    <div class="chatmain">
     <div class="thread" bind:this={scroller}>
       {#if messages.length === 0}
         <div class="empty">
@@ -185,6 +253,7 @@
       />
       <button class="ak-btn ak-btn--primary" on:click={() => send()} disabled={busy || !input.trim()}>送出 →</button>
     </div>
+    </div>
   </div>
 </div>
 
@@ -192,8 +261,25 @@
   .artboard { width: 1400px; height: 900px; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 1fr; overflow: hidden; margin: 0 auto; }
   .grow { flex: 1; }
   .topbar { display: flex; align-items: center; border-bottom: 1px solid var(--rule); padding: 0 16px; gap: 16px; }
-  .body { display: flex; flex-direction: column; min-height: 0; }
-  .thread { flex: 1; overflow: auto; padding: 24px 18%; display: flex; flex-direction: column; gap: 20px; }
+  .body { display: grid; grid-template-columns: 240px 1fr; min-height: 0; }
+  .convs { border-right: 1px solid var(--rule); display: flex; flex-direction: column; min-height: 0; }
+  .convhead { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 14px 16px; border-bottom: 1px solid var(--rule); }
+  .newchat { font-size: 9.5px; padding: 5px 8px; white-space: nowrap; }
+  .convlist { flex: 1; overflow: auto; padding: 8px; display: flex; flex-direction: column; gap: 2px; }
+  .convitem {
+    display: flex; flex-direction: column; gap: 3px; align-items: flex-start;
+    text-align: left; padding: 8px 10px; background: transparent; border: none;
+    border-left: 2px solid transparent; cursor: pointer; font-family: inherit; width: 100%;
+  }
+  .convitem:hover { background: var(--surface-2); }
+  .convitem.active { border-left-color: var(--invert); background: var(--surface-2); }
+  .convitem:disabled { cursor: default; opacity: 0.6; }
+  .convtitle {
+    font-size: 12px; color: var(--ink); line-height: 1.3; width: 100%;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .chatmain { display: flex; flex-direction: column; min-height: 0; }
+  .thread { flex: 1; overflow: auto; padding: 24px 10%; display: flex; flex-direction: column; gap: 20px; }
   .empty { display: flex; flex-direction: column; gap: 10px; padding-top: 40px; }
   .emptytitle { font-size: var(--fs-display-sm); color: var(--ink); margin: 4px 0; }
   .suggest { display: flex; flex-direction: column; gap: 8px; margin-top: 16px; align-items: flex-start; }
@@ -216,6 +302,6 @@
     background: transparent; cursor: pointer; appearance: none;
   }
   .exp:hover { color: var(--ink); border-color: var(--ink); }
-  .composer { border-top: 1px solid var(--rule); padding: 16px 18%; display: flex; gap: 10px; align-items: center; }
+  .composer { border-top: 1px solid var(--rule); padding: 16px 10%; display: flex; gap: 10px; align-items: center; }
   .chatinput { flex: 1; font-size: 13px; }
 </style>

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -52,6 +52,7 @@
 
   let liveTags = null
   let liveCollections = null
+  let engineLangs = null // [{code,label}] for the inspector's retranscribe picker
 
   // Multi-select for batch timeline export. Click order = sequence order on the
   // exported timeline (what the user picks first lands first in Resolve).
@@ -180,9 +181,17 @@
       if (d && d.id != null) { items = [toCard(d), ...items]; selectedId = sel }
     } catch (e) { /* unknown id → keep default selection */ }
   }
+  // Engine languages for the retranscribe picker — non-fatal (mock fallback in UI).
+  async function loadEngines() {
+    try {
+      const e = await api.getIngestEngines()
+      engineLangs = e?.languages || null
+    } catch (e) { /* picker falls back to its built-in zh/en list */ }
+  }
   onMount(async () => {
     await load()
     await selectFromParam()
+    loadEngines()
   })
 
   $: visible = items.filter((m) => {
@@ -300,6 +309,33 @@
     }
   }
 
+  // Per-clip re-processing. Returns {ok, message} for the inspector to surface;
+  // throws bubble up to the inspector's catch. Refetch detail on success so the
+  // transcript / vision / tags reflect the new run.
+  async function reprocess(action, opts = {}) {
+    if (!selected) return { ok: false, message: '未選取素材' }
+    const id = selected.id
+    if (action === 'retranscribe') {
+      const r = await api.retranscribe(id, opts.language || 'zh')
+      if (detailId === id) await fetchDetail(id)
+      return { ok: r.ok, message: `轉錄完成 · ${r.transcript_length} 字 · ${r.language}` }
+    }
+    if (action === 'retry-vision') {
+      const r = await api.retryVision(id)
+      if (detailId === id) await fetchDetail(id)
+      return {
+        ok: r.ok,
+        message: r.message || `視覺補上 ${r.patched}/${r.total_frames} 幀，剩 ${r.still_empty}`,
+      }
+    }
+    if (action === 'reingest') {
+      const r = await api.reingest(id)
+      if (detailId === id) await fetchDetail(id)
+      return { ok: r.ok, message: r.ok ? '完整重建完成' : '重建失敗（見後端 log）' }
+    }
+    return { ok: false, message: `未知動作: ${action}` }
+  }
+
   // C — rating write. UI value → backend value (db.set_rating: good/ng/review/None).
   const RATING_MAP = { good: 'good', rev: 'review', ng: 'ng', none: null }
   async function rate(uiRating) {
@@ -403,6 +439,9 @@
         tags={inspTags}
         onAddTag={selected ? addTag : null}
         onRemoveTag={selected ? removeTag : null}
+        onReprocess={selected ? reprocess : null}
+        languages={engineLangs}
+        mediaLang={detailLive ? detailLive.lang : null}
         onExport={selected ? (fmt) => exportClip(selected.id, fmt, selected.name) : null}
         onRate={rate}
       />

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -342,6 +342,11 @@
       if (detailId === id) await fetchDetail(id)
       return { ok: r.ok, message: r.ok ? '完整重建完成' : '重建失敗（見後端 log）' }
     }
+    if (action === 'proxy') {
+      // background build — returns immediately, no detail change to refetch
+      const r = await api.buildProxyOne(id)
+      return { ok: true, message: r.message || '已排入 proxy 生成（背景）' }
+    }
     return { ok: false, message: `未知動作: ${action}` }
   }
 

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -267,6 +267,38 @@
     : null
   $: inspThumb = selected ? selected.thumb : null
   $: inspPath = detailLive ? detailLive.path : null
+  // tags: detail carries the quality-filtered tag list [{id,name,source}].
+  $: inspTags = detailLive ? (detailLive.tags || []) : null
+
+  // Tag editing. Both endpoints return the full updated tag list, so reconcile
+  // `detail.tags` from the response (reassign detail so detailLive recomputes).
+  async function addTag(name) {
+    const n = (name || '').trim()
+    if (!n || !selected) return
+    const id = selected.id
+    try {
+      const r = await api.addTag(id, n)
+      if (detail && detail.id === id) detail = { ...detail, tags: r.tags }
+    } catch (e) {
+      err = `加標籤失敗: ${e.message}`
+    }
+  }
+  async function removeTag(name) {
+    if (!selected) return
+    const id = selected.id
+    const prev = detail && detail.id === id ? detail.tags : null
+    // optimistic: drop it immediately, reconcile (or revert) when the call lands
+    if (detail && detail.id === id) {
+      detail = { ...detail, tags: (detail.tags || []).filter((t) => t.name !== name) }
+    }
+    try {
+      const r = await api.removeTag(id, name)
+      if (detail && detail.id === id) detail = { ...detail, tags: r.tags }
+    } catch (e) {
+      if (detail && detail.id === id && prev) detail = { ...detail, tags: prev }
+      err = `刪標籤失敗: ${e.message}`
+    }
+  }
 
   // C — rating write. UI value → backend value (db.set_rating: good/ng/review/None).
   const RATING_MAP = { good: 'good', rev: 'review', ng: 'ng', none: null }
@@ -368,6 +400,9 @@
         transcriptLines={inspTranscript}
         frameDescriptions={inspFrames}
         frameScenes={inspScenes}
+        tags={inspTags}
+        onAddTag={selected ? addTag : null}
+        onRemoveTag={selected ? removeTag : null}
         onExport={selected ? (fmt) => exportClip(selected.id, fmt, selected.name) : null}
         onRate={rate}
       />

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -71,6 +71,15 @@
       err = `匯出失敗: ${e.message}`
     }
   }
+  // DaVinci Resolve metadata CSV (auth-safe download). ids=null → whole library;
+  // ids=picked → just the selected clips (camera-report / DIT handoff deliverable).
+  async function exportMetadataCsv(ids = null) {
+    try {
+      await api.downloadFile(api.metadataCsvPath(ids), 'arkiv_davinci_metadata.csv')
+    } catch (e) {
+      err = `CSV 匯出失敗: ${e.message}`
+    }
+  }
   // single-clip export from the inspector (auth-safe download).
   async function exportClip(id, fmt, name) {
     const stem = (name || `media_${id}`).replace(/\.[^.]+$/, '')
@@ -382,6 +391,11 @@
           href={query.trim() ? `#/search-live?q=${encodeURIComponent(query.trim())}` : '#/search-live'}
           title="排名檢視（score + 摘要）"
         >排名 →</a>
+        <button
+          class="ak-btn metacsv"
+          on:click={() => exportMetadataCsv(null)}
+          title="匯出整庫 metadata CSV（DaVinci Resolve）"
+        >CSV ↓</button>
         <FilterRow bind:activeFilter bind:activeRating />
         <ViewToggle bind:view />
       </div>
@@ -393,6 +407,7 @@
             {#each EXPORT_FMTS as fmt}
               <button class="ak-btn expbtn" on:click={() => exportTimeline(fmt)}>{fmt.toUpperCase()}</button>
             {/each}
+            <button class="ak-btn expbtn" on:click={() => exportMetadataCsv(picked)} title="匯出所選 metadata CSV">CSV</button>
             <button class="ak-btn expbtn clear" on:click={clearPicks}>清除</button>
           </div>
         </div>
@@ -458,6 +473,7 @@
   .projtitle { font-size: 28px; letter-spacing: -0.04em; line-height: 1; color: var(--ink); }
   .livesearch { flex: 1; max-width: 360px; font-size: 12px; }
   .ranked { font-size: 10px; padding: 6px 10px; text-decoration: none; white-space: nowrap; }
+  .metacsv { font-size: 10px; padding: 6px 10px; white-space: nowrap; }
   .gridwrap { flex: 1; overflow: auto; position: relative; }
   .mediagrid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px; padding: 22px; background: var(--rule); }
   .msg { padding: 40px 22px; display: flex; flex-direction: column; gap: 8px; }

--- a/frontend/src/routes/SettingsLive.svelte
+++ b/frontend/src/routes/SettingsLive.svelte
@@ -33,7 +33,32 @@
     sys = 'loading'
     try { stats = await api.getStats(); sys = 'ok' } catch { sys = 'error' }
   }
-  onMount(loadSystem)
+
+  // Editing proxies — status + background build (no completion signal, so we
+  // re-poll the status a couple of times after kicking a build off).
+  let proxy = null // {total, proxied, size_mb}
+  let proxyMsg = ''
+  let proxyBusy = false
+  async function loadProxy() {
+    try { proxy = await api.getProxyStatus() } catch { proxy = null }
+  }
+  async function runProxyBuild() {
+    if (proxyBusy) return
+    proxyBusy = true
+    proxyMsg = ''
+    try {
+      const r = await api.buildProxies()
+      proxyMsg = r.message || `已排入 ${r.queued} 個`
+      setTimeout(loadProxy, 2000)
+      setTimeout(loadProxy, 8000)
+    } catch (e) {
+      proxyMsg = `失敗: ${e.message}`
+    } finally {
+      proxyBusy = false
+    }
+  }
+
+  onMount(() => { loadSystem(); loadProxy() })
 
   const gb = (n) => (n == null ? '—' : n >= 1000 ? `${(n / 1000).toFixed(1)} TB` : `${Math.round(n)} GB`)
   $: disk = stats?.disk ?? null
@@ -117,6 +142,15 @@
                   {#if disk}<Mono style="font-size:12px;color:var(--ink);">{gb(disk.used_gb)} / {gb(disk.total_gb)} · {disk.pct}%</Mono>{:else}<Mono dim style="font-size:12px;">—</Mono>{/if}
                 </div>
               {/if}
+              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Proxies</Mono>
+                {#if proxy}<Mono style="font-size:12px;color:var(--ink);">{proxy.proxied}/{proxy.total} built · {proxy.size_mb} MB</Mono>{:else}<Mono dim style="font-size:12px;">—</Mono>{/if}
+              </div>
+              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Build proxies</Mono>
+                <div class="proxyctl">
+                  <button class="ak-btn" on:click={runProxyBuild} disabled={proxyBusy}>{proxyBusy ? '排入中…' : '生成缺漏 proxy'}</button>
+                  {#if proxyMsg}<Mono dim style="font-size:10.5px;">{proxyMsg}</Mono>{/if}
+                </div>
+              </div>
               <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Privacy</Mono><Mono dim style="font-size:11.5px;">Everything runs locally. Nothing leaves this machine.</Mono></div>
             </div>
           </section>
@@ -153,4 +187,5 @@
   .segbtn.on { background: var(--invert); color: var(--invert-ink); font-weight: 700; }
   .pend { font-family: var(--ak-mono); font-size: 9.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--quiet-2); border: 1px dashed var(--rule-hi); padding: 2px 7px; width: fit-content; }
   .livedot { color: var(--cyan); font-size: 9px; }
+  .proxyctl { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 </style>


### PR DESCRIPTION
Closes the **Tier 1** must-have gaps from #78 — the features the new Svelte UI was missing vs the backend, which would be daily-felt regressions if we cut over without them. Pure frontend wiring: **no backend changes** (all 5 endpoint groups already existed + are pytest-covered).

## What's wired (5 atomic commits)

| Feature | Where | Endpoint(s) |
|---------|-------|-------------|
| **Tag editing** | Inspector | `POST` / `DELETE /api/media/{id}/tags` — editable chips + add form, optimistic remove |
| **Per-clip reprocess** | Inspector | `retranscribe` (lang picker) · `retry-vision` · `reingest` — sync, busy state + result line, refetch on success |
| **Proxy build + status** | Settings→System + Inspector | `GET /api/proxy/status`, `POST /api/proxy/build[/{id}]` — coverage readout + library build (re-polls) + per-clip build |
| **Metadata CSV** | Main grid | `GET /api/export/metadata-csv` — whole-library toolbar button + picked-scoped (`ids=`) export-bar button |
| **Chat history** | Chat | `GET /api/chat/conversations` + `/api/chat/history/{id}` — sidebar lists past chats, restores thread (re-resolves scene thumbs), continues convId |

All new UI is **prop-gated** so the mock `_design/*` screens are unchanged.

## Verification

- `npm run build` green after every commit, **zero Svelte/a11y warnings**
- **Live smoke** against a real DB (13 media · 15 conversations), through the **browser→vite-proxy→FastAPI** path:
  - tag write round-trips cleanly (direct + via proxy)
  - `proxy/build/{id}` with browser `Origin` → HTTP 200 (`_assert_same_site` guard passes)
  - `metadata-csv` emits real rows; `chat/history` returns the `scene_ids_json` shape the restore path parses; `ingest/engines` → zh/en/ja/ko picker
  - heavy model paths (retranscribe/retry-vision/reingest) confirmed registered via OpenAPI, not triggered (load Whisper/Ollama)

## Not in this PR
The **cutover mechanics** (serve `frontend/dist`, add `npm run build` to deploy, retire old `ROOT/index.html`, tag release) are separate and unblocked once this lands + is confirmed — see #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)