### PR TITLE
feat: Svelte cutover Phase 1+2 — serve built SPA at / + automate build (#78)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,14 @@
 # arkiv — Multi-stage Dockerfile
+# Stage 0: Build the Svelte SPA (frontend/dist) that server.py serves at /.
+# .dockerignore excludes dist/ + node_modules, so this stage builds from clean
+# source. The built dist is copied into the app stage below.
+FROM node:20-slim AS ui
+WORKDIR /ui
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci --no-audit --no-fund
+COPY frontend/ ./
+RUN npm run build
+
 # Stage 1: Dependencies
 FROM python:3.11-slim AS deps
 
@@ -16,6 +26,9 @@ RUN pip install --no-cache-dir -r requirements.txt faster-whisper
 FROM deps AS app
 
 COPY . .
+# Overlay the built SPA (dist/ is gitignored + .dockerignore'd, so COPY . . brings
+# the frontend source but not its build — bring it from the ui stage).
+COPY --from=ui /ui/dist ./frontend/dist
 
 # Create data directories
 RUN mkdir -p thumbnails chroma_db

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,26 @@ PORT=${ARKIV_PORT:-8501}
 
 RED='\033[31m'; GREEN='\033[32m'; YELLOW='\033[33m'; BOLD='\033[1m'; NC='\033[0m'
 
+# Build the Svelte SPA (frontend/dist) that server.py serves at /. npm missing is
+# a loud warning, NOT fatal: server.py auto-falls back to the legacy page, so an
+# install on a Node-less box still works (just with the old UI). Never aborts the
+# installer (guarded so `set -e` can't trip on a build failure).
+build_frontend() {
+    local fe="$1"
+    if ! command -v npm &>/dev/null; then
+        echo -e "  ${YELLOW}⚠${NC}  npm not found — skipping UI build (server falls back to the legacy page)."
+        echo -e "      Install Node (brew install node), then: cd $fe && npm ci && npm run build"
+        return 0
+    fi
+    echo "  Building Svelte UI..."
+    if ( cd "$fe" && npm ci --no-audit --no-fund && npm run build ) >/dev/null 2>&1; then
+        echo -e "  ${GREEN}✓${NC} UI built ($fe/dist)"
+    else
+        echo -e "  ${YELLOW}⚠${NC}  UI build failed — server falls back to the legacy page. Re-run: cd $fe && npm ci && npm run build"
+    fi
+    return 0
+}
+
 echo -e "${BOLD}═══ arkiv installer ═══${NC}"
 echo ""
 
@@ -92,6 +112,21 @@ else
         git -C "$INSTALL_DIR" pull --quiet
     else
         git clone --quiet "$REPO" "$INSTALL_DIR"
+    fi
+fi
+
+# ── 2b. Build Svelte UI (server.py serves frontend/dist at /) ──
+# The copy path (local dir) only copies *.py + packages + a file list, NOT the
+# frontend/ tree — so build at the source and copy just the built dist over.
+# The clone / in-place paths have frontend/ at $INSTALL_DIR, so build there.
+if [ -d "$INSTALL_DIR/frontend" ]; then
+    build_frontend "$INSTALL_DIR/frontend"
+elif [ -d "$SRC/frontend" ]; then
+    build_frontend "$SRC/frontend"
+    if [ -d "$SRC/frontend/dist" ]; then
+        mkdir -p "$INSTALL_DIR/frontend"
+        rm -rf "$INSTALL_DIR/frontend/dist"
+        cp -R "$SRC/frontend/dist" "$INSTALL_DIR/frontend/dist"
     fi
 fi
 

--- a/server.py
+++ b/server.py
@@ -17,6 +17,7 @@ from typing import Any, List, Literal, Optional, Set
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Query, Request, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response, StreamingResponse
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, field_validator
 
 import admin
@@ -145,6 +146,8 @@ app.add_middleware(
 )
 
 ROOT = Path(__file__).parent
+# Built Svelte SPA (frontend/dist). Gitignored — produced by `npm run build`.
+FRONTEND_DIST = ROOT / "frontend" / "dist"
 
 # Serve thumbnails through an AUTHED route (create dir if missing so it always
 # works). Honor ARKIV_THUMBNAILS_DIR (via config.THUMBNAILS_DIR) instead of
@@ -3286,11 +3289,20 @@ def _rebuild_embeddings():
 
 # ── Serve Frontend ───────────────────────────────────────────────────────────
 
-# Dev mode: always read fresh index.html (no cache)
+# Serve the built Svelte SPA (frontend/dist/index.html) when present. The SPA is
+# hash-routed (svelte-spa-router) so "/" is the only HTML entry the browser ever
+# requests — no catch-all fallback needed; /assets/* is a StaticFiles mount below.
+# Auto-falls back to the legacy Tailwind index.html when the build is absent (a
+# fresh clone before `npm run build`); ARKIV_UI=legacy forces it (rollback hatch).
+# Read fresh each request (no cache), matching the previous dev behaviour.
 def _load_index() -> str:
-    index = ROOT / "index.html"
-    if index.exists():
-        return index.read_text(encoding="utf-8")
+    if os.environ.get("ARKIV_UI", "").lower() != "legacy":
+        spa = FRONTEND_DIST / "index.html"
+        if spa.exists():
+            return spa.read_text(encoding="utf-8")
+    legacy = ROOT / "index.html"
+    if legacy.exists():
+        return legacy.read_text(encoding="utf-8")
     return "<h1>arkiv</h1><p>index.html not found</p>"
 
 class OpenFileRequest(BaseModel):  # audit M22: malformed JSON → clean 422, not a raw 500
@@ -3363,3 +3375,11 @@ def client_log(body: ClientLogRequest):
 @app.get("/", response_class=HTMLResponse)
 def serve_index():
     return _load_index()
+
+
+# Built SPA assets (frontend/dist/assets/*-<hash>.js|css, referenced as /assets/…
+# by the built index.html). Mounted only when the build exists, so a fresh clone
+# without `npm run build` still boots and falls back to the legacy page at "/".
+# Registered last → never shadows the explicit /api, /thumbnails, /dit routes.
+if (FRONTEND_DIST / "assets").is_dir():
+    app.mount("/assets", StaticFiles(directory=str(FRONTEND_DIST / "assets")), name="spa-assets")

--- a/tests/test_spa_serving.py
+++ b/tests/test_spa_serving.py
@@ -1,0 +1,52 @@
+"""Svelte cutover (Phase 1): server.py serves the built SPA at / when
+frontend/dist exists, and falls back to the legacy Tailwind index.html when it
+doesn't (fresh clone before `npm run build`) or when ARKIV_UI=legacy is set.
+
+frontend/dist is gitignored and CI doesn't build the frontend, so these tests
+monkeypatch FRONTEND_DIST to a fake build dir — they exercise the cutover
+DECISION logic deterministically without needing a real Vite build. The SPA
+shell is identified by `id="app"` (the legacy page has no such marker).
+"""
+
+SPA_INDEX = '<!doctype html><html><body><div id="app"></div>' \
+            '<script type="module" src="/assets/index-abc.js"></script></body></html>'
+
+
+def _fake_dist(tmp_path):
+    dist = tmp_path / "dist"
+    (dist / "assets").mkdir(parents=True)
+    (dist / "index.html").write_text(SPA_INDEX, encoding="utf-8")
+    return dist
+
+
+def test_load_index_prefers_built_spa(server_module, tmp_path, monkeypatch):
+    monkeypatch.setattr(server_module, "FRONTEND_DIST", _fake_dist(tmp_path))
+    monkeypatch.delenv("ARKIV_UI", raising=False)
+    html = server_module._load_index()
+    assert 'id="app"' in html
+
+
+def test_load_index_falls_back_to_legacy_without_build(server_module, tmp_path, monkeypatch):
+    # No dist → the legacy ROOT/index.html (shipped in the repo) is returned.
+    monkeypatch.setattr(server_module, "FRONTEND_DIST", tmp_path / "does-not-exist")
+    monkeypatch.delenv("ARKIV_UI", raising=False)
+    html = server_module._load_index()
+    assert 'id="app"' not in html  # legacy Tailwind page, not the SPA shell
+    assert html.strip()  # non-empty
+
+
+def test_arkiv_ui_legacy_forces_old_page(server_module, tmp_path, monkeypatch):
+    # Rollback escape hatch: even with a build present, ARKIV_UI=legacy → old page.
+    monkeypatch.setattr(server_module, "FRONTEND_DIST", _fake_dist(tmp_path))
+    monkeypatch.setenv("ARKIV_UI", "legacy")
+    html = server_module._load_index()
+    assert 'id="app"' not in html
+
+
+def test_root_route_serves_spa_end_to_end(fastapi_client, server_module, tmp_path, monkeypatch):
+    monkeypatch.setattr(server_module, "FRONTEND_DIST", _fake_dist(tmp_path))
+    monkeypatch.delenv("ARKIV_UI", raising=False)
+    r = fastapi_client.get("/")
+    assert r.status_code == 200
+    assert "text/html" in r.headers["content-type"]
+    assert 'id="app"' in r.text


### PR DESCRIPTION
Cutover mechanics from #78, Phases 1+2 (per `references/plans/arkiv/2026-06-16-svelte-cutover-plan.md`). Both non-breaking with a legacy fallback, so they ship together.

## Phase 1 — serve the built SPA (`server.py`)
- `/` serves `frontend/dist/index.html` (built Svelte SPA) when present; `/assets/*` mounted as StaticFiles.
- Hash-routed SPA → **no catch-all fallback needed**.
- **Three safety nets**: no build (fresh clone) → auto-fallback to legacy Tailwind page; `ARKIV_UI=legacy` → force legacy (rollback hatch); `/assets` mount registered last + only when dist exists → never shadows `/api`·`/thumbnails`·`/dit`, and a build-less clone still boots.
- No backend behaviour change.

## Phase 2 — automate the build (`install.sh`, `Dockerfile`)
`frontend/dist` is gitignored, so without this the SPA would never deploy.
- **install.sh**: `build_frontend()` runs `npm ci && npm run build` (handles clone / in-place / local-copy paths). npm missing = loud warning, not fatal.
- **Dockerfile**: new `ui` stage (node:20) builds dist; app stage overlays via `COPY --from=ui` (`COPY . .` can't — dist is `.dockerignore`'d).

## Verification
- `pytest` full suite: **572 passed, 5 skipped**
- `test_spa_serving.py` (new, 4 tests): dist-present · no-build fallback · `ARKIV_UI=legacy` · end-to-end `/` (monkeypatches `FRONTEND_DIST` since CI doesn't build the frontend)
- **Production-mode live smoke** (no Vite): `/` serves SPA shell (`id="app"` + hashed assets), `/assets/index-*.js` → 200, `/api/*` intact
- `bash -n install.sh` clean; `docker build --target ui` builds the SPA in-container (dist has `id="app"` + assets)

## Not in this PR (Phase 3 + 4, gated on bake)
Retire legacy UI (remove tailwind routes, `/dit`→redirect, delete old `index.html`/`dit-offload.html`, Tauri `frontendDist` align) + version bump/tag/release + redeploy `~/.arkiv` (H11 drift). See #78 + the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)