### PR TITLE
feat(server): keep legacy UI at /legacy during cutover bake (#78)

### DIFF
--- a/server.py
+++ b/server.py
@@ -3377,6 +3377,18 @@ def serve_index():
     return _load_index()
 
 
+@app.get("/legacy", response_class=HTMLResponse)
+def serve_legacy():
+    """Old Tailwind UI, kept reachable alongside the new SPA during the cutover
+    bake — an escape hatch / side-by-side comparison view while the SPA earns
+    trust. Always the legacy page, regardless of ARKIV_UI or whether dist exists.
+    Retired in Phase 3 once the SPA is confirmed."""
+    legacy = ROOT / "index.html"
+    if legacy.exists():
+        return legacy.read_text(encoding="utf-8")
+    raise HTTPException(404, "legacy UI removed")
+
+
 # Built SPA assets (frontend/dist/assets/*-<hash>.js|css, referenced as /assets/…
 # by the built index.html). Mounted only when the build exists, so a fresh clone
 # without `npm run build` still boots and falls back to the legacy page at "/".

--- a/tests/test_spa_serving.py
+++ b/tests/test_spa_serving.py
@@ -50,3 +50,15 @@ def test_root_route_serves_spa_end_to_end(fastapi_client, server_module, tmp_pat
     assert r.status_code == 200
     assert "text/html" in r.headers["content-type"]
     assert 'id="app"' in r.text
+
+
+def test_legacy_route_serves_old_ui(fastapi_client, server_module, tmp_path, monkeypatch):
+    # /legacy is the cutover escape hatch — always the old Tailwind page, even when
+    # the SPA is built and the default (no ARKIV_UI). Identified by the absence of
+    # the SPA shell's id="app".
+    monkeypatch.setattr(server_module, "FRONTEND_DIST", _fake_dist(tmp_path))
+    monkeypatch.delenv("ARKIV_UI", raising=False)
+    r = fastapi_client.get("/legacy")
+    assert r.status_code == 200
+    assert "text/html" in r.headers["content-type"]
+    assert 'id="app"' not in r.text


### PR DESCRIPTION
Phase 2.5 of the #78 cutover: lets us **release the new UI while keeping the old one live**, instead of bake-then-retire.

- `/` → new Svelte SPA (release default, from Phase 1)
- `/legacy` → old Tailwind `index.html`, **always** (independent of `ARKIV_UI` / whether dist is built) — escape hatch + side-by-side comparison during bake
- `/api/*` shared, so the legacy UI keeps working (it was the production UI until now)

Phase 3 later retires `/legacy` + the old files (`index.html`, `dit-offload.html`, tailwind routes) once the SPA is confirmed.

## Verification
- `tests/test_spa_serving.py`: 5 passed (incl. new `test_legacy_route_serves_old_ui` — `/legacy` returns the old page even with a built SPA present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)