### PR TITLE
fix(vision): default to qwen2.5vl:7b + graceful configurable fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 ## Unreleased
 
+### Changed
+- **Default vision model is now `qwen2.5vl:7b` (was `qwen3-vl:8b`).** Qwen3-VL's vision path (DeepStack / interleaved-MRoPE) runs ~10x slower than Qwen2.5-VL under Ollama and often offloads the vision encoder to CPU — measured **~60s/frame vs ~8s/frame on an M2 Max** for identical frames (Ollama issues #12854 / #12882 / #14548). At ~2000 frames that's ~30h vs ~3.5h, at comparable tag quality (spot-checked). Override with `ARKIV_OLLAMA_VISION_MODEL=qwen3-vl:8b` for the higher ceiling once the Ollama regression is fixed.
+
+### Fixed
+- **Vision fallback no longer 404s on every fresh install.** The Phase-2 fallback model was hardcoded — and inconsistently (`ingest.py` used `minicpm-v`, `server.py` used `moondream2`) — while `install.sh` pulled neither, so the issue-#48 resilience path silently 404'd per failed frame and left those frames empty. Now: a single configurable `ARKIV_OLLAMA_VISION_FALLBACK_MODEL` (default `minicpm-v:latest`) used by both paths, pulled by `install.sh`, and **skipped gracefully** (logged once, frame left for a later `--vision-only` retry) when the model isn't installed instead of erroring per frame.
+- **`install.sh` pulls the right models** for the new defaults: `qwen2.5vl:7b` (vision) + `minicpm-v` (fallback), alongside `bge-m3` + `qwen2.5:14b`.
+
 ## v0.9.2 - 2026-06-17
 
 ### Added

--- a/config.py
+++ b/config.py
@@ -106,12 +106,31 @@ OLLAMA_EMBED_MODEL = os.getenv(
     "ARKIV_OLLAMA_EMBED_MODEL",
     os.getenv("ARKIV_EMBED_MODEL", "bge-m3"),
 )
+# Default vision model. qwen2.5-vl:7b, NOT qwen3-vl:8b: Qwen3-VL's vision path
+# (DeepStack / interleaved-MRoPE) is ~10x slower than Qwen2.5-VL under Ollama and
+# frequently offloads the vision encoder to CPU — measured ~60s/frame vs ~8s/frame
+# on an M2 Max for the same frames (Ollama issues #12854 / #12882 / #14548). At
+# ~2000 frames that's the difference between ~30h and ~3.5h, at comparable tag
+# quality. Override with ARKIV_OLLAMA_VISION_MODEL=qwen3-vl:8b for the higher
+# ceiling once Ollama fixes the regression.
 OLLAMA_VISION_MODEL = os.getenv(
     "ARKIV_OLLAMA_VISION_MODEL",
-    os.getenv("ARKIV_VISION_MODEL", "qwen3-vl:8b"),
+    os.getenv("ARKIV_VISION_MODEL", "qwen2.5vl:7b"),
 )
 EMBED_MODEL = OLLAMA_EMBED_MODEL
 VISION_MODEL = OLLAMA_VISION_MODEL
+
+# Lighter model retried on frames the primary leaves empty (issue #48 vision
+# resilience). Configurable, and skipped gracefully when not installed (the frame
+# is left empty for a later --vision-only retry) instead of erroring per frame.
+# install.sh pulls it so the fallback path works out of the box. Previously this
+# was hardcoded — and inconsistently: ingest used minicpm-v, the server used
+# moondream2, and install.sh pulled neither, so every fresh install's fallback
+# 404'd silently.
+OLLAMA_VISION_FALLBACK_MODEL = os.getenv(
+    "ARKIV_OLLAMA_VISION_FALLBACK_MODEL", "minicpm-v:latest"
+)
+VISION_FALLBACK_MODEL = OLLAMA_VISION_FALLBACK_MODEL
 
 # Cap the vision model's context window so it fits in GPU VRAM. qwen3-vl's
 # default context balloons the model to ~28 GB, which on a 12 GB GPU (e.g.

--- a/ingest.py
+++ b/ingest.py
@@ -734,17 +734,23 @@ def _describe_frames_with_fallback(frame_paths):
     frame_results = vis.describe_frames(frame_paths)
     failed_indices = [i for i, vr in enumerate(frame_results) if vr.get("error") or not vr.get("description")]
     if failed_indices:
-        print(f" [Phase 1: {len(failed_indices)} failed, trying fallback]", end="", flush=True)
-        fallback_model = "minicpm-v:latest"
-        original_model = vis.VISION_MODEL
-        try:
-            vis.VISION_MODEL = fallback_model
-            retry_results = vis.describe_frames([frame_paths[i] for i in failed_indices])
-            for idx, retry_r in zip(failed_indices, retry_results):
-                if retry_r.get("description") and not retry_r.get("error"):
-                    frame_results[idx] = retry_r
-        finally:
-            vis.VISION_MODEL = original_model
+        fallback_model = config.VISION_FALLBACK_MODEL
+        if not fallback_model or not vis.model_available(fallback_model):
+            # Graceful: don't hammer Ollama with a 404 per failed frame for a
+            # fallback model that isn't installed — leave them empty for a later
+            # --vision-only retry (issue #48 tolerance still applies).
+            print(f" [Phase 1: {len(failed_indices)} failed, fallback '{fallback_model or 'none'}' 未安裝 → 跳過]", end="", flush=True)
+        else:
+            print(f" [Phase 1: {len(failed_indices)} failed, trying fallback {fallback_model}]", end="", flush=True)
+            original_model = vis.VISION_MODEL
+            try:
+                vis.VISION_MODEL = fallback_model
+                retry_results = vis.describe_frames([frame_paths[i] for i in failed_indices])
+                for idx, retry_r in zip(failed_indices, retry_results):
+                    if retry_r.get("description") and not retry_r.get("error"):
+                        frame_results[idx] = retry_r
+            finally:
+                vis.VISION_MODEL = original_model
     still_failed = [i for i, vr in enumerate(frame_results) if vr.get("error") or not vr.get("description")]
     return frame_results, still_failed
 

--- a/install.sh
+++ b/install.sh
@@ -154,7 +154,12 @@ echo "Pulling Ollama models (this may take a while)..."
 ollama serve &>/dev/null &
 sleep 2
 ollama pull bge-m3 2>/dev/null && echo -e "  ${GREEN}✓${NC} bge-m3 (embeddings)" || echo -e "  ${YELLOW}⏭${NC} bge-m3 (pull later)"
-ollama pull qwen3-vl:8b 2>/dev/null && echo -e "  ${GREEN}✓${NC} qwen3-vl:8b (vision)" || echo -e "  ${YELLOW}⏭${NC} qwen3-vl:8b (pull later)"
+# Vision = qwen2.5vl:7b (config.py default). NOT qwen3-vl:8b — it's ~10x slower
+# under Ollama (vision-path regression, ~60s vs ~8s/frame on M2 Max).
+ollama pull qwen2.5vl:7b 2>/dev/null && echo -e "  ${GREEN}✓${NC} qwen2.5vl:7b (vision)" || echo -e "  ${YELLOW}⏭${NC} qwen2.5vl:7b (pull later)"
+# Vision fallback (config.VISION_FALLBACK_MODEL) — retried on frames the primary
+# leaves empty. Without it, that resilience path 404s.
+ollama pull minicpm-v 2>/dev/null && echo -e "  ${GREEN}✓${NC} minicpm-v (vision fallback)" || echo -e "  ${YELLOW}⏭${NC} minicpm-v (pull later)"
 ollama pull qwen2.5:14b 2>/dev/null && echo -e "  ${GREEN}✓${NC} qwen2.5:14b (chat)" || echo -e "  ${YELLOW}⏭${NC} qwen2.5:14b (pull later — needed for chat)"
 
 echo ""

--- a/server.py
+++ b/server.py
@@ -1941,9 +1941,11 @@ def retry_vision(
     results = vis.describe_frames(frame_paths)
     failed = [i for i, r in enumerate(results) if r.get("error") or not r.get("description")]
 
-    # Phase 2: fallback to lighter model for failed frames
-    if failed:
-        fallback_model = "moondream2:latest"
+    # Phase 2: fallback to lighter model for failed frames. Config-driven (unified
+    # with ingest.py) and skipped gracefully when the fallback model isn't
+    # installed, instead of 404-ing once per failed frame.
+    if failed and config.VISION_FALLBACK_MODEL and vis.model_available(config.VISION_FALLBACK_MODEL):
+        fallback_model = config.VISION_FALLBACK_MODEL
         # audit M9: hold the lock across save/swap/restore so a concurrent
         # retry-vision can't snapshot the fallback as "original" and restore it
         # as the permanent primary model.

--- a/tests/test_ingest_resource.py
+++ b/tests/test_ingest_resource.py
@@ -7,6 +7,8 @@ import importlib
 
 import pytest
 
+import config
+
 
 @pytest.fixture
 def ingest_mod(tmp_db, monkeypatch):
@@ -46,7 +48,7 @@ def _probe_seq(*results):
 # --------------------------------------------------------------------------
 def test_proceeds_immediately_when_under_threshold(ingest_mod):
     sleeps = []
-    probe = _probe_seq({"backend": "apple", "system_mem_pct": 0.4, "models_known": True, "models_loaded": ["qwen3-vl:8b"]})
+    probe = _probe_seq({"backend": "apple", "system_mem_pct": 0.4, "models_known": True, "models_loaded": [config.VISION_MODEL]})
     ingest_mod._ensure_vision_ready(_probe=probe, _sleep=sleeps.append)
     assert sleeps == []  # no backoff
     assert ingest_mod._test_calls["warmup"] == 0  # model already loaded
@@ -56,9 +58,9 @@ def test_backs_off_then_proceeds(ingest_mod):
     sleeps = []
     # busy, busy, then clear
     probe = _probe_seq(
-        {"backend": "apple", "system_mem_pct": 0.95, "models_known": True, "models_loaded": ["qwen3-vl:8b"]},
-        {"backend": "apple", "system_mem_pct": 0.95, "models_known": True, "models_loaded": ["qwen3-vl:8b"]},
-        {"backend": "apple", "system_mem_pct": 0.4, "models_known": True, "models_loaded": ["qwen3-vl:8b"]},
+        {"backend": "apple", "system_mem_pct": 0.95, "models_known": True, "models_loaded": [config.VISION_MODEL]},
+        {"backend": "apple", "system_mem_pct": 0.95, "models_known": True, "models_loaded": [config.VISION_MODEL]},
+        {"backend": "apple", "system_mem_pct": 0.4, "models_known": True, "models_loaded": [config.VISION_MODEL]},
     )
     ingest_mod._ensure_vision_ready(max_wait_s=120, _probe=probe, _sleep=sleeps.append)
     assert len(sleeps) == 2  # waited twice before clearing
@@ -68,7 +70,7 @@ def test_backs_off_then_proceeds(ingest_mod):
 
 def test_proceeds_after_max_wait_even_if_busy(ingest_mod):
     sleeps = []
-    probe = _probe_seq({"backend": "apple", "system_mem_pct": 0.99, "models_known": True, "models_loaded": ["qwen3-vl:8b"]})
+    probe = _probe_seq({"backend": "apple", "system_mem_pct": 0.99, "models_known": True, "models_loaded": [config.VISION_MODEL]})
     # max_wait small -> total backoff is STRICTLY bounded by max_wait (Codex
     # SHOULD-FIX: clamp each sleep to the remaining budget, no overshoot).
     ingest_mod._ensure_vision_ready(max_wait_s=5, _probe=probe, _sleep=sleeps.append)
@@ -94,7 +96,7 @@ def test_warms_up_when_model_not_loaded(ingest_mod):
 
 
 def test_skips_warmup_when_model_loaded(ingest_mod):
-    probe = _probe_seq({"backend": "apple", "system_mem_pct": 0.3, "models_known": True, "models_loaded": ["qwen3-vl:8b"]})
+    probe = _probe_seq({"backend": "apple", "system_mem_pct": 0.3, "models_known": True, "models_loaded": [config.VISION_MODEL]})
     ingest_mod._ensure_vision_ready(_probe=probe, _sleep=lambda s: None)
     assert ingest_mod._test_calls["warmup"] == 0
 

--- a/tests/test_vision_tolerance.py
+++ b/tests/test_vision_tolerance.py
@@ -70,6 +70,9 @@ def _install_fake_vision(ing, monkeypatch):
                 out.append({"description": "desc:" + ps, "tags": ["t"]})
         return out
     monkeypatch.setattr(ing.vis, "describe_frames", fake)
+    # The fallback path now gates on model availability; treat it as installed so
+    # the rescue logic runs deterministically without a live Ollama (CI has none).
+    monkeypatch.setattr(ing.vis, "model_available", lambda name: True)
 
 
 def test_fallback_rescues_transient_not_persistent(ing, monkeypatch):

--- a/vision.py
+++ b/vision.py
@@ -11,6 +11,28 @@ from llm import vision
 
 OLLAMA_URL = f"{config.OLLAMA_URL}/api/generate"
 VISION_MODEL = config.VISION_MODEL
+
+_model_avail_cache: Dict[str, bool] = {}
+
+
+def model_available(name: str) -> bool:
+    """True if `name` is installed in the local Ollama (matched by tag or base
+    name). Cached per process. Lets the fallback path skip cleanly when its model
+    isn't pulled instead of erroring (404) once per failed frame."""
+    if not name:
+        return False
+    if name in _model_avail_cache:
+        return _model_avail_cache[name]
+    avail = False
+    try:
+        r = requests.get(f"{config.OLLAMA_URL}/api/tags", timeout=5)
+        installed = {m.get("name", "") for m in r.json().get("models", [])}
+        base = name.split(":")[0]
+        avail = name in installed or any(n.split(":")[0] == base for n in installed)
+    except Exception:
+        avail = False
+    _model_avail_cache[name] = avail
+    return avail
 PROMPT = (
     "請用繁體中文分析這個影片畫面，回傳嚴格的 JSON 格式（不要加 markdown 標記）：\n"
     "{\n"


### PR DESCRIPTION
Two **user-facing** defects, found while ingesting a real ~2000-frame project (恬馨) and confirmed reproducible + research-backed.

## 1. Default vision model was ~10× too slow
`qwen3-vl:8b` (the old default) runs ~10× slower than Qwen2.5-VL under Ollama — its DeepStack/interleaved-MRoPE vision path frequently offloads to CPU. **Measured on an M2 Max, same frames: ~60s/frame → ~8s/frame.** For ~2000 frames that's **~30h → ~3.5h**, at comparable tag quality (spot-checked: clean zh descriptions + sensible tags + populated structured fields). Known Ollama regression: issues #12854 / #12882 / #14548.

→ Default is now **`qwen2.5vl:7b`**. `ARKIV_OLLAMA_VISION_MODEL=qwen3-vl:8b` still overrides for the higher ceiling once Ollama fixes it.

## 2. Vision fallback 404'd on every fresh install
The Phase-2 fallback model was hardcoded **and inconsistent** — `ingest.py` used `minicpm-v`, `server.py` used `moondream2` — while `install.sh` pulled **neither**. So the issue-#48 resilience path silently **404'd once per failed frame** and left those frames empty.

→ One configurable `ARKIV_OLLAMA_VISION_FALLBACK_MODEL` (default `minicpm-v:latest`) used by both paths, **pulled by install.sh**, and **skipped gracefully** (one log line, frame left for a later `--vision-only` retry) when not installed, via a cached `vision.model_available()` check.

## Also
- `install.sh` pulls `qwen2.5vl:7b` + `minicpm-v` for the new defaults.
- `num_ctx` left at 16384 — tested 4096, it made no difference (the bottleneck was the model, not context), and 16384 is entangled with frame-size/VRAM logic.
- `test_ingest_resource.py` now tracks `config.VISION_MODEL` instead of a hardcoded model name (won't re-break on future default changes).

## Verification
- A/B measured live on M2 Max (same frames, num_ctx=4096): qwen3-vl ~50–63s/frame, 1 fallback-404/file → **qwen2.5vl ~5–17s/frame, 0 failures**.
- Quality spot-check (qwen2.5vl): `一隻手正在打蛋，蛋黃在透明玻璃碗中` · tags 手/蛋/碗 · A-Roll · 平靜.
- Full test suite: **573 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)