### PR TITLE
feat(ui): basic drag-to-look 360 viewer in inspector

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,8 @@
         "@fontsource/inter": "^5.2.0",
         "@fontsource/jetbrains-mono": "^5.2.0",
         "@fontsource/noto-sans-tc": "^5.2.0",
-        "svelte-spa-router": "^4.0.2"
+        "svelte-spa-router": "^4.0.2",
+        "three": "^0.184.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^3.1.2",
@@ -2199,6 +2200,12 @@
       "dependencies": {
         "b4a": "^1.6.4"
       }
+    },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT"
     },
     "node_modules/through": {
       "version": "2.3.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@fontsource/inter": "^5.2.0",
     "@fontsource/jetbrains-mono": "^5.2.0",
     "@fontsource/noto-sans-tc": "^5.2.0",
-    "svelte-spa-router": "^4.0.2"
+    "svelte-spa-router": "^4.0.2",
+    "three": "^0.184.0"
   }
 }

--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -6,6 +6,13 @@
   import Waveform from './Waveform.svelte'
   export let media
   export let theme = 'dark'
+  // 360 footage (.insv / .360): the preview thumbnail is an equirectangular frame,
+  // so show a drag-to-look sphere viewer instead of the flat still. The viewer
+  // (three.js, ~600KB) is lazy-loaded only when a 360 clip is first opened, so the
+  // main bundle isn't bloated for the common non-360 case.
+  $: is360 = /\.(insv|360)$/i.test((media && media.name) || '')
+  let Pano360 = null
+  $: if (is360 && !Pano360) import('./Pano360.svelte').then((m) => (Pano360 = m.default))
   // Live overrides — all default to mock behaviour so mock screens are unchanged.
   export let thumbUrl = null // real <img> when set, else abstract Thumb
   export let pathLabel = null // file path string; null → mock /vol/... path
@@ -89,7 +96,9 @@
   </div>
 
   <div class="preview">
-    {#if thumbUrl && !imgFailed}
+    {#if is360 && thumbUrl && !imgFailed}
+      {#if Pano360}<svelte:component this={Pano360} src={thumbUrl} />{:else}<div class="panoload"><Mono dim style="font-size:11px;">360 · loading…</Mono></div>{/if}
+    {:else if thumbUrl && !imgFailed}
       <img class="previmg" src={thumbUrl} alt={media.name} on:error={() => (imgFailed = true)} />
     {:else}
       <Thumb seed={media.id} kind={media.kind} {theme} />
@@ -282,6 +291,7 @@
     border-bottom: 1px solid var(--rule);
   }
   .previmg { width: 100%; height: 100%; object-fit: cover; display: block; }
+  .panoload { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; background: var(--surface-2); }
   .scrim {
     position: absolute; left: 0; right: 0; bottom: 0; height: 40%;
     background-image: linear-gradient(to top, rgba(0, 0, 0, 0.55), transparent); pointer-events: none;

--- a/frontend/src/lib/Pano360.svelte
+++ b/frontend/src/lib/Pano360.svelte
@@ -1,0 +1,117 @@
+<!-- Basic drag-to-look 360 viewer: maps an equirectangular still (a reprojected
+     360 frame thumbnail, 2:1) onto the inside of a sphere and lets you pan/look
+     around. Triage/prospecting only — NOT a reframe editor (that's Insta360 /
+     Resolve). Still image, not video: the source is the extracted equirect frame
+     (arkiv reprojects 360 for tagging; there's no equirect video proxy). -->
+<script>
+  import { onMount, onDestroy } from 'svelte'
+  import * as THREE from 'three'
+
+  export let src // equirectangular image URL (the 360 frame thumbnail)
+
+  let container
+  let renderer, scene, camera, mesh, texture, raf
+  let lon = 0, lat = 0
+  let dragging = false, px = 0, py = 0, dLon = 0, dLat = 0
+  let ready = false
+
+  function loadTexture(url) {
+    const tex = new THREE.TextureLoader().load(url, () => { ready = true })
+    tex.colorSpace = THREE.SRGBColorSpace
+    return tex
+  }
+
+  function init() {
+    const w = container.clientWidth || 340
+    const h = container.clientHeight || 191
+    scene = new THREE.Scene()
+    camera = new THREE.PerspectiveCamera(75, w / h, 1, 1100)
+    renderer = new THREE.WebGLRenderer({ antialias: true })
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2))
+    renderer.setSize(w, h)
+    container.appendChild(renderer.domElement)
+
+    const geo = new THREE.SphereGeometry(500, 60, 40)
+    geo.scale(-1, 1, 1) // flip so the texture faces inward (we sit at the centre)
+    texture = loadTexture(src)
+    mesh = new THREE.Mesh(geo, new THREE.MeshBasicMaterial({ map: texture }))
+    scene.add(mesh)
+    animate()
+  }
+
+  function animate() {
+    raf = requestAnimationFrame(animate)
+    lat = Math.max(-85, Math.min(85, lat))
+    const phi = THREE.MathUtils.degToRad(90 - lat)
+    const theta = THREE.MathUtils.degToRad(lon)
+    camera.lookAt(
+      500 * Math.sin(phi) * Math.cos(theta),
+      500 * Math.cos(phi),
+      500 * Math.sin(phi) * Math.sin(theta),
+    )
+    renderer.render(scene, camera)
+  }
+
+  function down(e) {
+    dragging = true
+    const p = e.touches ? e.touches[0] : e
+    px = p.clientX; py = p.clientY; dLon = lon; dLat = lat
+  }
+  function move(e) {
+    if (!dragging) return
+    const p = e.touches ? e.touches[0] : e
+    lon = dLon - (p.clientX - px) * 0.18
+    lat = dLat + (p.clientY - py) * 0.18
+  }
+  function up() { dragging = false }
+
+  // Re-point the texture when the selected 360 clip changes (component is reused).
+  $: if (mesh && src) {
+    const old = texture
+    texture = loadTexture(src)
+    mesh.material.map = texture
+    mesh.material.needsUpdate = true
+    lon = 0; lat = 0
+    old?.dispose()
+  }
+
+  onMount(init)
+  onDestroy(() => {
+    cancelAnimationFrame(raf)
+    texture?.dispose()
+    mesh?.geometry?.dispose()
+    mesh?.material?.dispose()
+    renderer?.dispose()
+  })
+</script>
+
+<svelte:window on:pointerup={up} on:pointermove={move} />
+<div
+  class="pano"
+  class:grabbing={dragging}
+  bind:this={container}
+  on:pointerdown={down}
+  role="img"
+  aria-label="360 panorama — drag to look around"
+>
+  {#if !ready}<div class="loading">360 · loading…</div>{/if}
+  <div class="hint">360 · 拖曳環視</div>
+</div>
+
+<style>
+  .pano {
+    position: absolute; inset: 0; cursor: grab; touch-action: none;
+    background: var(--surface-2); overflow: hidden;
+  }
+  .pano.grabbing { cursor: grabbing; }
+  .pano :global(canvas) { display: block; width: 100%; height: 100%; }
+  .loading {
+    position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+    font-family: var(--ak-mono); font-size: 11px; color: var(--ink-2); letter-spacing: 0.06em;
+  }
+  .hint {
+    position: absolute; top: 8px; left: 8px; z-index: 2; pointer-events: none;
+    font-family: var(--ak-mono); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase;
+    color: #f3f2ee; background: rgba(0,0,0,0.45); padding: 2px 6px;
+  }
+</style>


### PR DESCRIPTION
360 footage is reprojected to equirectangular for tagging (Phase 8.3b), but the inspector only showed the **flat** equirect still — you couldn't look around. This adds a basic drag-to-look sphere viewer.

## What
- `Pano360.svelte`: maps the equirect frame onto the inside of a three.js sphere; pointer + touch drag to pan/look around.
- Inspector: for `.insv` / `.360` media, the preview becomes the 360 viewer instead of the flat `<img>`. Non-360 media unchanged.
- **Triage only**, not a reframe editor — finding what's in the shot, not the cut. The reframe/keyframe edit stays Insta360 Studio / Resolve. arkiv feeds them.
- Still-frame (the extracted equirect thumbnail), not video — there's no equirect video proxy.

## Bundle cost handled
three.js (~600KB) is **lazy-loaded** via `import('./Pano360.svelte')` only when a 360 clip is first opened. Verified: it lands in a separate `Pano360-*.js` chunk; the main `index-*.js` is unchanged (~448KB) for the common non-360 case.

## Scope
This is the lightweight standalone viewer. The heavier **#76** (viewport-aware 6-viewport tagging + selector) is separate — and its precondition (real 360 in a DB) was just unblocked by ingesting 寶礦力路跑 (29 clips / 135 frames).

## Verification
- `npm run build` green, no a11y warnings, three.js code-split confirmed.
- ⚠️ Browser drag-feel not yet eyeballed (WebGL/interactive) — needs opening a 360 clip in the running app. Logic is the standard equirect-sphere pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)