### PR TITLE
fix(ui): show real project name, not hardcoded 明燒肉

### DIFF
--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -143,7 +143,8 @@
         ['Unrated', stats.rating?.unrated ?? 0],
       ]
     : null
-  $: liveProjects = stats ? [{ id: 'msr', name: '明燒肉', count: stats.total, active: true }] : null
+  $: projectName = (stats && stats.project) || '素材庫'
+  $: liveProjects = stats ? [{ id: 'proj', name: projectName, count: stats.total, active: true }] : null
   // real disk usage for the sidebar Storage footer (replaces the mock placeholder)
   $: liveStorage = stats?.disk ?? null
   // tag click → search that tag
@@ -380,14 +381,14 @@
     <main class="center">
       <div class="toolrow">
         <div class="proj">
-          <div class="ak-display projtitle">明燒肉</div>
+          <div class="ak-display projtitle">{projectName}</div>
           <Mono dim style="font-size:11px;margin-top:5px;letter-spacing:0.04em;">
             {#if stats}{stats.total} items · {Math.round(stats.total_duration_s || 0)}s · {Math.round(stats.total_size_mb || 0)} MB · live{:else}loading…{/if}
           </Mono>
         </div>
         <input
           class="ak-input livesearch"
-          placeholder="搜尋（語意 + 關鍵字）… 試 餐廳 / 吧檯 / 燈光"
+          placeholder="搜尋（語意 + 關鍵字）…"
           bind:value={query}
           on:keydown={(e) => e.key === 'Enter' && runSearch()}
         />

--- a/server.py
+++ b/server.py
@@ -1148,6 +1148,10 @@ def get_stats(
     # stats-driven cloud read top_tags. Over-fetch then filter so we still get 10
     # real tags even if some of the top entries were noise.
     stats["top_tags"] = tag_quality.filter_tag_records(db.get_top_tags(40))[:10]
+    # Real project name (basename of PROJECT_ROOT) so the UI shows the loaded
+    # library instead of a hardcoded demo name. Multi-library installs (one .arkiv
+    # per project) each report their own name.
+    stats["project"] = config.PROJECT_ROOT.name if config.PROJECT_ROOT else None
     return stats
 
 


### PR DESCRIPTION
MainLive hardcoded the demo library name **明燒肉** as the project title + sidebar entry, so every library (恬馨, 寶礦力路跑, …) showed 明燒肉 regardless of what was loaded — surfaced when running one `.arkiv` per project. `/api/stats` now returns `project` (basename of `PROJECT_ROOT`); MainLive renders it (fallback 素材庫). Also neutralized the 明燒肉-specific search placeholder.

Verified: full suite 573 passed, frontend build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)