### PR TITLE
feat(tags): optional LLM tag canonicalization (E) — semantic synonym merge

### DIFF
--- a/db.py
+++ b/db.py
@@ -201,6 +201,11 @@ def init_db():
             # Phase: persist ffprobe codec so Phase 3 proxy decisions don't
             # re-probe the whole library each ingest (H1).
             ("codec", "TEXT"),
+            # Optional LLM-canonicalized media tag list (JSON array). Stored
+            # SEPARATELY from the raw vision tags (never overwrites them) so the
+            # UI can toggle raw ↔ canonical; populated on demand by the re-tag
+            # command, NULL until then.
+            ("canonical_tags", "TEXT"),
         ]:
             _add_column_if_missing(conn, "media", col, typ)  # audit L10
         for col, typ in [
@@ -503,6 +508,17 @@ def get_record_by_id(media_id: int) -> Optional[Dict]:
     with get_conn() as conn:
         row = conn.execute("SELECT * FROM media WHERE id=?", (media_id,)).fetchone()
         return dict(row) if row else None
+
+
+def set_canonical_tags(media_id: int, tags: list) -> None:
+    """Store the LLM-canonicalized tag list (JSON) for a media. Separate from the
+    raw vision tags — never touches frame_tags / the tags table."""
+    import json as _json
+    with get_conn() as conn:
+        conn.execute(
+            "UPDATE media SET canonical_tags=? WHERE id=?",
+            (_json.dumps(tags, ensure_ascii=False), media_id),
+        )
 
 
 def get_stats() -> Dict:

--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -31,6 +31,18 @@
   export let tags = null
   export let onAddTag = null // (name) => void
   export let onRemoveTag = null // (name) => void
+  // LLM-canonicalized tag list (string[]) — semantic-deduped (生肉/生魚→肉類).
+  // When present, a toggle switches the Tags block raw ⇄ canonical; default
+  // canonical (the cleaner view) unless the user flipped it (persisted).
+  export let canonicalTags = null
+  let showCanonical =
+    typeof localStorage === 'undefined' || localStorage.getItem('arkiv.tagview') !== 'raw'
+  function toggleTagView() {
+    showCanonical = !showCanonical
+    try { localStorage.setItem('arkiv.tagview', showCanonical ? 'canonical' : 'raw') } catch (e) { /* private mode */ }
+  }
+  $: hasCanon = !!(canonicalTags && canonicalTags.length)
+  $: useCanon = hasCanon && showCanonical
   // Live re-processing. onReprocess = async (action, opts) => {ok, message};
   // action ∈ 'retranscribe' | 'retry-vision' | 'reingest'. null → no block (mock).
   export let onReprocess = null
@@ -124,27 +136,40 @@
     </div>
   </div>
 
-  {#if tags}
+  {#if tags || hasCanon}
     <div class="block">
-      <Eyebrow style="margin-bottom:8px;">Tags</Eyebrow>
-      <div class="tagrow">
-        {#each tags as t (t.name)}
-          <span class="tagchip" class:auto={t.source === 'auto'}>
-            <span class="tagname">{t.name}</span>
-            {#if onRemoveTag}
-              <button class="tagx" title="移除標籤" on:click={() => onRemoveTag(t.name)}>×</button>
-            {/if}
-          </span>
-        {/each}
-        {#if tags.length === 0}
-          <Mono dim style="font-size:10.5px;">（無標籤）</Mono>
+      <div class="blockhead">
+        <Eyebrow>Tags</Eyebrow>
+        {#if hasCanon}
+          <button class="tagtoggle" on:click={toggleTagView} title="原始 vision tags ⇄ LLM 精簡（語意去重）">
+            {useCanon ? '精簡' : '原始'} ⇄
+          </button>
         {/if}
       </div>
-      {#if onAddTag}
-        <form class="tagadd" on:submit|preventDefault={submitTag}>
-          <input class="ak-input taginput" placeholder="加標籤…" bind:value={tagInput} />
-          <button class="ak-btn tagaddbtn" type="submit" disabled={!tagInput.trim()}>＋</button>
-        </form>
+      {#if useCanon}
+        <div class="tagrow">
+          {#each canonicalTags as t}<span class="tagchip canon">{t}</span>{/each}
+        </div>
+      {:else if tags}
+        <div class="tagrow">
+          {#each tags as t (t.name)}
+            <span class="tagchip" class:auto={t.source === 'auto'}>
+              <span class="tagname">{t.name}</span>
+              {#if onRemoveTag}
+                <button class="tagx" title="移除標籤" on:click={() => onRemoveTag(t.name)}>×</button>
+              {/if}
+            </span>
+          {/each}
+          {#if tags.length === 0}
+            <Mono dim style="font-size:10.5px;">（無標籤）</Mono>
+          {/if}
+        </div>
+        {#if onAddTag}
+          <form class="tagadd" on:submit|preventDefault={submitTag}>
+            <input class="ak-input taginput" placeholder="加標籤…" bind:value={tagInput} />
+            <button class="ak-btn tagaddbtn" type="submit" disabled={!tagInput.trim()}>＋</button>
+          </form>
+        {/if}
       {/if}
     </div>
   {/if}
@@ -317,6 +342,13 @@
     background: var(--surface-2);
   }
   .tagchip.auto { border-style: dashed; border-color: var(--rule); color: var(--ink-2); }
+  .tagchip.canon { border-color: var(--invert); }
+  .tagtoggle {
+    appearance: none; background: transparent; border: 1px solid var(--rule);
+    font-family: var(--ak-mono); font-size: 9px; letter-spacing: 0.06em;
+    color: var(--ink-2); padding: 2px 6px; cursor: pointer;
+  }
+  .tagtoggle:hover { color: var(--ink); border-color: var(--ink); }
   .tagchip .tagname { white-space: nowrap; }
   .tagx {
     appearance: none; background: transparent; border: none; cursor: pointer;

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -288,6 +288,8 @@
   $: inspPath = detailLive ? detailLive.path : null
   // tags: detail carries the quality-filtered tag list [{id,name,source}].
   $: inspTags = detailLive ? (detailLive.tags || []) : null
+  // LLM-canonicalized tags (string[]) when the canonicalize pass has run; null otherwise.
+  $: inspCanonTags = detailLive ? (detailLive.canonical_tags || null) : null
 
   // Tag editing. Both endpoints return the full updated tag list, so reconcile
   // `detail.tags` from the response (reassign detail so detailLive recomputes).
@@ -458,6 +460,7 @@
         frameDescriptions={inspFrames}
         frameScenes={inspScenes}
         tags={inspTags}
+        canonicalTags={inspCanonTags}
         onAddTag={selected ? addTag : null}
         onRemoveTag={selected ? removeTag : null}
         onReprocess={selected ? reprocess : null}

--- a/ingest.py
+++ b/ingest.py
@@ -22,6 +22,7 @@ import codec
 import config
 import db
 import frames as frm
+import tag_quality
 import transcribe as tr
 import vision as vis
 
@@ -1121,6 +1122,52 @@ def _migrate_storage():
     print(f"         rm -rf {arkiv_dir} && tar xzf {backup_path} -C {base}")
 
 
+_CANON_PROMPT = (
+    "以下是同一支影片的標籤，可能有同義詞或同概念不同詞（例：生肉/生魚/肉類、夜間/夜景）。"
+    "請把同義或同概念的合併成一個，**只能從原標籤清單裡選一個最通用的詞代表，"
+    "絕對不可創造清單以外的新詞**；不同概念一律保留。回傳 {\"tags\":[...]}，只輸出 JSON。\n原標籤："
+)
+
+
+def _run_canonicalize_tags(args):
+    """Populate media.canonical_tags via one LLM semantic-merge per media. Reads
+    the raw vision tags (rank_media_tags over frame_tags), asks the chat model to
+    merge synonyms picking only existing words, guards the result (no invention /
+    no over-merge → falls back to raw), and stores it SEPARATELY from the raw
+    tags. Skips media already canonicalized. No re-vision, no footage needed."""
+    import json as _json
+    import llm
+    with db.get_conn() as conn:
+        rows = conn.execute(
+            "SELECT id, frame_tags FROM media WHERE frame_tags IS NOT NULL AND canonical_tags IS NULL"
+        ).fetchall()
+    print("Canonicalize tags: {0} media pending".format(len(rows)))
+    processed = changed = failed = 0
+    for r in rows:
+        try:
+            frames = _json.loads(r["frame_tags"]) or []
+        except Exception:
+            continue
+        raw = tag_quality.rank_media_tags(frames)
+        if not raw:
+            db.set_canonical_tags(r["id"], [])
+            continue
+        try:
+            resp = llm.chat(_CANON_PROMPT + _json.dumps(raw, ensure_ascii=False), json_mode=True)
+            proposed = _json.loads(resp["text"]).get("tags", [])
+        except Exception as e:
+            failed += 1
+            print("  media {0}: LLM 失敗 ({1}) → 跳過".format(r["id"], e))
+            continue
+        clean = tag_quality.guard_canonical(raw, proposed)
+        db.set_canonical_tags(r["id"], clean)
+        processed += 1
+        if clean != raw:
+            changed += 1
+            print("  media {0}: {1} → {2}".format(r["id"], raw, clean))
+    print("Done. {0} processed, {1} changed, {2} failed.".format(processed, changed, failed))
+
+
 def main():
     parser = argparse.ArgumentParser(description="Ingest media files into SQLite DB")
     parser.add_argument("--dir", help="Media directory to scan (required unless --migrate-* / --regenerate-proxies / --vision-only)")
@@ -1128,6 +1175,7 @@ def main():
     parser.add_argument("--skip-vision", action="store_true", help="Skip llava frame description")
     parser.add_argument("--refresh", action="store_true", help="Re-process already-indexed files — re-extracts thumbnail + frames (not reusing cached ones, so changed extraction logic like 360 reproject re-applies) + re-runs vision (issue #53)")
     parser.add_argument("--vision-only", action="store_true", help="Only run vision on frames with empty descriptions (resume after halt)")
+    parser.add_argument("--canonicalize-tags", action="store_true", help="Populate media.canonical_tags via one LLM semantic-merge per media (生肉/生魚/肉類→肉類). Non-destructive (raw tags untouched, stored separately for the UI toggle). Skips media already canonicalized. No --dir / no re-vision needed.")
     parser.add_argument("--max-failures", type=int, default=0, metavar="N", help="issue #48: tolerate N cumulative failed frames before halting vision (0=halt on first, the default). Failed frames are left empty for a later --vision-only retry.")
     parser.add_argument("--skip-failed", action="store_true", help="issue #48: never halt on individual frame vision failures — skip them (left empty for retry), report at end. Recommended for large unattended/overnight runs. A whole-Ollama outage still halts fast.")
     parser.add_argument(
@@ -1174,6 +1222,7 @@ def main():
     maintenance_mode = (
         args.migrate_storage or args.migrate_relative
         or args.regenerate_proxies or args.regenerate_thumbnails or args.vision_only
+        or args.canonicalize_tags
         or bool(args.queue) or args.status
     )
     if not maintenance_mode and not args.dir:
@@ -1191,7 +1240,7 @@ def main():
 
     # Phase 8.0e: pre-flight storage check before any pipeline work.
     # Skip for maintenance modes (they're the tools that fix broken state).
-    if not (args.migrate_relative or args.regenerate_proxies or args.regenerate_thumbnails or args.queue or args.status):
+    if not (args.migrate_relative or args.regenerate_proxies or args.regenerate_thumbnails or args.queue or args.status or args.canonicalize_tags):
         import health
         ok_pf, errors_pf = health.preflight_paths()
         if not ok_pf:
@@ -1228,6 +1277,11 @@ def main():
         halted = _run_vision_only(args)
         if halted:
             sys.exit(1)  # halt mid-patch must not report success to cron/watch
+        return
+
+    # ── Canonicalize tags: LLM semantic-merge into media.canonical_tags ──
+    if args.canonicalize_tags:
+        _run_canonicalize_tags(args)
         return
 
     # Warm up models before batch processing

--- a/server.py
+++ b/server.py
@@ -940,6 +940,13 @@ def get_media_detail(
     top = set(tag_quality.rank_media_tags(rec.get("frame_tags_parsed") or []))
     all_tags = tag_quality.filter_tag_records(db.get_tags(media_id))
     rec["tags"] = [t for t in all_tags if t["name"] in top] if top else all_tags
+    # Optional LLM-canonicalized tag list (populated by `ingest.py --canonicalize-tags`).
+    # Returned alongside raw tags so the UI can toggle raw ↔ canonical; null until run.
+    if rec.get("canonical_tags"):
+        try:
+            rec["canonical_tags"] = json.loads(rec["canonical_tags"])
+        except Exception:
+            rec["canonical_tags"] = None
     return rec
 
 

--- a/tag_quality.py
+++ b/tag_quality.py
@@ -60,6 +60,31 @@ def canonicalize(tag: str) -> str:
     return (tag or "").strip().translate(_CHAR_VARIANTS)
 
 
+def guard_canonical(raw: List[str], proposed: Iterable[str], min_keep_ratio: float = 0.34) -> List[str]:
+    """Sanitize an LLM tag-canonicalization proposal against the raw tag list.
+
+    The LLM semantic merge (生肉/生魚/肉類 → 肉類) is non-deterministic and can
+    (a) invent words not in the source (生食) or (b) over-merge / drop distinct
+    tags. This makes it SAFE: keep only proposed tags that actually existed in
+    raw (no invention), dedup preserving order, and if the merge collapses the
+    list below `min_keep_ratio` of the raw count (over-aggressive), reject it and
+    return raw unchanged. Combined with non-destructive storage + the UI toggle,
+    the worst case is "no change", never "tags destroyed".
+    """
+    raw_dedup = list(dict.fromkeys(canonicalize(t) for t in raw if t))
+    raw_set = set(raw_dedup)
+    seen = set()
+    out = []
+    for t in proposed:
+        t = canonicalize(t)
+        if t and t in raw_set and t not in seen:
+            seen.add(t)
+            out.append(t)
+    if not out or len(out) < max(1, int(len(raw_set) * min_keep_ratio)):
+        return raw_dedup  # over-merge / empty → keep raw
+    return out
+
+
 def filter_tags(tags: Iterable[str]) -> List[str]:
     """Drop quality-defect tags, preserving order, de-duplicating."""
     seen = set()

--- a/tests/test_tag_quality.py
+++ b/tests/test_tag_quality.py
@@ -43,3 +43,23 @@ def test_rank_media_tags_does_not_merge_distinct_concepts():
     frames = [{"tags": ["室內", "餐廳", "刀"], "focus_score": 3}]
     ranked = tq.rank_media_tags(frames)
     assert set(["室內", "餐廳", "刀"]).issubset(set(ranked))
+
+
+# ── guard_canonical: sanitize an LLM merge proposal ─────────────────────────
+def test_guard_strips_invented_words():
+    raw = ["生肉", "魚肉", "肉類", "生魚"]
+    # LLM invented 生食 (not in raw) + picked 肉類 (in raw)
+    assert tq.guard_canonical(raw, ["肉類", "生食"]) == ["肉類"]
+
+
+def test_guard_rejects_over_merge_falls_back_to_raw():
+    raw = ["手套", "生肉", "刀", "切割", "食品", "處理"]
+    # collapsing 6 distinct down to 1 is over-aggressive → keep raw
+    out = tq.guard_canonical(raw, ["食品"])
+    assert out == list(dict.fromkeys(raw))
+
+
+def test_guard_accepts_reasonable_merge():
+    raw = ["生肉", "魚肉", "肉類", "脂肪層", "生魚", "切片"]
+    out = tq.guard_canonical(raw, ["肉類", "脂肪層", "切片"])
+    assert out == ["肉類", "脂肪層", "切片"]  # all ⊂ raw, not over-merged


### PR DESCRIPTION
The semantic-duplicate layer that A+B (#86, deterministic) can't reach — `生肉/魚肉/肉類/生魚` → `肉類`. **Opt-in + non-destructive**, so it ships safely.

## What
- **`ingest.py --canonicalize-tags`**: one LLM merge per media over its raw ranked tags → stores `media.canonical_tags`. No `--dir`, no re-vision; skips already-canonicalized media → existing libraries clean up cheaply.
- **`tag_quality.guard_canonical()`**: sanitizes the LLM output — keeps **only words that existed in raw** (no invented terms like 生食) and **rejects over-aggressive collapse** (< ~⅓ of raw) → falls back to raw. Worst case = no change, never destroyed tags.
- **Non-destructive storage**: new `media.canonical_tags` column (migration via `_add_column_if_missing`), separate from raw vision tags; `get_media` returns **both** → the UI toggles raw ↔ canonical (frontend PR next).

## Why opt-in / toggle, not auto
The merge is non-deterministic (one run kept `刀`, the prototype dropped it). So: never overwrite raw, store canonical separately, let the user toggle + eyeball. The guard handles the extremes; the toggle handles the rest.

## Verification
- Live on 明燒肉 DB: media-3 `[生肉,魚肉,肉類,脂肪層,生魚,切片]` → `[肉類,脂肪層,切片]`; 0 invented, 0 failed.
- `tests/test_tag_quality.py`: guard strip-invention / over-merge fallback / reasonable-merge. Full suite **581 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)