### PR TITLE
fix(tags): shrink global tag cloud — variant merge + UI cap + library alias map

### DIFF
--- a/config.py
+++ b/config.py
@@ -71,6 +71,10 @@ THUMBNAILS_DIR = _validate_writable_path(
 PROXIES_DIR = _validate_writable_path(
     Path(os.getenv("ARKIV_PROXIES_DIR", str(_ARKIV_DIR / "proxies"))), "ARKIV_PROXIES_DIR"
 )
+# Reviewed library tag alias map (tag_aliases.py) + its proposal staging file.
+# Plain JSON in the project data dir — reviewable, version-controllable, per-project.
+TAG_ALIASES_PATH = _ARKIV_DIR / "tag_aliases.json"
+TAG_ALIASES_PROPOSED_PATH = _ARKIV_DIR / "tag_aliases.proposed.json"
 
 # Auth bootstrap (auth-tokens-1b handover).
 ARKIV_ADMIN_BOOTSTRAP_TOKEN = os.getenv("ARKIV_ADMIN_BOOTSTRAP_TOKEN", "").strip()

--- a/frontend/src/lib/PoolSidebar.svelte
+++ b/frontend/src/lib/PoolSidebar.svelte
@@ -84,7 +84,9 @@
     <div class="tags">
       {#each visibleTags as t (t.name)}
         <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-        <span class="tag" class:clickable={onTag} on:click={() => onTag && onTag(t.name)}>{t.name} <span class="tagcount">{t.count}</span></span>
+        <span class="tag" class:clickable={onTag} class:folded={t.aliases && t.aliases.length}
+          title={t.aliases && t.aliases.length ? `含別名：${t.aliases.join('、')}` : null}
+          on:click={() => onTag && onTag(t.name)}>{t.name} <span class="tagcount">{t.count}</span></span>
       {/each}
     </div>
     {#if tags.length > TAG_CAP}
@@ -138,6 +140,8 @@
   }
   .tagcount { color: var(--quiet); }
   .tag.clickable:hover { border-color: var(--ink); color: var(--ink); }
+  /* folded = absorbed near-synonyms via the alias map; subtle dotted underline. */
+  .tag.folded { border-style: dashed; }
   .moretag {
     display: inline-block; margin-top: 8px; font-family: var(--ak-mono);
     font-size: 10.5px; color: var(--quiet); cursor: pointer;

--- a/frontend/src/lib/PoolSidebar.svelte
+++ b/frontend/src/lib/PoolSidebar.svelte
@@ -22,6 +22,11 @@
   $: projects = liveProjects ?? PROJECTS
   $: pools = livePools ?? MOCK_POOLS
   $: tags = liveTags ?? TAGS
+  // Cap the cloud so a long tail (74+ on a real library) doesn't bury the useful
+  // ones. Tags arrive sorted by count desc, so the top slice is the most-used.
+  const TAG_CAP = 24
+  let showAllTags = false
+  $: visibleTags = showAllTags ? tags : tags.slice(0, TAG_CAP)
   // Storage footer: real disk usage when wired (live), else the design placeholder.
   const gb = (n) => (n >= 1000 ? `${(n / 1000).toFixed(1)} TB` : `${Math.round(n)} GB`)
   $: storage = liveStorage
@@ -75,13 +80,19 @@
   {/if}
 
   <section class="tagsec">
-    <Eyebrow style="margin-bottom:10px;">Tags · auto</Eyebrow>
+    <Eyebrow style="margin-bottom:10px;">Tags · auto · {tags.length}</Eyebrow>
     <div class="tags">
-      {#each tags as t (t.name)}
+      {#each visibleTags as t (t.name)}
         <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
         <span class="tag" class:clickable={onTag} on:click={() => onTag && onTag(t.name)}>{t.name} <span class="tagcount">{t.count}</span></span>
       {/each}
     </div>
+    {#if tags.length > TAG_CAP}
+      <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+      <span class="moretag" on:click={() => (showAllTags = !showAllTags)}>
+        {showAllTags ? '收合' : `+${tags.length - TAG_CAP} 更多`}
+      </span>
+    {/if}
   </section>
 
   <div class="spacer"></div>
@@ -127,6 +138,11 @@
   }
   .tagcount { color: var(--quiet); }
   .tag.clickable:hover { border-color: var(--ink); color: var(--ink); }
+  .moretag {
+    display: inline-block; margin-top: 8px; font-family: var(--ak-mono);
+    font-size: 10.5px; color: var(--quiet); cursor: pointer;
+  }
+  .moretag:hover { color: var(--ink); }
   .spacer { flex: 1; }
   .storage { border-top: 1px solid var(--rule); padding-top: 12px; }
   .strow { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 6px; }

--- a/ingest.py
+++ b/ingest.py
@@ -1219,7 +1219,7 @@ def _run_propose_aliases(args):
     import json as _json
     import llm
     import vectordb
-    threshold = getattr(args, "alias_threshold", 0.62) or 0.62
+    threshold = getattr(args, "alias_threshold", 0.80) or 0.80
     records = tag_quality.merge_tag_records(db.get_all_tag_names())
     names = [r["name"] for r in records]
     print("Propose aliases: {0} distinct tags, cosine threshold {1}".format(len(names), threshold))
@@ -1250,7 +1250,10 @@ def _run_propose_aliases(args):
             alts = [a for a in alts if a and a in cl_set and a != pref]
             if pref in cl_set and alts:
                 out_groups.append({"pref": pref, "alts": alts})
-                print("    {0}  ←  {1}".format(pref, "/".join(alts)))
+                # A group folding many alts is the over-merge risk — flag it so
+                # review scrutinizes (馬拉松≠路跑 class errors). Human gate decides.
+                warn = " ⚠ 多，請複查" if len(alts) >= 5 else ""
+                print("    {0}  ←  {1}{2}".format(pref, "/".join(alts), warn))
     payload = {"version": 1, "groups": out_groups}
     config.TAG_ALIASES_PROPOSED_PATH.parent.mkdir(parents=True, exist_ok=True)
     config.TAG_ALIASES_PROPOSED_PATH.write_text(
@@ -1300,7 +1303,7 @@ def main():
     parser.add_argument("--canonicalize-tags", action="store_true", help="Populate media.canonical_tags via one LLM semantic-merge per media (生肉/生魚/肉類→肉類). Non-destructive (raw tags untouched, stored separately for the UI toggle). Skips media already canonicalized. No --dir / no re-vision needed.")
     parser.add_argument("--propose-aliases", action="store_true", help="Library-level tag dedup: embed the global tag cloud (bge-m3) → cluster near-synonyms → LLM judges each group (运动会/比赛→赛事) → writes a REVIEWABLE proposal to .arkiv/tag_aliases.proposed.json. Not applied until --apply-aliases. Non-destructive.")
     parser.add_argument("--apply-aliases", action="store_true", help="Activate the reviewed proposal: copy tag_aliases.proposed.json → tag_aliases.json (the live map /api/tags folds the cloud by). Reversible — delete tag_aliases.json to restore.")
-    parser.add_argument("--alias-threshold", type=float, default=0.62, metavar="F", help="With --propose-aliases: cosine threshold for clustering candidate synonyms (default 0.62; lower = looser proposals, the LLM is the real gate).")
+    parser.add_argument("--alias-threshold", type=float, default=0.80, metavar="F", help="With --propose-aliases: cosine threshold for clustering candidate synonyms (default 0.80 — bge-m3 is anisotropic so related terms all score high; below ~0.75 every tag collapses into one blob. Raise toward 0.85 for tighter groups).")
     parser.add_argument("--max-failures", type=int, default=0, metavar="N", help="issue #48: tolerate N cumulative failed frames before halting vision (0=halt on first, the default). Failed frames are left empty for a later --vision-only retry.")
     parser.add_argument("--skip-failed", action="store_true", help="issue #48: never halt on individual frame vision failures — skip them (left empty for retry), report at end. Recommended for large unattended/overnight runs. A whole-Ollama outage still halts fast.")
     parser.add_argument(

--- a/ingest.py
+++ b/ingest.py
@@ -1168,6 +1168,128 @@ def _run_canonicalize_tags(args):
     print("Done. {0} processed, {1} changed, {2} failed.".format(processed, changed, failed))
 
 
+# ── Library-level alias-map proposal (embed → cluster → LLM judge → review) ──
+_ALIAS_JUDGE_PROMPT = (
+    "以下是一組語意相近的標籤候選。請判斷哪些是「同義或同概念」該合併、哪些其實是不同概念要分開。"
+    "每個要合併的概念，從候選清單裡選一個最通用的詞當代表(pref)，其餘同義詞放 alts。"
+    "不同概念各自獨立；若整組其實都不同概念就回空陣列。"
+    "**只能用清單裡出現的詞，絕對不可創造新詞，也不要把不同距離/不同事物硬合(例：路跑≠馬拉松)**。"
+    "回傳 {\"groups\":[{\"pref\":\"...\",\"alts\":[\"...\"]}]}，只輸出 JSON。\n候選標籤："
+)
+
+
+def _cosine(a, b):
+    dot = sum(x * y for x, y in zip(a, b))
+    na = sum(x * x for x in a) ** 0.5
+    nb = sum(y * y for y in b) ** 0.5
+    return dot / (na * nb) if na and nb else 0.0
+
+
+def _cluster_by_cosine(names, vectors, threshold):
+    """Union-find: tags within `threshold` cosine of each other land in one group.
+    Returns candidate groups of size >= 2 (loose on purpose — the LLM is the real
+    gate that splits/rejects; clustering only needs high recall to not miss pairs)."""
+    n = len(names)
+    parent = list(range(n))
+
+    def find(i):
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            if _cosine(vectors[i], vectors[j]) >= threshold:
+                parent[find(i)] = find(j)
+    groups = {}
+    for i in range(n):
+        groups.setdefault(find(i), []).append(names[i])
+    return [g for g in groups.values() if len(g) >= 2]
+
+
+def _run_propose_aliases(args):
+    """Propose a library-level tag alias map. Pulls the global tag cloud (already
+    variant-merged + noise-filtered), embeds every tag with bge-m3, clusters by
+    cosine to PROPOSE near-synonym groups, then asks the local chat LLM to judge
+    each cluster (pick a preferred term, confirm true synonyms, split distinct
+    concepts). Guards every group against invention. Writes a reviewable proposal
+    to .arkiv/tag_aliases.proposed.json — NOT applied until you review +
+    --apply-aliases. Non-destructive: raw tags are never touched."""
+    import json as _json
+    import llm
+    import vectordb
+    threshold = getattr(args, "alias_threshold", 0.62) or 0.62
+    records = tag_quality.merge_tag_records(db.get_all_tag_names())
+    names = [r["name"] for r in records]
+    print("Propose aliases: {0} distinct tags, cosine threshold {1}".format(len(names), threshold))
+    if len(names) < 2:
+        print("Too few tags — nothing to propose.")
+        return
+    try:
+        vectors = vectordb.embed_batch(names)
+    except Exception as e:
+        print("  batch embed failed ({0}) → per-tag embed".format(e))
+        vectors = [llm.embed(t) for t in names]
+    clusters = _cluster_by_cosine(names, vectors, threshold)
+    print("  {0} candidate clusters (size>=2) → LLM judging".format(len(clusters)))
+    out_groups = []
+    for cl in clusters:
+        cl_set = set(cl)
+        try:
+            resp = llm.chat(_ALIAS_JUDGE_PROMPT + _json.dumps(cl, ensure_ascii=False), json_mode=True)
+            proposed = _json.loads(resp["text"]).get("groups", [])
+        except Exception as e:
+            print("  cluster {0}: LLM 失敗 ({1}) → 跳過".format(cl, e))
+            continue
+        for g in proposed:
+            pref = tag_quality.canonicalize(g.get("pref") or "")
+            alts = [tag_quality.canonicalize(a) for a in (g.get("alts") or [])]
+            # guard: pref + every alt must be a real tag from THIS cluster (no
+            # invention, no cross-cluster bleed); need >=1 alt or there's no merge.
+            alts = [a for a in alts if a and a in cl_set and a != pref]
+            if pref in cl_set and alts:
+                out_groups.append({"pref": pref, "alts": alts})
+                print("    {0}  ←  {1}".format(pref, "/".join(alts)))
+    payload = {"version": 1, "groups": out_groups}
+    config.TAG_ALIASES_PROPOSED_PATH.parent.mkdir(parents=True, exist_ok=True)
+    config.TAG_ALIASES_PROPOSED_PATH.write_text(
+        _json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    merged = sum(len(g["alts"]) for g in out_groups)
+    print("\nProposed {0} merge groups (folds {1} tags) → {2}".format(
+        len(out_groups), merged, config.TAG_ALIASES_PROPOSED_PATH))
+    print("Review/edit that file, then: python ingest.py --apply-aliases")
+
+
+def _run_apply_aliases(args):
+    """Activate the reviewed proposal: validate shape, then copy
+    tag_aliases.proposed.json → tag_aliases.json (the live map /api/tags reads).
+    Reversible — delete tag_aliases.json to restore the unfolded cloud."""
+    import json as _json
+    src = config.TAG_ALIASES_PROPOSED_PATH
+    if not src.exists():
+        print("No proposal at {0}. Run --propose-aliases first.".format(src))
+        return
+    try:
+        data = _json.loads(src.read_text(encoding="utf-8"))
+        groups = data.get("groups", [])
+        clean = []
+        for g in groups:
+            pref = (g.get("pref") or "").strip()
+            alts = [a.strip() for a in (g.get("alts") or []) if a and a.strip() and a.strip() != pref]
+            if pref and alts:
+                clean.append({"pref": pref, "alts": alts})
+    except (ValueError, OSError) as e:
+        print("Proposal malformed ({0}) — not applying.".format(e))
+        return
+    config.TAG_ALIASES_PATH.write_text(
+        _json.dumps({"version": 1, "groups": clean}, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    print("Applied {0} alias groups → {1}".format(len(clean), config.TAG_ALIASES_PATH))
+    print("Tag cloud will fold on next /api/tags (map auto-reloads on file change).")
+
+
 def main():
     parser = argparse.ArgumentParser(description="Ingest media files into SQLite DB")
     parser.add_argument("--dir", help="Media directory to scan (required unless --migrate-* / --regenerate-proxies / --vision-only)")
@@ -1176,6 +1298,9 @@ def main():
     parser.add_argument("--refresh", action="store_true", help="Re-process already-indexed files — re-extracts thumbnail + frames (not reusing cached ones, so changed extraction logic like 360 reproject re-applies) + re-runs vision (issue #53)")
     parser.add_argument("--vision-only", action="store_true", help="Only run vision on frames with empty descriptions (resume after halt)")
     parser.add_argument("--canonicalize-tags", action="store_true", help="Populate media.canonical_tags via one LLM semantic-merge per media (生肉/生魚/肉類→肉類). Non-destructive (raw tags untouched, stored separately for the UI toggle). Skips media already canonicalized. No --dir / no re-vision needed.")
+    parser.add_argument("--propose-aliases", action="store_true", help="Library-level tag dedup: embed the global tag cloud (bge-m3) → cluster near-synonyms → LLM judges each group (运动会/比赛→赛事) → writes a REVIEWABLE proposal to .arkiv/tag_aliases.proposed.json. Not applied until --apply-aliases. Non-destructive.")
+    parser.add_argument("--apply-aliases", action="store_true", help="Activate the reviewed proposal: copy tag_aliases.proposed.json → tag_aliases.json (the live map /api/tags folds the cloud by). Reversible — delete tag_aliases.json to restore.")
+    parser.add_argument("--alias-threshold", type=float, default=0.62, metavar="F", help="With --propose-aliases: cosine threshold for clustering candidate synonyms (default 0.62; lower = looser proposals, the LLM is the real gate).")
     parser.add_argument("--max-failures", type=int, default=0, metavar="N", help="issue #48: tolerate N cumulative failed frames before halting vision (0=halt on first, the default). Failed frames are left empty for a later --vision-only retry.")
     parser.add_argument("--skip-failed", action="store_true", help="issue #48: never halt on individual frame vision failures — skip them (left empty for retry), report at end. Recommended for large unattended/overnight runs. A whole-Ollama outage still halts fast.")
     parser.add_argument(
@@ -1223,6 +1348,7 @@ def main():
         args.migrate_storage or args.migrate_relative
         or args.regenerate_proxies or args.regenerate_thumbnails or args.vision_only
         or args.canonicalize_tags
+        or args.propose_aliases or args.apply_aliases
         or bool(args.queue) or args.status
     )
     if not maintenance_mode and not args.dir:
@@ -1240,7 +1366,7 @@ def main():
 
     # Phase 8.0e: pre-flight storage check before any pipeline work.
     # Skip for maintenance modes (they're the tools that fix broken state).
-    if not (args.migrate_relative or args.regenerate_proxies or args.regenerate_thumbnails or args.queue or args.status or args.canonicalize_tags):
+    if not (args.migrate_relative or args.regenerate_proxies or args.regenerate_thumbnails or args.queue or args.status or args.canonicalize_tags or args.propose_aliases or args.apply_aliases):
         import health
         ok_pf, errors_pf = health.preflight_paths()
         if not ok_pf:
@@ -1282,6 +1408,14 @@ def main():
     # ── Canonicalize tags: LLM semantic-merge into media.canonical_tags ──
     if args.canonicalize_tags:
         _run_canonicalize_tags(args)
+        return
+
+    # ── Library-level alias map: propose / apply (global tag-cloud dedup) ──
+    if args.propose_aliases:
+        _run_propose_aliases(args)
+        return
+    if args.apply_aliases:
+        _run_apply_aliases(args)
         return
 
     # Warm up models before batch processing

--- a/server.py
+++ b/server.py
@@ -30,6 +30,7 @@ import db
 import federation
 import projects as project_registry
 import smart_collections
+import tag_aliases
 import tag_quality
 
 
@@ -1167,9 +1168,10 @@ def get_all_tags(
     _tok: dict = Depends(require_scopes("videos_read")),
 ):
     """All unique tag names with counts. Quality-defect tags (模糊/低解析度…)
-    are screened out and variant-char spellings (人群/人羣) are merged into one
-    row with summed counts — see tag_quality."""
-    return tag_quality.merge_tag_records(db.get_all_tag_names())
+    are screened out, variant-char spellings (人群/人羣) merged (tag_quality), then
+    near-synonyms folded to their preferred label via the reviewed alias map
+    (tag_aliases) — a no-op until `ingest --propose-aliases`/`--apply-aliases`."""
+    return tag_aliases.fold_records(tag_quality.merge_tag_records(db.get_all_tag_names()))
 
 
 def _thumb_url(thumbnail_path):

--- a/server.py
+++ b/server.py
@@ -1167,8 +1167,9 @@ def get_all_tags(
     _tok: dict = Depends(require_scopes("videos_read")),
 ):
     """All unique tag names with counts. Quality-defect tags (模糊/低解析度…)
-    are screened out — see tag_quality. Pass include_noise=1 to bypass."""
-    return tag_quality.filter_tag_records(db.get_all_tag_names())
+    are screened out and variant-char spellings (人群/人羣) are merged into one
+    row with summed counts — see tag_quality."""
+    return tag_quality.merge_tag_records(db.get_all_tag_names())
 
 
 def _thumb_url(thumbnail_path):

--- a/tag_aliases.py
+++ b/tag_aliases.py
@@ -1,0 +1,123 @@
+"""Library-level tag alias map (SKOS-lite preferred-term / synonym-ring).
+
+The per-clip canonicalize pass (ingest --canonicalize-tags) merges synonyms
+*within one clip*, but across the whole library near-synonyms still coexist in
+the global tag cloud (運動 / 跑步 / 賽事 / 路跑 / 運動會 all describe one running
+event). The industry answer is a thesaurus equivalence layer, NOT a hierarchy:
+one *preferred label* per concept, the rest kept as reversible *aliases*.
+
+This module is the runtime half — it loads a reviewed alias map and folds the
+cloud so each concept shows once with summed counts. It is REVERSIBLE and
+NON-DESTRUCTIVE: the raw `tags` rows are never touched, so dropping the map file
+restores the unfolded cloud, and an alt-label is never lost (search can expand a
+pref back to its alts). The proposal half (embed → cluster → LLM judge → human
+review) lives in ingest.py (--propose-aliases / --apply-aliases).
+
+File shape (`.arkiv/tag_aliases.json`):
+    {"version": 1, "groups": [{"pref": "賽事", "alts": ["運動會", "比賽"]}, ...]}
+"""
+from __future__ import annotations
+
+import json
+from typing import Dict, Iterable, List
+
+import config
+import tag_quality
+
+# Reload-on-change cache so a freshly-applied map takes effect without a restart.
+_CACHE: Dict[str, object] = {"mtime": None, "alt2pref": {}, "pref2alts": {}}
+
+
+def _maps():
+    """Return (alt2pref, pref2alts), reloading if the file changed. Empty if absent
+    or malformed (fail-soft — a bad map must never break the tag cloud)."""
+    path = config.TAG_ALIASES_PATH
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        _CACHE.update(mtime=None, alt2pref={}, pref2alts={})
+        return _CACHE["alt2pref"], _CACHE["pref2alts"]
+    if _CACHE["mtime"] == mtime:
+        return _CACHE["alt2pref"], _CACHE["pref2alts"]
+    alt2pref: Dict[str, str] = {}
+    pref2alts: Dict[str, List[str]] = {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        for g in data.get("groups", []):
+            pref = tag_quality.canonicalize(g.get("pref") or "")
+            if not pref:
+                continue
+            alts = []
+            for a in g.get("alts", []):
+                a = tag_quality.canonicalize(a or "")
+                if a and a != pref and a not in alt2pref:
+                    alt2pref[a] = pref
+                    alts.append(a)
+            if alts:
+                pref2alts.setdefault(pref, []).extend(alts)
+    except (ValueError, OSError):
+        alt2pref, pref2alts = {}, {}  # malformed → behave as no map
+    _CACHE.update(mtime=mtime, alt2pref=alt2pref, pref2alts=pref2alts)
+    return alt2pref, pref2alts
+
+
+def is_active() -> bool:
+    """True if a non-empty alias map is loaded."""
+    alt2pref, _ = _maps()
+    return bool(alt2pref)
+
+
+def to_pref(name: str) -> str:
+    """Map a tag to its preferred label (identity if not aliased)."""
+    alt2pref, _ = _maps()
+    return alt2pref.get(tag_quality.canonicalize(name), tag_quality.canonicalize(name))
+
+
+def expand(name: str) -> List[str]:
+    """A tag expands to every spelling of its concept: the pref + all its alts.
+    Used so a search/filter on the preferred label still hits alt-tagged media
+    (the reversibility guarantee). Returns [name] unchanged when not in the map."""
+    alt2pref, pref2alts = _maps()
+    c = tag_quality.canonicalize(name)
+    pref = alt2pref.get(c, c)
+    out = [pref] + list(pref2alts.get(pref, []))
+    return list(dict.fromkeys(out)) if len(out) > 1 else [c]
+
+
+def fold_records(records: Iterable[Dict]) -> List[Dict]:
+    """Fold a tag-cloud record list ({name, count}) by the alias map: alt rows
+    merge into their preferred label, counts summed, sorted by merged count desc.
+    Each folded pref carries `aliases` (the alt spellings it absorbed) so the UI
+    can show "賽事 ·3" with a "+運動會/比賽" hint. A no-op when no map is loaded."""
+    alt2pref, _ = _maps()
+    if not alt2pref:
+        return list(records)
+    merged: Dict[str, int] = {}
+    alts_seen: Dict[str, List[str]] = {}
+    order: Dict[str, int] = {}
+    seq = 0
+    for r in records or []:
+        name = tag_quality.canonicalize(r.get("name") or "")
+        if not name:
+            continue
+        pref = alt2pref.get(name, name)
+        try:
+            cnt = int(r.get("count") or 0)
+        except (TypeError, ValueError):
+            cnt = 0
+        if pref not in order:
+            order[pref] = seq
+            seq += 1
+        merged[pref] = merged.get(pref, 0) + cnt
+        if name != pref:
+            alts_seen.setdefault(pref, [])
+            if name not in alts_seen[pref]:
+                alts_seen[pref].append(name)
+    ranked = sorted(merged, key=lambda n: (-merged[n], order[n]))
+    out = []
+    for n in ranked:
+        rec = {"name": n, "count": merged[n]}
+        if alts_seen.get(n):
+            rec["aliases"] = alts_seen[n]
+        out.append(rec)
+    return out

--- a/tag_quality.py
+++ b/tag_quality.py
@@ -51,6 +51,9 @@ _CHAR_VARIANTS = str.maketrans({
     "檯": "台",   # 吧檯 → 吧台
     "裏": "裡",   # 裏 → 裡
     "着": "著",   # 着 → 著
+    "羣": "群",   # 人羣 → 人群 (VLM mixes the 羣/群 variant across frames)
+    "牀": "床",   # 牀 → 床
+    "麪": "麵",   # 麪 → 麵
 })
 
 
@@ -101,6 +104,33 @@ def filter_tags(tags: Iterable[str]) -> List[str]:
 def filter_tag_records(records: Iterable[Dict]) -> List[Dict]:
     """Drop noise from a list of {name, count, ...} tag dicts (e.g. /api/tags)."""
     return [r for r in records if r.get("name") and not is_noise(r["name"])]
+
+
+def merge_tag_records(records: Iterable[Dict]) -> List[Dict]:
+    """Build the global tag cloud: drop noise, collapse variant-char spellings to
+    one canonical name, and SUM their counts (人群 + 人羣 → one row, count merged).
+
+    SQL `GROUP BY name` keeps variant spellings as separate rows; this re-aggregates
+    on the canonicalized name so the cloud shows one chip per word with the true
+    total. Output is sorted by merged count desc (stable on first-seen for ties).
+    """
+    merged: Dict[str, int] = {}
+    order: Dict[str, int] = {}
+    seq = 0
+    for r in records or []:
+        name = canonicalize(r.get("name") or "")
+        if not name or is_noise(name):
+            continue
+        try:
+            cnt = int(r.get("count") or 0)
+        except (TypeError, ValueError):
+            cnt = 0
+        if name not in order:
+            order[name] = seq
+            seq += 1
+        merged[name] = merged.get(name, 0) + cnt
+    ranked = sorted(merged, key=lambda n: (-merged[n], order[n]))
+    return [{"name": n, "count": merged[n]} for n in ranked]
 
 
 # Per-media tag count. Industry DAMs (Canto/Adobe) cap auto-tags to avoid noise —

--- a/tests/test_tag_aliases.py
+++ b/tests/test_tag_aliases.py
@@ -1,0 +1,67 @@
+"""tag_aliases: library-level alias-map folding of the global tag cloud.
+
+The map is reversible/non-destructive — these tests drive it through a temp
+JSON file (config.TAG_ALIASES_PATH) and assert fold/expand behaviour, including
+the no-map no-op and malformed-file fail-soft.
+"""
+import json
+
+import config
+import tag_aliases
+
+
+def _write_map(tmp_path, groups):
+    p = tmp_path / "tag_aliases.json"
+    p.write_text(json.dumps({"version": 1, "groups": groups}, ensure_ascii=False), encoding="utf-8")
+    config.TAG_ALIASES_PATH = p
+    # bust the mtime cache so the new file is picked up within one test process
+    tag_aliases._CACHE["mtime"] = None
+    return p
+
+
+def test_no_map_is_noop(tmp_path):
+    config.TAG_ALIASES_PATH = tmp_path / "absent.json"
+    tag_aliases._CACHE["mtime"] = None
+    recs = [{"name": "賽事", "count": 5}, {"name": "運動會", "count": 3}]
+    assert tag_aliases.fold_records(recs) == recs
+    assert tag_aliases.is_active() is False
+
+
+def test_fold_merges_alts_into_pref_and_sums(tmp_path):
+    _write_map(tmp_path, [{"pref": "賽事", "alts": ["運動會", "比賽"]}])
+    recs = [
+        {"name": "賽事", "count": 16},
+        {"name": "運動會", "count": 8},
+        {"name": "比賽", "count": 4},
+        {"name": "跑步", "count": 17},
+    ]
+    out = tag_aliases.fold_records(recs)
+    by = {r["name"]: r for r in out}
+    assert by["賽事"]["count"] == 28          # 16 + 8 + 4
+    assert set(by["賽事"]["aliases"]) == {"運動會", "比賽"}
+    assert "運動會" not in by and "比賽" not in by  # alts folded away
+    assert by["跑步"]["count"] == 17           # untouched concept survives
+    assert out[0]["name"] == "賽事"            # 28 > 17, sorted by merged count
+
+
+def test_fold_pref_with_no_own_row(tmp_path):
+    # The pref term itself may have zero direct tags — only alts exist.
+    _write_map(tmp_path, [{"pref": "賽事", "alts": ["運動會"]}])
+    out = tag_aliases.fold_records([{"name": "運動會", "count": 8}])
+    assert out == [{"name": "賽事", "count": 8, "aliases": ["運動會"]}]
+
+
+def test_expand_pref_to_all_spellings(tmp_path):
+    _write_map(tmp_path, [{"pref": "賽事", "alts": ["運動會", "比賽"]}])
+    assert set(tag_aliases.expand("賽事")) == {"賽事", "運動會", "比賽"}
+    assert set(tag_aliases.expand("運動會")) == {"賽事", "運動會", "比賽"}  # alt → whole ring
+    assert tag_aliases.expand("跑步") == ["跑步"]  # unmapped → identity
+
+
+def test_malformed_map_fails_soft(tmp_path):
+    p = tmp_path / "tag_aliases.json"
+    p.write_text("{ not valid json", encoding="utf-8")
+    config.TAG_ALIASES_PATH = p
+    tag_aliases._CACHE["mtime"] = None
+    recs = [{"name": "賽事", "count": 5}]
+    assert tag_aliases.fold_records(recs) == recs  # behaves as no map

--- a/tests/test_tag_quality.py
+++ b/tests/test_tag_quality.py
@@ -63,3 +63,22 @@ def test_guard_accepts_reasonable_merge():
     raw = ["生肉", "魚肉", "肉類", "脂肪層", "生魚", "切片"]
     out = tq.guard_canonical(raw, ["肉類", "脂肪層", "切片"])
     assert out == ["肉類", "脂肪層", "切片"]  # all ⊂ raw, not over-merged
+
+
+# ── merge_tag_records: global tag-cloud aggregation ─────────────────────────
+def test_merge_tag_records_collapses_variant_and_sums_counts():
+    recs = [
+        {"name": "人群", "count": 15},
+        {"name": "人羣", "count": 9},   # 羣→群 variant of the above
+        {"name": "跑步", "count": 17},
+        {"name": "模糊", "count": 3},   # noise, dropped
+    ]
+    out = tq.merge_tag_records(recs)
+    names = {r["name"]: r["count"] for r in out}
+    assert names == {"跑步": 17, "人群": 24}  # variants merged, noise gone
+    assert out[0]["name"] == "人群"  # sorted by merged count desc (24 > 17)
+
+
+def test_merge_tag_records_handles_missing_count():
+    out = tq.merge_tag_records([{"name": "餐廳"}, {"name": "餐廳", "count": 2}])
+    assert out == [{"name": "餐廳", "count": 2}]


### PR DESCRIPTION
Three stacked layers to fix the noisy/over-long global tag cloud (74 chips, variant dupes, near-synonym sprawl on the 寶礦力 library).

## 1. Variant chars (字)
`羣→群` (+ `牀→床`, `麪→麵`) in `_CHAR_VARIANTS` → `人群`+`人羣` collapse. `merge_tag_records()` re-aggregates the cloud on canonicalized names and **sums** counts. `/api/tags` uses it.

## 2. UI cap (視覺)
`PoolSidebar` shows top-24 (count-sorted) with `+N 更多 / 收合` expander + distinct total in header. No more 74-chip wall.

## 3. Library alias map (語意) — SKOS-lite
Per-clip canonicalize merges *within* a clip; near-synonyms still coexist *across* the library. Industry answer = a thesaurus equivalence layer (preferred label + reversible aliases), not a hierarchy.

- `tag_aliases.py`: `fold_records()` (alt→pref, sum counts, attach absorbed aliases) + `expand()` (pref→all spellings, for search). Reversible/non-destructive (raw tags untouched), fail-soft, mtime-cached.
- `ingest.py --propose-aliases`: embed cloud (bge-m3) → cosine cluster → local LLM judges each group → reviewable `.arkiv/tag_aliases.proposed.json`. `--apply-aliases` activates after human review. **Default threshold 0.80** (bge-m3 is anisotropic — below ~0.75 every tag blobs into one).
- `/api/tags` folds via the map (no-op until applied). PoolSidebar: folded chips dashed + `含別名:…` tooltip.

## Result on 寶礦力
73 → **59 concepts**; 跑步←路跑/賽跑, 比賽←賽事/參賽, 用餐←餐桌/聚餐/晚餐 … `馬拉松` correctly stays separate (red line: ≠路跑). Verified live on M2.

## Tests
`merge_tag_records` + `tag_aliases` fold/expand/no-op/fail-soft. Full suite **588 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)