### PR TITLE
fix: make arkiv Windows-portable (cross-platform paths + green Win test suite)

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,23 +11,36 @@ BASE_DIR = Path(__file__).parent
 # arkiv write generated proxy mp4 files into /etc on every HEVC ingest. Same
 # risk for THUMBNAILS_DIR / CHROMA_PATH / DB_PATH (any operator-tunable
 # writable path). Hard-fail when env override resolves under a system root.
-_SYSTEM_DIR_DENYLIST = (
+_POSIX_SYSTEM_DENYLIST = (
     "/etc", "/usr", "/bin", "/sbin", "/sys", "/proc", "/dev",
     "/var/log", "/var/run", "/Library", "/System",
     "/private/etc", "/private/var/log", "/private/var/run",
 )
+# Windows system roots — same intent (never let an env override clobber the OS).
+_WINDOWS_SYSTEM_DENYLIST = (
+    r"C:\Windows", r"C:\Program Files", r"C:\Program Files (x86)", r"C:\ProgramData",
+)
+_SYSTEM_DIR_DENYLIST = _WINDOWS_SYSTEM_DENYLIST if os.name == "nt" else _POSIX_SYSTEM_DENYLIST
+
+
+def _is_under(child: Path, prefix: str) -> bool:
+    """True if `child` is at/under `prefix`. Uses os.path.normcase so the match is
+    case-insensitive on Windows (C:\\WINDOWS == C:\\Windows) and separator-normal."""
+    try:
+        c = os.path.normcase(os.path.normpath(str(child)))
+        p = os.path.normcase(os.path.normpath(str(Path(prefix))))
+    except (TypeError, ValueError):
+        return False
+    return c == p or c.startswith(p + os.sep)
 
 
 def _validate_writable_path(path: Path, env_var: str) -> Path:
     canonical = path.expanduser().resolve()
     for prefix in _SYSTEM_DIR_DENYLIST:
-        try:
-            canonical.relative_to(prefix)
-        except ValueError:
-            continue
-        raise ValueError(
-            f"{env_var} 不可指向系統目錄：{canonical}（matched {prefix}; denylist={_SYSTEM_DIR_DENYLIST}）"
-        )
+        if _is_under(canonical, prefix):
+            raise ValueError(
+                f"{env_var} 不可指向系統目錄：{canonical}（matched {prefix}; denylist={_SYSTEM_DIR_DENYLIST}）"
+            )
     return path
 
 

--- a/db.py
+++ b/db.py
@@ -62,11 +62,18 @@ def get_conn():
 
 
 def to_relative(abs_path: str) -> str:
-    """Absolute path -> relative to PROJECT_ROOT. Idempotent."""
+    """Absolute path -> relative to PROJECT_ROOT, stored POSIX-style. Idempotent.
+
+    Cross-platform: relative paths are persisted with forward slashes on EVERY
+    OS (`.as_posix()`), so a DB written on Windows and a DB written on mac/NAS
+    agree. Without this, str(WindowsPath('media/clip.mp4')) == 'media\\clip.mp4',
+    and a PC opening a NAS DB that mac wrote saw every file as unprocessed
+    (backslash rel != stored forward-slash rel) → whole-library re-ingest. No-op
+    on POSIX (str == as_posix there)."""
     if not abs_path:
         return abs_path
     try:
-        return str(Path(abs_path).relative_to(_config.PROJECT_ROOT))
+        return Path(abs_path).relative_to(_config.PROJECT_ROOT).as_posix()
     except ValueError:
         return abs_path
 
@@ -85,7 +92,14 @@ def resolve_path(rel_path: str) -> str:
     """
     if not rel_path:
         return rel_path
+    # Defense-in-depth: a row written by a pre-fix Windows ingest may hold
+    # backslashes ('media\\clip.mp4'). On POSIX that's a literal filename, not a
+    # path — normalize so such legacy rows still resolve cross-OS. New writes are
+    # already forward-slash (to_relative.as_posix). Skip if it's a real absolute
+    # Windows path (drive-letter), which Path handles natively.
     path_obj = Path(rel_path)
+    if not path_obj.is_absolute() and "\\" in rel_path:
+        path_obj = Path(rel_path.replace("\\", "/"))
     if path_obj.is_absolute():
         return str(path_obj)
     project_root = _config.PROJECT_ROOT.resolve()

--- a/ingest.py
+++ b/ingest.py
@@ -985,7 +985,14 @@ def _regenerate_thumbnails():
     size_before = _dir_size_bytes(config.THUMBNAILS_DIR)
     ok, failed = 0, 0
     for idx, rec in enumerate(videos, 1):
-        src = db.resolve_path(rec["path"])
+        try:
+            src = db.resolve_path(rec["path"])
+        except ValueError:
+            # Poisoned/cross-OS row whose path escapes PROJECT_ROOT — treat as a
+            # missing source and skip, never crash the whole regen pass.
+            print(f"  [{idx}/{len(videos)}] id={rec['id']}: unresolvable path, skipping")
+            failed += 1
+            continue
         if not Path(src).exists():
             print(f"  [{idx}/{len(videos)}] id={rec['id']}: source missing, skipping")
             failed += 1

--- a/server.py
+++ b/server.py
@@ -2083,7 +2083,18 @@ def reingest_media(
 # ── Cache Management ──────────────────────────────────────────────────────────
 
 def _dir_size_mb(p: Path) -> int:
-    return round(sum(f.stat().st_size for f in p.rglob("*") if f.is_file()) / 1048576)
+    total = 0
+    for f in p.rglob("*"):
+        try:
+            if f.is_file():
+                total += f.stat().st_size
+        except OSError:
+            # Skip un-stattable entries so a cache-size estimate never 500s. On
+            # Windows the HF cache's snapshots/ are symlinks into blobs/ that
+            # raise WinError 448 when symlink support is off — one bad link must
+            # not crash /api/cache/info.
+            continue
+    return round(total / 1048576)
 
 
 @app.get("/api/cache/info")

--- a/server.py
+++ b/server.py
@@ -1626,7 +1626,9 @@ def _allowed_ingest_roots() -> list:
     """
     custom = os.environ.get("ARKIV_INGEST_ROOTS", "").strip()
     if custom:
-        return [Path(p).expanduser().resolve() for p in custom.split(":") if p.strip()]
+        # os.pathsep, not ':' — Windows uses ';' AND ':' appears in drive letters
+        # (C:\...), so splitting on ':' shredded every Windows path.
+        return [Path(p).expanduser().resolve() for p in custom.split(os.pathsep) if p.strip()]
     home = Path.home()
     roots = [
         config.PROJECT_ROOT.resolve() if config.PROJECT_ROOT else None,
@@ -1641,10 +1643,16 @@ def _allowed_ingest_roots() -> list:
         try:
             for vol in volumes.iterdir():
                 if vol.is_dir():
-                    roots.append(vol.resolve())
+                    resolved = vol.resolve()
+                    # Skip a volume that resolves to the filesystem root (e.g.
+                    # /Volumes/Macintosh HD → '/'): allowing '/' makes the J1
+                    # bound a no-op — every path is then "under an approved root".
+                    if str(resolved) != resolved.anchor:
+                        roots.append(resolved)
         except OSError:
             pass
-    return [r for r in roots if r is not None]
+    # Final guard: never allow a bare filesystem/drive root through (defeats J1).
+    return [r for r in roots if r is not None and str(r) != r.anchor]
 
 
 def _assert_ingest_path_safe(target: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,16 +35,28 @@ def _check_config_loads(env_overrides):
     return result.returncode, result.stderr
 
 
-@pytest.mark.parametrize(
-    "env_var,bad_path",
+# OS-native system roots — the denylist is platform-specific (config picks the
+# POSIX or Windows set), so the bad paths must match the running OS.
+_BAD_PATHS = (
     [
+        ("ARKIV_PROXIES_DIR", r"C:\Windows\arkiv-proxies"),
+        ("ARKIV_THUMBNAILS_DIR", r"C:\Program Files\arkiv"),
+        ("ARKIV_DB_PATH", r"C:\ProgramData\arkiv.db"),
+        ("ARKIV_CHROMA_PATH", r"C:\Program Files (x86)\arkiv-chroma"),
+        ("ARKIV_PROJECT_ROOT", r"C:\Windows\System32\arkiv"),
+    ]
+    if sys.platform == "win32"
+    else [
         ("ARKIV_PROXIES_DIR", "/etc/arkiv-proxies"),
         ("ARKIV_THUMBNAILS_DIR", "/usr/local/share/arkiv"),
         ("ARKIV_DB_PATH", "/var/log/arkiv.db"),
         ("ARKIV_CHROMA_PATH", "/Library/arkiv-chroma"),
         ("ARKIV_PROJECT_ROOT", "/System/arkiv"),
-    ],
+    ]
 )
+
+
+@pytest.mark.parametrize("env_var,bad_path", _BAD_PATHS)
 def test_config_rejects_writable_path_under_system_root(tmp_path, env_var, bad_path):
     code, stderr = _check_config_loads({env_var: bad_path})
     assert code != 0, f"expected failure but config loaded with {env_var}={bad_path}"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -215,12 +215,15 @@ def test_resolve_path_rejects_traversal_outside_project_root():
 
 
 def test_resolve_path_passes_through_inside_root_and_absolute():
+    import sys
     db = importlib.import_module("db")
-    # Relative inside root → joined absolute path under PROJECT_ROOT
+    # Relative inside root → joined absolute path under PROJECT_ROOT. Stored
+    # rel-paths are POSIX (to_relative.as_posix), but the RESOLVED absolute path
+    # is OS-native (it's handed to open()/streaming), so compare separator-agnostically.
     inside = db.resolve_path("media/clip.mp4")
-    assert inside.endswith("media/clip.mp4")
-    # Absolute path passed through as-is (legacy rows)
-    abs_path = "/tmp/some_clip.mp4"
+    assert inside.replace("\\", "/").endswith("media/clip.mp4")
+    # Absolute path passed through as-is (legacy rows) — OS-native absolute form.
+    abs_path = "C:\\tmp\\some_clip.mp4" if sys.platform == "win32" else "/tmp/some_clip.mp4"
     assert db.resolve_path(abs_path) == abs_path
     # Empty stays empty (idempotent)
     assert db.resolve_path("") == ""

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7,14 +7,30 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def _imported_top_level(py_file: Path) -> set:
-    """Top-level module names this file imports (absolute imports only)."""
+    """Top-level module names this file imports (absolute imports only).
+
+    Imports inside a `try:` block are EXCLUDED — those are intentionally-optional
+    deps guarded by `except ImportError` (e.g. health.py's `import mlx`, which is
+    Apple-Silicon only and absent on Windows/Linux). They can't crash a fresh
+    install, so flagging them as "unresolved" is a false positive."""
     tree = ast.parse(py_file.read_text(encoding="utf-8"))
+    guarded = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Try):
+            for stmt in node.body:
+                for sub in ast.walk(stmt):
+                    if isinstance(sub, (ast.Import, ast.ImportFrom)):
+                        guarded.add(id(sub))
     names = set()
     for node in ast.walk(tree):
+        if id(node) in guarded:
+            continue
         if isinstance(node, ast.Import):
             names.update(a.name.split(".")[0] for a in node.names)
         elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
@@ -61,6 +77,12 @@ def test_install_copies_first_party_package_dirs():
     )
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="install.sh is the POSIX (mac/Linux/NAS) installer — its bash copy loop "
+    "with `cp -R` and POSIX paths isn't the Windows install path (arkiv on Windows "
+    "installs via venv directly). Nothing to assert about install.sh here.",
+)
 def test_package_copy_actually_ships_packages_not_tests(tmp_path):
     """Functional proof (Codex SHOULD-FIX): run install.sh's package-copy loop
     against a synthetic source tree and assert a first-party package dir lands

--- a/tests/test_scan_manifest.py
+++ b/tests/test_scan_manifest.py
@@ -2,7 +2,10 @@
 category + unsupported-stills skip count). Pure aggregation over the scan."""
 
 
-def test_scan_manifest_categorizes_and_sizes(fastapi_client, tmp_path):
+def test_scan_manifest_categorizes_and_sizes(fastapi_client, tmp_path, monkeypatch):
+    # The scan endpoint allowlists ingest roots (J1). pytest's tmp_path isn't
+    # under the default roots (esp. on Windows: AppData\Local\Temp), so approve it.
+    monkeypatch.setenv("ARKIV_INGEST_ROOTS", str(tmp_path))
     card = tmp_path / "card"; (card / "DCIM").mkdir(parents=True)
     (card / "DCIM" / "A001.MP4").write_bytes(b"v" * (2 * 1048576))   # 2 MB video
     (card / "DCIM" / "A002.MOV").write_bytes(b"v" * (1 * 1048576))   # 1 MB video
@@ -24,7 +27,8 @@ def test_scan_manifest_categorizes_and_sizes(fastapi_client, tmp_path):
     assert m["total_size_mb"] == 3.5               # video+audio only, stills not counted
 
 
-def test_scan_manifest_empty_dir(fastapi_client, tmp_path):
+def test_scan_manifest_empty_dir(fastapi_client, tmp_path, monkeypatch):
+    monkeypatch.setenv("ARKIV_INGEST_ROOTS", str(tmp_path))
     d = tmp_path / "empty"; d.mkdir()
     m = fastapi_client.post("/api/ingest/scan", json={"path": str(d)}).json()["manifest"]
     assert m["video"]["count"] == 0 and m["audio"]["count"] == 0


### PR DESCRIPTION
First-ever run of the arkiv suite on the Windows PC node (Python 3.12.10) surfaced 17 failures. Root-caused all of them: **4 real cross-platform runtime bugs** + POSIX test assumptions. Windows suite now **572 passed / 3 skipped / 0 failed**; mac unaffected (588 passed / 5 skipped).

## Real bugs (would actually break arkiv on PC)
1. **Relative paths stored with OS-native separator** — `to_relative` emitted `media\clip.mp4` on Windows. DBs live on the shared NAS, so a PC opening a mac-written DB matched nothing → `is_processed()` False for every file → **whole-library re-ingest**. Fixed with `.as_posix()` (+ defensive backslash normalize in `resolve_path`).
2. **`/api/cache/info` 500s** — `_dir_size_mb` did `f.stat()` over the HF cache; Windows symlinked snapshots/ raise WinError 448. Now skips un-stattable entries.
3. **`ARKIV_INGEST_ROOTS` split on `':'`** — colon is in every Windows drive letter (`C:\...`), shredding the override. Use `os.pathsep`.
4. **`/` leaked into the ingest allowlist on mac** — a `/Volumes/*` entry resolves to `/`, so every path counted as approved, silently defeating the J1 bound. Skip roots resolving to a bare anchor.

## Hardening / robustness
- config system-root denylist was POSIX-only → added Windows roots (`C:\Windows`, `C:\Program Files[ (x86)]`, `C:\ProgramData`) + case-insensitive matcher, so an env override can't point a writable path at the Windows system tree.
- `_regenerate_thumbnails` skips a row whose path fails `resolve_path` instead of crashing the pass.

## Test portability (POSIX-only assumptions, no runtime impact)
- `test_resolve_path` / `test_config`: OS-native paths + separator-agnostic asserts.
- `test_scan_manifest`: sets `ARKIV_INGEST_ROOTS=tmp_path` (was relying on the mac `/` leak; hermetic now).
- `test_install`: skipif win32 on the bash cp-loop test; `_imported_top_level` now ignores try/except-guarded optional imports (health.py's Apple-only `mlx` was false-flagged on Windows).

Verified green on Windows (PC), mac (mini), and Linux CI.