### PR TITLE
fix(ui): wire a real video/audio player into the inspector

### DIFF
--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -15,6 +15,13 @@
   $: if (is360 && !Pano360) import('./Pano360.svelte').then((m) => (Pano360 = m.default))
   // Live overrides — all default to mock behaviour so mock screens are unchanged.
   export let thumbUrl = null // real <img> when set, else abstract Thumb
+  // Real stream URL (api.streamUrl) → the preview becomes a playable <video>/<audio>
+  // element instead of a static poster. This is the actual playback the
+  // mock-derived inspector was missing (the old .controls overlay was a fake
+  // scrubber on a still image). null → poster/placeholder behaviour unchanged.
+  export let videoSrc = null
+  $: useVideo = !!videoSrc && !is360 && !!media && media.kind !== 'audio'
+  $: useAudio = !!videoSrc && !!media && media.kind === 'audio'
   export let pathLabel = null // file path string; null → mock /vol/... path
   export let transcriptLines = null // [[tc,text,hl],...]; null → mock lines
   export let frameDescriptions = null // string[]; when set, render a Vision block
@@ -107,23 +114,34 @@
     </Mono>
   </div>
 
-  <div class="preview">
+  <div class="preview" class:hasplayer={useVideo || useAudio}>
     {#if is360 && thumbUrl && !imgFailed}
       {#if Pano360}<svelte:component this={Pano360} src={thumbUrl} />{:else}<div class="panoload"><Mono dim style="font-size:11px;">360 · loading…</Mono></div>{/if}
+    {:else if useVideo}
+      <!-- svelte-ignore a11y-media-has-caption -->
+      <video class="previmg" controls playsinline preload="metadata" poster={thumbUrl || undefined} src={videoSrc}></video>
+    {:else if useAudio}
+      {#if thumbUrl && !imgFailed}
+        <img class="previmg" src={thumbUrl} alt={media.name} on:error={() => (imgFailed = true)} />
+      {/if}
+      <audio class="prevaudio" controls preload="metadata" src={videoSrc}></audio>
     {:else if thumbUrl && !imgFailed}
       <img class="previmg" src={thumbUrl} alt={media.name} on:error={() => (imgFailed = true)} />
     {:else}
       <Thumb seed={media.id} kind={media.kind} {theme} />
     {/if}
-    <div class="scrim"></div>
-    <div class="controls">
-      <Mono style="font-size:11px;color:#f3f2ee;">00:00:42</Mono>
-      <div class="track">
-        <div class="trackfill"></div>
-        <div class="trackhead"></div>
+    {#if !useVideo && !useAudio}
+      <!-- mock/poster fallback only: fake scrubber overlay (no real player wired) -->
+      <div class="scrim"></div>
+      <div class="controls">
+        <Mono style="font-size:11px;color:#f3f2ee;">00:00:42</Mono>
+        <div class="track">
+          <div class="trackfill"></div>
+          <div class="trackhead"></div>
+        </div>
+        <Mono style="font-size:11px;color:#f3f2ee;">{media.dur}</Mono>
       </div>
-      <Mono style="font-size:11px;color:#f3f2ee;">{media.dur}</Mono>
-    </div>
+    {/if}
   </div>
 
   <div class="block">
@@ -316,6 +334,9 @@
     border-bottom: 1px solid var(--rule);
   }
   .previmg { width: 100%; height: 100%; object-fit: cover; display: block; }
+  /* the real player: contain (don't crop footage) on black; audio sits at the bottom */
+  video.previmg { object-fit: contain; background: #000; }
+  .prevaudio { position: absolute; left: 12px; right: 12px; bottom: 12px; width: auto; }
   .panoload { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; background: var(--surface-2); }
   .scrim {
     position: absolute; left: 0; right: 0; bottom: 0; height: 40%;

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -285,6 +285,9 @@
       })()
     : null
   $: inspThumb = selected ? selected.thumb : null
+  // Real playback stream for the inspector player (loopback = token-free; remote
+  // carries ?token). Inspector turns this into a <video>/<audio> element.
+  $: inspVideoSrc = selected ? api.streamUrl(selected.id) : null
   $: inspPath = detailLive ? detailLive.path : null
   // tags: detail carries the quality-filtered tag list [{id,name,source}].
   $: inspTags = detailLive ? (detailLive.tags || []) : null
@@ -455,6 +458,7 @@
         media={inspectorMedia}
         {theme}
         thumbUrl={inspThumb}
+        videoSrc={inspVideoSrc}
         pathLabel={inspPath}
         transcriptLines={inspTranscript}
         frameDescriptions={inspFrames}


### PR DESCRIPTION
The inspector preview only ever rendered a static `<img>` poster with a **fake scrubber overlay** (`.scrim` + `.controls`) carried over from the Claude-design mock — there was no `<video>` element anywhere, and `api.streamUrl()` was defined but never consumed. So **no clip could play** (reported on both mac and Windows — platform-independent because it's a missing element, not a backend issue; `/api/stream/{id}` serves fine, verified 200 + full bytes, and already returns the H.264 proxy for HEVC/ProRes).

## Fix
- **Inspector**: new `videoSrc` prop → preview becomes a real `<video controls>` (or `<audio>` for audio kind), `poster=thumbUrl`, `object-fit:contain` on black. The fake scrubber overlay now only renders in the poster/mock fallback. 360 still uses the Pano360 sphere.
- **MainLive**: passes `videoSrc={api.streamUrl(selected.id)}` (loopback token-free; remote carries `?token`).

## Verified
Live on the Windows PC node against a real 53-clip project (`H:\Project_V1-LAN`): h264 plays directly, HEVC plays via the auto-served proxy, audio via `<audio>`. User confirmed playback works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)