### PR TITLE
fix(ui): full-window layout + finish the inspector (player/transcript/waveform/scroll)

### DIFF
--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -220,8 +220,8 @@
 
   <div class="block transcript">
     <div class="blockhead">
-      <Eyebrow>Transcript · zh-Hant</Eyebrow>
-      <Mono dim style="font-size:9.5px;">whisper-large · 98.2%</Mono>
+      <Eyebrow>Transcript{mediaLang ? ` · ${mediaLang}` : ''}</Eyebrow>
+      <Mono dim style="font-size:9.5px;">{lines.length} 段</Mono>
     </div>
     <div class="lines">
       {#if lines.length === 0}
@@ -342,7 +342,11 @@
 <style>
   .inspector {
     border-left: 1px solid var(--rule); display: flex; flex-direction: column;
-    min-height: 0; overflow: hidden;
+    /* the WHOLE inspector scrolls — preview + metadata + waveform + transcript +
+       scenes + tags + reprocess + rate can exceed the viewport, and the bottom
+       (rate buttons) was being clipped under overflow:hidden with no way to reach
+       it. The transcript no longer scrolls internally; the panel scrolls as one. */
+    min-height: 0; overflow-y: auto;
   }
   .header { padding: 18px 18px 16px; border-bottom: 1px solid var(--rule); }
   .fname {
@@ -369,10 +373,10 @@
   .block { padding: 14px 18px; border-bottom: 1px solid var(--rule); }
   .metagrid { display: grid; grid-template-columns: 64px 1fr; row-gap: 4px; column-gap: 12px; font-size: 11.5px; }
   .blockhead { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 8px; }
-  /* flex column + min-height:0 lets .lines scroll inside the inspector instead of
-     clipping a long transcript (was overflow:hidden → couldn't scroll the subs). */
-  .transcript { flex: 1; min-height: 0; display: flex; flex-direction: column; }
-  .lines { display: flex; flex-direction: column; gap: 8px; font-size: 12px; line-height: 1.5; overflow-y: auto; min-height: 0; padding-right: 4px; }
+  /* transcript flows naturally now — the whole inspector scrolls (see .inspector),
+     so a long transcript extends the panel and is reached by scrolling it. */
+  .transcript { }
+  .lines { display: flex; flex-direction: column; gap: 8px; font-size: 12px; line-height: 1.5; padding-right: 4px; }
   .line { display: flex; gap: 10px; }
   .line.seekable { cursor: pointer; }
   .line.seekable:hover .ttext { color: var(--invert); }

--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -22,6 +22,15 @@
   export let videoSrc = null
   $: useVideo = !!videoSrc && !is360 && !!media && media.kind !== 'audio'
   $: useAudio = !!videoSrc && !!media && media.kind === 'audio'
+  // The player element (video or audio) — bound so clicking a transcript line
+  // seeks playback to that timecode.
+  let playerEl = null
+  function seekTo(t) {
+    if (playerEl && typeof t === 'number' && !Number.isNaN(t)) {
+      playerEl.currentTime = t
+      playerEl.play && playerEl.play().catch(() => {})
+    }
+  }
   export let pathLabel = null // file path string; null → mock /vol/... path
   export let transcriptLines = null // [[tc,text,hl],...]; null → mock lines
   export let frameDescriptions = null // string[]; when set, render a Vision block
@@ -119,12 +128,12 @@
       {#if Pano360}<svelte:component this={Pano360} src={thumbUrl} />{:else}<div class="panoload"><Mono dim style="font-size:11px;">360 · loading…</Mono></div>{/if}
     {:else if useVideo}
       <!-- svelte-ignore a11y-media-has-caption -->
-      <video class="previmg" controls playsinline preload="metadata" poster={thumbUrl || undefined} src={videoSrc}></video>
+      <video bind:this={playerEl} class="previmg" controls playsinline preload="metadata" poster={thumbUrl || undefined} src={videoSrc}></video>
     {:else if useAudio}
       {#if thumbUrl && !imgFailed}
         <img class="previmg" src={thumbUrl} alt={media.name} on:error={() => (imgFailed = true)} />
       {/if}
-      <audio class="prevaudio" controls preload="metadata" src={videoSrc}></audio>
+      <audio bind:this={playerEl} class="prevaudio" controls preload="metadata" src={videoSrc}></audio>
     {:else if thumbUrl && !imgFailed}
       <img class="previmg" src={thumbUrl} alt={media.name} on:error={() => (imgFailed = true)} />
     {:else}
@@ -209,8 +218,10 @@
       {#if lines.length === 0}
         <Mono dim style="font-size:11px;">（無語音 · no speech detected）</Mono>
       {:else}
-        {#each lines as [tc, text, hl]}
-          <div class="line">
+        {#each lines as [tc, text, hl, t]}
+          <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+          <div class="line" class:seekable={typeof t === 'number' && (useVideo || useAudio)}
+            on:click={() => (typeof t === 'number') && seekTo(t)}>
             <Mono dim style="font-size:10.5px;flex:0 0 36px;">{tc}</Mono>
             <span class="ttext" class:hl>{text}</span>
           </div>
@@ -349,9 +360,13 @@
   .block { padding: 14px 18px; border-bottom: 1px solid var(--rule); }
   .metagrid { display: grid; grid-template-columns: 64px 1fr; row-gap: 4px; column-gap: 12px; font-size: 11.5px; }
   .blockhead { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 8px; }
-  .transcript { flex: 1; overflow: hidden; }
-  .lines { display: flex; flex-direction: column; gap: 8px; font-size: 12px; line-height: 1.5; }
+  /* flex column + min-height:0 lets .lines scroll inside the inspector instead of
+     clipping a long transcript (was overflow:hidden → couldn't scroll the subs). */
+  .transcript { flex: 1; min-height: 0; display: flex; flex-direction: column; }
+  .lines { display: flex; flex-direction: column; gap: 8px; font-size: 12px; line-height: 1.5; overflow-y: auto; min-height: 0; padding-right: 4px; }
   .line { display: flex; gap: 10px; }
+  .line.seekable { cursor: pointer; }
+  .line.seekable:hover .ttext { color: var(--invert); }
   .ttext { color: var(--ink); }
   .ttext.hl { border-bottom: 1px solid var(--invert); padding-bottom: 1px; }
   /* tags */

--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -22,14 +22,23 @@
   export let videoSrc = null
   $: useVideo = !!videoSrc && !is360 && !!media && media.kind !== 'audio'
   $: useAudio = !!videoSrc && !!media && media.kind === 'audio'
-  // The player element (video or audio) — bound so clicking a transcript line
-  // seeks playback to that timecode.
+  // Real audio waveform peaks (0..1) from the backend; null → flat fallback.
+  export let peaks = null
+  // The player element (video or audio) — bound so clicking a transcript line or
+  // the waveform seeks playback, and so the waveform playhead tracks currentTime.
   let playerEl = null
+  let playProgress = 0 // 0..1 playhead position, driven by the player's timeupdate
   function seekTo(t) {
     if (playerEl && typeof t === 'number' && !Number.isNaN(t)) {
       playerEl.currentTime = t
       playerEl.play && playerEl.play().catch(() => {})
     }
+  }
+  function onTimeUpdate() {
+    if (playerEl && playerEl.duration) playProgress = playerEl.currentTime / playerEl.duration
+  }
+  function seekFraction(frac) {
+    if (playerEl && playerEl.duration) seekTo(frac * playerEl.duration)
   }
   export let pathLabel = null // file path string; null → mock /vol/... path
   export let transcriptLines = null // [[tc,text,hl],...]; null → mock lines
@@ -128,12 +137,12 @@
       {#if Pano360}<svelte:component this={Pano360} src={thumbUrl} />{:else}<div class="panoload"><Mono dim style="font-size:11px;">360 · loading…</Mono></div>{/if}
     {:else if useVideo}
       <!-- svelte-ignore a11y-media-has-caption -->
-      <video bind:this={playerEl} class="previmg" controls playsinline preload="metadata" poster={thumbUrl || undefined} src={videoSrc}></video>
+      <video bind:this={playerEl} on:timeupdate={onTimeUpdate} class="previmg" controls playsinline preload="metadata" poster={thumbUrl || undefined} src={videoSrc}></video>
     {:else if useAudio}
       {#if thumbUrl && !imgFailed}
         <img class="previmg" src={thumbUrl} alt={media.name} on:error={() => (imgFailed = true)} />
       {/if}
-      <audio bind:this={playerEl} class="prevaudio" controls preload="metadata" src={videoSrc}></audio>
+      <audio bind:this={playerEl} on:timeupdate={onTimeUpdate} class="prevaudio" controls preload="metadata" src={videoSrc}></audio>
     {:else if thumbUrl && !imgFailed}
       <img class="previmg" src={thumbUrl} alt={media.name} on:error={() => (imgFailed = true)} />
     {:else}
@@ -204,9 +213,9 @@
   <div class="block">
     <div class="blockhead">
       <Eyebrow>Waveform</Eyebrow>
-      <Mono dim style="font-size:9.5px;">IN 00:05 · OUT 00:42</Mono>
+      <Mono dim style="font-size:9.5px;">{media.dur}</Mono>
     </div>
-    <Waveform />
+    <Waveform {peaks} progress={playProgress} on:seek={(e) => seekFraction(e.detail)} />
   </div>
 
   <div class="block transcript">

--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -116,8 +116,15 @@
     ['00:24', '氧氣比想像中還少，海拔 4800。', false],
     ['00:36', '車架被打到變形，但人沒事。', false],
   ]
-  $: lines = transcriptLines ?? MOCK_TRANSCRIPT
-  $: pathStr = pathLabel ?? `/vol/nas01/bicycle-diaries/raw/${media.name}`
+  // `live` (set by the real product) makes empty states HONEST — an empty
+  // transcript shows 「無語音」, an absent path shows the filename — instead of the
+  // design-mock placeholders. The /_design/* mock screens leave live=false so they
+  // stay populated for reference.
+  export let live = false
+  $: lines = live ? (transcriptLines ?? []) : (transcriptLines ?? MOCK_TRANSCRIPT)
+  $: pathStr = live
+    ? (pathLabel ?? media.name)
+    : (pathLabel ?? `/vol/nas01/bicycle-diaries/raw/${media.name}`)
   const rateBtns = [['good', 'Good'], ['rev', 'Review'], ['ng', 'N·G'], ['none', '—']]
 </script>
 
@@ -148,11 +155,12 @@
     {:else}
       <Thumb seed={media.id} kind={media.kind} {theme} />
     {/if}
-    {#if !useVideo && !useAudio}
-      <!-- mock/poster fallback only: fake scrubber overlay (no real player wired) -->
+    {#if !useVideo && !useAudio && !live}
+      <!-- design-mock only: fake scrubber overlay. In live (no player available)
+           the poster shows alone — no faked playback chrome. -->
       <div class="scrim"></div>
       <div class="controls">
-        <Mono style="font-size:11px;color:#f3f2ee;">00:00:42</Mono>
+        <Mono style="font-size:11px;color:#f3f2ee;">{media.dur}</Mono>
         <div class="track">
           <div class="trackfill"></div>
           <div class="trackhead"></div>

--- a/frontend/src/lib/Waveform.svelte
+++ b/frontend/src/lib/Waveform.svelte
@@ -1,29 +1,42 @@
-<!-- Deterministic SVG waveform with in/out markers + playhead. -->
+<!-- Real audio waveform: backend peaks (0..1) → bars, with a live playhead that
+     tracks the inspector player + click-to-seek. Falls back to a flat baseline
+     when a clip has no peaks (no audio / not yet computed). -->
 <script>
+  import { createEventDispatcher } from 'svelte'
+  export let peaks = null // number[] 0..1 from /api/media/{id}/waveform, or null
+  export let progress = 0 // 0..1 playhead position (player currentTime / duration)
+  const dispatch = createEventDispatcher()
   const N = 80
-  const bars = Array.from({ length: N }, (_, i) => {
-    const v = Math.sin(i * 0.7) * 0.4 + Math.sin(i * 0.13) * 0.35 + Math.sin(i * 0.42 + 1) * 0.3
-    return Math.abs(v) * (0.6 + Math.sin(i * 0.18) * 0.4)
-  }).map((v) => Math.max(2, v * 50))
+  // Resample the incoming peaks to N bars and scale to the 56-tall viewBox.
+  $: bars = (() => {
+    const src = Array.isArray(peaks) && peaks.length ? peaks : null
+    if (!src) return Array.from({ length: N }, () => 2) // flat baseline, no data
+    return Array.from({ length: N }, (_, i) => {
+      const v = src[Math.floor((i / N) * src.length)] || 0
+      return Math.max(2, v * 50)
+    })
+  })()
+  function onClick(e) {
+    const r = e.currentTarget.getBoundingClientRect()
+    dispatch('seek', Math.min(1, Math.max(0, (e.clientX - r.left) / r.width)))
+  }
 </script>
 
-<div class="wf">
+<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+<div class="wf" on:click={onClick} title="點擊跳到該位置">
   <svg viewBox="0 0 80 56" preserveAspectRatio="none" class="svg">
     {#each bars as h, i}
       <rect x={i + 0.15} y={(56 - h) / 2} width="0.7" height={h} fill="var(--ink-2)" />
     {/each}
   </svg>
-  <div class="mark mark-in"><div class="flag"></div></div>
-  <div class="mark mark-out"><div class="flag"></div></div>
-  <div class="playhead"></div>
+  <div class="playhead" style="left:{Math.min(100, Math.max(0, progress * 100))}%"></div>
 </div>
 
 <style>
-  .wf { position: relative; height: 56px; }
+  .wf { position: relative; height: 56px; cursor: pointer; }
   .svg { width: 100%; height: 100%; display: block; }
-  .mark { position: absolute; top: 0; bottom: 0; width: 1px; background: var(--invert); }
-  .mark-in { left: 8%; }
-  .mark-out { left: 78%; }
-  .flag { position: absolute; top: -4px; left: -3px; width: 7px; height: 4px; background: var(--invert); }
-  .playhead { position: absolute; top: -6px; bottom: -6px; left: 32%; width: 1px; background: var(--ink); }
+  .playhead {
+    position: absolute; top: -6px; bottom: -6px; width: 1px;
+    background: var(--ink); pointer-events: none;
+  }
 </style>

--- a/frontend/src/routes/ChatLive.svelte
+++ b/frontend/src/routes/ChatLive.svelte
@@ -258,7 +258,7 @@
 </div>
 
 <style>
-  .artboard { width: 1400px; height: 900px; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 1fr; overflow: hidden; margin: 0 auto; }
+  .artboard { width: 100%; max-width: 1920px; height: 100vh; height: 100dvh; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 1fr; overflow: hidden; margin: 0 auto; }
   .grow { flex: 1; }
   .topbar { display: flex; align-items: center; border-bottom: 1px solid var(--rule); padding: 0 16px; gap: 16px; }
   .body { display: grid; grid-template-columns: 240px 1fr; min-height: 0; }

--- a/frontend/src/routes/IngestLive.svelte
+++ b/frontend/src/routes/IngestLive.svelte
@@ -361,7 +361,7 @@
 </div>
 
 <style>
-  .artboard { width: 1400px; height: 900px; background: var(--bg); color: var(--ink); display: flex; flex-direction: column; overflow: hidden; margin: 0 auto; }
+  .artboard { width: 100%; max-width: 1920px; height: 100vh; height: 100dvh; background: var(--bg); color: var(--ink); display: flex; flex-direction: column; overflow: hidden; margin: 0 auto; }
   .grow { flex: 1; }
   .quiet { color: var(--quiet); }
   .on { color: var(--cyan); }

--- a/frontend/src/routes/IngestSetup.svelte
+++ b/frontend/src/routes/IngestSetup.svelte
@@ -182,7 +182,7 @@
 </div>
 
 <style>
-  .artboard { width: 1400px; height: 900px; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 1fr; overflow: hidden; margin: 0 auto; }
+  .artboard { width: 100%; max-width: 1920px; height: 100vh; height: 100dvh; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 1fr; overflow: hidden; margin: 0 auto; }
   .grow { flex: 1; }
   .topbar { display: flex; align-items: center; border-bottom: 1px solid var(--rule); padding: 0 16px; gap: 16px; }
 

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -246,6 +246,20 @@
   }
   $: if (selected && selected.id !== detailId) fetchDetail(selected.id)
 
+  // Real audio waveform peaks (0..1) from the backend ffmpeg endpoint — fetched
+  // per clip, passed to the inspector's <Waveform>. Replaces the old mock sin bars.
+  let wavePeaks = null
+  let waveId = null
+  async function fetchWaveform(id) {
+    waveId = id; wavePeaks = null
+    try {
+      const w = await api.getWaveform(id)
+      if (waveId === id) wavePeaks = (w && w.peaks) || null
+    } catch (e) { if (waveId === id) wavePeaks = null }
+  }
+  $: if (selected && selected.id !== waveId) fetchWaveform(selected.id)
+  $: inspPeaks = waveId === (selected && selected.id) ? wavePeaks : null
+
   const secToTc = (s) => {
     s = Math.round(s || 0)
     return `${String(Math.floor(s / 60)).padStart(2, '0')}:${String(s % 60).padStart(2, '0')}`
@@ -459,6 +473,7 @@
         {theme}
         thumbUrl={inspThumb}
         videoSrc={inspVideoSrc}
+        peaks={inspPeaks}
         pathLabel={inspPath}
         transcriptLines={inspTranscript}
         frameDescriptions={inspFrames}

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -471,6 +471,7 @@
       <Inspector
         media={inspectorMedia}
         {theme}
+        live={true}
         thumbUrl={inspThumb}
         videoSrc={inspVideoSrc}
         peaks={inspPeaks}

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -258,7 +258,7 @@
   $: detailLive = detail && detail.id === (selected && selected.id) ? detail : null
   // transcript: segments_json = [{start,end,text}, ...]
   $: inspTranscript = detailLive
-    ? (parseJson(detailLive.segments_json) || []).map((sg) => [secToTc(sg.start), sg.text, false])
+    ? (parseJson(detailLive.segments_json) || []).map((sg) => [secToTc(sg.start), sg.text, false, sg.start])
     : null
   // vision: frame_tags_parsed = [{description, tags, ...}, ...]
   $: inspFrames = detailLive

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -478,7 +478,7 @@
 </div>
 
 <style>
-  .artboard { width: 1400px; height: 900px; position: relative; display: grid; grid-template-rows: 52px 1fr; background: var(--bg); color: var(--ink); overflow: hidden; margin: 0 auto; }
+  .artboard { width: 100%; max-width: 1920px; height: 100vh; height: 100dvh; position: relative; display: grid; grid-template-rows: 52px 1fr; background: var(--bg); color: var(--ink); overflow: hidden; margin: 0 auto; }
   .body { display: grid; grid-template-columns: 220px 1fr 340px; min-height: 0; }
   .center { display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
   .toolrow { display: flex; align-items: center; gap: 14px; padding: 14px 22px; border-bottom: 1px solid var(--rule); }

--- a/frontend/src/routes/Offload.svelte
+++ b/frontend/src/routes/Offload.svelte
@@ -233,7 +233,7 @@
 
 <style>
   /* error red — the LOCKED exception to the B&W palette, failures only */
-  .artboard { --danger: #e0563a; width: 1400px; height: 900px; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 1fr; overflow: hidden; margin: 0 auto; }
+  .artboard { --danger: #e0563a; width: 100%; max-width: 1920px; height: 100vh; height: 100dvh; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 1fr; overflow: hidden; margin: 0 auto; }
   .grow { flex: 1; }
   .topbar { display: flex; align-items: center; border-bottom: 1px solid var(--rule); padding: 0 16px; gap: 16px; }
 

--- a/frontend/src/routes/SearchLive.svelte
+++ b/frontend/src/routes/SearchLive.svelte
@@ -223,7 +223,7 @@
 </div>
 
 <style>
-  .artboard { width: 1400px; height: 900px; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 1fr; overflow: hidden; margin: 0 auto; }
+  .artboard { width: 100%; max-width: 1920px; height: 100vh; height: 100dvh; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 1fr; overflow: hidden; margin: 0 auto; }
   .grow { flex: 1; }
   .topbar { display: flex; align-items: center; border-bottom: 1px solid var(--rule); padding: 0 16px; gap: 16px; }
   .topbar a { text-decoration: none; }

--- a/frontend/src/routes/SettingsLive.svelte
+++ b/frontend/src/routes/SettingsLive.svelte
@@ -161,7 +161,7 @@
 </div>
 
 <style>
-  .artboard { width: 1400px; height: 900px; background: var(--bg); color: var(--ink); position: relative; overflow: hidden; margin: 0 auto; }
+  .artboard { width: 100%; max-width: 1920px; height: 100vh; height: 100dvh; background: var(--bg); color: var(--ink); position: relative; overflow: hidden; margin: 0 auto; }
   .scrim { position: absolute; inset: 0; background: rgba(10, 10, 12, 0.55); }
 
   .modal { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); width: 960px; height: 640px; background: var(--bg); box-shadow: inset 0 0 0 1px var(--invert); display: grid; grid-template-rows: 56px 1fr; }


### PR DESCRIPTION
A batch of UI-completeness fixes for the cutover — mock-derived live screens that shipped without full live behaviour. All verified on the Windows PC node against a real 53-clip project.

## Layout
- **Full-window**: live screens were a fixed 1400×900 artboard (Figma-frame spec, shipped literally) → small centered box on larger monitors. The 7 live routes now use `width:100%; max-width:1920px; height:100dvh` (100vh fallback), centered+capped. `/_design/*` mocks keep fixed size.
- **Inspector scrolls as one panel**: was `overflow:hidden`, so when content exceeded the viewport the bottom (rate buttons) was clipped with no way to reach it. Now `overflow-y:auto`.

## Inspector — finished the mock-leftovers
- **Real video/audio player** (was a static poster + fake scrubber overlay; `streamUrl` was never consumed). Plays h264 directly, HEVC via the auto-served proxy, audio via `<audio>`.
- **Transcript**: scrolls + **click-to-seek** (jumps the player to a segment); carries raw start seconds. Header now shows the real language + segment count (was hardcoded `zh-Hant · 98.2%`).
- **Real waveform**: wired the existing `/api/media/{id}/waveform` (ffmpeg peaks); live playhead tracks the player + click-to-seek (was deterministic `Math.sin()` bars).
- **Honest empty states** via a `live` flag: empty transcript → 「無語音」, absent path → filename, no fake scrubber chrome. Mock screens keep their placeholders.

## Audit note
Smart Pools counts / storage / metadata / scenes / tags / project name verified live (not mock). Remaining honestly-disabled: IngestSetup vision pickers (no ollama model-list backend yet — brick 4b, tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)