### PR TITLE
fix(collections): domain-agnostic smart collections (drop hardcoded food vocab)

### DIFF
--- a/server.py
+++ b/server.py
@@ -1202,7 +1202,8 @@ def list_collections(
     with db.get_conn() as conn:
         rows = conn.execute(
             "SELECT id, filename, thumbnail_path, duration_s, has_audio, "
-            "frame_tags, content_type, atmosphere, energy, gps_lat, gps_lon "
+            "frame_tags, content_type, atmosphere, energy, gps_lat, gps_lon, "
+            "rating, processed_at "
             "FROM media ORDER BY id"
         ).fetchall()
     for rec in (dict(r) for r in rows):

--- a/smart_collections.py
+++ b/smart_collections.py
@@ -17,9 +17,10 @@ Consumes the shape returned by db helpers (see media_signal()).
 """
 from __future__ import annotations
 
+import datetime as _dt
 import json
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Callable, Dict, List, Optional, Sequence
 
 import geo
 
@@ -59,6 +60,11 @@ class Collection:
     boosters: Sequence[Booster] = field(default_factory=tuple)
     # Weight of the base tag-overlap signal (rest of score comes from boosters).
     tag_weight: float = 1.0
+    # Optional STRUCTURAL membership: a predicate on the raw media row (rating,
+    # processed_at, has_audio…) instead of tag overlap. When set, membership is
+    # purely predicate(row) and tags are ignored — this is how domain-agnostic
+    # collections (待審查 / 最近匯入) work for ANY project, not a hardcoded vocab.
+    predicate: Optional[Callable[[Dict[str, Any]], bool]] = None
 
 
 def media_signal(media: Dict[str, Any]) -> Dict[str, Any]:
@@ -153,6 +159,9 @@ def _booster_applies(b: Booster, sig: Dict[str, Any]) -> bool:
 
 def score_collection(media: Dict[str, Any], col: Collection) -> float:
     """Score a media item against one collection. 0.0 = no signal / hard-rejected."""
+    # Structural collections: membership is the predicate, not tag overlap.
+    if col.predicate is not None:
+        return 1.0 if col.predicate(media) else 0.0
     sig = media_signal(media)
 
     # Hard filters (membership gates).
@@ -203,27 +212,47 @@ def classify(media: Dict[str, Any], collections: Sequence[Collection]) -> List[D
 
 # ── Tier-1 definitions — Hevin's real shooting archetypes ────────────────────
 # Tags are arkiv's qwen3-vl Chinese vocabulary (verified against ingested data).
+_RECENT_DAYS = 14
+
+
+def _is_unrated(m: Dict[str, Any]) -> bool:
+    """No editorial rating yet → belongs in the review queue."""
+    r = m.get("rating")
+    return r is None or (isinstance(r, str) and r.strip() == "")
+
+
+def _recently_ingested(m: Dict[str, Any]) -> bool:
+    """processed_at within the last _RECENT_DAYS — project-agnostic 'new arrivals'."""
+    ts = m.get("processed_at")
+    if not ts:
+        return False
+    try:
+        t = _dt.datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return False
+    if t.tzinfo is None:
+        t = t.replace(tzinfo=_dt.timezone.utc)
+    return (_dt.datetime.now(_dt.timezone.utc) - t).days <= _RECENT_DAYS
+
+
+# Tier-1 collections are now DOMAIN-AGNOSTIC structural buckets that hold for any
+# project (the old food-specific 食材特寫/店內空景 were hardcoded for one shoot and
+# mis-classified e.g. cable-making clips via the 切割 tag). Topical/auto-derived
+# and per-project collections are deferred (B + C).
 DEFAULT_COLLECTIONS: List[Collection] = [
     Collection(
-        key="food_closeup",
-        title="食材特寫",
-        category="content",
-        tags=["生肉", "肉類", "肉品", "生豬肉", "生魚", "三文魚", "切割", "切片", "切痕",
-              "脂肪層", "食材", "食品處理", "肉類加工", "砧板", "廚房"],
-        boosters=(
-            Booster(boost=0.15, any_tags=["切割", "切片", "切痕"]),
-            Booster(boost=0.10, any_tags=["手套", "紫色手套", "手部操作"]),
-        ),
+        key="recent",
+        title="最近匯入",
+        category="status",
+        tags=(),
+        predicate=_recently_ingested,
     ),
     Collection(
-        key="interior_establishing",
-        title="店內空景",
-        category="content",
-        tags=["餐廳", "咖啡館", "吧檯", "室內", "座椅", "燈光", "低光", "條紋牆面", "幾何結構"],
-        boosters=(
-            Booster(boost=0.15, content_types=["Establishing"]),
-            Booster(boost=0.10, atmospheres=["舒適", "幽暗"]),
-        ),
+        key="needs_review",
+        title="待審查",
+        category="status",
+        tags=(),
+        predicate=_is_unrated,
     ),
     Collection(
         key="unusable",

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1,8 +1,9 @@
-"""Unit tests for smart collections engine (collections.py).
+"""Unit tests for smart collections engine (smart_collections.py).
 
-Fixtures are the REAL qwen3-vl tags from the 5 明燒肉 clips ingested 2026-05-31
-(verified against .arkiv/project.db), so expected memberships are ground truth:
-  C3742 → 店內空景   C3747/C3750/C3756 → 食材特寫   C3811 → 廢鏡
+Tier-1 collections are now DOMAIN-AGNOSTIC structural buckets (待審查 / 最近匯入 /
+廢鏡) so any project classifies correctly — the old hardcoded food vocab
+(食材特寫/店內空景) mis-filed non-food projects (cable-making's 切割 tag). The
+qwen3-vl tag fixtures (C37xx) still exercise the tag engine + media_signal.
 """
 from __future__ import annotations
 
@@ -47,64 +48,73 @@ def _keys(media):
     return {r["key"] for r in sc.classify(media, COLS)}
 
 
-# ── ground-truth membership ──────────────────────────────────────────────────
-def test_interior_clip_joins_interior_collection():
-    assert "interior_establishing" in _keys(C3742)
+# ── structural collection membership (domain-agnostic Tier-1) ────────────────
+# The Tier-1 collections are now project-agnostic structural buckets (待審查 /
+# 最近匯入 / 廢鏡), NOT the old hardcoded food vocab — so a non-food project
+# (e.g. cable-making) is never mis-filed into 食材特寫.
+def _now_iso():
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
 
 
-def test_meat_clips_join_food_collection():
-    for clip in (C3747, C3750, C3756):
-        assert "food_closeup" in _keys(clip), clip["tags"]
+def test_unrated_clip_joins_needs_review():
+    assert "needs_review" in _keys({"duration_s": 5, "has_audio": 1, "tags": [], "rating": None})
+
+
+def test_rated_clip_not_in_needs_review():
+    assert "needs_review" not in _keys(
+        {"duration_s": 5, "has_audio": 1, "tags": [], "rating": "good"})
+
+
+def test_recent_clip_joins_recent():
+    assert "recent" in _keys(
+        {"duration_s": 5, "tags": [], "rating": "good", "processed_at": _now_iso()})
+
+
+def test_old_clip_not_in_recent():
+    assert "recent" not in _keys(
+        {"duration_s": 5, "tags": [], "rating": "good", "processed_at": "2000-01-01T00:00:00+00:00"})
 
 
 def test_unusable_clip_joins_unusable_collection():
     assert "unusable" in _keys(C3811)
 
 
-# ── separation (no false positives across the obvious divides) ───────────────
-def test_interior_clip_not_in_food():
-    assert "food_closeup" not in _keys(C3742)
+def test_clip_can_belong_to_multiple_structural_collections():
+    # non-exclusive membership: unrated AND recent → both buckets
+    keys = _keys({"duration_s": 5, "tags": [], "rating": None, "processed_at": _now_iso()})
+    assert {"needs_review", "recent"} <= keys
 
 
-def test_meat_clip_not_in_interior():
-    assert "interior_establishing" not in _keys(C3747)
-
-
-# ── scoring mechanics ────────────────────────────────────────────────────────
-def test_no_tag_overlap_scores_zero():
-    blank = {"duration_s": 5, "has_audio": 1, "tags": ["航空", "雲海", "日出"], "frames": []}
+# ── scoring mechanics (tag engine, exercised via 廢鏡 + ad-hoc collections) ────
+def test_no_defect_tags_not_unusable():
+    # content tags but no quality-defect tags, rated + old → joins NOTHING
+    blank = {"duration_s": 5, "has_audio": 1, "tags": ["航空", "雲海", "日出"],
+             "rating": "good", "processed_at": "2000-01-01T00:00:00+00:00"}
     assert sc.classify(blank, COLS) == []
 
 
 def test_score_below_threshold_excluded():
-    # a single weak tag hit stays under MIN_CONFIDENCE without boosters
+    # a single weak tag hit stays under MIN_CONFIDENCE without boosters (ad-hoc col)
+    col = sc.Collection(key="t", title="t", category="c",
+                        tags=["室內", "吧檯", "座椅", "燈光", "低光", "餐廳"])
     weak = {"duration_s": 5, "has_audio": 1, "tags": ["室內"], "frames": []}
-    interior = next(c for c in COLS if c.key == "interior_establishing")
-    s = sc.score_collection(weak, interior)
-    assert s < sc.MIN_CONFIDENCE
+    assert sc.score_collection(weak, col) < sc.MIN_CONFIDENCE
 
 
 def test_booster_raises_score():
-    interior = next(c for c in COLS if c.key == "interior_establishing")
-    # same tags, but C3742 has Establishing frames → booster fires
-    base = {"duration_s": 6, "has_audio": 1,
-            "tags": ["餐廳", "咖啡館", "吧檯", "室內"], "frames": []}
-    boosted = dict(base, frames=[{"content_type": "Establishing", "atmosphere": "舒適"}])
-    assert sc.score_collection(boosted, interior) > sc.score_collection(base, interior)
+    # boosters lift a tag-based score (ad-hoc col, project-neutral)
+    col = sc.Collection(key="t", title="t", category="c", tags=["吧檯", "室內", "座椅"],
+                        boosters=(sc.Booster(boost=0.2, content_types=["Establishing"]),))
+    base = {"duration_s": 6, "has_audio": 1, "tags": ["吧檯", "室內", "座椅"], "frames": []}
+    boosted = dict(base, frames=[{"content_type": "Establishing"}])
+    assert sc.score_collection(boosted, col) > sc.score_collection(base, col)
 
 
 def test_classify_sorted_desc():
-    rows = sc.classify(C3747, COLS)
+    rows = sc.classify(C3811, COLS)
     scores = [r["score"] for r in rows]
     assert scores == sorted(scores, reverse=True)
-
-
-def test_non_exclusive_membership_possible():
-    # C3756 is both 食材 (三文魚/切片/肉類) and has 模糊 — but 模糊 alone is 1 weak
-    # hit for 廢鏡, should stay under threshold → only food. Asserts non-exclusivity
-    # is allowed yet threshold still gates.
-    keys = _keys(C3756)
-    assert "food_closeup" in keys
 
 
 # ── media_signal normalization ───────────────────────────────────────────────


### PR DESCRIPTION
## Bug
Smart Collections showed **食材特寫** (food close-up) on a **cable-making** project. Root cause: `smart_collections.DEFAULT_COLLECTIONS` was hardcoded for the 明燒肉 food shoot — 食材特寫 had a `切割/切片/手部操作` booster, and cable clips carry `切割` (cut wire) + `手部操作` → mis-filed. The collections never adapted to the project's domain.

## Why the earlier UI audit missed it
The audit checked (a) frontend mock strings and (b) component-gets-live-data. Collections **are** live (real `/api/collections`), and the "食材特寫" string lives in the backend — so both checks passed. The blind spot: a hardcoded **domain assumption** in backend logic, invisible to a mock-vs-live audit.

## Fix (option A — generic structural)
Replace the food vocab with project-agnostic structural buckets:
- **最近匯入** — `processed_at` within 14 days
- **待審查** — no editorial rating yet
- **廢鏡 · 待汰** — quality-defect tags (kept; already generic)

`Collection` gains an optional `predicate` (test on the raw media row); when set, membership is the predicate, not tag overlap. `/api/collections` SELECT now pulls `rating` + `processed_at`. Tests rewritten.

B (auto-derived topical) + C (per-project config) deferred to a follow-up.

Full suite: 588 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)