### PR TITLE
fix(tags): pipeline root fixes — S→T, artifact/English filter, per-clip dedup

### DIFF
--- a/tag_quality.py
+++ b/tag_quality.py
@@ -13,6 +13,7 @@ a small curated noise vocabulary (Chinese, qwen3-vl's output language).
 """
 from __future__ import annotations
 
+import re
 from typing import Dict, Iterable, List
 
 # Quality-defect vocabulary. A tag is noise if it CONTAINS any of these — covers
@@ -35,11 +36,31 @@ _NOISE_SUBSTRINGS = (
 )
 
 
+# English scene-descriptor words the VLM leaks into the (otherwise Chinese) tag
+# list on every clip (day/interior/…). They're not content tags. Exact-match,
+# lowercased — does NOT touch useful ASCII tags like LED / USB / 4K / RJ45, which
+# the electronics/cable domain legitimately produces.
+_ENGLISH_SCENE_NOISE = frozenset({
+    "day", "night", "interior", "exterior", "indoor", "outdoor",
+    "daytime", "nighttime", "morning", "evening",
+})
+
+# A tag with NO Chinese ideograph AND no alphanumeric content is a parse artifact
+# (e.g. the bare "}" that leaks from the JSON-fallback parser) → drop it.
+_HAS_CONTENT = re.compile(r"[一-鿿0-9A-Za-z]")
+
+
 def is_noise(tag: str) -> bool:
-    """True if the tag describes an image-quality defect rather than content."""
+    """True if the tag is an image-quality defect, a JSON/punctuation artifact, or
+    a leaked English scene-descriptor — anything that isn't real content."""
     if not tag:
         return True
-    return any(sub in tag for sub in _NOISE_SUBSTRINGS)
+    t = tag.strip()
+    if not t or not _HAS_CONTENT.search(t):
+        return True  # empty / pure-punctuation artifact (e.g. "}")
+    if t.lower() in _ENGLISH_SCENE_NOISE:
+        return True  # leaked English scene word (day/interior/…)
+    return any(sub in t for sub in _NOISE_SUBSTRINGS)
 
 
 # CJK variant-character normalization. The VLM writes the same word with variant
@@ -47,20 +68,78 @@ def is_noise(tag: str) -> bool:
 # separate tags. Map the variant char → one canonical so they collapse. CONSERVATIVE:
 # only TRUE same-word character variants, never semantic merges (生肉/生魚 is the
 # LLM-canonicalization pass's job, not this). Extend as real variants surface.
-_CHAR_VARIANTS = str.maketrans({
+_VARIANT_MAP = {
     "檯": "台",   # 吧檯 → 吧台
     "裏": "裡",   # 裏 → 裡
     "着": "著",   # 着 → 著
     "羣": "群",   # 人羣 → 人群 (VLM mixes the 羣/群 variant across frames)
     "牀": "床",   # 牀 → 床
     "麪": "麵",   # 麪 → 麵
-})
+}
+
+# Simplified → Traditional character normalization. qwen2.5vl leaks Simplified
+# chars into its (prompted-Traditional) output, so 电子/電子, 维修/維修, 电线/電線
+# coexist as separate tags across a library — a major, cross-project source of
+# duplication. We have no opencc dependency, so this is a curated map of the
+# high-frequency Simplified characters that actually appear in vision tags (a
+# few hundred); extend as new ones surface. Per-CHARACTER (not word), so it
+# composes with everything (个→個 fixes 个/個, 零个件 → 零個件, etc.).
+_SIMP_TO_TRAD = {
+    "电": "電", "线": "線", "维": "維", "缆": "纜", "个": "個", "纸": "紙",
+    "这": "這", "们": "們", "时": "時", "应": "應", "实": "實", "现": "現",
+    "发": "發", "对": "對", "开": "開", "关": "關", "门": "門", "间": "間",
+    "问": "問", "题": "題", "业": "業", "东": "東", "车": "車", "长": "長",
+    "马": "馬", "鸟": "鳥", "鱼": "魚", "鸡": "雞", "见": "見", "观": "觀",
+    "视": "視", "觉": "覺", "说": "說", "语": "語", "读": "讀", "课": "課",
+    "谁": "誰", "让": "讓", "认": "認", "识": "識", "记": "記", "设": "設",
+    "计": "計", "论": "論", "议": "議", "讲": "講", "话": "話", "试": "試",
+    "师": "師", "务": "務", "动": "動", "劳": "勞", "单": "單", "学": "學",
+    "写": "寫", "头": "頭", "体": "體", "万": "萬", "与": "與", "专": "專",
+    "丝": "絲", "双": "雙", "历": "歷", "压": "壓", "厅": "廳", "厂": "廠",
+    "备": "備", "处": "處", "复": "復", "够": "夠", "构": "構", "样": "樣",
+    "标": "標", "检": "檢", "测": "測", "济": "濟", "环": "環", "电": "電",
+    "节": "節", "约": "約", "纲": "綱", "纳": "納", "纵": "縱", "织": "織",
+    "终": "終", "组": "組", "细": "細", "经": "經", "绕": "繞", "绘": "繪",
+    "给": "給", "络": "絡", "统": "統", "继": "繼", "续": "續", "绿": "綠",
+    "网": "網", "罗": "羅", "义": "義", "习": "習", "乡": "鄉", "书": "書",
+    "买": "買", "乱": "亂", "争": "爭", "亏": "虧", "产": "產", "亩": "畝",
+    "亲": "親", "仅": "僅", "从": "從", "仑": "侖", "仓": "倉", "仪": "儀",
+    "们": "們", "价": "價", "众": "眾", "优": "優", "会": "會", "伞": "傘",
+    "传": "傳", "伤": "傷", "伥": "倀", "伦": "倫", "伪": "偽", "体": "體",
+    "余": "餘", "佣": "傭", "侠": "俠", "侣": "侶", "侥": "僥", "侦": "偵",
+    "侧": "側", "侨": "僑", "俭": "儉", "债": "債", "倾": "傾", "假": "假",
+    "储": "儲", "儿": "兒", "克": "克", "兑": "兌", "兰": "蘭", "关": "關",
+    "兴": "興", "兹": "茲", "养": "養", "兽": "獸", "冁": "囅", "内": "內",
+    "册": "冊", "写": "寫", "军": "軍", "农": "農", "冯": "馮", "冲": "衝",
+    "决": "決", "况": "況", "冻": "凍", "净": "淨", "凄": "悽", "减": "減",
+    "凤": "鳳", "处": "處", "凭": "憑", "击": "擊", "凿": "鑿", "刘": "劉",
+    "则": "則", "刚": "剛", "创": "創", "删": "刪", "别": "別", "刹": "剎",
+    "刽": "劊", "剀": "剴", "剂": "劑", "剐": "剮", "剑": "劍", "剥": "剝",
+    "剧": "劇", "劝": "勸", "办": "辦", "务": "務", "劢": "勱", "动": "動",
+    "励": "勵", "劲": "勁", "劳": "勞", "势": "勢", "勐": "猛", "勚": "勩",
+    "匀": "勻", "匦": "匭", "匮": "匱", "区": "區", "医": "醫", "华": "華",
+    "协": "協", "单": "單", "卖": "賣", "卢": "盧", "卤": "鹵", "卫": "衛",
+    "却": "卻", "卷": "捲", "厂": "廠", "厅": "廳", "历": "歷", "厉": "厲",
+    "压": "壓", "厌": "厭", "厍": "厙", "厦": "廈", "厨": "廚", "厩": "廄",
+    "县": "縣", "参": "參", "叆": "靉", "双": "雙", "发": "發", "变": "變",
+    "叙": "敘", "叠": "疊", "号": "號", "叹": "嘆", "叽": "嘰", "吓": "嚇",
+    "吕": "呂", "吗": "嗎", "员": "員", "呐": "吶", "呒": "嘸", "呓": "囈",
+    "周": "週", "钳": "鉗", "钻": "鑽", "铁": "鐵", "铜": "銅", "银": "銀",
+    "铝": "鋁", "锅": "鍋", "锈": "鏽", "锋": "鋒", "错": "錯", "锯": "鋸",
+    "键": "鍵", "锤": "錘", "锁": "鎖", "焊": "焊", "贴": "貼", "费": "費",
+    "贵": "貴", "质": "質", "购": "購", "贮": "貯", "货": "貨", "软": "軟",
+    "轮": "輪", "转": "轉", "输": "輸", "适": "適", "选": "選", "递": "遞",
+    "运": "運", "过": "過", "还": "還", "进": "進", "远": "遠", "连": "連",
+    "迟": "遲", "达": "達", "迁": "遷",
+}
+
+_CANON_TRANS = str.maketrans({**_VARIANT_MAP, **_SIMP_TO_TRAD})
 
 
 def canonicalize(tag: str) -> str:
-    """Trim + normalize variant characters so variant spellings of one word
-    collapse on dedup (吧台/吧檯 → 吧台)."""
-    return (tag or "").strip().translate(_CHAR_VARIANTS)
+    """Trim + normalize variant chars AND Simplified→Traditional so different
+    spellings of one word collapse on dedup (吧台/吧檯 → 吧台, 电子/電子 → 電子)."""
+    return (tag or "").strip().translate(_CANON_TRANS)
 
 
 def guard_canonical(raw: List[str], proposed: Iterable[str], min_keep_ratio: float = 0.34) -> List[str]:
@@ -102,8 +181,19 @@ def filter_tags(tags: Iterable[str]) -> List[str]:
 
 
 def filter_tag_records(records: Iterable[Dict]) -> List[Dict]:
-    """Drop noise from a list of {name, count, ...} tag dicts (e.g. /api/tags)."""
-    return [r for r in records if r.get("name") and not is_noise(r["name"])]
+    """Clean a list of {name, source, ...} tag dicts for a single surface (e.g. the
+    inspector's per-clip tags): drop noise/artifacts, normalize each name
+    (Simplified→Traditional + variant chars), and DEDUP by canonical name so
+    电子/電子 and 工作台/工作檯 collapse to one chip instead of several."""
+    seen = set()
+    out = []
+    for r in records:
+        name = canonicalize(r.get("name") or "")
+        if not name or is_noise(name) or name in seen:
+            continue
+        seen.add(name)
+        out.append({**r, "name": name})
+    return out
 
 
 def merge_tag_records(records: Iterable[Dict]) -> List[Dict]:

--- a/tests/test_tag_quality.py
+++ b/tests/test_tag_quality.py
@@ -21,6 +21,42 @@ def test_canonicalize_collapses_variant_chars():
     assert tq.canonicalize("餐廳") == "餐廳"  # unaffected
 
 
+def test_canonicalize_simplified_to_traditional():
+    # the big cross-project dedup win: Simplified leaks collapse to Traditional
+    assert tq.canonicalize("电子") == "電子"
+    assert tq.canonicalize("电线") == "電線"
+    assert tq.canonicalize("维修") == "維修"
+    assert tq.canonicalize("鉗子") == "鉗子"   # already Traditional, unaffected
+
+
+def test_simplified_and_traditional_dedup_together():
+    out = tq.filter_tags(["电子", "電子", "电线", "電線", "维修"])
+    assert out == ["電子", "電線", "維修"]  # S/T pairs collapse
+
+
+def test_is_noise_drops_json_artifacts_and_english_scene_words():
+    assert tq.is_noise("}")          # JSON-fallback parse artifact
+    assert tq.is_noise("{")
+    assert tq.is_noise("、")          # pure punctuation
+    assert tq.is_noise("day")        # leaked English scene word
+    assert tq.is_noise("Interior")   # case-insensitive
+    assert not tq.is_noise("LED")    # useful ASCII tag — kept
+    assert not tq.is_noise("USB")
+    assert not tq.is_noise("工具")
+
+
+def test_filter_tag_records_canonicalizes_and_dedups():
+    recs = [
+        {"name": "电子", "source": "auto"},
+        {"name": "電子", "source": "auto"},   # S/T dup of above
+        {"name": "}", "source": "auto"},      # artifact
+        {"name": "day", "source": "auto"},    # english leak
+        {"name": "鉗子", "source": "auto"},
+    ]
+    out = tq.filter_tag_records(recs)
+    assert [r["name"] for r in out] == ["電子", "鉗子"]
+
+
 def test_filter_tags_dedupes_including_variants():
     out = tq.filter_tags(["吧台", "吧檯", "餐廳", "餐廳", "模糊"])
     assert out == ["吧台", "餐廳"]  # 吧檯→吧台 merged, exact dup dropped, noise dropped

--- a/vision.py
+++ b/vision.py
@@ -131,7 +131,13 @@ def describe_frames(frame_paths: List[str]) -> List[Dict]:
 def _normalize_result(parsed: Dict) -> Dict:
     result = _empty_result()
     result["description"] = parsed.get("description", "")
-    result["tags"] = parsed.get("tags", []) or []
+    # Sanitize at the source: drop empty / pure-punctuation tags (e.g. the bare
+    # "}" the JSON-fallback parser leaks) so they never enter the DB. Read-side
+    # filtering (tag_quality.is_noise) also screens them, this just keeps storage clean.
+    result["tags"] = [
+        t.strip() for t in (parsed.get("tags") or [])
+        if isinstance(t, str) and t.strip() and re.search(r"[一-鿿0-9A-Za-z]", t)
+    ]
     for field in _VISION_FIELDS:
         result[field] = parsed.get(field)
     return result


### PR DESCRIPTION
Per-project canonicalize/alias is whack-a-mole — each new library starts noisy. The real sources are pipeline-level and hit every project. A cable-making library's raw tags showed: 電子/电子 + 維修/维修 (Simplified leaks despite the Traditional prompt), a bare `}` tag (JSON-fallback parse artifact), day/interior (English scene-word leaks), 工作台/工作檯 variants — **20-30 tags/clip, 404 in the cloud**.

Fixed centrally in `tag_quality` so ALL read surfaces (cloud, inspector, stats) clean automatically for **existing AND future** data — no re-ingest:
- **`canonicalize()`**: curated **Simplified→Traditional** map (~250 chars, no opencc dep) → 电子/電子, 维修/维修, 电线/電線 collapse everywhere.
- **`is_noise()`**: drop pure-punctuation/JSON artifacts + leaked English scene words (day/interior), while KEEPING useful ASCII (LED/USB/4K/RJ45 — the electronics domain needs them).
- **`filter_tag_records()`**: canonicalize + dedup per-clip chips (was noise-only).
- **`vision._normalize_result()`**: sanitize at the source so `}` never enters the DB.

Per-project LLM alias becomes the last-mile, not the main cleanup. Tests added. Full suite 592 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)