### PR TITLE
feat(ui): close the audit gaps — IN/OUT trim, chapters, remotion, reveal, analytics, cache + ingest utf-8

### DIFF
--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -34,12 +34,40 @@
       playerEl.play && playerEl.play().catch(() => {})
     }
   }
+  let mediaDuration = 0 // seconds, from the player once metadata loads
   function onTimeUpdate() {
-    if (playerEl && playerEl.duration) playProgress = playerEl.currentTime / playerEl.duration
+    if (playerEl && playerEl.duration) {
+      mediaDuration = playerEl.duration
+      playProgress = playerEl.currentTime / playerEl.duration
+    }
   }
   function seekFraction(frac) {
     if (playerEl && playerEl.duration) seekTo(frac * playerEl.duration)
   }
+  // IN/OUT trim points (seconds). The backend export accepts ?in_s&out_s, so a
+  // set range exports just that sub-clip (EDL/SRT/FCPXML). Set at the playhead.
+  let inSec = null
+  let outSec = null
+  function setIn() {
+    if (!playerEl) return
+    inSec = playerEl.currentTime
+    if (outSec != null && outSec <= inSec) outSec = null
+  }
+  function setOut() {
+    if (!playerEl) return
+    outSec = playerEl.currentTime
+    if (inSec != null && inSec >= outSec) inSec = null
+  }
+  function clearInOut() { inSec = null; outSec = null }
+  const _tc = (s) => {
+    if (s == null) return '—'
+    s = Math.max(0, Math.round(s))
+    return `${String(Math.floor(s / 60)).padStart(2, '0')}:${String(s % 60).padStart(2, '0')}`
+  }
+  $: inFrac = inSec != null && mediaDuration ? inSec / mediaDuration : null
+  $: outFrac = outSec != null && mediaDuration ? outSec / mediaDuration : null
+  // export args: include the trim window only when a real range is set
+  $: trimArgs = (inSec != null || outSec != null) ? { in_s: inSec ?? 0, out_s: outSec ?? undefined } : null
   export let pathLabel = null // file path string; null → mock /vol/... path
   export let transcriptLines = null // [[tc,text,hl],...]; null → mock lines
   export let frameDescriptions = null // string[]; when set, render a Vision block
@@ -91,6 +119,9 @@
     reBusy = null
     reMsg = ''
     reLang = mediaLang || 'zh'
+    inSec = null
+    outSec = null
+    mediaDuration = 0
   }
   async function doReprocess(action) {
     if (!onReprocess || reBusy) return
@@ -221,9 +252,19 @@
   <div class="block">
     <div class="blockhead">
       <Eyebrow>Waveform</Eyebrow>
-      <Mono dim style="font-size:9.5px;">{media.dur}</Mono>
+      <Mono dim style="font-size:9.5px;">IN {_tc(inSec)} · OUT {_tc(outSec)}</Mono>
     </div>
-    <Waveform {peaks} progress={playProgress} on:seek={(e) => seekFraction(e.detail)} />
+    <Waveform {peaks} progress={playProgress} {inFrac} {outFrac} on:seek={(e) => seekFraction(e.detail)} />
+    {#if useVideo || useAudio}
+      <div class="inout">
+        <button class="ak-btn io" on:click={setIn} title="設 IN（目前播放位置）">設 IN</button>
+        <button class="ak-btn io" on:click={setOut} title="設 OUT（目前播放位置）">設 OUT</button>
+        {#if inSec != null || outSec != null}
+          <button class="ak-btn io clr" on:click={clearInOut} title="清除 IN/OUT">清除</button>
+          <Mono dim style="font-size:9.5px;margin-left:auto;align-self:center;">匯出將套用此區間</Mono>
+        {/if}
+      </div>
+    {/if}
   </div>
 
   <div class="block transcript">
@@ -336,7 +377,7 @@
     <div class="exports">
       {#if onExport}
         {#each EXPORT_FMTS as fmt}
-          <button class="ak-btn exp" on:click={() => onExport(fmt)}>{fmt.toUpperCase()}</button>
+          <button class="ak-btn exp" on:click={() => onExport(fmt, trimArgs)}>{fmt.toUpperCase()}{trimArgs ? ' ✂' : ''}</button>
         {/each}
       {:else}
         <button class="ak-btn exp">EDL</button>
@@ -365,6 +406,9 @@
     position: relative; aspect-ratio: 16 / 9; background: var(--surface-2);
     border-bottom: 1px solid var(--rule);
   }
+  .inout { display: flex; gap: 6px; margin-top: 8px; }
+  .io { font-size: 10.5px; padding: 3px 8px; }
+  .io.clr { color: var(--quiet); }
   .previmg { width: 100%; height: 100%; object-fit: cover; display: block; }
   /* the real player: contain (don't crop footage) on black; audio sits at the bottom */
   video.previmg { object-fit: contain; background: #000; }

--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -79,6 +79,12 @@
   // (fmt) => void; triggers an authenticated download for this clip. When set,
   // the export buttons become live; null → mock screens keep the inert buttons.
   export let onExport = null
+  // Extra clip actions (live only): onChapters(format) downloads YouTube chapters,
+  // onRemotion() downloads Remotion caption props, onReveal() reveals the source
+  // file in Finder/Explorer. null → button hidden (mock screens unchanged).
+  export let onChapters = null
+  export let onRemotion = null
+  export let onReveal = null
   // Live tag editing. tags = [{id,name,source}] → renders the editable Tags block;
   // null → no block (mock screens unchanged). onAddTag/onRemoveTag wire the writes.
   export let tags = null
@@ -379,12 +385,17 @@
         {#each EXPORT_FMTS as fmt}
           <button class="ak-btn exp" on:click={() => onExport(fmt, trimArgs)}>{fmt.toUpperCase()}{trimArgs ? ' ✂' : ''}</button>
         {/each}
+        {#if onChapters}<button class="ak-btn exp" on:click={() => onChapters('youtube')} title="YouTube 章節（場景時間軸）">章節</button>{/if}
+        {#if onRemotion}<button class="ak-btn exp" on:click={onRemotion} title="Remotion 字幕 props（逐字時間戳）">Remotion</button>{/if}
       {:else}
         <button class="ak-btn exp">EDL</button>
         <button class="ak-btn exp">FCPXML</button>
         <button class="ak-btn exp">SRT</button>
       {/if}
     </div>
+    {#if onReveal}
+      <button class="ak-btn reveal" on:click={onReveal} title="在 Finder / 檔案總管中顯示原始檔">⊙ 在 Finder 顯示</button>
+    {/if}
   </div>
 </aside>
 
@@ -406,6 +417,7 @@
     position: relative; aspect-ratio: 16 / 9; background: var(--surface-2);
     border-bottom: 1px solid var(--rule);
   }
+  .reveal { font-size: 11px; padding: 4px 10px; margin-top: 8px; width: 100%; }
   .inout { display: flex; gap: 6px; margin-top: 8px; }
   .io { font-size: 10.5px; padding: 3px 8px; }
   .io.clr { color: var(--quiet); }

--- a/frontend/src/lib/Waveform.svelte
+++ b/frontend/src/lib/Waveform.svelte
@@ -5,7 +5,14 @@
   import { createEventDispatcher } from 'svelte'
   export let peaks = null // number[] 0..1 from /api/media/{id}/waveform, or null
   export let progress = 0 // 0..1 playhead position (player currentTime / duration)
+  export let inFrac = null // 0..1 IN trim point, or null
+  export let outFrac = null // 0..1 OUT trim point, or null
   const dispatch = createEventDispatcher()
+  const _pct = (f) => Math.min(100, Math.max(0, f * 100))
+  // shaded selection between IN and OUT (open-ended if only one set)
+  $: selL = inFrac != null ? _pct(inFrac) : 0
+  $: selR = outFrac != null ? _pct(outFrac) : 100
+  $: hasSel = inFrac != null || outFrac != null
   const N = 80
   // Resample the incoming peaks to N bars and scale to the 56-tall viewBox.
   $: bars = (() => {
@@ -24,12 +31,17 @@
 
 <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
 <div class="wf" on:click={onClick} title="點擊跳到該位置">
+  {#if hasSel}
+    <div class="sel" style="left:{selL}%;right:{100 - selR}%"></div>
+  {/if}
   <svg viewBox="0 0 80 56" preserveAspectRatio="none" class="svg">
     {#each bars as h, i}
       <rect x={i + 0.15} y={(56 - h) / 2} width="0.7" height={h} fill="var(--ink-2)" />
     {/each}
   </svg>
-  <div class="playhead" style="left:{Math.min(100, Math.max(0, progress * 100))}%"></div>
+  {#if inFrac != null}<div class="mark mk-in" style="left:{_pct(inFrac)}%"></div>{/if}
+  {#if outFrac != null}<div class="mark mk-out" style="left:{_pct(outFrac)}%"></div>{/if}
+  <div class="playhead" style="left:{_pct(progress)}%"></div>
 </div>
 
 <style>
@@ -39,4 +51,12 @@
     position: absolute; top: -6px; bottom: -6px; width: 1px;
     background: var(--ink); pointer-events: none;
   }
+  /* IN/OUT trim: shaded selection band + edge markers with a top flag */
+  .sel { position: absolute; top: 0; bottom: 0; background: var(--ink); opacity: 0.10; pointer-events: none; }
+  .mark { position: absolute; top: -4px; bottom: -4px; width: 1px; background: var(--invert); pointer-events: none; }
+  .mark::before {
+    content: ''; position: absolute; top: -4px; width: 5px; height: 4px; background: var(--invert);
+  }
+  .mk-in::before { left: 0; }
+  .mk-out::before { right: 0; }
 </style>

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -195,6 +195,36 @@ export async function downloadFile(path, filename) {
 export const exportPath = (id, fmt) => `/api/media/${id}/export/${fmt}`
 export const exportTimelinePath = (ids, fmt) =>
   `/api/export/timeline/${fmt}?ids=${ids.join(',')}`
+
+// ---- chapters / remotion / reveal-in-finder / cache / analytics ----
+// /api/media/{id}/chapters?format=youtube|ffmetadata → {chapters: text, count}
+export const getChapters = (id, format = 'youtube', opts) =>
+  req(`/api/media/${id}/chapters?format=${format}`, opts)
+// /api/media/{id}/remotion-props → word-level caption props (JSON)
+export const getRemotionProps = (id, opts) => req(`/api/media/${id}/remotion-props`, opts)
+// POST /api/open-file {path, reveal} → reveal in Finder/Explorer (reveal=true) or open
+export const openFile = (path, reveal = true, opts) =>
+  req('/api/open-file', { method: 'POST', body: { path, reveal }, ...opts })
+// /api/cache/info → {caches:{...}}; POST /api/cache/clear?target=app|thumbnails|chromadb|waveforms|all
+export const cacheInfo = (opts) => req('/api/cache/info', opts)
+export const clearCache = (target = 'app', opts) =>
+  req(`/api/cache/clear?target=${target}`, { method: 'POST', ...opts })
+// analytics breakdowns
+export const durationByLang = (opts) => req('/api/duration-by-lang', opts)
+export const sizeByExt = (opts) => req('/api/size-by-ext', opts)
+
+// Save an in-memory string as a downloaded file (chapters text / remotion json).
+export function downloadText(text, filename, mime = 'text/plain') {
+  const blob = new Blob([text], { type: mime })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  setTimeout(() => URL.revokeObjectURL(url), 10000)
+}
 // DaVinci Resolve metadata CSV (File → Import Metadata from CSV). ids optional
 // (CSV of media ids) → batch-scoped; omitted/empty → whole library.
 export const metadataCsvPath = (ids = null) =>

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -81,10 +81,18 @@
     }
   }
   // single-clip export from the inspector (auth-safe download).
-  async function exportClip(id, fmt, name) {
+  async function exportClip(id, fmt, name, trim = null) {
     const stem = (name || `media_${id}`).replace(/\.[^.]+$/, '')
+    // trim = {in_s, out_s?} from the inspector IN/OUT points → backend trims the export
+    let path = api.exportPath(id, fmt)
+    if (trim && (trim.in_s != null || trim.out_s != null)) {
+      const q = []
+      if (trim.in_s != null) q.push(`in_s=${trim.in_s}`)
+      if (trim.out_s != null) q.push(`out_s=${trim.out_s}`)
+      path += `?${q.join('&')}`
+    }
     try {
-      await api.downloadFile(api.exportPath(id, fmt), `${stem}.${fmt}`)
+      await api.downloadFile(path, `${stem}.${fmt}`)
     } catch (e) {
       err = `匯出失敗: ${e.message}`
     }
@@ -486,7 +494,7 @@
         onReprocess={selected ? reprocess : null}
         languages={engineLangs}
         mediaLang={detailLive ? detailLive.lang : null}
-        onExport={selected ? (fmt) => exportClip(selected.id, fmt, selected.name) : null}
+        onExport={selected ? (fmt, trim) => exportClip(selected.id, fmt, selected.name, trim) : null}
         onRate={rate}
       />
     {/if}

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -97,6 +97,22 @@
       err = `匯出失敗: ${e.message}`
     }
   }
+  const _stem = (id, name) => (name || `media_${id}`).replace(/\.[^.]+$/, '')
+  async function exportChapters(id, name, format = 'youtube') {
+    try {
+      const r = await api.getChapters(id, format)
+      api.downloadText(r.chapters || '', `${_stem(id, name)}.chapters.txt`)
+    } catch (e) { err = `章節匯出失敗: ${e.message}` }
+  }
+  async function exportRemotion(id, name) {
+    try {
+      const r = await api.getRemotionProps(id)
+      api.downloadText(JSON.stringify(r, null, 2), `${_stem(id, name)}.remotion.json`, 'application/json')
+    } catch (e) { err = `Remotion 匯出失敗: ${e.message}` }
+  }
+  async function revealFile(path) {
+    try { await api.openFile(path, true) } catch (e) { err = `在 Finder 顯示失敗: ${e.message}` }
+  }
 
   async function load() {
     state = 'loading'
@@ -495,6 +511,9 @@
         languages={engineLangs}
         mediaLang={detailLive ? detailLive.lang : null}
         onExport={selected ? (fmt, trim) => exportClip(selected.id, fmt, selected.name, trim) : null}
+        onChapters={selected ? (fmt) => exportChapters(selected.id, selected.name, fmt) : null}
+        onRemotion={selected ? () => exportRemotion(selected.id, selected.name) : null}
+        onReveal={inspPath ? () => revealFile(inspPath) : null}
         onRate={rate}
       />
     {/if}

--- a/frontend/src/routes/SettingsLive.svelte
+++ b/frontend/src/routes/SettingsLive.svelte
@@ -58,10 +58,41 @@
     }
   }
 
-  onMount(() => { loadSystem(); loadProxy() })
+  // Analytics breakdowns (real /api/duration-by-lang + /api/size-by-ext)
+  let durLang = null // [{lang, total_s, count}]
+  let sizeExt = null // [{ext, total_mb, count}]
+  async function loadAnalytics() {
+    try { durLang = await api.durationByLang() } catch { durLang = null }
+    try { sizeExt = await api.sizeByExt() } catch { sizeExt = null }
+  }
+  // Cache management (info + targeted clear)
+  let cache = null // {caches:{name:{size_mb,count?}}, total_mb}
+  let cacheMsg = ''
+  let cacheBusy = false
+  async function loadCache() {
+    try { cache = await api.cacheInfo() } catch { cache = null }
+  }
+  async function runClearCache(target) {
+    if (cacheBusy) return
+    cacheBusy = true; cacheMsg = ''
+    try {
+      const r = await api.clearCache(target)
+      cacheMsg = r.message || `已清除 ${target}`
+      setTimeout(loadCache, 800)
+    } catch (e) { cacheMsg = `失敗: ${e.message}` } finally { cacheBusy = false }
+  }
+
+  onMount(() => { loadSystem(); loadProxy(); loadAnalytics(); loadCache() })
 
   const gb = (n) => (n == null ? '—' : n >= 1000 ? `${(n / 1000).toFixed(1)} TB` : `${Math.round(n)} GB`)
+  const mb = (n) => (n == null ? '—' : n >= 1000 ? `${(n / 1000).toFixed(1)} GB` : `${Math.round(n)} MB`)
+  const hms = (s) => {
+    s = Math.round(s || 0)
+    const h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60)
+    return h ? `${h}h ${m}m` : `${m}m`
+  }
   $: disk = stats?.disk ?? null
+  $: cacheRows = cache?.caches ? Object.entries(cache.caches) : []
 </script>
 
 <div class="artboard" data-theme={$resolvedTheme}>
@@ -149,6 +180,20 @@
                 <div class="proxyctl">
                   <button class="ak-btn" on:click={runProxyBuild} disabled={proxyBusy}>{proxyBusy ? '排入中…' : '生成缺漏 proxy'}</button>
                   {#if proxyMsg}<Mono dim style="font-size:10.5px;">{proxyMsg}</Mono>{/if}
+                </div>
+              </div>
+              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">語言時長</Mono>
+                {#if durLang && durLang.length}<Mono style="font-size:12px;color:var(--ink);">{durLang.slice(0, 4).map((d) => `${d.lang} ${hms(d.total_s)}`).join(' · ')}</Mono>{:else}<Mono dim style="font-size:12px;">—</Mono>{/if}
+              </div>
+              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">格式容量</Mono>
+                {#if sizeExt && sizeExt.length}<Mono style="font-size:12px;color:var(--ink);">{sizeExt.slice(0, 4).map((s) => `${s.ext || '?'} ${mb(s.total_mb)}`).join(' · ')}</Mono>{:else}<Mono dim style="font-size:12px;">—</Mono>{/if}
+              </div>
+              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">快取</Mono>
+                <div class="proxyctl">
+                  <Mono style="font-size:12px;color:var(--ink);">{mb(cache?.total_mb)}</Mono>
+                  <button class="ak-btn" on:click={() => runClearCache('app')} disabled={cacheBusy}>清 app 快取</button>
+                  <button class="ak-btn" on:click={() => runClearCache('all')} disabled={cacheBusy}>清全部</button>
+                  {#if cacheMsg}<Mono dim style="font-size:10.5px;">{cacheMsg}</Mono>{/if}
                 </div>
               </div>
               <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Privacy</Mono><Mono dim style="font-size:11.5px;">Everything runs locally. Nothing leaves this machine.</Mono></div>

--- a/ingest.py
+++ b/ingest.py
@@ -1301,6 +1301,14 @@ def _run_apply_aliases(args):
 
 
 def main():
+    # Windows: the console codepage (cp950 on zh-TW) can't encode chars the CLI
+    # prints (⚠, →, emoji) → UnicodeEncodeError crashes mid-run. Force UTF-8 on
+    # stdout/stderr so progress output is robust on every platform.
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, ValueError):
+            pass
     parser = argparse.ArgumentParser(description="Ingest media files into SQLite DB")
     parser.add_argument("--dir", help="Media directory to scan (required unless --migrate-* / --regenerate-proxies / --vision-only)")
     parser.add_argument("--limit", type=int, default=0, help="Max files to process (0=all)")


### PR DESCRIPTION
Fills the backend-ready-but-no-UI gaps the spec audit found, plus a Windows ingest console fix.

## Inspector
- **IN/OUT trim**: 設 IN / 設 OUT at the playhead → waveform shows a shaded selection band + edge markers; export buttons pass `in_s/out_s` (show ✂) → backend exports the sub-clip. 清除 to reset; resets per clip.
- **章節**: YouTube chapters from `/api/media/{id}/chapters` → `.txt` download.
- **Remotion**: caption props from `/api/media/{id}/remotion-props` → `.json` download.
- **在 Finder 顯示**: reveals the source file via `/api/open-file` (Finder/Explorer select).

## SettingsLive
- **語言時長** + **格式容量** breakdowns (`/api/duration-by-lang`, `/api/size-by-ext`).
- **快取** total + 清 app / 清全部 buttons (`/api/cache/clear`).

## ingest UTF-8 console (Windows)
cp950 can't encode `⚠`/`→`/emoji the CLI prints → crashed `--propose-aliases`. Force UTF-8 on stdout/stderr.

api.js: getChapters, getRemotionProps, openFile, cacheInfo, clearCache, durationByLang, sizeByExt, downloadText. All endpoints verified 200 on the Windows node. Full suite 592 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)