### PR TITLE
fix(ui): left sidebar scrolls (was clipped)

### DIFF
--- a/frontend/src/lib/PoolSidebar.svelte
+++ b/frontend/src/lib/PoolSidebar.svelte
@@ -112,7 +112,10 @@
 <style>
   .pool {
     border-right: 1px solid var(--rule); padding: 20px 14px 14px 16px;
-    display: flex; flex-direction: column; gap: 20px; min-height: 0; overflow: hidden;
+    /* scroll the whole sidebar — projects + pools + collections + tag cloud +
+       storage can exceed the viewport; overflow:hidden clipped the bottom with
+       no way to reach it (same bug as the inspector). */
+    display: flex; flex-direction: column; gap: 20px; min-height: 0; overflow-y: auto;
   }
   .col { display: flex; flex-direction: column; }
   .proj {


### PR DESCRIPTION
PoolSidebar was `overflow:hidden` → on a tall library the bottom (long tag cloud + storage footer) was clipped with no way to scroll to it. Same class as the inspector clip fix. `overflow-y:auto`; the flex spacer still pins storage to the bottom when content is short.

🤖 Generated with [Claude Code](https://claude.com/claude-code)