### PR TITLE
feat(ui): draggable IN/OUT waveform markers + click-to-play

### DIFF
--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -59,6 +59,21 @@
     if (inSec != null && inSec >= outSec) inSec = null
   }
   function clearInOut() { inSec = null; outSec = null }
+  // Waveform marker drag → set IN/OUT directly (no need to scrub the playhead there)
+  function onTrim(e) {
+    if (!mediaDuration) return
+    const t = e.detail.frac * mediaDuration
+    if (e.detail.which === 'in') {
+      inSec = t
+      if (outSec != null && outSec <= inSec) outSec = null
+    } else {
+      outSec = t
+      if (inSec != null && inSec >= outSec) inSec = null
+    }
+  }
+  function onLoadedMeta() {
+    if (playerEl && playerEl.duration) mediaDuration = playerEl.duration
+  }
   const _tc = (s) => {
     if (s == null) return '—'
     s = Math.max(0, Math.round(s))
@@ -181,12 +196,12 @@
       {#if Pano360}<svelte:component this={Pano360} src={thumbUrl} />{:else}<div class="panoload"><Mono dim style="font-size:11px;">360 · loading…</Mono></div>{/if}
     {:else if useVideo}
       <!-- svelte-ignore a11y-media-has-caption -->
-      <video bind:this={playerEl} on:timeupdate={onTimeUpdate} class="previmg" controls playsinline preload="metadata" poster={thumbUrl || undefined} src={videoSrc}></video>
+      <video bind:this={playerEl} on:timeupdate={onTimeUpdate} on:loadedmetadata={onLoadedMeta} class="previmg" controls playsinline preload="metadata" poster={thumbUrl || undefined} src={videoSrc}></video>
     {:else if useAudio}
       {#if thumbUrl && !imgFailed}
         <img class="previmg" src={thumbUrl} alt={media.name} on:error={() => (imgFailed = true)} />
       {/if}
-      <audio bind:this={playerEl} on:timeupdate={onTimeUpdate} class="prevaudio" controls preload="metadata" src={videoSrc}></audio>
+      <audio bind:this={playerEl} on:timeupdate={onTimeUpdate} on:loadedmetadata={onLoadedMeta} class="prevaudio" controls preload="metadata" src={videoSrc}></audio>
     {:else if thumbUrl && !imgFailed}
       <img class="previmg" src={thumbUrl} alt={media.name} on:error={() => (imgFailed = true)} />
     {:else}
@@ -260,7 +275,7 @@
       <Eyebrow>Waveform</Eyebrow>
       <Mono dim style="font-size:9.5px;">IN {_tc(inSec)} · OUT {_tc(outSec)}</Mono>
     </div>
-    <Waveform {peaks} progress={playProgress} {inFrac} {outFrac} on:seek={(e) => seekFraction(e.detail)} />
+    <Waveform {peaks} progress={playProgress} {inFrac} {outFrac} on:seek={(e) => seekFraction(e.detail)} on:trim={onTrim} />
     {#if useVideo || useAudio}
       <div class="inout">
         <button class="ak-btn io" on:click={setIn} title="設 IN（目前播放位置）">設 IN</button>

--- a/frontend/src/lib/Waveform.svelte
+++ b/frontend/src/lib/Waveform.svelte
@@ -1,6 +1,6 @@
-<!-- Real audio waveform: backend peaks (0..1) → bars, with a live playhead that
-     tracks the inspector player + click-to-seek. Falls back to a flat baseline
-     when a clip has no peaks (no audio / not yet computed). -->
+<!-- Real audio waveform: backend peaks (0..1) → bars. Click to seek+play; the
+     playhead tracks the player; IN/OUT trim markers are DRAGGABLE (grab the flag
+     and slide). Flat baseline when a clip has no peaks. -->
 <script>
   import { createEventDispatcher } from 'svelte'
   export let peaks = null // number[] 0..1 from /api/media/{id}/waveform, or null
@@ -9,28 +9,47 @@
   export let outFrac = null // 0..1 OUT trim point, or null
   const dispatch = createEventDispatcher()
   const _pct = (f) => Math.min(100, Math.max(0, f * 100))
-  // shaded selection between IN and OUT (open-ended if only one set)
   $: selL = inFrac != null ? _pct(inFrac) : 0
   $: selR = outFrac != null ? _pct(outFrac) : 100
   $: hasSel = inFrac != null || outFrac != null
   const N = 80
-  // Resample the incoming peaks to N bars and scale to the 56-tall viewBox.
   $: bars = (() => {
     const src = Array.isArray(peaks) && peaks.length ? peaks : null
-    if (!src) return Array.from({ length: N }, () => 2) // flat baseline, no data
+    if (!src) return Array.from({ length: N }, () => 2)
     return Array.from({ length: N }, (_, i) => {
       const v = src[Math.floor((i / N) * src.length)] || 0
       return Math.max(2, v * 50)
     })
   })()
+
+  let wfEl
+  let dragging = null // 'in' | 'out'
+  let didDrag = false
+  const fracAt = (clientX) => {
+    const r = wfEl.getBoundingClientRect()
+    return Math.min(1, Math.max(0, (clientX - r.left) / r.width))
+  }
+  function startDrag(which, e) {
+    e.stopPropagation()
+    dragging = which
+    didDrag = false
+    wfEl.setPointerCapture?.(e.pointerId) // capture on container → moves land on .wf
+  }
+  function onMove(e) {
+    if (!dragging) return
+    didDrag = true
+    dispatch('trim', { which: dragging, frac: fracAt(e.clientX) })
+  }
+  function endDrag() { dragging = null }
   function onClick(e) {
-    const r = e.currentTarget.getBoundingClientRect()
-    dispatch('seek', Math.min(1, Math.max(0, (e.clientX - r.left) / r.width)))
+    if (didDrag) { didDrag = false; return } // finished a drag, not a click
+    dispatch('seek', fracAt(e.clientX)) // seek + play (handled by the inspector)
   }
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
-<div class="wf" on:click={onClick} title="點擊跳到該位置">
+<div class="wf" bind:this={wfEl} on:click={onClick} on:pointermove={onMove}
+  on:pointerup={endDrag} on:pointercancel={endDrag} title="點擊跳播 · 拖曳 IN/OUT 標記調整區間">
   {#if hasSel}
     <div class="sel" style="left:{selL}%;right:{100 - selR}%"></div>
   {/if}
@@ -39,23 +58,31 @@
       <rect x={i + 0.15} y={(56 - h) / 2} width="0.7" height={h} fill="var(--ink-2)" />
     {/each}
   </svg>
-  {#if inFrac != null}<div class="mark mk-in" style="left:{_pct(inFrac)}%"></div>{/if}
-  {#if outFrac != null}<div class="mark mk-out" style="left:{_pct(outFrac)}%"></div>{/if}
+  {#if inFrac != null}
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <div class="mark mk-in handle" style="left:{_pct(inFrac)}%" on:pointerdown={(e) => startDrag('in', e)}></div>
+  {/if}
+  {#if outFrac != null}
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <div class="mark mk-out handle" style="left:{_pct(outFrac)}%" on:pointerdown={(e) => startDrag('out', e)}></div>
+  {/if}
   <div class="playhead" style="left:{_pct(progress)}%"></div>
 </div>
 
 <style>
-  .wf { position: relative; height: 56px; cursor: pointer; }
+  .wf { position: relative; height: 56px; cursor: pointer; touch-action: none; }
   .svg { width: 100%; height: 100%; display: block; }
   .playhead {
     position: absolute; top: -6px; bottom: -6px; width: 1px;
     background: var(--ink); pointer-events: none;
   }
-  /* IN/OUT trim: shaded selection band + edge markers with a top flag */
   .sel { position: absolute; top: 0; bottom: 0; background: var(--ink); opacity: 0.10; pointer-events: none; }
   .mark { position: absolute; top: -4px; bottom: -4px; width: 1px; background: var(--invert); pointer-events: none; }
+  /* draggable handles: wider invisible grab zone + a top flag, ew-resize cursor */
+  .handle { pointer-events: auto; cursor: ew-resize; }
+  .handle::after { content: ''; position: absolute; left: -6px; right: -6px; top: -4px; bottom: -4px; }
   .mark::before {
-    content: ''; position: absolute; top: -4px; width: 5px; height: 4px; background: var(--invert);
+    content: ''; position: absolute; top: -4px; width: 6px; height: 5px; background: var(--invert);
   }
   .mk-in::before { left: 0; }
   .mk-out::before { right: 0; }


### PR DESCRIPTION
IN/OUT trim points were settable by button but not adjustable on the waveform. Now the IN/OUT marker flags are **draggable** (grab + slide to fine-tune; pointer-capture, drag distinguished from click so it doesn't also seek). Waveform click already seeks **and plays**; title now spells it out (點擊跳播 · 拖曳 IN/OUT). Duration captured on `loadedmetadata` so dragging works before playback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)