### PR TITLE
feat(transcribe): per-project correction dictionary + batch recorrect (Phase 9.6b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 ## Unreleased
 
+### Added
+- **Per-project correction dictionary + batch recorrect (Phase 9.6b).** A `.arkiv/corrections.json` dictionary of `{from, to, scope, pre, post}` rules drives two paths from one source: `pre` terms feed the Whisper hotword list (`initial_prompt`, hot-read like `vocabulary.txt`), and `post` rules batch-rewrite **already-stored** transcripts — fixing the whole backlog's search recall in seconds without re-running audio. Endpoints: `GET/PUT /api/corrections`, `POST /api/recorrect` (defaults to dry-run preview — writes nothing; `dry_run=0` applies, `rebuild=1` chains the embedding rebuild), `GET /api/recorrect/backups`, `POST /api/recorrect/revert`. CLI: `python recorrect.py --dry-run | --apply [--rebuild] | --revert [NAME]`. **RP-4 safe**: preview-first, and every apply writes a timestamped backup restorable via revert. The recorrect **syncs `segments_json` alongside the transcript blob** (else search/SRT drift), and `words_json` gets whole-token renames. Scope `word` guards against bleeding into a longer token (a `松→鬆` rule never touches `馬拉松`). Operates on the active project. 16 tests in `tests/test_corrections.py`; full suite 608 passed / 5 skipped.
+
 ### Changed
 - **Default vision model is now `qwen2.5vl:7b` (was `qwen3-vl:8b`).** Qwen3-VL's vision path (DeepStack / interleaved-MRoPE) runs ~10x slower than Qwen2.5-VL under Ollama and often offloads the vision encoder to CPU — measured **~60s/frame vs ~8s/frame on an M2 Max** for identical frames (Ollama issues #12854 / #12882 / #14548). At ~2000 frames that's ~30h vs ~3.5h, at comparable tag quality (spot-checked). Override with `ARKIV_OLLAMA_VISION_MODEL=qwen3-vl:8b` for the higher ceiling once the Ollama regression is fixed.
 

--- a/corrections.py
+++ b/corrections.py
@@ -1,0 +1,384 @@
+"""Per-project correction dictionary — one dictionary, two application paths.
+
+A correction rule (``{from, to, scope, pre, post}``) lives in
+``PROJECT_ROOT/.arkiv/corrections.json`` (beside ``vocabulary.txt``). One
+dictionary feeds two paths so a name like 富田→Furutech is maintained once:
+
+  pre  — the ``to`` term enters the Whisper hotword list (``initial_prompt``),
+         preventing the mis-hearing in *future* transcriptions. This is the
+         FatSub "專有名詞" path; arkiv already hot-reloads ``vocabulary.txt``,
+         so ``hotword_terms()`` just merges the dictionary's pre-terms in.
+
+  post — ``from``→``to`` is applied to *already-stored* transcripts (batch
+         recorrect). Fixes the entire NAS backlog's search recall in seconds
+         without touching audio — the cheap, default, arkiv-native path
+         (Phase 9.6b). Stronger than FatSub's search-replace, which only
+         auto-applies to future clips; this rewrites the past library.
+
+Why one dictionary instead of FatSub's two unrelated lists: a proper-noun fix
+usually wants BOTH — feed the hotword AND repair the old clips. One row, two
+switches (``pre`` / ``post``).
+
+RP-4 discipline (no silent destruction): batch recorrect is preview-first
+(``scan()`` lists every hit, writes nothing) and reversible (``apply()`` writes
+a timestamped backup of the pre-correction transcript/segments/words before any
+UPDATE; ``revert()`` restores it exactly).
+
+Scope semantics (per rule, default ``global``):
+  global — substring replace anywhere. The workhorse for distinctive multi-char
+           renames (富田→Furutech). The dry-run preview is the safety net.
+  word   — standalone occurrence only: the match must NOT be flanked by another
+           CJK ideograph or word char on either side. The guard for short /
+           ambiguous terms so a rule never bleeds into a longer word
+           (e.g. a 松→鬆 rule must not touch 馬拉松 — the tag-dedup red line).
+  line   — segment/line-initial only (after optional leading whitespace).
+
+All operations target the ACTIVE project (``config.PROJECT_ROOT`` /
+``db.get_conn()``), matching every other arkiv endpoint. Batch-targeting an
+arbitrary project DB is deferred (no such entry point exists anywhere yet).
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import config
+
+SCOPES = ("global", "word", "line")
+
+# A "word"/"line" boundary char: another CJK ideograph or an ASCII word char.
+# A match flanked by one of these is part of a longer token, so word-scope skips
+# it. CJK range covers the common ideograph block qwen/Whisper emit.
+_BOUNDARY = r"\w一-鿿"
+
+
+def corrections_path() -> Path:
+    """``PROJECT_ROOT/.arkiv/corrections.json`` for the active project."""
+    return Path(config.PROJECT_ROOT) / ".arkiv" / "corrections.json"
+
+
+def _backups_dir() -> Path:
+    return Path(config.PROJECT_ROOT) / ".arkiv" / "corrections-backups"
+
+
+# ── rule load / save / validate ──────────────────────────────────────────────
+
+def _clean_rule(raw: Dict) -> Optional[Dict]:
+    """Validate + normalize one raw rule. Returns None if unusable.
+
+    A rule needs a non-empty ``from``; ``to`` may be empty (a deletion). ``scope``
+    falls back to ``global``; ``pre`` defaults off (don't silently grow the
+    hotword list), ``post`` defaults on (recorrect is the rule's main job).
+    """
+    if not isinstance(raw, dict):
+        return None
+    frm = raw.get("from")
+    to = raw.get("to", "")
+    if not isinstance(frm, str) or not frm:
+        return None
+    if not isinstance(to, str):
+        return None
+    scope = raw.get("scope", "global")
+    if scope not in SCOPES:
+        scope = "global"
+    return {
+        "from": frm,
+        "to": to,
+        "scope": scope,
+        "pre": bool(raw.get("pre", False)),
+        "post": bool(raw.get("post", True)),
+    }
+
+
+def load_rules() -> List[Dict]:
+    """Read + validate rules from ``corrections.json``. Missing / corrupt → []
+    (non-fatal, matching ``vocabulary.txt`` tolerance)."""
+    path = corrections_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    raw_rules = data.get("rules") if isinstance(data, dict) else data
+    if not isinstance(raw_rules, list):
+        return []
+    out = []
+    for raw in raw_rules:
+        rule = _clean_rule(raw)
+        if rule is not None:
+            out.append(rule)
+    return out
+
+
+def save_rules(rules: Iterable[Dict]) -> List[Dict]:
+    """Validate + atomically write rules. Returns the cleaned list that was
+    persisted (caller can echo it back)."""
+    cleaned = [r for r in (_clean_rule(x) for x in rules) if r is not None]
+    path = corrections_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(
+        json.dumps({"version": 1, "rules": cleaned}, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    tmp.replace(path)  # atomic on POSIX + Windows
+    return cleaned
+
+
+def hotword_terms() -> List[str]:
+    """The ``to`` terms of rules with ``pre=True`` — merged into the Whisper
+    hotword list by ``transcribe._custom_terms()``. De-duplicated, order kept."""
+    seen = set()
+    out = []
+    for r in load_rules():
+        if r.get("pre") and r["to"] and r["to"] not in seen:
+            seen.add(r["to"])
+            out.append(r["to"])
+    return out
+
+
+# ── correction application (pure, testable) ──────────────────────────────────
+
+def _apply_rule(text: str, rule: Dict) -> Tuple[str, int]:
+    """Apply one rule to one text blob. Returns ``(new_text, n_hits)``."""
+    frm, to, scope = rule["from"], rule["to"], rule.get("scope", "global")
+    if not text or not frm or frm == to:
+        return text, 0
+    if scope == "global":
+        n = text.count(frm)
+        return (text.replace(frm, to), n) if n else (text, 0)
+    if scope == "word":
+        pat = re.compile(
+            r"(?<![" + _BOUNDARY + r"])" + re.escape(frm) + r"(?![" + _BOUNDARY + r"])"
+        )
+    else:  # line — segment/line-initial, after optional leading whitespace
+        pat = re.compile(r"(?m)^([ \t]*)" + re.escape(frm))
+    matches = pat.findall(text)
+    if not matches:
+        return text, 0
+    if scope == "line":
+        new = pat.sub(lambda m: m.group(1) + to, text)
+    else:
+        new = pat.sub(to, text)
+    return new, len(matches)
+
+
+def apply_rules_to_text(text: str, rules: Iterable[Dict]) -> Tuple[str, int]:
+    """Apply every (post) rule in order. Returns ``(new_text, total_hits)``."""
+    total = 0
+    for rule in rules:
+        text, n = _apply_rule(text, rule)
+        total += n
+    return text, total
+
+
+def _correct_segments(segments_json: Optional[str], rules: List[Dict]) -> Tuple[Optional[str], int]:
+    """Apply rules to each segment's ``text`` field, preserving timestamps.
+    Returns ``(new_json_or_unchanged, hits)``. Malformed JSON is left untouched."""
+    if not segments_json:
+        return segments_json, 0
+    try:
+        segs = json.loads(segments_json)
+    except ValueError:
+        return segments_json, 0
+    if not isinstance(segs, list):
+        return segments_json, 0
+    hits = 0
+    changed = False
+    for seg in segs:
+        if isinstance(seg, dict) and isinstance(seg.get("text"), str):
+            new_text, n = apply_rules_to_text(seg["text"], rules)
+            if n:
+                seg["text"] = new_text
+                hits += n
+                changed = True
+    if not changed:
+        return segments_json, 0
+    return json.dumps(segs, ensure_ascii=False), hits
+
+
+def _correct_words(words_json: Optional[str], rules: List[Dict]) -> Tuple[Optional[str], int]:
+    """Whole-token rename in ``words_json`` only — replace a word token that
+    EXACTLY equals a rule's ``from`` (after strip). Multi-token names (富田 split
+    across tokens) are deliberately left as-is: the handoff blesses words_json as
+    "近似可接受", and a partial token rewrite would corrupt the timing array.
+    Search/SRT use transcript+segments, not words, so this is cosmetic."""
+    if not words_json:
+        return words_json, 0
+    try:
+        words = json.loads(words_json)
+    except ValueError:
+        return words_json, 0
+    if not isinstance(words, list):
+        return words_json, 0
+    # exact whole-token map from rules (later rule wins, matching ordered apply)
+    swap = {}
+    for r in rules:
+        swap[r["from"]] = r["to"]
+    hits = 0
+    changed = False
+    for w in words:
+        if isinstance(w, dict) and isinstance(w.get("word"), str):
+            key = w["word"].strip()
+            if key in swap and swap[key] != w["word"].strip():
+                # preserve surrounding whitespace the tokenizer kept
+                w["word"] = w["word"].replace(key, swap[key])
+                hits += 1
+                changed = True
+    if not changed:
+        return words_json, 0
+    return json.dumps(words, ensure_ascii=False), hits
+
+
+# ── DB-facing scan / apply / revert ──────────────────────────────────────────
+
+def _iter_transcribed():
+    """Yield ``(id, filename, transcript, segments_json, words_json)`` for every
+    media row with a non-empty transcript in the active project DB."""
+    import db
+    with db.get_conn() as conn:
+        rows = conn.execute(
+            "SELECT id, filename, transcript, segments_json, words_json "
+            "FROM media WHERE transcript IS NOT NULL AND transcript != ''"
+        ).fetchall()
+    for row in rows:
+        yield row
+
+
+def scan(rules: Optional[List[Dict]] = None) -> Dict:
+    """Dry-run preview. Counts hits per rule and per media WITHOUT writing.
+    Hit count is measured on the transcript blob (what search matches on)."""
+    rules = [r for r in (rules if rules is not None else load_rules()) if r.get("post")]
+    per_rule = {i: 0 for i in range(len(rules))}
+    affected = []  # [{id, filename, hits, samples:[{rule, before, after}]}]
+    for row in _iter_transcribed():
+        transcript = row["transcript"] or ""
+        media_hits = 0
+        samples = []
+        for i, rule in enumerate(rules):
+            _, n = _apply_rule(transcript, rule)
+            if n:
+                per_rule[i] += n
+                media_hits += n
+                samples.append({"from": rule["from"], "to": rule["to"], "count": n})
+        if media_hits:
+            affected.append({
+                "id": row["id"],
+                "filename": row["filename"],
+                "hits": media_hits,
+                "rules": samples,
+            })
+    return {
+        "rules": [
+            {"from": rules[i]["from"], "to": rules[i]["to"],
+             "scope": rules[i]["scope"], "hits": per_rule[i]}
+            for i in range(len(rules))
+        ],
+        "media_affected": len(affected),
+        "total_hits": sum(per_rule.values()),
+        "affected": affected,
+    }
+
+
+def _write_backup(rows: List[Dict], rules: List[Dict]) -> str:
+    """Persist pre-correction state of the affected rows. Returns backup name."""
+    import time
+    name = "recorrect-{0}.json".format(time.strftime("%Y%m%dT%H%M%S", time.gmtime()))
+    bdir = _backups_dir()
+    bdir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "created_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "rules": rules,
+        "media": rows,
+    }
+    path = bdir / name
+    # if two applies land in the same second, suffix to avoid clobbering a backup
+    n = 1
+    while path.exists():
+        path = bdir / name.replace(".json", "-{0}.json".format(n))
+        n += 1
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path.name
+
+
+def apply(rules: Optional[List[Dict]] = None) -> Dict:
+    """Apply post-rules to transcript + segments_json (+ whole-token words_json)
+    for every affected media, in ONE transaction. Writes a backup of the
+    pre-correction state first (RP-4 reversibility). Returns a summary including
+    the backup name to feed ``revert()``."""
+    import db
+    rules = [r for r in (rules if rules is not None else load_rules()) if r.get("post")]
+    if not rules:
+        return {"media_updated": 0, "total_hits": 0, "backup": None, "rule_count": 0}
+
+    backup_rows = []   # pre-correction snapshot
+    updates = []       # (id, new_transcript, new_segments, new_words)
+    total_hits = 0
+    for row in _iter_transcribed():
+        new_t, n_t = apply_rules_to_text(row["transcript"] or "", rules)
+        new_s, n_s = _correct_segments(row["segments_json"], rules)
+        new_w, _n_w = _correct_words(row["words_json"], rules)
+        if n_t or n_s:  # transcript or segments changed → this row is affected
+            backup_rows.append({
+                "id": row["id"],
+                "transcript": row["transcript"],
+                "segments_json": row["segments_json"],
+                "words_json": row["words_json"],
+            })
+            updates.append((row["id"], new_t, new_s, new_w))
+            total_hits += n_t
+
+    if not updates:
+        return {"media_updated": 0, "total_hits": 0, "backup": None,
+                "rule_count": len(rules)}
+
+    backup_name = _write_backup(backup_rows, rules)
+    with db.get_conn() as conn:
+        conn.executemany(
+            "UPDATE media SET transcript=?, segments_json=?, words_json=? WHERE id=?",
+            [(t, s, w, mid) for (mid, t, s, w) in updates],
+        )
+    return {
+        "media_updated": len(updates),
+        "total_hits": total_hits,
+        "backup": backup_name,
+        "rule_count": len(rules),
+    }
+
+
+def list_backups() -> List[str]:
+    """Backup names, newest first."""
+    bdir = _backups_dir()
+    if not bdir.exists():
+        return []
+    return sorted((p.name for p in bdir.glob("recorrect-*.json")), reverse=True)
+
+
+def revert(backup_name: Optional[str] = None) -> Dict:
+    """Restore transcript/segments/words from a backup (latest if unspecified).
+    Exact inverse of the UPDATE ``apply()`` performed."""
+    import db
+    backups = list_backups()
+    if not backups:
+        return {"restored": 0, "backup": None, "error": "no backups"}
+    name = backup_name or backups[0]
+    path = _backups_dir() / name
+    if not path.exists() or name not in backups:
+        return {"restored": 0, "backup": None, "error": "backup not found"}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {"restored": 0, "backup": name, "error": "backup unreadable"}
+    media = payload.get("media", [])
+    rows = [
+        (m.get("transcript"), m.get("segments_json"), m.get("words_json"), m["id"])
+        for m in media if isinstance(m, dict) and "id" in m
+    ]
+    if rows:
+        with db.get_conn() as conn:
+            conn.executemany(
+                "UPDATE media SET transcript=?, segments_json=?, words_json=? WHERE id=?",
+                rows,
+            )
+    return {"restored": len(rows), "backup": name}

--- a/recorrect.py
+++ b/recorrect.py
@@ -1,0 +1,92 @@
+"""CLI for the per-project correction dictionary (Phase 9.6b).
+
+Batch-applies .arkiv/corrections.json's post-rules to the active project's
+stored transcripts — the cheap, audio-free path to fix the whole backlog's
+search recall. Preview-first and reversible (RP-4).
+
+  python recorrect.py --dry-run            # preview hits, write nothing (default)
+  python recorrect.py --apply              # apply + write a backup
+  python recorrect.py --apply --rebuild    # apply, then rebuild the vector index
+  python recorrect.py --list-backups
+  python recorrect.py --revert [NAME]      # restore latest (or named) backup
+
+Operates on the ACTIVE project (ARKIV_PROJECT_ROOT / config.DB_PATH). Point
+those at the target project's .arkiv before running.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+import config
+import corrections
+
+
+def _print_scan(scan: dict) -> None:
+    print("📋 Dry-run — 預覽（未寫入）")
+    print("  規則命中：")
+    for r in scan["rules"]:
+        mark = "•" if r["hits"] else "·"
+        print("    {0} {1} → {2}  [{3}]  命中 {4}".format(
+            mark, r["from"], r["to"] or "(刪除)", r["scope"], r["hits"]))
+    print("  受影響素材：{0} 筆，總命中 {1}".format(
+        scan["media_affected"], scan["total_hits"]))
+    for m in scan["affected"][:20]:
+        parts = ", ".join("{0}→{1}×{2}".format(s["from"], s["to"], s["count"])
+                          for s in m["rules"])
+        print("    #{0} {1}  ({2})".format(m["id"], m["filename"], parts))
+    if scan["media_affected"] > 20:
+        print("    … 另 {0} 筆".format(scan["media_affected"] - 20))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="arkiv correction dictionary — batch recorrect")
+    g = parser.add_mutually_exclusive_group()
+    g.add_argument("--dry-run", action="store_true", help="預覽命中，不寫入（預設）")
+    g.add_argument("--apply", action="store_true", help="套用校正（寫 backup 後改 transcript + segments）")
+    g.add_argument("--list-backups", action="store_true", help="列出可還原的 backup")
+    g.add_argument("--revert", nargs="?", const="", metavar="NAME", help="還原最新（或指定）backup")
+    parser.add_argument("--rebuild", action="store_true", help="套用後重建向量索引（搭 --apply）")
+    args = parser.parse_args()
+
+    rules = corrections.load_rules()
+    print("專案：{0}".format(config.PROJECT_ROOT))
+    print("字典：{0}（{1} 條規則）".format(corrections.corrections_path(), len(rules)))
+
+    if args.list_backups:
+        for name in corrections.list_backups():
+            print("  {0}".format(name))
+        return 0
+
+    if args.revert is not None:
+        result = corrections.revert(args.revert or None)
+        if result.get("error"):
+            print("⚠️  還原失敗：{0}".format(result["error"]))
+            return 1
+        print("↩️  已還原 {0} 筆（backup {1}）".format(result["restored"], result["backup"]))
+        return 0
+
+    if not rules:
+        print("⚠️  字典為空，無事可做。")
+        return 0
+
+    if args.apply:
+        result = corrections.apply()
+        print("✅ 已套用 {0} 條規則：更新 {1} 筆素材、{2} 處替換。".format(
+            result["rule_count"], result["media_updated"], result["total_hits"]))
+        if result["backup"]:
+            print("   backup：{0}（--revert 可還原）".format(result["backup"]))
+        if args.rebuild and result["media_updated"]:
+            print("🔁 重建向量索引…")
+            subprocess.run([sys.executable, str(Path(__file__).parent / "embed.py"), "--rebuild"], check=False)
+        return 0
+
+    # default: dry-run
+    _print_scan(corrections.scan(rules))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server.py
+++ b/server.py
@@ -26,6 +26,7 @@ import codec
 import auth
 from auth import require_scopes
 import config
+import corrections
 import db
 import federation
 import projects as project_registry
@@ -3321,6 +3322,81 @@ def _rebuild_embeddings():
     finally:
         with _embed_rebuild_lock:  # audit M8: always free the single-flight slot
             _embed_rebuild_active = False
+
+
+# ── Phase 9.6b: per-project correction dictionary ────────────────────────────
+
+class CorrectionsBody(BaseModel):
+    # raw dicts; corrections._clean_rule validates (sidesteps `from` keyword).
+    rules: List[dict] = []
+
+
+class RevertBody(BaseModel):
+    backup: Optional[str] = None
+
+
+@app.get("/api/corrections")
+def get_corrections(_tok: dict = Depends(require_scopes("projects_read"))):
+    """The active project's correction dictionary (.arkiv/corrections.json)."""
+    return {"rules": corrections.load_rules()}
+
+
+@app.put("/api/corrections")
+def put_corrections(
+    body: CorrectionsBody,
+    request: Request,
+    _tok: dict = Depends(require_scopes("projects_write")),
+):
+    """Replace the dictionary. Returns the cleaned rules actually persisted."""
+    _assert_same_site(request)
+    saved = corrections.save_rules(body.rules)
+    return {"ok": True, "rules": saved, "count": len(saved)}
+
+
+@app.post("/api/recorrect")
+def recorrect(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    dry_run: int = Query(1, description="1 = preview only (default, writes nothing)"),
+    rebuild: int = Query(0, description="1 = rebuild embeddings after applying"),
+    _tok: dict = Depends(require_scopes("ingest_write")),
+):
+    """Batch-apply the dictionary's post-rules to stored transcripts.
+
+    Defaults to dry-run (RP-4): a bare POST previews hits and writes nothing.
+    dry_run=0 applies (transcript + segments_json synced, backup written first);
+    rebuild=1 then chains the existing single-flight embedding rebuild so search
+    reflects the corrected text."""
+    if dry_run:
+        return {"dry_run": True, **corrections.scan()}
+    _assert_same_site(request)  # mutating — same-origin only (audit M14 pattern)
+    result = corrections.apply()
+    embed_started = False
+    if rebuild and result.get("media_updated"):
+        global _embed_rebuild_active
+        with _embed_rebuild_lock:  # audit M8: refuse concurrent rebuilds
+            if not _embed_rebuild_active:
+                _embed_rebuild_active = True
+                background_tasks.add_task(_rebuild_embeddings)
+                embed_started = True
+    return {"dry_run": False, **result, "embed_rebuild_started": embed_started}
+
+
+@app.get("/api/recorrect/backups")
+def recorrect_backups(_tok: dict = Depends(require_scopes("projects_read"))):
+    """Reversible recorrect backups, newest first (for the revert picker)."""
+    return {"backups": corrections.list_backups()}
+
+
+@app.post("/api/recorrect/revert")
+def recorrect_revert(
+    body: RevertBody,
+    request: Request,
+    _tok: dict = Depends(require_scopes("ingest_write")),
+):
+    """Restore transcripts from a recorrect backup (latest if unspecified)."""
+    _assert_same_site(request)
+    return corrections.revert(body.backup)
 
 
 # ── Serve Frontend ───────────────────────────────────────────────────────────

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -1,0 +1,252 @@
+"""Phase 9.6b — per-project correction dictionary.
+
+Covers the unit surface (load/save/validate, scope-aware apply, segments sync,
+backup/revert, hotword pre-path) and the API surface (GET/PUT corrections,
+POST /api/recorrect dry-run → apply → revert). The red line guarded here is the
+word-scope boundary (a 松→鬆 rule must never touch 馬拉松) and the gotcha that
+recorrect MUST sync segments_json alongside the transcript blob.
+"""
+import importlib
+import json
+
+import pytest
+
+
+@pytest.fixture
+def corr_env(tmp_db, tmp_path, monkeypatch):
+    """Active project rooted at tmp_path with an initialized tmp DB.
+    corrections.py reads config.PROJECT_ROOT for the dict + backups."""
+    config = importlib.import_module("config")
+    corrections = importlib.import_module("corrections")
+    monkeypatch.setattr(config, "PROJECT_ROOT", tmp_path)
+    return corrections
+
+
+def _seed(transcript, segments=None, words=None):
+    """Insert one media row, return its id."""
+    db = importlib.import_module("db")
+    with db.get_conn() as conn:
+        cur = conn.execute(
+            "INSERT INTO media (path, filename, transcript, segments_json, words_json) "
+            "VALUES (?,?,?,?,?)",
+            ("/tmp/clip.mp4", "clip.mp4", transcript,
+             json.dumps(segments, ensure_ascii=False) if segments is not None else None,
+             json.dumps(words, ensure_ascii=False) if words is not None else None),
+        )
+        return cur.lastrowid
+
+
+def _fetch(mid):
+    db = importlib.import_module("db")
+    with db.get_conn() as conn:
+        row = conn.execute(
+            "SELECT transcript, segments_json, words_json FROM media WHERE id=?", (mid,)
+        ).fetchone()
+    return dict(row)
+
+
+# ── rule load / save / validate ──────────────────────────────────────────────
+
+def test_save_load_roundtrip_and_validation(corr_env):
+    corrections = corr_env
+    saved = corrections.save_rules([
+        {"from": "富田", "to": "Furutech"},                 # defaults: global, post on
+        {"from": "", "to": "x"},                            # invalid: empty from → dropped
+        {"to": "no-from"},                                  # invalid: no from → dropped
+        {"from": "嗯", "to": "", "scope": "bogus"},          # bad scope → global
+        {"from": "名", "to": "Name", "pre": True, "post": False},
+    ])
+    assert len(saved) == 3
+    assert saved[0] == {"from": "富田", "to": "Furutech", "scope": "global",
+                        "pre": False, "post": True}
+    assert saved[1]["scope"] == "global"  # bogus normalized
+    loaded = corrections.load_rules()
+    assert loaded == saved
+
+
+def test_load_missing_is_empty(corr_env):
+    assert corr_env.load_rules() == []
+
+
+def test_hotword_terms_only_pre(corr_env):
+    corrections = corr_env
+    corrections.save_rules([
+        {"from": "富田", "to": "Furutech", "pre": True},
+        {"from": "保礦力", "to": "寶礦力", "pre": False},
+        {"from": "名", "to": "Furutech", "pre": True},  # dup `to` deduped
+    ])
+    assert corrections.hotword_terms() == ["Furutech"]
+
+
+# ── scope semantics (the red line) ───────────────────────────────────────────
+
+def test_global_scope_replaces_everywhere(corr_env):
+    c = corr_env
+    new, n = c._apply_rule("我用富田電源也用富田線", {"from": "富田", "to": "Furutech", "scope": "global"})
+    assert new == "我用Furutech電源也用Furutech線"
+    assert n == 2
+
+
+def test_word_scope_guards_against_longer_token(corr_env):
+    """A 松→鬆 word-scope rule must NOT bleed into 馬拉松 (the tag-dedup red line)."""
+    c = corr_env
+    rule = {"from": "松", "to": "鬆", "scope": "word"}
+    # flanked by CJK on the left → no match
+    new, n = c._apply_rule("馬拉松比賽", rule)
+    assert new == "馬拉松比賽"
+    assert n == 0
+    # standalone → matches
+    new2, n2 = c._apply_rule("放 松 一下", rule)
+    assert new2 == "放 鬆 一下"
+    assert n2 == 1
+
+
+def test_line_scope_only_line_initial(corr_env):
+    c = corr_env
+    rule = {"from": "嗯", "to": "", "scope": "line"}
+    new, n = c._apply_rule("嗯我覺得\n他說嗯\n嗯好", rule)
+    assert new == "我覺得\n他說嗯\n好"   # only the two line-initial 嗯 removed
+    assert n == 2
+
+
+def test_noop_when_from_equals_to(corr_env):
+    new, n = corr_env._apply_rule("富田", {"from": "富田", "to": "富田", "scope": "global"})
+    assert (new, n) == ("富田", 0)
+
+
+# ── segments sync (gotcha #1) ────────────────────────────────────────────────
+
+def test_correct_segments_syncs_text_preserves_timing(corr_env):
+    c = corr_env
+    segs = json.dumps([
+        {"start": 0.0, "end": 1.0, "text": "我用富田"},
+        {"start": 1.0, "end": 2.0, "text": "電源"},
+    ], ensure_ascii=False)
+    new_json, hits = c._correct_segments(segs, [{"from": "富田", "to": "Furutech", "scope": "global"}])
+    out = json.loads(new_json)
+    assert out[0]["text"] == "我用Furutech"
+    assert out[0]["start"] == 0.0 and out[0]["end"] == 1.0  # timing untouched
+    assert hits == 1
+
+
+def test_correct_segments_malformed_untouched(corr_env):
+    c = corr_env
+    assert c._correct_segments("not json", [{"from": "a", "to": "b", "scope": "global"}]) == ("not json", 0)
+    assert c._correct_segments(None, []) == (None, 0)
+
+
+# ── scan / apply / revert against a real DB ──────────────────────────────────
+
+def test_scan_does_not_write(corr_env):
+    corrections = corr_env
+    mid = _seed("我用富田電源", [{"start": 0, "end": 1, "text": "我用富田電源"}])
+    corrections.save_rules([{"from": "富田", "to": "Furutech"}])
+    scan = corrections.scan()
+    assert scan["media_affected"] == 1
+    assert scan["total_hits"] == 1
+    assert scan["rules"][0]["hits"] == 1
+    # DB untouched
+    assert _fetch(mid)["transcript"] == "我用富田電源"
+
+
+def test_apply_syncs_transcript_and_segments_then_revert(corr_env):
+    corrections = corr_env
+    mid = _seed(
+        "我用富田電源，富田很好",
+        [{"start": 0, "end": 1, "text": "我用富田電源"},
+         {"start": 1, "end": 2, "text": "富田很好"}],
+        [{"word": "富田", "start": 0.1, "end": 0.4, "score": 0.9}],
+    )
+    corrections.save_rules([{"from": "富田", "to": "Furutech"}])
+
+    result = corrections.apply()
+    assert result["media_updated"] == 1
+    assert result["total_hits"] == 2
+    assert result["backup"]
+
+    after = _fetch(mid)
+    assert after["transcript"] == "我用Furutech電源，Furutech很好"
+    segs = json.loads(after["segments_json"])
+    assert segs[0]["text"] == "我用Furutech電源"
+    assert segs[1]["text"] == "Furutech很好"
+    # whole-token word rename applied too
+    assert json.loads(after["words_json"])[0]["word"] == "Furutech"
+
+    # revert restores the exact pre-correction state
+    rev = corrections.revert()
+    assert rev["restored"] == 1
+    back = _fetch(mid)
+    assert back["transcript"] == "我用富田電源，富田很好"
+    assert json.loads(back["segments_json"])[0]["text"] == "我用富田電源"
+    assert json.loads(back["words_json"])[0]["word"] == "富田"
+
+
+def test_apply_empty_dictionary_is_noop(corr_env):
+    corrections = corr_env
+    _seed("我用富田電源")
+    result = corrections.apply()
+    assert result["media_updated"] == 0
+    assert result["backup"] is None
+
+
+def test_apply_only_post_rules(corr_env):
+    """A pre-only rule (post=False) feeds the hotword but never rewrites text."""
+    corrections = corr_env
+    mid = _seed("我用富田電源")
+    corrections.save_rules([{"from": "富田", "to": "Furutech", "pre": True, "post": False}])
+    result = corrections.apply()
+    assert result["media_updated"] == 0
+    assert _fetch(mid)["transcript"] == "我用富田電源"
+
+
+# ── API surface ──────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def client_env(fastapi_client, tmp_path, monkeypatch):
+    """fastapi_client whose server's config.PROJECT_ROOT points at the tmp DB dir."""
+    import config
+    import corrections
+    monkeypatch.setattr(config, "PROJECT_ROOT", tmp_path)
+    return fastapi_client
+
+
+def test_api_get_put_corrections(client_env):
+    client = client_env
+    assert client.get("/api/corrections").json() == {"rules": []}
+    r = client.put("/api/corrections", json={"rules": [{"from": "富田", "to": "Furutech"}]})
+    assert r.status_code == 200
+    assert r.json()["count"] == 1
+    assert client.get("/api/corrections").json()["rules"][0]["from"] == "富田"
+
+
+def test_api_recorrect_dry_run_then_apply_then_revert(client_env):
+    client = client_env
+    _seed("我用富田電源", [{"start": 0, "end": 1, "text": "我用富田電源"}])
+    client.put("/api/corrections", json={"rules": [{"from": "富田", "to": "Furutech"}]})
+
+    # default POST = dry-run, writes nothing
+    dry = client.post("/api/recorrect").json()
+    assert dry["dry_run"] is True
+    assert dry["media_affected"] == 1
+    assert _fetch(1)["transcript"] == "我用富田電源"
+
+    # apply
+    applied = client.post("/api/recorrect?dry_run=0").json()
+    assert applied["dry_run"] is False
+    assert applied["media_updated"] == 1
+    assert _fetch(1)["transcript"] == "我用Furutech電源"
+
+    # revert via API
+    rev = client.post("/api/recorrect/revert", json={}).json()
+    assert rev["restored"] == 1
+    assert _fetch(1)["transcript"] == "我用富田電源"
+
+
+def test_api_recorrect_apply_requires_same_site(client_env):
+    """Mutating apply is same-origin only; a cross-site Origin is refused."""
+    client = client_env
+    _seed("我用富田電源")
+    client.put("/api/corrections", json={"rules": [{"from": "富田", "to": "Furutech"}]})
+    r = client.post("/api/recorrect?dry_run=0", headers={"Origin": "https://evil.example"})
+    assert r.status_code == 403
+    assert _fetch(1)["transcript"] == "我用富田電源"  # untouched

--- a/transcribe.py
+++ b/transcribe.py
@@ -268,6 +268,14 @@ def _custom_terms() -> list:
                         terms.append(line)
         except OSError:
             pass  # missing / unreadable file is non-fatal — just use env terms
+    # Phase 9.6: the per-project correction dictionary is one source for two
+    # paths — its pre-flagged `to` terms feed the hotword list here (the same
+    # rows also drive post-hoc recorrect). Hot-read per call like vocabulary.txt.
+    try:
+        import corrections
+        terms.extend(corrections.hotword_terms())
+    except Exception:
+        pass  # dictionary is optional — never block transcription on it
     seen = set()
     out = []
     for t in terms:


### PR DESCRIPTION
## Phase 9.6b — 校正字典 + 批次文字校正

One `.arkiv/corrections.json` dictionary of `{from,to,scope,pre,post}` rules drives **two paths from one source**:

- **pre** — `to` terms feed the Whisper hotword list (`initial_prompt`), hot-read per call via `transcribe._custom_terms()` like `vocabulary.txt` → prevents the mis-hearing in *future* transcriptions.
- **post** — `from`→`to` batch-rewrites *already-stored* transcripts (recorrect), fixing the whole NAS backlog's search recall in seconds without touching audio. Stronger than FatSub's search-replace (which only auto-applies to future clips).

### What's new
- `corrections.py` — load/save/validate, scope-aware apply, scan/apply/revert, `hotword_terms()`
- `recorrect.py` CLI — `--dry-run | --apply [--rebuild] | --revert [NAME]`
- Endpoints — `GET/PUT /api/corrections`, `POST /api/recorrect` (**dry-run default — writes nothing**; `dry_run=0` applies, `rebuild=1` chains the embedding rebuild), `GET /api/recorrect/backups`, `POST /api/recorrect/revert`
- `transcribe._custom_terms()` merges the dictionary's pre-terms into the hotword list

### Red lines held
- **segments_json synced** alongside the transcript blob (else search/SRT drift) — `words_json` gets whole-token renames
- **RP-4**: preview-first + every apply writes a timestamped backup, restorable via revert
- **No mis-correction**: scope `word` guards against bleeding into a longer token (a `松→鬆` rule never touches `馬拉松`)
- Operates on the **active project** (no project-DB switching entry point exists yet — `/api/projects/{id}/recorrect` from the handoff would be a new risk surface; multi-project targeting deferred)

### Verification
- 16 tests in `tests/test_corrections.py`; **full suite 608 passed / 5 skipped / 0 failed**
- End-to-end via CLI on a seeded 2-clip DB: dry-run → apply (transcript + segments synced, 馬拉松 untouched) → revert (exact restore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)