### PR TITLE
feat(ui): real UI scale control via zoom (Phase 9.7 G4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 
 ### Added
+- **UI scale control in Settings → Appearance (Phase 9.7 G4).** A real, persisted scale slider (80–140%) — long deferred because the layout is px-based (a root font-size does nothing). Implemented via CSS `zoom` on the document root, which scales the whole tree regardless of px/rem and is supported in WebKit (Tauri/WKWebView) + Chromium. Persists to localStorage and re-applies on load; a 重設 button returns to 100%. Type density stays honestly disabled (px spacing won't reflow from a density class).
 - **List view in the main browser (Phase 9.7 G1).** The Grid/List toggle is now wired: List renders a real table (thumbnail · filename · rating · resolution · duration · size · ingest date) with row-select, selection highlight, and multi-select checkboxes — same selection/pick state as the grid. Columns are drawn from the existing light-list payload; camera/lens columns from the design are deferred (not carried by the list query). Grid remains the default.
 - **VTT subtitle export in the inspector (Phase 9.7 G3).** The export row now offers VTT alongside EDL / FCPXML / SRT (the backend already produced WebVTT — the button was just missing). Honours the IN/OUT trim window like the other subtitle exports.
 - **Tag-source breakdown in the inspector (Phase 9.7 G8).** The Tags section header shows `N AUTO · N MANUAL`, surfacing how many tags came from vision vs were hand-added — matching the design SSOT. Reads the existing `tags.source` field; no schema change.

--- a/frontend/src/lib/prefs.js
+++ b/frontend/src/lib/prefs.js
@@ -48,3 +48,26 @@ export const resolvedTheme = derived(
 export function cycleTheme() {
   themePref.update((t) => (t === 'dark' ? 'light' : t === 'light' ? 'system' : 'dark'))
 }
+
+// ── UI scale (Phase 9.7 G4) ──────────────────────────────────────────────────
+// The layout is px-based, so a root font-size has no effect (why this was long
+// deferred). CSS `zoom` scales the whole rendered tree regardless of px/rem and
+// is supported in WebKit (Tauri/WKWebView) + Chromium — so it's the honest way
+// to make a real, working UI-scale control. Type density (independent spacing)
+// stays deferred: px spacing won't reflow from a density class.
+const SCALE_KEY = 'arkiv.uiScale'
+export const SCALE_MIN = 0.8
+export const SCALE_MAX = 1.4
+function readScale() {
+  try {
+    const v = parseFloat(localStorage.getItem(SCALE_KEY))
+    return v >= SCALE_MIN && v <= SCALE_MAX ? v : 1.0
+  } catch {
+    return 1.0
+  }
+}
+export const uiScale = writable(readScale())
+uiScale.subscribe((v) => {
+  try { localStorage.setItem(SCALE_KEY, String(v)) } catch { /* private mode / quota */ }
+  try { document.documentElement.style.zoom = String(v) } catch { /* SSR / no DOM */ }
+})

--- a/frontend/src/routes/SettingsLive.svelte
+++ b/frontend/src/routes/SettingsLive.svelte
@@ -15,7 +15,7 @@
   import * as api from '../lib/api.js'
   import Mono from '../lib/Mono.svelte'
   import Eyebrow from '../lib/Eyebrow.svelte'
-  import { themePref, resolvedTheme } from '../lib/prefs.js'
+  import { themePref, resolvedTheme, uiScale, SCALE_MIN, SCALE_MAX } from '../lib/prefs.js'
 
   const VERSION = 'v0.9.2'
   let section = 'appearance' // appearance | vocab | engine | system
@@ -209,13 +209,17 @@
                   {/each}
                 </div>
               </div>
-              <div class="frow disabled">
+              <div class="frow">
                 <Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">UI scale</Mono>
-                <span class="pend">px-layout · not adjustable yet</span>
+                <div class="scalectl">
+                  <input class="scalerange" type="range" min={SCALE_MIN} max={SCALE_MAX} step="0.05" bind:value={$uiScale} />
+                  <Mono style="font-size:11px;color:var(--ink);min-width:38px;">{Math.round($uiScale * 100)}%</Mono>
+                  <button class="ak-btn" on:click={() => uiScale.set(1)} disabled={$uiScale === 1}>重設</button>
+                </div>
               </div>
               <div class="frow disabled">
                 <Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Type density</Mono>
-                <span class="pend">px-layout · not adjustable yet</span>
+                <span class="pend">px-layout · spacing not reflowable yet</span>
               </div>
             </div>
           </section>
@@ -385,6 +389,8 @@
   .pend { font-family: var(--ak-mono); font-size: 9.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--quiet-2); border: 1px dashed var(--rule-hi); padding: 2px 7px; width: fit-content; }
   .livedot { color: var(--cyan); font-size: 9px; }
   .proxyctl { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+  .scalectl { display: flex; align-items: center; gap: 12px; }
+  .scalerange { width: 180px; accent-color: var(--invert); cursor: pointer; }
 
   /* correction dictionary (Phase 9.6c) */
   .vrules { display: flex; flex-direction: column; gap: 6px; margin-bottom: 14px; }


### PR DESCRIPTION
## Phase 9.7 — G4 UI scale

UI scale was shown disabled ("px-layout · not adjustable") because a root font-size has no effect on a px-based layout. CSS `zoom` sidesteps that — it scales the whole rendered tree regardless of px/rem and is supported in WebKit (Tauri/WKWebView) + Chromium.

- `prefs.js`: `uiScale` store (80–140%), persisted to localStorage, applied via `document.documentElement.style.zoom` on every change **and on load**.
- Settings → Appearance: the disabled row becomes a live slider with a live percentage readout + a 重設 (reset to 100%) button.
- **Type density** stays honestly disabled — px spacing won't reflow from a density class.

### Verified by rendering
Slider shows in Appearance at 100%; temp-defaulting the store to 1.25 and reloading scaled the whole app (slider read **125%**, modal + type visibly larger), confirming zoom takes effect. Full suite 614 passed / 5 skipped.

Phase 9.7 progress: G1/G3/G8/G4 done; remaining G2/G5/G6/G7/G9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)