### PR TITLE
fix(ui): media grid reflows by card size, not fixed 4 columns (Phase 9.7 G9)

### DIFF
--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -607,7 +607,11 @@
   .ranked { font-size: 10px; padding: 6px 10px; text-decoration: none; white-space: nowrap; }
   .metacsv { font-size: 10px; padding: 6px 10px; white-space: nowrap; }
   .gridwrap { flex: 1; overflow: auto; position: relative; }
-  .mediagrid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px; padding: 22px; background: var(--rule); }
+  /* G9: prototype card width = 198px (runtime-measured from the 1400px design canvas).
+     repeat(4,1fr) ballooned cards on wide windows (310px @1920) and squeezed them on
+     narrow (168px @1280). auto-fill holds the design rhythm and reflows column count;
+     auto-fill (not auto-fit) so a sparse last row keeps card size instead of stretching. */
+  .mediagrid { display: grid; grid-template-columns: repeat(auto-fill, minmax(198px, 1fr)); gap: 1px; padding: 22px; background: var(--rule); }
 
   /* G1 list view */
   .medialist { width: 100%; border-collapse: collapse; font-size: 12.5px; }


### PR DESCRIPTION
## G9 版面保真度 — measure-first

**Problem.** The Claude-design prototype is a fixed 1400px canvas with 198px cards in 4 columns. `MainLive` made the artboard fluid (`max-width:1920px; width:100%`) but kept `.mediagrid` at `repeat(4,1fr)`, so cards scaled with the window instead of holding the design's card rhythm:

| viewport | before | after |
|----------|--------|-------|
| 1280 | 4 cols @168px | 3 cols @224px |
| 1440 | 4 cols @208px | 4 cols @208px (≈design) |
| 1920 | 4 cols @**328px** (+66%) | **6 cols @218px** |

**Fix.** `.mediagrid` → `repeat(auto-fill, minmax(198px, 1fr))`. Cards hold ~198px; column count reflows with width. `auto-fill` (not `auto-fit`) so a sparse last row keeps card size instead of stretching.

**Verification (puppeteer + Chrome, MainLive @ 1280/1440/1920 with seeded data).** Cards land in 198–224px across all widths; clip detector reports 0 overflow-clipped elements at every width.

Two findings from the same measurement pass reshaped the G9 scope (see gap-audit doc):
- The gap-audit's framed "truncation clip bug" was **already resolved** by prior individual patches — no active clipping at any width.
- The prototype itself renders **half-step font sizes** (10.5px is its single most-used size, ×518). So the planned inspector/sidebar font-token sweep (A1) was **retracted** — the live half-step px faithfully mirror the design; snapping them to whole-step tokens would reduce fidelity.

One-line CSS change (+comment). No backend, no schema, no behavior change beyond grid layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)