### PR TITLE
Phase 9.7 G5② settings persistence + G6 structured query builder

### DIFF
--- a/db.py
+++ b/db.py
@@ -331,6 +331,21 @@ def init_db():
                 UNIQUE(media_id, lang)
             )
         """)
+        # Phase 9.7 G5②: persisted settings overrides. config.py holds the
+        # baked-in defaults; this table stores only what the operator has
+        # explicitly changed. scope='global' is the library-wide default; a
+        # scope set to a PROJECT_ROOT path overrides global for that project.
+        # The effective value for a key = default ← global row ← project row.
+        # Only curated keys (settings.SETTINGS_SCHEMA) are ever written here.
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS settings (
+                scope      TEXT NOT NULL DEFAULT 'global',
+                key        TEXT NOT NULL,
+                value      TEXT,
+                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                UNIQUE(scope, key)
+            )
+        """)
         # audit M6: PRAGMA foreign_keys was never enabled before, so orphan
         # child rows accumulated (e.g. scopes of revoked tokens, tags/frames of
         # deleted media). Clear them once here so the now-active enforcement in

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -16,6 +16,7 @@
   import IngestSetup from './routes/IngestSetup.svelte'
   import ChatLive from './routes/ChatLive.svelte'
   import SearchLive from './routes/SearchLive.svelte'
+  import QueryLive from './routes/QueryLive.svelte'
   import Offload from './routes/Offload.svelte'
   import SettingsLive from './routes/SettingsLive.svelte'
   import { resolvedTheme } from './lib/prefs.js'
@@ -36,6 +37,7 @@
     '/offload': Offload, // S4 — DIT offload (card → backup), ported from the /dit island into the SPA
     '/chat-live': ChatLive, // E2 — chat wired to live /api/chat
     '/search-live': SearchLive, // search wired to live /api/media?q=
+    '/query-live': QueryLive, // G6 — structured query builder, live /api/search/query
     '/settings': SettingsLive, // settings — live theme switcher + real system/about (engine config deferred)
 
     // ── design reference (Claude-design mock artboards; not the product) ──────

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -60,6 +60,13 @@ const qs = (params = {}) => {
 export const getStats = (opts) => req('/api/stats', opts)
 export const getProjects = (opts) => req('/api/projects', opts)
 export const getProjectsHealth = (opts) => req('/api/projects/health', opts)
+// ---- project registry mutations (projects_write; token-free on loopback) ----
+// POST /api/projects {name, path, tags} → project dict (409 if name exists).
+export const addProject = (body, opts) => req('/api/projects', { method: 'POST', body, ...opts })
+// DELETE /api/projects/{name} → removed project dict (404 if unknown).
+export const deleteProject = (name, opts) => req(`/api/projects/${encodeURIComponent(name)}`, { method: 'DELETE', ...opts })
+// POST /api/projects/sync → {projects, total} (refresh last_indexed_at from DB).
+export const syncProjects = (opts) => req('/api/projects/sync', { method: 'POST', ...opts })
 export const getTags = (opts) => req('/api/tags', opts)
 // /api/collections → {collections:[{key,title,category,count,items:[{id,filename,thumb,score}]}], total}
 export const getCollections = (opts) => req('/api/collections', opts)

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -183,6 +183,18 @@ export const getMediaTags = (id, opts) => req(`/api/media/${id}/tags`, opts)
 export const search = (q, params = {}, opts) =>
   req(`/api/search/all${qs({ q, ...params })}`, opts)
 
+// G6 — structured query (typed conditions, AND/OR, optional semantic leg)
+export const structuredQuery = (body, opts) =>
+  req('/api/search/query', { method: 'POST', body, ...opts })
+
+// G5② — persisted settings (curated overrides; default ← global ← project)
+export const getSettings = (scope = 'global', opts) =>
+  req(`/api/settings${qs({ scope })}`, opts)
+export const putSettings = (values, scope = 'global', opts) =>
+  req('/api/settings', { method: 'PUT', body: { scope, values }, ...opts })
+export const resetSetting = (key, scope = 'global', opts) =>
+  req(`/api/settings/${encodeURIComponent(key)}${qs({ scope })}`, { method: 'DELETE', ...opts })
+
 // ---- asset URLs (no fetch — for <img>/<video src>) ----
 // Thumbnails are served by a static mount at /thumbnails/<basename>, NOT a
 // per-id route. /api/media items carry `thumbnail_path` (absolute fs path);

--- a/frontend/src/routes/IngestSetup.svelte
+++ b/frontend/src/routes/IngestSetup.svelte
@@ -61,7 +61,13 @@
   // 2-phase DIT handoff: /offload sends the completed destination here as
   // #/ingest-setup?src=<path> so the user can ingest what they just offloaded.
   onMount(async () => {
-    try { engines = await api.getIngestEngines() } catch (e) { /* picker falls back to default-only */ }
+    try {
+      engines = await api.getIngestEngines()
+      // G5③ — pre-fill the dialog from the persisted library defaults so the
+      // operator's Settings choices are honored as the starting point here.
+      if (engines && engines.default_language) language = engines.default_language
+      if (engines && typeof engines.default_recursive === 'boolean') opts.recursive = engines.default_recursive
+    } catch (e) { /* picker falls back to default-only */ }
     const h = window.location.hash
     const qi = h.indexOf('?')
     if (qi === -1) return

--- a/frontend/src/routes/QueryLive.svelte
+++ b/frontend/src/routes/QueryLive.svelte
@@ -1,0 +1,276 @@
+<!-- Phase 9.7 G6 — structured query builder, wired LIVE to POST /api/search/query.
+     The Flows.svelte B2 artboard is the design baseline; this is its functional
+     twin. Typed field conditions combined by AND/OR, with an optional semantic
+     (vector) leg. Empty / no-result states are honest, not faked. -->
+<script>
+  import { onMount } from 'svelte'
+  import * as api from '../lib/api.js'
+  import ArkivLogo from '../lib/ArkivLogo.svelte'
+  import Mono from '../lib/Mono.svelte'
+  import Eyebrow from '../lib/Eyebrow.svelte'
+  import Thumb from '../lib/Thumb.svelte'
+  import { resolvedTheme } from '../lib/prefs.js'
+
+  $: theme = $resolvedTheme
+
+  // Field catalogue — mirrors query_builder._FIELDS on the backend. `kind` drives
+  // which input renders; `ops` are the operators the backend accepts per field.
+  const FIELDS = [
+    { key: 'semantic', label: 'Semantic（語意）', ops: ['contains'], kind: 'text' },
+    { key: 'transcript', label: 'Transcript（逐字稿）', ops: ['contains'], kind: 'text' },
+    { key: 'tag', label: 'Tag（標籤）', ops: ['contains', 'eq'], kind: 'text' },
+    { key: 'filename', label: 'Filename（檔名）', ops: ['contains', 'eq'], kind: 'text' },
+    { key: 'camera', label: 'Camera（機型）', ops: ['contains', 'eq'], kind: 'text' },
+    { key: 'content_type', label: 'Content type', ops: ['contains', 'eq'], kind: 'text' },
+    { key: 'lang', label: 'Language', ops: ['eq'], kind: 'text' },
+    { key: 'rating', label: 'Rating（評分）', ops: ['eq'], kind: 'enum', options: ['good', 'ng', 'review', 'unrated'] },
+    { key: 'media_type', label: 'Media type', ops: ['eq'], kind: 'enum', options: ['video', 'audio'] },
+    { key: 'duration', label: 'Duration（秒）', ops: ['range'], kind: 'range' },
+    { key: 'iso', label: 'ISO', ops: ['range'], kind: 'range' },
+    { key: 'date', label: 'Processed date', ops: ['range'], kind: 'daterange' },
+  ]
+  const fieldMeta = (k) => FIELDS.find((f) => f.key === k) || FIELDS[0]
+
+  const OP_LABEL = { contains: 'contains', eq: 'equals', range: 'between' }
+
+  let match = 'all' // all | any
+  // each condition: {field, op, value, vmin, vmax}
+  let conditions = [{ field: 'semantic', op: 'contains', value: '', vmin: '', vmax: '' }]
+
+  let state = 'idle' // idle | loading | ok | error
+  let err = ''
+  let results = []
+  let total = 0
+  let elapsedMs = 0
+  let degraded = ''
+
+  function addCondition() {
+    conditions = [...conditions, { field: 'transcript', op: 'contains', value: '', vmin: '', vmax: '' }]
+  }
+  function removeCondition(i) {
+    conditions = conditions.filter((_, idx) => idx !== i)
+  }
+  function onFieldChange(i) {
+    // reset op to the field's first valid op when the field changes
+    const c = conditions[i]
+    c.op = fieldMeta(c.field).ops[0]
+    c.value = ''; c.vmin = ''; c.vmax = ''
+    conditions = conditions
+  }
+
+  const fmtDur = (s) => {
+    s = Math.round(s || 0)
+    const m = Math.floor(s / 60), ss = s % 60
+    const p = (n) => String(n).padStart(2, '0')
+    return `${p(m)}:${p(ss)}`
+  }
+
+  // Build the API spec from the UI rows, dropping empty conditions.
+  function buildSpec() {
+    const out = []
+    for (const c of conditions) {
+      const meta = fieldMeta(c.field)
+      if (meta.kind === 'range' || meta.kind === 'daterange') {
+        const lo = c.vmin === '' ? null : (meta.kind === 'range' ? Number(c.vmin) : c.vmin)
+        const hi = c.vmax === '' ? null : (meta.kind === 'range' ? Number(c.vmax) : c.vmax)
+        if (lo === null && hi === null) continue
+        out.push({ field: c.field, op: 'range', value: [lo, hi] })
+      } else {
+        if (!String(c.value).trim()) continue
+        out.push({ field: c.field, op: c.op, value: String(c.value).trim() })
+      }
+    }
+    return out
+  }
+
+  async function run() {
+    const spec = buildSpec()
+    if (!spec.length) { state = 'idle'; results = []; total = 0; err = '至少填一個條件'; return }
+    err = ''; degraded = ''; state = 'loading'
+    const t0 = performance.now()
+    try {
+      const r = await api.structuredQuery({ match, conditions: spec, limit: 60 })
+      elapsedMs = Math.round(performance.now() - t0)
+      total = r.total ?? (r.items || []).length
+      if (r.search_degraded) degraded = r.warning || 'semantic search degraded'
+      results = (r.items || []).map((it) => ({
+        id: it.id,
+        name: it.filename || `#${it.id}`,
+        dur: fmtDur(it.duration_s),
+        thumb: api.thumbUrlFromPath(it.thumbnail_path),
+        rating: it.rating || null,
+        tags: (it.tags || []).map((t) => t.name).slice(0, 4),
+      }))
+      state = 'ok'
+    } catch (e) {
+      state = 'error'
+      err = (e?.body?.detail) || e.message
+    }
+  }
+</script>
+
+<div class="artboard" data-theme={theme}>
+  <div class="topbar">
+    <ArkivLogo size={16} />
+    <Mono dim style="font-size:10px;">live · query builder</Mono>
+    <div class="grow"></div>
+    <a class="ak-btn" href="#/search-live">⌕ simple search</a>
+    <a class="ak-btn" href="#/main-live">← back to grid</a>
+  </div>
+
+  <div class="main">
+    <div class="builder">
+      <div class="bhead">
+        <Eyebrow style="margin-bottom:6px;">Query builder · compound（結構化查詢）</Eyebrow>
+        <div class="matchrow">
+          <Mono dim style="font-size:11px;">Find media matching</Mono>
+          <div class="seg">
+            <button class="segbtn" class:on={match === 'all'} on:click={() => (match = 'all')}>All（AND）</button>
+            <div class="segsep"></div>
+            <button class="segbtn" class:on={match === 'any'} on:click={() => (match = 'any')}>Any（OR）</button>
+          </div>
+          <Mono dim style="font-size:11px;">of the conditions:</Mono>
+        </div>
+      </div>
+
+      <div class="clauses">
+        {#each conditions as c, i}
+          {@const meta = fieldMeta(c.field)}
+          <div class="clause">
+            <select class="ak-input sel cfield" bind:value={c.field} on:change={() => onFieldChange(i)}>
+              {#each FIELDS as f}<option value={f.key}>{f.label}</option>{/each}
+            </select>
+
+            {#if meta.ops.length > 1}
+              <select class="ak-input sel cop" bind:value={c.op}>
+                {#each meta.ops as op}<option value={op}>{OP_LABEL[op]}</option>{/each}
+              </select>
+            {:else}
+              <span class="cop static">{OP_LABEL[meta.ops[0]]}</span>
+            {/if}
+
+            {#if meta.kind === 'range'}
+              <span class="rangewrap">
+                <input class="ak-input num" type="number" placeholder="min" bind:value={c.vmin} />
+                <Mono dim style="font-size:11px;">—</Mono>
+                <input class="ak-input num" type="number" placeholder="max" bind:value={c.vmax} />
+              </span>
+            {:else if meta.kind === 'daterange'}
+              <span class="rangewrap">
+                <input class="ak-input" type="date" bind:value={c.vmin} />
+                <Mono dim style="font-size:11px;">→</Mono>
+                <input class="ak-input" type="date" bind:value={c.vmax} />
+              </span>
+            {:else if meta.kind === 'enum'}
+              <select class="ak-input sel cvalue" bind:value={c.value}>
+                <option value="" disabled selected>選擇…</option>
+                {#each meta.options as o}<option value={o}>{o}</option>{/each}
+              </select>
+            {:else}
+              <input class="ak-input cvalue" placeholder="值…" bind:value={c.value}
+                     on:keydown={(e) => e.key === 'Enter' && run()} spellcheck="false" />
+            {/if}
+
+            <button class="cx" title="移除" on:click={() => removeCondition(i)} disabled={conditions.length === 1}>✕</button>
+          </div>
+        {/each}
+        <button class="addclause" on:click={addCondition}>+ Add condition</button>
+      </div>
+
+      <div class="brun">
+        <button class="ak-btn ak-btn--primary" on:click={run} disabled={state === 'loading'}>
+          {state === 'loading' ? 'Running…' : 'Run query →'}
+        </button>
+        {#if state === 'ok'}
+          <Mono dim style="font-size:10.5px;">{total} matches · {elapsedMs}ms</Mono>
+        {:else if state === 'error'}
+          <Mono style="font-size:10.5px;color:var(--cyan);">ERROR: {err}</Mono>
+        {:else if err}
+          <Mono dim style="font-size:10.5px;">{err}</Mono>
+        {/if}
+        {#if degraded}<Mono style="font-size:10px;color:var(--cyan);">⚠ {degraded}</Mono>{/if}
+      </div>
+    </div>
+
+    <div class="results">
+      {#if state === 'ok' && results.length === 0}
+        <div class="emptyresult">沒有符合條件的素材</div>
+      {:else if results.length}
+        <section class="rgroup">
+          <div class="ghead">
+            <Mono dim style="font-size:10px;letter-spacing:0.1em;">RESULTS</Mono>
+            <Mono dim style="font-size:10.5px;">{results.length} of {total}</Mono>
+            <div class="grow"></div>
+            <Mono dim style="font-size:9.5px;letter-spacing:0.08em;">● LIVE</Mono>
+          </div>
+          <div class="rows">
+            {#each results as r, i (r.id)}
+              <a class="rrow" class:first={i === 0} href={`#/main-live?sel=${r.id}`}>
+                <div class="rthumb">
+                  {#if r.thumb}
+                    <img class="rthumbimg" src={r.thumb} alt={r.name} loading="lazy" />
+                  {:else}
+                    <Thumb seed={r.id} kind="video" {theme} />
+                  {/if}
+                  <Mono style="position:absolute;bottom:2px;right:3px;font-size:9px;color:#f3f2ee;background:rgba(10,10,12,.78);padding:1px 3px;">{r.dur}</Mono>
+                </div>
+                <div class="rcontent">
+                  <div class="rtop">
+                    <Mono style="font-size:11.5px;font-weight:500;color:var(--ink);">{r.name}</Mono>
+                    <div class="rtags">{#each r.tags as t}<span class="rtag">{t}</span>{/each}</div>
+                  </div>
+                </div>
+                {#if r.rating}<div class="rrating"><Mono dim style="font-size:9px;letter-spacing:0.08em;text-transform:uppercase;">{r.rating}</Mono></div>{/if}
+                <div class="raction"><span class="ak-btn openbtn">Open →</span></div>
+              </a>
+            {/each}
+          </div>
+        </section>
+      {/if}
+    </div>
+  </div>
+</div>
+
+<style>
+  .artboard { width: 100%; max-width: 1920px; height: 100vh; height: 100dvh; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 1fr; overflow: hidden; margin: 0 auto; }
+  .grow { flex: 1; }
+  .topbar { display: flex; align-items: center; border-bottom: 1px solid var(--rule); padding: 0 16px; gap: 16px; }
+  .topbar a { text-decoration: none; }
+  .main { display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
+  .builder { padding: 22px 64px 16px; border-bottom: 1px solid var(--rule); }
+  .matchrow { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+  .seg { display: flex; border: 1px solid var(--rule); width: fit-content; }
+  .segsep { width: 1px; background: var(--rule); }
+  .segbtn { font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.06em; text-transform: uppercase; padding: 5px 12px; background: transparent; color: var(--ink-2); border: none; cursor: pointer; line-height: 1; }
+  .segbtn.on { background: var(--invert); color: var(--invert-ink); font-weight: 700; }
+  .clauses { display: flex; flex-direction: column; gap: 8px; margin-top: 14px; }
+  .clause { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+  .cfield { min-width: 190px; }
+  .cop { min-width: 110px; }
+  .cop.static { font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.05em; color: var(--quiet); padding: 0 8px; min-width: 110px; }
+  .cvalue { min-width: 240px; }
+  .rangewrap { display: flex; align-items: center; gap: 8px; }
+  .rangewrap .num { width: 110px; }
+  .cx { background: transparent; border: 1px solid var(--rule); color: var(--quiet); cursor: pointer; width: 26px; height: 26px; line-height: 1; }
+  .cx:hover:not(:disabled) { border-color: var(--cyan); color: var(--cyan); }
+  .cx:disabled { opacity: 0.4; cursor: default; }
+  .addclause { margin-top: 4px; align-self: flex-start; font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.06em; text-transform: uppercase; background: transparent; border: 1px dashed var(--rule-hi); color: var(--ink-2); padding: 6px 12px; cursor: pointer; }
+  .addclause:hover { border-style: solid; }
+  .brun { display: flex; align-items: center; gap: 14px; margin-top: 16px; }
+  .results { flex: 1; overflow: auto; padding: 14px 64px 18px; }
+  .rgroup { margin-bottom: 16px; }
+  .ghead { display: flex; align-items: baseline; gap: 12px; margin-bottom: 8px; padding-bottom: 6px; border-bottom: 1px solid var(--rule); }
+  .emptyresult { padding: 24px 16px; font-family: var(--ak-mono); font-size: 11px; color: var(--quiet); text-align: center; letter-spacing: 0.05em; }
+  .rrow { display: grid; grid-template-columns: 100px 1fr 70px 78px; gap: 14px; align-items: center; padding: 5px 0; border-top: 1px solid var(--rule); cursor: pointer; text-decoration: none; color: inherit; }
+  .rrow.first { border-top: none; }
+  .rrow:hover { background: var(--surface-2); }
+  .rthumb { position: relative; aspect-ratio: 16 / 9; background: var(--surface-2); overflow: hidden; }
+  .rthumbimg { width: 100%; height: 100%; object-fit: cover; display: block; }
+  .rcontent { min-width: 0; }
+  .rtop { display: flex; align-items: baseline; gap: 8px; }
+  .rtags { display: flex; gap: 4px; }
+  .rtag { font-family: var(--ak-mono); font-size: 9px; padding: 1px 4px; border: 1px solid var(--rule); color: var(--quiet); line-height: 1.2; }
+  .rrating { text-align: right; }
+  .raction { display: flex; justify-content: flex-end; }
+  .openbtn { padding: 5px 9px; }
+</style>

--- a/frontend/src/routes/SearchLive.svelte
+++ b/frontend/src/routes/SearchLive.svelte
@@ -137,6 +137,7 @@
     <ArkivLogo size={16} />
     <Mono dim style="font-size:10px;">live</Mono>
     <div class="grow"></div>
+    <a class="ak-btn" href="#/query-live">⊞ query builder</a>
     <a class="ak-btn" href="#/main-live">← back to grid</a>
   </div>
 

--- a/frontend/src/routes/SettingsLive.svelte
+++ b/frontend/src/routes/SettingsLive.svelte
@@ -18,14 +18,67 @@
   import { themePref, resolvedTheme, uiScale, SCALE_MIN, SCALE_MAX } from '../lib/prefs.js'
 
   const VERSION = 'v0.9.2'
-  let section = 'appearance' // appearance | vocab | engine | system
+  // G5 step ①: nav expanded to the design's tab set. Real-backed tabs are
+  // interactive; tabs without backend (vision/export) show honest pending rows.
+  let section = 'general'
   const nav = [
-    ['appearance', 'Appearance'],
-    ['vocab', 'Vocabulary'],
-    ['engine', 'Engine'],
+    ['general', 'General'],
+    ['transcription', 'Transcription'],
+    ['vision', 'Vision tagging'],
+    ['export', 'Export defaults'],
+    ['storage', 'Storage · proxy'],
+    ['projects', 'Projects'],
+    ['advanced', 'Advanced'],
     ['system', 'System · about'],
   ]
   const themeOpts = [['dark', 'Dark'], ['light', 'Light'], ['system', 'System']]
+
+  // Transcription engines (brick 4, PR #77) — real whisper quality presets +
+  // forced-language set. We display the available options + current default; the
+  // per-ingest picker lives in IngestSetup. Persisting a库-wide default = step ②.
+  let engines = null // {whisper_modes:[{mode,name}], default_mode, languages:[{code,label}]}
+  async function loadEngines() {
+    try { engines = await api.getIngestEngines() } catch { engines = null }
+  }
+
+  // Project registry — full CRUD (projects_read/write, token-free on loopback).
+  let projects = [] // [{name, path, added_at, last_indexed_at, tags, source}]
+  let projHealth = {} // name -> status string ("ok" | …)
+  let projMsg = ''
+  let projBusy = false
+  let newName = '', newPath = '', newTags = ''
+  async function loadProjects() {
+    try { projects = (await api.getProjects()).projects || [] } catch { projects = [] }
+    try {
+      const h = await api.getProjectsHealth()
+      projHealth = Object.fromEntries((h.projects || []).map((p) => [p.name, p.status]))
+    } catch { projHealth = {} }
+  }
+  async function addProj() {
+    if (projBusy) return
+    const name = newName.trim(), path = newPath.trim()
+    if (!name || !path) { projMsg = '名稱與路徑都要填'; return }
+    projBusy = true; projMsg = ''
+    try {
+      await api.addProject({ name, path, tags: newTags.split(',').map((t) => t.trim()).filter(Boolean) })
+      newName = ''; newPath = ''; newTags = ''
+      await loadProjects()
+      projMsg = `已加入 ${name}`
+    } catch (e) { projMsg = e.status === 409 ? `已存在同名專案：${name}` : `失敗: ${e.message}` }
+    finally { projBusy = false }
+  }
+  async function delProj(name) {
+    if (projBusy) return
+    projBusy = true; projMsg = ''
+    try { await api.deleteProject(name); await loadProjects(); projMsg = `已移除 ${name}` }
+    catch (e) { projMsg = `失敗: ${e.message}` } finally { projBusy = false }
+  }
+  async function syncProj() {
+    if (projBusy) return
+    projBusy = true; projMsg = ''
+    try { await api.syncProjects(); await loadProjects(); projMsg = '已同步索引時間' }
+    catch (e) { projMsg = `失敗: ${e.message}` } finally { projBusy = false }
+  }
 
   // System panel — real backend state.
   let sys = 'loading' // loading | ok | error
@@ -160,7 +213,9 @@
   }
   onDestroy(() => { if (retrTimer) clearTimeout(retrTimer) })
 
-  onMount(() => { loadSystem(); loadProxy(); loadAnalytics(); loadCache(); loadVocab() })
+  onMount(() => { loadSystem(); loadProxy(); loadAnalytics(); loadCache(); loadVocab(); loadEngines(); loadProjects() })
+
+  const shortDate = (s) => (s ? String(s).slice(0, 10) : '—')
 
   const gb = (n) => (n == null ? '—' : n >= 1000 ? `${(n / 1000).toFixed(1)} TB` : `${Math.round(n)} GB`)
   const mb = (n) => (n == null ? '—' : n >= 1000 ? `${(n / 1000).toFixed(1)} GB` : `${Math.round(n)} MB`)
@@ -192,11 +247,11 @@
       </nav>
 
       <div class="form">
-        {#if section === 'appearance'}
+        {#if section === 'general'}
           <section>
             <div class="fshead">
               <Eyebrow style="margin-bottom:4px;">THEME · INTERFACE</Eyebrow>
-              <div class="ak-display fstitle">Appearance</div>
+              <div class="ak-display fstitle">General</div>
               <div class="fsdesc">vulture.s editorial. Theme applies across the whole app and persists. System follows your OS.</div>
             </div>
             <div class="frows">
@@ -223,11 +278,11 @@
               </div>
             </div>
           </section>
-        {:else if section === 'vocab'}
+        {:else if section === 'advanced'}
           <section>
             <div class="fshead">
               <Eyebrow style="margin-bottom:4px;">CORRECTION DICTIONARY · 校正字典</Eyebrow>
-              <div class="ak-display fstitle">Vocabulary</div>
+              <div class="ak-display fstitle">Advanced</div>
               <div class="fsdesc">一本 per-project 字典，兩條路徑：<b>pre</b> 把 <code>to</code> 詞餵 Whisper hotword（轉錄前防聽錯）；<b>post</b> 把 <code>from→to</code> 套到已存逐字稿（批次校正，秒級修整庫搜尋召回、不碰音訊）。寫入 <code>.arkiv/corrections.json</code>。</div>
             </div>
 
@@ -297,38 +352,67 @@
               {/if}
             </div>
           </section>
-        {:else if section === 'engine'}
+        {:else if section === 'transcription'}
           <section>
             <div class="fshead">
-              <Eyebrow style="margin-bottom:4px;">WHISPER · OLLAMA · RESOLVE</Eyebrow>
-              <div class="ak-display fstitle">Engine</div>
-              <div class="fsdesc">Transcription / vision models and export defaults are chosen per ingest. In-app pickers have no API yet (brick 4).</div>
+              <Eyebrow style="margin-bottom:4px;">WHISPER · GUARD PRESETS</Eyebrow>
+              <div class="ak-display fstitle">Transcription</div>
+              <div class="fsdesc">轉錄品質預設（whisper-guard 0–4）與強制語言，每次匯入於 setup 對話框選。此處顯示可用選項 + 目前預設；設成全庫預設＝下一步（settings 表）。</div>
+            </div>
+            {#if engines}
+              <div class="frows">
+                <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Quality presets</Mono>
+                  <div class="chips">
+                    {#each engines.whisper_modes as m}
+                      <span class="chip" class:chipon={m.mode === engines.default_mode}>{m.mode} · {m.name}{m.mode === engines.default_mode ? ' ●' : ''}</span>
+                    {/each}
+                  </div>
+                </div>
+                <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Languages</Mono>
+                  <div class="chips">
+                    {#each engines.languages as l}<span class="chip">{l.label} · {l.code}</span>{/each}
+                    <span class="chip">auto-detect</span>
+                  </div>
+                </div>
+                <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Current default</Mono><Mono style="font-size:12px;color:var(--ink);">preset {engines.default_mode} · 語言自動偵測</Mono></div>
+              </div>
+            {:else}
+              <span class="pend">engines endpoint unreachable</span>
+            {/if}
+          </section>
+        {:else if section === 'vision'}
+          <section>
+            <div class="fshead">
+              <Eyebrow style="margin-bottom:4px;">VLM · TAG POOL</Eyebrow>
+              <div class="ak-display fstitle">Vision tagging</div>
+              <div class="fsdesc">畫面標籤的視覺模型與標籤池設定。後端待補（brick 4b：vision-model 清單來源、tag pool 概念、frames 取樣未定）— 不造假可調控制項。</div>
             </div>
             <div class="frows">
-              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Transcription</Mono><span class="pend">model picker pending · brick 4</span></div>
-              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Vision tagging</Mono><span class="pend">model + tag pool pending · brick 4</span></div>
-              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Export defaults</Mono><span class="pend">EDL fps / proxy pending · brick 4</span></div>
+              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Vision model</Mono><span class="pend">picker pending · brick 4b</span></div>
+              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Tag pool · confidence</Mono><span class="pend">no config endpoint yet</span></div>
             </div>
           </section>
-        {:else}
+        {:else if section === 'export'}
           <section>
             <div class="fshead">
-              <Eyebrow style="margin-bottom:4px;">RUNTIME</Eyebrow>
-              <div class="ak-display fstitle">System</div>
+              <Eyebrow style="margin-bottom:4px;">EDL · FCPXML · PROXY</Eyebrow>
+              <div class="ak-display fstitle">Export defaults</div>
+              <div class="fsdesc">匯出預設（EDL fps、proxy 解析度、drop-frame）。後端待補——目前匯出參數每次呼叫帶入、無持久預設（需 settings 表）。</div>
             </div>
             <div class="frows">
-              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Version</Mono><Mono style="font-size:12px;color:var(--ink);">arkiv {VERSION}</Mono></div>
-              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Backend</Mono>
-                {#if sys === 'loading'}<Mono dim style="font-size:12px;">checking…</Mono>
-                {:else if sys === 'ok'}<Mono style="font-size:12px;color:var(--ink);"><span class="livedot">●</span> online</Mono>
-                {:else}<Mono style="font-size:12px;color:var(--cyan);">unreachable</Mono>{/if}
-              </div>
-              {#if sys === 'ok' && stats}
-                <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Library</Mono><Mono style="font-size:12px;color:var(--ink);">{stats.total} media · {Math.round((stats.total_size_mb || 0) / 1024)} GB indexed</Mono></div>
-                <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Disk</Mono>
-                  {#if disk}<Mono style="font-size:12px;color:var(--ink);">{gb(disk.used_gb)} / {gb(disk.total_gb)} · {disk.pct}%</Mono>{:else}<Mono dim style="font-size:12px;">—</Mono>{/if}
-                </div>
-              {/if}
+              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">EDL frame rate</Mono><span class="pend">default pending · no settings store</span></div>
+              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Proxy resolution</Mono><span class="pend">default pending</span></div>
+              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Drop frame</Mono><span class="pend">default pending</span></div>
+            </div>
+          </section>
+        {:else if section === 'storage'}
+          <section>
+            <div class="fshead">
+              <Eyebrow style="margin-bottom:4px;">PROXY · CACHE · BREAKDOWN</Eyebrow>
+              <div class="ak-display fstitle">Storage · proxy</div>
+              <div class="fsdesc">編輯用 proxy 狀態與生成、快取清理，以及庫的語言時長 / 格式容量分布。</div>
+            </div>
+            <div class="frows">
               <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Proxies</Mono>
                 {#if proxy}<Mono style="font-size:12px;color:var(--ink);">{proxy.proxied}/{proxy.total} built · {proxy.size_mb} MB</Mono>{:else}<Mono dim style="font-size:12px;">—</Mono>{/if}
               </div>
@@ -352,6 +436,64 @@
                   {#if cacheMsg}<Mono dim style="font-size:10.5px;">{cacheMsg}</Mono>{/if}
                 </div>
               </div>
+            </div>
+          </section>
+        {:else if section === 'projects'}
+          <section>
+            <div class="fshead">
+              <Eyebrow style="margin-bottom:4px;">PROJECT REGISTRY · 專案註冊表</Eyebrow>
+              <div class="ak-display fstitle">Projects</div>
+              <div class="fsdesc">跨庫專案登記——加入 / 移除 / 同步索引時間。寫入 <code>~/.arkiv-projects.json</code>。健康狀態來自 <code>/api/projects/health</code>。</div>
+            </div>
+
+            <div class="ptable">
+              <div class="phead"><span>NAME</span><span>PATH</span><span>INDEXED</span><span>HEALTH</span><span></span></div>
+              {#each projects as p}
+                <div class="prow">
+                  <span class="pname">{p.name}</span>
+                  <span class="ppath" title={p.path}>{p.path}</span>
+                  <Mono dim style="font-size:10.5px;">{shortDate(p.last_indexed_at)}</Mono>
+                  <span class="phealth" class:ok={projHealth[p.name] === 'ok'}>{projHealth[p.name] || '—'}</span>
+                  <button class="vx" on:click={() => delProj(p.name)} disabled={projBusy} title="移除">✕</button>
+                </div>
+              {/each}
+              {#if !projects.length}<div class="vempty">尚無註冊專案 — 下方加入第一個。</div>{/if}
+            </div>
+
+            <div class="vdiv"></div>
+            <div class="fshead">
+              <Eyebrow style="margin-bottom:4px;">ADD PROJECT · 加入</Eyebrow>
+            </div>
+            <div class="paddrow">
+              <input class="vin" bind:value={newName} placeholder="專案名稱" />
+              <input class="vin" bind:value={newPath} placeholder="/Volumes/… 路徑" />
+              <input class="vin" bind:value={newTags} placeholder="tags（逗號分隔，可空）" />
+            </div>
+            <div class="vctl">
+              <button class="ak-btn" on:click={addProj} disabled={projBusy}>+ 加入專案</button>
+              <button class="ak-btn" on:click={syncProj} disabled={projBusy}>同步索引時間</button>
+              {#if projMsg}<Mono dim style="font-size:11px;">{projMsg}</Mono>{/if}
+            </div>
+          </section>
+        {:else}
+          <section>
+            <div class="fshead">
+              <Eyebrow style="margin-bottom:4px;">RUNTIME</Eyebrow>
+              <div class="ak-display fstitle">System</div>
+            </div>
+            <div class="frows">
+              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Version</Mono><Mono style="font-size:12px;color:var(--ink);">arkiv {VERSION}</Mono></div>
+              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Backend</Mono>
+                {#if sys === 'loading'}<Mono dim style="font-size:12px;">checking…</Mono>
+                {:else if sys === 'ok'}<Mono style="font-size:12px;color:var(--ink);"><span class="livedot">●</span> online</Mono>
+                {:else}<Mono style="font-size:12px;color:var(--cyan);">unreachable</Mono>{/if}
+              </div>
+              {#if sys === 'ok' && stats}
+                <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Library</Mono><Mono style="font-size:12px;color:var(--ink);">{stats.total} media · {Math.round((stats.total_size_mb || 0) / 1024)} GB indexed</Mono></div>
+                <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Disk</Mono>
+                  {#if disk}<Mono style="font-size:12px;color:var(--ink);">{gb(disk.used_gb)} / {gb(disk.total_gb)} · {disk.pct}%</Mono>{:else}<Mono dim style="font-size:12px;">—</Mono>{/if}
+                </div>
+              {/if}
               <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Privacy</Mono><Mono dim style="font-size:11.5px;">Everything runs locally. Nothing leaves this machine.</Mono></div>
             </div>
           </section>
@@ -410,4 +552,20 @@
   .vdiv { height: 1px; background: var(--rule); margin: 20px 0 16px; }
   .vresult { display: flex; flex-direction: column; gap: 3px; margin-top: 12px; padding: 10px 12px; box-shadow: inset 0 0 0 1px var(--rule); }
   .vmsg { margin-top: 8px; }
+
+  /* G5 transcription engines (read-only chips) */
+  .chips { display: flex; flex-wrap: wrap; gap: 6px; }
+  .chip { font-family: var(--ak-mono); font-size: 10px; letter-spacing: 0.04em; color: var(--ink-2); border: 1px solid var(--rule); padding: 3px 8px; line-height: 1.2; }
+  .chip.chipon { background: var(--invert); color: var(--invert-ink); border-color: var(--invert); }
+
+  /* G5 project registry table */
+  .ptable { display: flex; flex-direction: column; gap: 6px; margin-bottom: 14px; }
+  .phead, .prow { display: grid; grid-template-columns: 1.2fr 2fr 78px 64px 28px; align-items: center; gap: 10px; }
+  .phead { font-family: var(--ak-mono); font-size: 9px; letter-spacing: 0.08em; color: var(--quiet-2); padding: 0 2px; }
+  .prow { padding: 5px 2px; border-bottom: 1px solid var(--rule); }
+  .pname { font-size: 13px; color: var(--ink); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .ppath { font-family: var(--ak-mono); font-size: 10.5px; color: var(--quiet); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .phealth { font-family: var(--ak-mono); font-size: 10px; letter-spacing: 0.04em; text-transform: uppercase; color: var(--quiet-2); }
+  .phealth.ok { color: var(--cyan); }
+  .paddrow { display: grid; grid-template-columns: 1.2fr 2fr 1.4fr; gap: 8px; margin-bottom: 12px; }
 </style>

--- a/frontend/src/routes/SettingsLive.svelte
+++ b/frontend/src/routes/SettingsLive.svelte
@@ -41,6 +41,34 @@
     try { engines = await api.getIngestEngines() } catch { engines = null }
   }
 
+  // G5②③ — persisted settings (default ← global ← project). These are REAL:
+  // vision.model / vision.num_ctx are read by the ingest run (vision.py /
+  // ingest.py warm-up); export.default_dir is the fallback dest for the
+  // server-write CSV export. We only expose controls that are genuinely consumed.
+  let settingsList = []     // describe() output
+  let settingsBusy = false
+  let settingsMsg = ''
+  let visModel = '', visNumCtx = 16384, expDir = ''  // local edit buffers
+  function settingMeta(key) { return settingsList.find((s) => s.key === key) || null }
+  async function loadSettings() {
+    try { settingsList = (await api.getSettings()).settings || [] } catch { settingsList = [] }
+    const vm = settingMeta('vision.model'); if (vm) visModel = vm.value
+    const vc = settingMeta('vision.num_ctx'); if (vc) visNumCtx = vc.value
+    const ed = settingMeta('export.default_dir'); if (ed) expDir = ed.value
+  }
+  async function saveSetting(values) {
+    settingsBusy = true; settingsMsg = ''
+    try { await api.putSettings(values); await loadSettings(); settingsMsg = '已儲存 ✓' }
+    catch (e) { settingsMsg = '儲存失敗：' + (e?.body?.detail || e.message) }
+    finally { settingsBusy = false }
+  }
+  async function resetSettingKey(key) {
+    settingsBusy = true; settingsMsg = ''
+    try { await api.resetSetting(key); await loadSettings(); settingsMsg = '已重設為預設 ✓' }
+    catch (e) { settingsMsg = '重設失敗：' + (e?.body?.detail || e.message) }
+    finally { settingsBusy = false }
+  }
+
   // Project registry — full CRUD (projects_read/write, token-free on loopback).
   let projects = [] // [{name, path, added_at, last_indexed_at, tags, source}]
   let projHealth = {} // name -> status string ("ok" | …)
@@ -213,7 +241,7 @@
   }
   onDestroy(() => { if (retrTimer) clearTimeout(retrTimer) })
 
-  onMount(() => { loadSystem(); loadProxy(); loadAnalytics(); loadCache(); loadVocab(); loadEngines(); loadProjects() })
+  onMount(() => { loadSystem(); loadProxy(); loadAnalytics(); loadCache(); loadVocab(); loadEngines(); loadProjects(); loadSettings() })
 
   const shortDate = (s) => (s ? String(s).slice(0, 10) : '—')
 
@@ -281,8 +309,26 @@
         {:else if section === 'advanced'}
           <section>
             <div class="fshead">
-              <Eyebrow style="margin-bottom:4px;">CORRECTION DICTIONARY · 校正字典</Eyebrow>
+              <Eyebrow style="margin-bottom:4px;">EFFECTIVE SETTINGS · 生效設定</Eyebrow>
               <div class="ak-display fstitle">Advanced</div>
+              <div class="fsdesc">所有持久化設定的<b>生效值</b>與來源（<code>default</code> = config 預設／<code>global</code> = 全庫覆寫）。可從這裡一鍵重設任一覆寫回預設。</div>
+            </div>
+            {#if settingsList.length}
+              <div class="settbl">
+                <div class="settbl-h"><span>KEY</span><span>VALUE</span><span>SOURCE</span><span></span></div>
+                {#each settingsList as s}
+                  <div class="settbl-r">
+                    <span class="setk" title={s.label}>{s.key}</span>
+                    <span class="setv">{s.value === '' ? '—' : s.value}</span>
+                    <span class="srctag" class:srcset={s.source !== 'default'}>{s.source}</span>
+                    <span>{#if s.source !== 'default'}<button class="vx" title="重設為預設" on:click={() => resetSettingKey(s.key)} disabled={settingsBusy}>↺</button>{/if}</span>
+                  </div>
+                {/each}
+              </div>
+            {/if}
+            <div class="fshead" style="margin-top:24px;">
+              <Eyebrow style="margin-bottom:4px;">CORRECTION DICTIONARY · 校正字典</Eyebrow>
+              <div class="ak-display fstitle" style="font-size:15px;">Correction dictionary</div>
               <div class="fsdesc">一本 per-project 字典，兩條路徑：<b>pre</b> 把 <code>to</code> 詞餵 Whisper hotword（轉錄前防聽錯）；<b>post</b> 把 <code>from→to</code> 套到已存逐字稿（批次校正，秒級修整庫搜尋召回、不碰音訊）。寫入 <code>.arkiv/corrections.json</code>。</div>
             </div>
 
@@ -383,26 +429,55 @@
         {:else if section === 'vision'}
           <section>
             <div class="fshead">
-              <Eyebrow style="margin-bottom:4px;">VLM · TAG POOL</Eyebrow>
+              <Eyebrow style="margin-bottom:4px;">VLM · LIBRARY DEFAULT</Eyebrow>
               <div class="ak-display fstitle">Vision tagging</div>
-              <div class="fsdesc">畫面標籤的視覺模型與標籤池設定。後端待補（brick 4b：vision-model 清單來源、tag pool 概念、frames 取樣未定）— 不造假可調控制項。</div>
+              <div class="fsdesc">視覺模型與 context window 的全庫預設。<strong>真實生效</strong>：每次 ingest 的 vision 標註與 warm-up 都讀這裡（未設＝沿用 config 預設）。Tag pool 約束仍待後端（brick 4b），不造假。</div>
             </div>
             <div class="frows">
-              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Vision model</Mono><span class="pend">picker pending · brick 4b</span></div>
-              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Tag pool · confidence</Mono><span class="pend">no config endpoint yet</span></div>
+              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Vision model</Mono>
+                <div class="setctl">
+                  <input class="ak-input" bind:value={visModel} placeholder="qwen2.5vl:7b" spellcheck="false" />
+                  {#if settingMeta('vision.model')}<span class="srctag">{settingMeta('vision.model').source}</span>{/if}
+                </div>
+              </div>
+              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Context window (num_ctx)</Mono>
+                <div class="setctl">
+                  <input class="ak-input num" type="number" min="512" max="131072" bind:value={visNumCtx} />
+                  {#if settingMeta('vision.num_ctx')}<span class="srctag">{settingMeta('vision.num_ctx').source}</span>{/if}
+                </div>
+              </div>
+              <div class="frow"><span></span>
+                <div class="setctl">
+                  <button class="ak-btn" on:click={() => saveSetting({ 'vision.model': visModel, 'vision.num_ctx': Number(visNumCtx) })} disabled={settingsBusy}>儲存全庫預設</button>
+                  <button class="ak-btn" on:click={() => { resetSettingKey('vision.model'); resetSettingKey('vision.num_ctx') }} disabled={settingsBusy}>重設</button>
+                  {#if settingsMsg}<span class="setmsg">{settingsMsg}</span>{/if}
+                </div>
+              </div>
+              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Tag pool · confidence</Mono><span class="pend">no config endpoint yet · brick 4b</span></div>
             </div>
           </section>
         {:else if section === 'export'}
           <section>
             <div class="fshead">
-              <Eyebrow style="margin-bottom:4px;">EDL · FCPXML · PROXY</Eyebrow>
+              <Eyebrow style="margin-bottom:4px;">EXPORT · DEFAULT DEST</Eyebrow>
               <div class="ak-display fstitle">Export defaults</div>
-              <div class="fsdesc">匯出預設（EDL fps、proxy 解析度、drop-frame）。後端待補——目前匯出參數每次呼叫帶入、無持久預設（需 settings 表）。</div>
+              <div class="fsdesc">預設匯出資料夾。<strong>真實生效</strong>：server-write CSV 匯出（Tauri 存檔路徑）未指定時落這個目錄。EDL fps / proxy 解析度 / drop-frame 仍每次呼叫帶入、無持久預設（待後端）。</div>
             </div>
             <div class="frows">
-              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">EDL frame rate</Mono><span class="pend">default pending · no settings store</span></div>
-              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Proxy resolution</Mono><span class="pend">default pending</span></div>
-              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Drop frame</Mono><span class="pend">default pending</span></div>
+              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Default export dir</Mono>
+                <div class="setctl">
+                  <input class="ak-input" bind:value={expDir} placeholder="~/Desktop/arkiv-exports（空＝瀏覽器下載）" spellcheck="false" />
+                  {#if settingMeta('export.default_dir')}<span class="srctag">{settingMeta('export.default_dir').source}</span>{/if}
+                </div>
+              </div>
+              <div class="frow"><span></span>
+                <div class="setctl">
+                  <button class="ak-btn" on:click={() => saveSetting({ 'export.default_dir': expDir })} disabled={settingsBusy}>儲存</button>
+                  <button class="ak-btn" on:click={() => resetSettingKey('export.default_dir')} disabled={settingsBusy}>重設</button>
+                  {#if settingsMsg}<span class="setmsg">{settingsMsg}</span>{/if}
+                </div>
+              </div>
+              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">EDL frame rate · proxy · drop-frame</Mono><span class="pend">default pending · per-call only</span></div>
             </div>
           </section>
         {:else if section === 'storage'}
@@ -530,6 +605,20 @@
   .segbtn.on { background: var(--invert); color: var(--invert-ink); font-weight: 700; }
   .pend { font-family: var(--ak-mono); font-size: 9.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--quiet-2); border: 1px dashed var(--rule-hi); padding: 2px 7px; width: fit-content; }
   .livedot { color: var(--cyan); font-size: 9px; }
+  /* G5②③ settings controls */
+  .setctl { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+  .setctl .ak-input { min-width: 220px; }
+  .setctl .ak-input.num { min-width: 110px; }
+  .setmsg { font-family: var(--ak-mono); font-size: 10px; letter-spacing: 0.04em; color: var(--cyan); }
+  .srctag { font-family: var(--ak-mono); font-size: 9px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--quiet-2); border: 1px solid var(--rule); padding: 1px 6px; }
+  .srctag.srcset { color: var(--cyan); border-color: var(--cyan); }
+  .settbl { display: flex; flex-direction: column; border: 1px solid var(--rule); }
+  .settbl-h, .settbl-r { display: grid; grid-template-columns: 1.6fr 1.4fr 0.7fr 32px; align-items: center; gap: 10px; padding: 7px 10px; }
+  .settbl-h { font-family: var(--ak-mono); font-size: 9px; letter-spacing: 0.08em; color: var(--quiet-2); border-bottom: 1px solid var(--rule); }
+  .settbl-r { border-bottom: 1px solid var(--rule-lo, var(--rule)); }
+  .settbl-r:last-child { border-bottom: none; }
+  .setk { font-family: var(--ak-mono); font-size: 11px; color: var(--ink-2); }
+  .setv { font-family: var(--ak-mono); font-size: 11px; color: var(--ink); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .proxyctl { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
   .scalectl { display: flex; align-items: center; gap: 12px; }
   .scalerange { width: 180px; accent-color: var(--invert); cursor: pointer; }

--- a/ingest.py
+++ b/ingest.py
@@ -73,9 +73,13 @@ def _stage(marker: str, stage: str) -> None:
 
 
 def _warm_up_vision_model():
-    """Send a dummy request to ensure qwen3-vl:8b is loaded in VRAM."""
+    """Send a dummy request to ensure the vision model is loaded in VRAM."""
     import urllib.request
-    model = config.VISION_MODEL
+    import settings as _settings
+    # Warm up the SAME model + num_ctx the real calls will use (settings library
+    # default, falling back to config) — otherwise warm-up and run diverge.
+    model = _settings.vision_model()
+    num_ctx = _settings.vision_num_ctx()
     print(f"  Warming up vision model ({model})...", end="", flush=True)
     try:
         payload = json.dumps({
@@ -83,11 +87,11 @@ def _warm_up_vision_model():
             "prompt": "hi",
             "stream": False,
             # Load with the same capped context the real vision calls use
-            # (config.OLLAMA_VISION_NUM_CTX). Warming up at the model's default
+            # (settings vision.num_ctx). Warming up at the model's default
             # context first balloons VRAM and leaves the model CPU-offloaded
             # even after the real calls reload it — keep them consistent so the
             # model lands 100% on GPU from the first frame.
-            "options": {"num_predict": 1, "num_ctx": config.OLLAMA_VISION_NUM_CTX},
+            "options": {"num_predict": 1, "num_ctx": num_ctx},
         }).encode()
         req = urllib.request.Request(
             f"{config.OLLAMA_URL}/api/generate",
@@ -173,7 +177,8 @@ def _ensure_vision_ready(max_wait_s=None, _probe=None, _sleep=None):
         decision, reason = rp.decide(result)
     if decision == "WAIT":
         print(f"  [backpressure] still busy after {max_wait_s:.0f}s — proceeding anyway (sensor, not gate)")
-    if not rp.is_model_loaded(result, config.VISION_MODEL):
+    import settings as _settings
+    if not rp.is_model_loaded(result, _settings.vision_model()):
         _warm_up_vision_model()
     return result
 

--- a/llm.py
+++ b/llm.py
@@ -90,8 +90,11 @@ def vision(
     image_b64: str,
     model: Optional[str] = None,
     provider: Provider = Provider.OLLAMA,
+    num_ctx: Optional[int] = None,
 ) -> Dict[str, Any]:
     model = model or OLLAMA_VISION_MODEL
+    if num_ctx is None:
+        num_ctx = OLLAMA_VISION_NUM_CTX
     start = time.time()
     response = _ollama_post(
         "/api/generate",
@@ -100,7 +103,7 @@ def vision(
             "prompt": prompt,
             "images": [image_b64],
             "stream": False,
-            "options": {"num_ctx": OLLAMA_VISION_NUM_CTX},
+            "options": {"num_ctx": num_ctx},
         },
         timeout=300,
     )

--- a/query_builder.py
+++ b/query_builder.py
@@ -1,0 +1,170 @@
+"""Phase 9.7 G6 — structured query builder.
+
+Turns a JSON query spec into a parameterized SQL WHERE clause (+ a list of
+semantic terms the caller runs through the vector index separately). Every
+field maps to a known media column or the tags table — there is no free-form
+column name, and every value is bound as a parameter, so a hostile spec can't
+inject SQL or read arbitrary columns.
+
+Spec shape::
+
+    {
+      "match": "all" | "any",          # AND / OR across conditions (default all)
+      "conditions": [
+        {"field": "tag",        "op": "contains", "value": "貓"},
+        {"field": "transcript", "op": "contains", "value": "咖啡"},
+        {"field": "camera",     "op": "eq",       "value": "ILME-FX30"},
+        {"field": "rating",     "op": "eq",       "value": "good"},   # 'unrated' = NULL
+        {"field": "duration",   "op": "range",    "value": [10, 120]},  # seconds
+        {"field": "date",       "op": "range",    "value": ["2026-01-01", null]},
+        {"field": "media_type", "op": "eq",       "value": "video"},
+        {"field": "semantic",   "op": "contains", "value": "海邊的日落"}
+      ]
+    }
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+
+class QueryError(ValueError):
+    """Raised on an unknown field, disallowed op, or malformed value."""
+
+
+# field -> (column, {allowed ops}, kind). kind drives value handling.
+#   text    : contains (LIKE %v%) / eq (= v)
+#   numeric : range ([min,max], either bound may be null)
+#   enum    : eq, special NULL handling for rating='unrated'
+#   tag     : subquery against tags
+#   bucket  : ext IN (video/audio buckets)
+#   semantic: not SQL — collected for the vector index
+_FIELDS: Dict[str, Tuple[Optional[str], set, str]] = {
+    "tag": (None, {"contains", "eq"}, "tag"),
+    "transcript": ("transcript", {"contains"}, "text"),
+    "filename": ("filename", {"contains", "eq"}, "text"),
+    "camera": ("camera_model", {"contains", "eq"}, "text"),
+    "content_type": ("content_type", {"contains", "eq"}, "text"),
+    "lang": ("lang", {"eq"}, "text"),
+    "rating": ("rating", {"eq"}, "enum"),
+    "iso": ("iso", {"range"}, "numeric"),
+    "duration": ("duration_s", {"range"}, "numeric"),
+    "date": ("processed_at", {"range"}, "numeric"),
+    "media_type": (None, {"eq"}, "bucket"),
+    "semantic": (None, {"contains"}, "semantic"),
+}
+
+# ext buckets — kept in sync with server._VIDEO_EXTS / _AUDIO_EXTS.
+_VIDEO_EXTS = (".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts", ".insv", ".360")
+_AUDIO_EXTS = (".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg")
+
+
+def _one_condition(cond: Dict[str, Any]) -> Tuple[Optional[str], List[Any], Optional[str]]:
+    """Compile one condition → (sql_fragment, params, semantic_term).
+
+    Exactly one of (sql_fragment, semantic_term) is non-None.
+    """
+    if not isinstance(cond, dict):
+        raise QueryError("each condition must be an object")
+    field = cond.get("field")
+    op = cond.get("op")
+    value = cond.get("value")
+    if field not in _FIELDS:
+        raise QueryError("unknown field: {0}".format(field))
+    column, allowed_ops, kind = _FIELDS[field]
+    if op not in allowed_ops:
+        raise QueryError("op '{0}' not allowed for field '{1}'".format(op, field))
+
+    if kind == "semantic":
+        term = str(value or "").strip()
+        if not term:
+            raise QueryError("semantic condition needs a non-empty value")
+        return None, [], term
+
+    if kind == "tag":
+        v = str(value or "").strip()
+        if not v:
+            raise QueryError("tag condition needs a non-empty value")
+        if op == "eq":
+            return "id IN (SELECT media_id FROM tags WHERE name = ?)", [v], None
+        return "id IN (SELECT media_id FROM tags WHERE name LIKE ?)", ["%{0}%".format(v)], None
+
+    if kind == "bucket":
+        v = str(value or "").lower()
+        if v == "video":
+            exts = _VIDEO_EXTS
+        elif v == "audio":
+            exts = _AUDIO_EXTS
+        else:
+            raise QueryError("media_type must be 'video' or 'audio'")
+        placeholders = ",".join("?" * len(exts))
+        return "LOWER(ext) IN ({0})".format(placeholders), list(exts), None
+
+    if kind == "enum":  # rating
+        v = str(value or "").strip()
+        if v == "unrated":
+            return "rating IS NULL", [], None
+        return "{0} = ?".format(column), [v], None
+
+    if kind == "text":
+        v = str(value or "").strip()
+        if not v:
+            raise QueryError("{0} condition needs a non-empty value".format(field))
+        if op == "eq":
+            return "{0} = ?".format(column), [v], None
+        return "{0} LIKE ?".format(column), ["%{0}%".format(v)], None
+
+    if kind == "numeric":  # range, value = [min, max] (either may be null)
+        if not isinstance(value, (list, tuple)) or len(value) != 2:
+            raise QueryError("{0} range needs a [min, max] pair".format(field))
+        lo, hi = value
+        frags, params = [], []
+        if lo is not None:
+            frags.append("{0} >= ?".format(column))
+            params.append(lo)
+        if hi is not None:
+            frags.append("{0} <= ?".format(column))
+            params.append(hi)
+        if not frags:
+            raise QueryError("{0} range needs at least one bound".format(field))
+        return "(" + " AND ".join(frags) + ")", params, None
+
+    raise QueryError("unsupported field kind: {0}".format(kind))  # pragma: no cover
+
+
+def compile_spec(spec: Dict[str, Any]) -> Dict[str, Any]:
+    """Compile a full spec → {where, params, semantic_terms, match}.
+
+    `where` is the SQL after WHERE (empty string if no SQL conditions). The
+    caller runs each semantic term through the vector index and combines the
+    media-id sets using `match` (all = intersect, any = union).
+    """
+    if not isinstance(spec, dict):
+        raise QueryError("query spec must be an object")
+    match = (spec.get("match") or "all").lower()
+    if match not in ("all", "any"):
+        raise QueryError("match must be 'all' or 'any'")
+    conditions = spec.get("conditions")
+    if not isinstance(conditions, list) or not conditions:
+        raise QueryError("query needs at least one condition")
+    if len(conditions) > 32:
+        raise QueryError("too many conditions (max 32)")
+
+    sql_frags: List[str] = []
+    params: List[Any] = []
+    semantic_terms: List[str] = []
+    for cond in conditions:
+        frag, frag_params, term = _one_condition(cond)
+        if term is not None:
+            semantic_terms.append(term)
+        else:
+            sql_frags.append(frag)
+            params.extend(frag_params)
+
+    joiner = " AND " if match == "all" else " OR "
+    where = joiner.join(sql_frags)
+    return {
+        "where": where,
+        "params": params,
+        "semantic_terms": semantic_terms,
+        "match": match,
+    }

--- a/server.py
+++ b/server.py
@@ -30,6 +30,7 @@ import corrections
 import db
 import federation
 import projects as project_registry
+import settings as settings_store
 import smart_collections
 import tag_aliases
 import tag_quality
@@ -640,6 +641,76 @@ def projects_health(
     return {"projects": projects, "total": len(projects), "ok": ok_count}
 
 
+# --- Phase 9.7 G5②: persisted settings (curated key/value overrides) ---
+
+def _resolve_settings_scope(scope: str) -> str:
+    """Validate the scope param. 'global' is the library-wide default; any other
+    value must be a known project root (registry or the current PROJECT_ROOT) —
+    we never let an arbitrary string become a scope row, so the table can't be
+    used as free-form key/value storage."""
+    if not scope or scope == settings_store.GLOBAL_SCOPE:
+        return settings_store.GLOBAL_SCOPE
+    known = {str(config.PROJECT_ROOT)}
+    try:
+        known.update(p.path for p in project_registry.list_registry_projects())
+    except project_registry.RegistryError:
+        pass
+    if scope not in known:
+        raise HTTPException(status_code=400, detail="unknown settings scope: {0}".format(scope))
+    return scope
+
+
+@app.get("/api/settings")
+def get_settings(
+    scope: str = "global",
+    _tok: dict = Depends(require_scopes("projects_read")),
+):
+    """Effective settings (default ← global ← project) + metadata per key."""
+    resolved = _resolve_settings_scope(scope)
+    project = None if resolved == settings_store.GLOBAL_SCOPE else resolved
+    return {"scope": resolved, "settings": settings_store.describe(project=project)}
+
+
+class SettingsUpdate(BaseModel):
+    scope: str = "global"
+    values: dict
+
+
+@app.put("/api/settings")
+def put_settings(
+    body: SettingsUpdate,
+    _tok: dict = Depends(require_scopes("admin")),
+):
+    """Persist a batch of overrides at the given scope. Validate-all-then-write:
+    a single bad key/value rejects the whole batch (422), nothing is stored."""
+    resolved = _resolve_settings_scope(body.scope)
+    try:
+        written = settings_store.put(body.values, scope=resolved)
+    except settings_store.SettingError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+    project = None if resolved == settings_store.GLOBAL_SCOPE else resolved
+    return {
+        "scope": resolved,
+        "written": written,
+        "settings": settings_store.describe(project=project),
+    }
+
+
+@app.delete("/api/settings/{key}")
+def reset_setting(
+    key: str,
+    scope: str = "global",
+    _tok: dict = Depends(require_scopes("admin")),
+):
+    """Drop one override so the key falls back to the next layer down."""
+    resolved = _resolve_settings_scope(scope)
+    try:
+        settings_store.reset(key, scope=resolved)
+    except settings_store.SettingError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return {"scope": resolved, "reset": key}
+
+
 @app.get("/api/media/position/{media_id}")
 def media_position(
     media_id: int,
@@ -917,6 +988,102 @@ def list_media(
         rec["tags"] = tags_by_id.get(rec["id"], [])
 
     return {"items": records, "total": total, "search": False}
+
+
+class StructuredQuery(BaseModel):
+    # Phase 9.7 G6: structured query — AND/OR over typed field conditions, with
+    # an optional semantic (vector) leg. `conditions` is validated by
+    # query_builder.compile_spec; we keep the model permissive and let the
+    # builder raise the precise error.
+    match: str = "all"
+    conditions: List[dict]
+    limit: int = 50
+    offset: int = 0
+    sort: str = "date"
+
+
+def _structured_sort_key(sort: str):
+    if sort == "duration":
+        return lambda r: (r.get("duration_s") or 0), True
+    if sort == "size":
+        return lambda r: (r.get("size_mb") or 0), True
+    if sort == "name":
+        return lambda r: (r.get("filename") or "").lower(), False
+    # default: most recent first
+    return lambda r: (r.get("processed_at") or ""), True
+
+
+@app.post("/api/search/query")
+def structured_query(
+    body: StructuredQuery,
+    _tok: dict = Depends(require_scopes("videos_read")),
+):
+    """Structured query: typed field conditions combined by AND/OR, with an
+    optional semantic leg run through the vector index. Returns the same
+    `{items, total, search}` shape as /api/media so the UI can reuse renderers."""
+    import query_builder
+
+    try:
+        compiled = query_builder.compile_spec(
+            {"match": body.match, "conditions": body.conditions}
+        )
+    except query_builder.QueryError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    where, params = compiled["where"], compiled["params"]
+    terms, match = compiled["semantic_terms"], compiled["match"]
+    warning = None
+
+    sql_ids = None
+    if where:
+        with db.get_conn() as conn:
+            rows = conn.execute(
+                "SELECT id FROM media WHERE " + where, params
+            ).fetchall()
+        sql_ids = {r["id"] for r in rows}
+
+    sem_ids = None
+    if terms:
+        import vectordb as vdb
+        sets = []
+        for term in terms:
+            try:
+                raw = vdb.search(term, n_results=2000)
+                sets.append({int(r["media_id"]) for r in raw})
+            except Exception as exc:  # Ollama down / dim mismatch → degrade, flag it
+                _logging.getLogger(__name__).warning(
+                    "structured query semantic leg failed: %s", exc
+                )
+                warning = "semantic search unavailable (some terms ignored)"
+                sets.append(set())
+        if sets:
+            sem_ids = set.intersection(*sets) if match == "all" else set.union(*sets)
+
+    if sql_ids is not None and sem_ids is not None:
+        final_ids = (sql_ids & sem_ids) if match == "all" else (sql_ids | sem_ids)
+    elif sql_ids is not None:
+        final_ids = sql_ids
+    else:
+        final_ids = sem_ids or set()
+
+    records = _get_light_records_by_ids(list(final_ids))
+    keyfn, reverse = _structured_sort_key(body.sort)
+    records.sort(key=keyfn, reverse=reverse)
+
+    total = len(records)
+    offset = max(0, body.offset)
+    limit = max(1, min(500, body.limit))
+    items = records[offset:offset + limit]
+    tags_by_id = _get_tags_bulk([rec["id"] for rec in items])
+    for rec in items:
+        _resolve_record(rec)
+        rec["tags"] = tags_by_id.get(rec["id"], [])
+
+    resp = {"items": items, "total": total, "search": True, "structured": True}
+    if warning:
+        resp["search_degraded"] = True
+        resp["warning"] = warning
+    return resp
 
 
 @app.get("/api/media/{media_id}")
@@ -1506,7 +1673,9 @@ def export_metadata_csv(
 
 
 class MetadataCsvExportRequest(BaseModel):
-    dest: str
+    # dest optional: when omitted/blank, fall back to the persisted
+    # export.default_dir setting (Phase 9.7 G5③) + a default filename.
+    dest: Optional[str] = None
     ids: Optional[list] = None  # batch-scoped variant; None = full library
 
 
@@ -1523,7 +1692,18 @@ def export_metadata_csv_to(
     所以 Tauri front-end 用 dialog.save 拿 path 後 POST 來這裡，由 server 直接寫
     檔；browser 端則繼續用 GET + blob download。
     body.ids 給時為 batch-scoped；不給為整庫匯出。"""
-    dest = Path(body.dest).expanduser().resolve()
+    # Phase 9.7 G5③: resolve dest from the request, else the persisted
+    # export.default_dir setting (+ a default filename). A bare directory also
+    # gets the default filename appended.
+    raw_dest = (body.dest or "").strip()
+    if not raw_dest:
+        default_dir = settings_store.effective("export.default_dir")
+        if not default_dir:
+            raise HTTPException(400, "no dest provided and export.default_dir is unset")
+        raw_dest = str(Path(default_dir) / "arkiv-metadata.csv")
+    dest = Path(raw_dest).expanduser().resolve()
+    if dest.is_dir() or raw_dest.endswith(("/", "\\")):
+        dest = dest / "arkiv-metadata.csv"
     _assert_export_dest_safe(dest)
     dest.parent.mkdir(parents=True, exist_ok=True)
     media_ids = None
@@ -1689,9 +1869,17 @@ def ingest_engines(
         {"mode": k, "name": config.WHISPER_GUARD_LAYERS[k].get("name", str(k))}
         for k in sorted(config.WHISPER_GUARD_LAYERS)
     ]
+    # Phase 9.7 G5③: the dialog's defaults come from the persisted settings
+    # (library default), falling back to config. These are genuinely consumed —
+    # IngestSetup pre-fills its pickers from them, and the vision model/num_ctx
+    # are what an ingest run actually uses (ingest.py reads settings.effective).
     return {
         "whisper_modes": modes,
-        "default_mode": config.WHISPER_GUARD_DEFAULT_MODE,
+        "default_mode": settings_store.effective("transcription.default_mode"),
+        "default_language": settings_store.effective("transcription.default_language"),
+        "default_recursive": settings_store.effective("ingest.recursive"),
+        "vision_model": settings_store.effective("vision.model"),
+        "vision_num_ctx": settings_store.effective("vision.num_ctx"),
         "languages": _INGEST_LANGUAGES,
     }
 

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,237 @@
+"""Phase 9.7 G5② — persisted, curated settings overrides.
+
+config.py holds the baked-in defaults (env-driven). This module layers an
+operator-editable override on top, persisted in the `settings` table:
+
+    effective(key) = SCHEMA default ← global row ← project row
+
+Only keys declared in SETTINGS_SCHEMA can ever be read or written, so a
+malicious/garbage PUT can't poison arbitrary state. Each key carries a type
+that PUT coerces + validates against; an out-of-range / wrong-type value is
+rejected (422) rather than silently stored.
+
+Discipline note (no-fake): a setting only belongs here if something actually
+consumes it. The pipeline / export paths read these via effective(); the
+frontend pre-fills its pickers from the same values. We do NOT add a control
+that has no downstream effect.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Dict, List, Optional
+
+import config
+import db
+
+GLOBAL_SCOPE = "global"
+
+
+class SettingError(ValueError):
+    """Raised on an unknown key, non-editable key, or invalid value."""
+
+
+# Each entry: group/label for the UI, a `type`, a lazy `default` (callable so a
+# test that rebinds config still gets the live default), optional `choices` for
+# enums and `min`/`max` for numerics, and `editable` (False = read-only surface).
+def _schema() -> Dict[str, Dict[str, Any]]:
+    return {
+        # --- Transcription ---
+        "transcription.default_mode": {
+            "group": "transcription",
+            "label": "Whisper guard mode (0–4)",
+            "type": "int",
+            "default": lambda: config.WHISPER_GUARD_DEFAULT_MODE,
+            "min": 0,
+            "max": 4,
+        },
+        "transcription.default_language": {
+            "group": "transcription",
+            "label": "Forced language (blank = auto-detect)",
+            "type": "str",
+            "default": lambda: "",
+        },
+        # --- Vision ---
+        "vision.model": {
+            "group": "vision",
+            "label": "Ollama vision model",
+            "type": "str",
+            "default": lambda: config.OLLAMA_VISION_MODEL,
+        },
+        "vision.num_ctx": {
+            "group": "vision",
+            "label": "Vision context window (num_ctx)",
+            "type": "int",
+            "default": lambda: config.OLLAMA_VISION_NUM_CTX,
+            "min": 512,
+            "max": 131072,
+        },
+        # --- Export defaults ---
+        "export.default_dir": {
+            "group": "export",
+            "label": "Default export directory (blank = browser download)",
+            "type": "str",
+            "default": lambda: "",
+        },
+        # --- Ingest defaults ---
+        "ingest.recursive": {
+            "group": "ingest",
+            "label": "Recurse into sub-folders by default",
+            "type": "bool",
+            "default": lambda: True,
+        },
+    }
+
+
+# Built once per process; cheap to rebuild but stable across a request.
+SETTINGS_SCHEMA: Dict[str, Dict[str, Any]] = _schema()
+
+
+def _coerce(key: str, raw: Any) -> Any:
+    """Coerce + validate a raw value against the key's schema type."""
+    spec = SETTINGS_SCHEMA.get(key)
+    if spec is None:
+        raise SettingError(f"unknown setting key: {key}")
+    if not spec.get("editable", True):
+        raise SettingError(f"setting is read-only: {key}")
+    t = spec["type"]
+    if t == "int":
+        try:
+            v = int(raw)
+        except (TypeError, ValueError):
+            raise SettingError(f"{key} must be an integer")
+        lo, hi = spec.get("min"), spec.get("max")
+        if lo is not None and v < lo:
+            raise SettingError(f"{key} must be >= {lo}")
+        if hi is not None and v > hi:
+            raise SettingError(f"{key} must be <= {hi}")
+        return v
+    if t == "bool":
+        if isinstance(raw, bool):
+            return raw
+        if isinstance(raw, str):
+            return raw.strip().lower() in ("1", "true", "yes", "on")
+        return bool(raw)
+    if t == "str":
+        v = "" if raw is None else str(raw)
+        choices = spec.get("choices")
+        if choices is not None and v not in choices:
+            raise SettingError(f"{key} must be one of {choices}")
+        return v
+    raise SettingError(f"unsupported setting type: {t}")
+
+
+def _stored_to_typed(key: str, stored: str) -> Any:
+    """Decode a stored (always-TEXT) value back to its typed form."""
+    spec = SETTINGS_SCHEMA[key]
+    t = spec["type"]
+    if t == "int":
+        try:
+            return int(stored)
+        except (TypeError, ValueError):
+            return spec["default"]()
+    if t == "bool":
+        return str(stored).strip().lower() in ("1", "true", "yes", "on")
+    return "" if stored is None else str(stored)
+
+
+def _typed_to_stored(value: Any) -> str:
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    return str(value)
+
+
+def _rows_for(scope: str) -> Dict[str, str]:
+    with db.get_conn() as conn:
+        rows = conn.execute(
+            "SELECT key, value FROM settings WHERE scope = ?", (scope,)
+        ).fetchall()
+    return {r["key"]: r["value"] for r in rows}
+
+
+def effective(key: str, project: Optional[str] = None) -> Any:
+    """Resolve the effective value: default ← global ← project."""
+    if key not in SETTINGS_SCHEMA:
+        raise SettingError(f"unknown setting key: {key}")
+    value = SETTINGS_SCHEMA[key]["default"]()
+    g = _rows_for(GLOBAL_SCOPE)
+    if key in g and g[key] is not None:
+        value = _stored_to_typed(key, g[key])
+    if project:
+        p = _rows_for(project)
+        if key in p and p[key] is not None:
+            value = _stored_to_typed(key, p[key])
+    return value
+
+
+def vision_model(project: Optional[str] = None) -> str:
+    """Effective vision model for an ingest run. Equals config.VISION_MODEL when
+    unset, so wiring this in is behavior-preserving until an operator overrides."""
+    return effective("vision.model", project=project)
+
+
+def vision_num_ctx(project: Optional[str] = None) -> int:
+    """Effective vision num_ctx. Equals config.OLLAMA_VISION_NUM_CTX when unset."""
+    return effective("vision.num_ctx", project=project)
+
+
+def describe(project: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Effective settings + metadata for every schema key (for GET)."""
+    g = _rows_for(GLOBAL_SCOPE)
+    p = _rows_for(project) if project else {}
+    out: List[Dict[str, Any]] = []
+    for key, spec in SETTINGS_SCHEMA.items():
+        default = spec["default"]()
+        value = default
+        source = "default"
+        if key in g and g[key] is not None:
+            value = _stored_to_typed(key, g[key])
+            source = "global"
+        if project and key in p and p[key] is not None:
+            value = _stored_to_typed(key, p[key])
+            source = "project"
+        item = {
+            "key": key,
+            "group": spec["group"],
+            "label": spec["label"],
+            "type": spec["type"],
+            "value": value,
+            "default": default,
+            "source": source,
+            "editable": spec.get("editable", True),
+        }
+        for opt in ("choices", "min", "max"):
+            if opt in spec:
+                item[opt] = spec[opt]
+        out.append(item)
+    return out
+
+
+def put(values: Dict[str, Any], scope: str = GLOBAL_SCOPE) -> List[str]:
+    """Validate + persist a batch of overrides. Returns the keys written.
+
+    Raises SettingError on the first invalid key/value — nothing is written in
+    that case (validate-all-then-write), so a bad key can't leave a partial set.
+    """
+    if not isinstance(values, dict) or not values:
+        raise SettingError("values must be a non-empty object")
+    coerced = {k: _coerce(k, v) for k, v in values.items()}  # validates all first
+    with db.get_conn() as conn:
+        for key, val in coerced.items():
+            conn.execute(
+                "INSERT INTO settings(scope, key, value, updated_at) "
+                "VALUES(?, ?, ?, datetime('now')) "
+                "ON CONFLICT(scope, key) DO UPDATE SET "
+                "value=excluded.value, updated_at=excluded.updated_at",
+                (scope, key, _typed_to_stored(val)),
+            )
+        conn.commit()
+    return list(coerced.keys())
+
+
+def reset(key: str, scope: str = GLOBAL_SCOPE) -> None:
+    """Drop an override so the key falls back to the next layer down."""
+    if key not in SETTINGS_SCHEMA:
+        raise SettingError(f"unknown setting key: {key}")
+    with db.get_conn() as conn:
+        conn.execute("DELETE FROM settings WHERE scope = ? AND key = ?", (scope, key))
+        conn.commit()

--- a/tests/test_query_builder_g6.py
+++ b/tests/test_query_builder_g6.py
@@ -1,0 +1,188 @@
+"""Phase 9.7 G6 — structured query builder (pure compile + API)."""
+import importlib
+
+import pytest
+
+import query_builder as qb
+
+
+# ---- pure compile_spec unit tests ----
+
+def test_text_contains_and_eq():
+    c = qb.compile_spec({"conditions": [
+        {"field": "camera", "op": "contains", "value": "FX30"},
+    ]})
+    assert c["where"] == "camera_model LIKE ?"
+    assert c["params"] == ["%FX30%"]
+
+    c = qb.compile_spec({"conditions": [
+        {"field": "camera", "op": "eq", "value": "ILME-FX30"},
+    ]})
+    assert c["where"] == "camera_model = ?"
+    assert c["params"] == ["ILME-FX30"]
+
+
+def test_rating_unrated_is_null():
+    c = qb.compile_spec({"conditions": [
+        {"field": "rating", "op": "eq", "value": "unrated"},
+    ]})
+    assert c["where"] == "rating IS NULL"
+    assert c["params"] == []
+
+
+def test_tag_subquery():
+    c = qb.compile_spec({"conditions": [
+        {"field": "tag", "op": "contains", "value": "貓"},
+    ]})
+    assert "SELECT media_id FROM tags WHERE name LIKE ?" in c["where"]
+    assert c["params"] == ["%貓%"]
+
+
+def test_numeric_range_both_bounds():
+    c = qb.compile_spec({"conditions": [
+        {"field": "duration", "op": "range", "value": [10, 120]},
+    ]})
+    assert c["where"] == "(duration_s >= ? AND duration_s <= ?)"
+    assert c["params"] == [10, 120]
+
+
+def test_numeric_range_open_upper():
+    c = qb.compile_spec({"conditions": [
+        {"field": "duration", "op": "range", "value": [10, None]},
+    ]})
+    assert c["where"] == "(duration_s >= ?)"
+    assert c["params"] == [10]
+
+
+def test_media_type_bucket():
+    c = qb.compile_spec({"conditions": [
+        {"field": "media_type", "op": "eq", "value": "video"},
+    ]})
+    assert c["where"].startswith("LOWER(ext) IN (")
+    assert ".mp4" in c["params"]
+
+
+def test_match_all_vs_any_joiner():
+    spec = {"match": "any", "conditions": [
+        {"field": "camera", "op": "contains", "value": "FX30"},
+        {"field": "lang", "op": "eq", "value": "zh"},
+    ]}
+    c = qb.compile_spec(spec)
+    assert " OR " in c["where"]
+    c2 = qb.compile_spec({**spec, "match": "all"})
+    assert " AND " in c2["where"]
+
+
+def test_semantic_term_is_separated_not_sql():
+    c = qb.compile_spec({"conditions": [
+        {"field": "semantic", "op": "contains", "value": "海邊日落"},
+        {"field": "lang", "op": "eq", "value": "zh"},
+    ]})
+    assert c["semantic_terms"] == ["海邊日落"]
+    assert c["where"] == "lang = ?"
+
+
+def test_unknown_field_and_bad_op_rejected():
+    with pytest.raises(qb.QueryError):
+        qb.compile_spec({"conditions": [{"field": "nope", "op": "eq", "value": 1}]})
+    with pytest.raises(qb.QueryError):
+        qb.compile_spec({"conditions": [{"field": "duration", "op": "contains", "value": 1}]})
+
+
+def test_empty_conditions_rejected():
+    with pytest.raises(qb.QueryError):
+        qb.compile_spec({"conditions": []})
+
+
+# ---- API tests (SQL legs; semantic leg degrades cleanly without Ollama) ----
+
+def _seed(db):
+    db.upsert({
+        "path": "/tmp/a.mp4", "filename": "a.mp4", "ext": ".mp4",
+        "duration_s": 15.0, "size_mb": 5.0, "width": 1920, "height": 1080,
+        "fps": 30.0, "has_audio": 1, "transcript": "海邊的咖啡廳", "lang": "zh",
+        "frame_tags": "", "thumbnail_path": "/tmp/a.jpg",
+        "processed_at": "2026-05-01T09:00:00", "rating": "good",
+        "camera_model": "ILME-FX30",
+    })
+    db.upsert({
+        "path": "/tmp/b.mov", "filename": "b.mov", "ext": ".mov",
+        "duration_s": 200.0, "size_mb": 80.0, "width": 1920, "height": 1080,
+        "fps": 24.0, "has_audio": 1, "transcript": "棚內訪談", "lang": "zh",
+        "frame_tags": "", "thumbnail_path": "/tmp/b.jpg",
+        "processed_at": "2026-05-02T09:00:00", "rating": "ng",
+        "camera_model": "Canon R5",
+    })
+    db.upsert({
+        "path": "/tmp/c.mp3", "filename": "c.mp3", "ext": ".mp3",
+        "duration_s": 60.0, "size_mb": 2.0, "width": 0, "height": 0,
+        "fps": 0.0, "has_audio": 1, "transcript": "純音訊", "lang": "zh",
+        "frame_tags": "", "thumbnail_path": "",
+        "processed_at": "2026-05-03T09:00:00",
+    })
+
+
+def test_query_camera_eq(fastapi_client, server_module):
+    db = importlib.import_module("db")
+    _seed(db)
+    r = fastapi_client.post("/api/search/query", json={
+        "conditions": [{"field": "camera", "op": "eq", "value": "ILME-FX30"}],
+    })
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["structured"] is True
+    assert {it["filename"] for it in body["items"]} == {"a.mp4"}
+
+
+def test_query_rating_and_duration_range_all(fastapi_client, server_module):
+    db = importlib.import_module("db")
+    _seed(db)
+    r = fastapi_client.post("/api/search/query", json={
+        "match": "all",
+        "conditions": [
+            {"field": "rating", "op": "eq", "value": "good"},
+            {"field": "duration", "op": "range", "value": [10, 60]},
+        ],
+    })
+    assert r.status_code == 200
+    assert {it["filename"] for it in r.json()["items"]} == {"a.mp4"}
+
+
+def test_query_media_type_audio(fastapi_client, server_module):
+    db = importlib.import_module("db")
+    _seed(db)
+    r = fastapi_client.post("/api/search/query", json={
+        "conditions": [{"field": "media_type", "op": "eq", "value": "audio"}],
+    })
+    assert {it["filename"] for it in r.json()["items"]} == {"c.mp3"}
+
+
+def test_query_match_any_union(fastapi_client, server_module):
+    db = importlib.import_module("db")
+    _seed(db)
+    r = fastapi_client.post("/api/search/query", json={
+        "match": "any",
+        "conditions": [
+            {"field": "camera", "op": "eq", "value": "ILME-FX30"},
+            {"field": "rating", "op": "eq", "value": "ng"},
+        ],
+    })
+    assert {it["filename"] for it in r.json()["items"]} == {"a.mp4", "b.mov"}
+
+
+def test_query_tag_condition(fastapi_client, server_module):
+    db = importlib.import_module("db")
+    _seed(db)
+    # tag the FX30 clip (id 1)
+    db.add_tag(1, "海景")
+    r = fastapi_client.post("/api/search/query", json={
+        "conditions": [{"field": "tag", "op": "eq", "value": "海景"}],
+    })
+    assert {it["filename"] for it in r.json()["items"]} == {"a.mp4"}
+
+
+def test_query_invalid_spec_is_422(fastapi_client):
+    r = fastapi_client.post("/api/search/query", json={
+        "conditions": [{"field": "bogus", "op": "eq", "value": 1}],
+    })
+    assert r.status_code == 422

--- a/tests/test_settings_g5.py
+++ b/tests/test_settings_g5.py
@@ -1,0 +1,118 @@
+"""Phase 9.7 G5② — persisted settings overrides (module + API)."""
+import importlib
+
+import pytest
+
+
+# ---- module-level unit tests (default ← global ← project) ----
+
+def test_effective_falls_back_to_config_default(tmp_db):
+    settings = importlib.reload(importlib.import_module("settings"))
+    config = importlib.import_module("config")
+    assert settings.effective("vision.num_ctx") == config.OLLAMA_VISION_NUM_CTX
+    assert settings.effective("export.default_dir") == ""
+    assert settings.effective("transcription.default_mode") == config.WHISPER_GUARD_DEFAULT_MODE
+
+
+def test_global_override_then_project_override_layering(tmp_db):
+    settings = importlib.reload(importlib.import_module("settings"))
+    settings.put({"vision.num_ctx": 8192})
+    assert settings.effective("vision.num_ctx") == 8192
+    # project layer wins over global for that project, global untouched elsewhere
+    settings.put({"vision.num_ctx": 4096}, scope="/some/project")
+    assert settings.effective("vision.num_ctx", project="/some/project") == 4096
+    assert settings.effective("vision.num_ctx") == 8192
+    assert settings.effective("vision.num_ctx", project="/other") == 8192
+
+
+def test_reset_drops_override(tmp_db):
+    settings = importlib.reload(importlib.import_module("settings"))
+    config = importlib.import_module("config")
+    settings.put({"vision.num_ctx": 8192})
+    settings.reset("vision.num_ctx")
+    assert settings.effective("vision.num_ctx") == config.OLLAMA_VISION_NUM_CTX
+
+
+def test_unknown_key_rejected(tmp_db):
+    settings = importlib.reload(importlib.import_module("settings"))
+    with pytest.raises(settings.SettingError):
+        settings.put({"vision.no_such_key": 1})
+    with pytest.raises(settings.SettingError):
+        settings.effective("nope.nope")
+
+
+def test_int_range_validation(tmp_db):
+    settings = importlib.reload(importlib.import_module("settings"))
+    with pytest.raises(settings.SettingError):
+        settings.put({"transcription.default_mode": 9})  # max 4
+    with pytest.raises(settings.SettingError):
+        settings.put({"transcription.default_mode": "abc"})
+
+
+def test_validate_all_then_write_is_atomic(tmp_db):
+    """A bad key in the batch must roll back the whole PUT (nothing stored)."""
+    settings = importlib.reload(importlib.import_module("settings"))
+    config = importlib.import_module("config")
+    with pytest.raises(settings.SettingError):
+        settings.put({"vision.num_ctx": 8192, "vision.bad": 1})
+    # the good key must NOT have been written
+    assert settings.effective("vision.num_ctx") == config.OLLAMA_VISION_NUM_CTX
+
+
+def test_bool_coercion_round_trips(tmp_db):
+    settings = importlib.reload(importlib.import_module("settings"))
+    settings.put({"ingest.recursive": False})
+    assert settings.effective("ingest.recursive") is False
+    settings.put({"ingest.recursive": "true"})
+    assert settings.effective("ingest.recursive") is True
+
+
+# ---- API tests ----
+
+def test_get_settings_returns_schema_with_sources(fastapi_client):
+    r = fastapi_client.get("/api/settings")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["scope"] == "global"
+    keys = {s["key"]: s for s in body["settings"]}
+    assert "vision.num_ctx" in keys
+    assert keys["vision.num_ctx"]["source"] == "default"
+    assert keys["vision.num_ctx"]["type"] == "int"
+
+
+def test_put_settings_persists_and_reports_source(fastapi_client):
+    r = fastapi_client.put(
+        "/api/settings", json={"scope": "global", "values": {"vision.num_ctx": 2048}}
+    )
+    assert r.status_code == 200, r.text
+    assert "vision.num_ctx" in r.json()["written"]
+    g = fastapi_client.get("/api/settings").json()
+    row = next(s for s in g["settings"] if s["key"] == "vision.num_ctx")
+    assert row["value"] == 2048
+    assert row["source"] == "global"
+
+
+def test_put_invalid_value_is_422(fastapi_client):
+    r = fastapi_client.put(
+        "/api/settings", json={"scope": "global", "values": {"transcription.default_mode": 99}}
+    )
+    assert r.status_code == 422
+
+
+def test_put_unknown_scope_is_400(fastapi_client):
+    r = fastapi_client.put(
+        "/api/settings",
+        json={"scope": "/not/a/known/project", "values": {"vision.num_ctx": 2048}},
+    )
+    assert r.status_code == 400
+
+
+def test_delete_setting_resets(fastapi_client):
+    fastapi_client.put(
+        "/api/settings", json={"scope": "global", "values": {"export.default_dir": "/tmp/x"}}
+    )
+    r = fastapi_client.delete("/api/settings/export.default_dir")
+    assert r.status_code == 200
+    g = fastapi_client.get("/api/settings").json()
+    row = next(s for s in g["settings"] if s["key"] == "export.default_dir")
+    assert row["source"] == "default"

--- a/vision.py
+++ b/vision.py
@@ -147,9 +147,14 @@ def _call_vision(img_path, prompt, max_retries=2):
     """Send image to Ollama vision, return raw response text."""
     with open(img_path, "rb") as f:
         b64 = base64.b64encode(f.read()).decode()
+    # Phase 9.7 G5③: honor the operator's library default (settings table),
+    # falling back to config.VISION_MODEL / num_ctx when unset (behavior-preserving).
+    import settings as _settings
+    eff_model = _settings.vision_model()
+    eff_num_ctx = _settings.vision_num_ctx()
     for attempt in range(max_retries):
         try:
-            resp = vision(prompt=prompt, image_b64=b64, model=VISION_MODEL)
+            resp = vision(prompt=prompt, image_b64=b64, model=eff_model, num_ctx=eff_num_ctx)
             raw = resp.get("text", "").strip()
             raw = re.sub(r"^```(?:json)?\s*", "", raw)
             raw = re.sub(r"\s*```$", "", raw)


### PR DESCRIPTION
Replaces auto-closed #107 (its base branch `feat/g5-settings-tabs` was deleted when #106 merged, which closed the PR; head branch was intact and is rebased onto main here).

## Scope — Phase 9.7 G5② + G6

**G5② — settings persistence (genuine consumption, not a fake panel).**
- `settings` table (scope/key/value, UNIQUE(scope,key)); curated `SETTINGS_SCHEMA` (6 keys) with `default ← global ← project` layering in `settings.py`.
- `GET/PUT/DELETE /api/settings` — validate-all-then-write `put()`, `reset()`, `describe()`.
- **Really consumed:** `vision.model` / `vision.num_ctx` read by the ingest vision run + warm-up (`vision.py`, `ingest.py`, `llm.vision(num_ctx=…)`); `export.default_dir` is the fallback dest for server-write export; engines endpoint pre-fills settings-effective defaults. Behaviour-preserving when unset.
- Settings → Advanced shows the effective-value table with one-click reset; Vision/Export tabs got real persisted controls (replacing the G5① "pending" placeholders).

**G6 — structured query builder.**
- Pure `compile_spec(spec)` (`query_builder.py`): 12 whitelisted fields × contains/eq/range, AND/OR, parameterized SQL, semantic leg separated out.
- `POST /api/search/query` + `_structured_sort_key`; new `/query-live` Svelte route.

## Tests / verification
- 28 new tests (`test_settings_g5.py` 12 + `test_query_builder_g6.py` 16), all green; no regression in the full suite.
- Live-verified API round-trip (curl) + UI accessibility snapshots.
- Dropped `export.csv_columns` from the schema — DaVinci's CSV layout is fixed, so a control there would be fake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)