### PR TITLE
fix(export): RFC 6266 filename* — CJK-named clips export instead of 500ing

### DIFF
--- a/server.py
+++ b/server.py
@@ -2578,10 +2578,12 @@ def _attachment_headers(stem: str, ext: str) -> dict:
 
     name = f"{stem}.{ext}"
     ascii_fallback = _re.sub(r'[^\x20-\x7e]|["\\]', "_", name)
+    # safe="" so a "/" in the name is percent-encoded too — RFC 5987 ext-value
+    # forbids a raw "/" (not an attr-char), and quote()'s default leaves it bare.
     return {
         "Content-Disposition": (
             f'attachment; filename="{ascii_fallback}"; '
-            f"filename*=UTF-8''{quote(name)}"
+            f"filename*=UTF-8''{quote(name, safe='')}"
         )
     }
 

--- a/server.py
+++ b/server.py
@@ -2564,6 +2564,28 @@ def _start_tc_seconds(rec: dict, clip_fps: float) -> float:
     return 0.0
 
 
+def _attachment_headers(stem: str, ext: str) -> dict:
+    """Content-Disposition for a download, safe for non-ASCII (e.g. CJK) filenames.
+
+    Starlette encodes response headers as latin-1, so a raw
+    f'attachment; filename="{stem}.{ext}"' whose stem contains CJK characters
+    raises UnicodeEncodeError → 500 (broke batch + single-clip export for every
+    中日韓-named clip). Per RFC 6266/5987 we emit an ASCII-only `filename`
+    fallback (non-ASCII + quote/backslash → "_") plus a percent-encoded
+    `filename*` carrying the real UTF-8 name, which every modern client — and the
+    Tauri WKWebView — prefers."""
+    from urllib.parse import quote
+
+    name = f"{stem}.{ext}"
+    ascii_fallback = _re.sub(r'[^\x20-\x7e]|["\\]', "_", name)
+    return {
+        "Content-Disposition": (
+            f'attachment; filename="{ascii_fallback}"; '
+            f"filename*=UTF-8''{quote(name)}"
+        )
+    }
+
+
 @app.get("/api/media/{media_id}/export/{fmt}")
 def export_media(
     media_id: int,
@@ -2627,7 +2649,7 @@ def export_media(
         return HTMLResponse(
             content=content,
             media_type="text/plain; charset=utf-8",
-            headers={"Content-Disposition": f'attachment; filename="{stem}.txt"'},
+            headers=_attachment_headers(stem, "txt"),
         )
 
     if fmt == "srt":
@@ -2652,7 +2674,7 @@ def export_media(
         return HTMLResponse(
             content=srt,
             media_type="text/plain; charset=utf-8",
-            headers={"Content-Disposition": f'attachment; filename="{stem}.srt"'},
+            headers=_attachment_headers(stem, "srt"),
         )
 
     if fmt == "vtt":
@@ -2672,7 +2694,7 @@ def export_media(
         return HTMLResponse(
             content=vtt,
             media_type="text/plain; charset=utf-8",
-            headers={"Content-Disposition": f'attachment; filename="{stem}.vtt"'},
+            headers=_attachment_headers(stem, "vtt"),
         )
 
     if fmt in ("edl", "edl-markers"):
@@ -2731,7 +2753,7 @@ def export_media(
         return HTMLResponse(
             content=edl,
             media_type="text/plain; charset=utf-8",
-            headers={"Content-Disposition": f'attachment; filename="{stem}.edl"'},
+            headers=_attachment_headers(stem, "edl"),
         )
 
     if fmt == "fcpxml":
@@ -2825,7 +2847,7 @@ def export_media(
         return HTMLResponse(
             content=fcpxml,
             media_type="application/xml; charset=utf-8",
-            headers={"Content-Disposition": f'attachment; filename="{stem}.fcpxml"'},
+            headers=_attachment_headers(stem, "fcpxml"),
         )
 
     raise HTTPException(400, f"不支援的格式：{fmt}。請使用 srt/vtt/txt/edl/edl-markers/fcpxml")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -136,7 +136,9 @@ def test_export_endpoints_cover_supported_formats_and_current_json_gap(fastapi_c
     srt = fastapi_client.get("/api/media/1/export/srt")
     assert srt.status_code == 200
     assert "第一行中文逐字稿" in srt.text
-    assert srt.headers["content-disposition"].endswith("interview-zh.srt\"")
+    # RFC 6266: ASCII `filename` fallback is still present; `filename*` is appended
+    # (so the header no longer ends with the filename).
+    assert 'filename="interview-zh.srt"' in srt.headers["content-disposition"]
 
     vtt = fastapi_client.get("/api/media/1/export/vtt")
     assert vtt.status_code == 200
@@ -149,6 +151,37 @@ def test_export_endpoints_cover_supported_formats_and_current_json_gap(fastapi_c
     json_resp = fastapi_client.get("/api/media/1/export/json")
     assert json_resp.status_code == 400
     assert "json" in json_resp.json()["detail"]
+
+
+def test_export_cjk_filename_does_not_crash_header(fastapi_client, sample_record):
+    """Regression: a CJK filename used to 500 because Starlette latin-1-encodes
+    the Content-Disposition header (UnicodeEncodeError). The download must succeed
+    with an RFC 6266 `filename*` carrying the percent-encoded UTF-8 name."""
+    from urllib.parse import quote
+
+    db = importlib.import_module("db")
+    db.upsert(sample_record(
+        path="/tmp/黑沙灘.mp4",
+        filename="黑沙灘.mp4",
+        duration_s=8,
+        transcript="海浪聲",
+        lang="zh",
+    ))
+
+    for fmt in ("srt", "vtt", "txt", "edl", "fcpxml"):
+        resp = fastapi_client.get(f"/api/media/1/export/{fmt}")
+        assert resp.status_code == 200, f"{fmt} export crashed: {resp.status_code}"
+        cd = resp.headers["content-disposition"]
+        # latin-1-safe: header must encode without error and carry the real name.
+        cd.encode("latin-1")
+        assert f"filename*=UTF-8''{quote(f'黑沙灘.{fmt}')}" in cd
+
+    # Batch (#111) reuses the single-clip builder — it crashed on the same header.
+    batch = fastapi_client.post("/api/export/batch", json={"ids": [1], "fmt": "srt"})
+    assert batch.status_code == 200
+    import io, zipfile
+    names = zipfile.ZipFile(io.BytesIO(batch.content)).namelist()
+    assert names == ["黑沙灘.srt"]
 
 
 def _insert_media_with_segments(sample_record):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -184,6 +184,28 @@ def test_export_cjk_filename_does_not_crash_header(fastapi_client, sample_record
     assert names == ["黑沙灘.srt"]
 
 
+def test_export_filename_resists_header_injection(fastapi_client, sample_record):
+    """A filename carrying CR/LF or a quote must not split the response header or
+    inject a second Content-Disposition — CR/LF/`"`/`\\` are neutralized in the
+    ASCII fallback and percent-encoded in filename*."""
+    db = importlib.import_module("db")
+    db.upsert(sample_record(
+        path="/tmp/evil.mp4",
+        filename='a\r\nSet-Cookie: x=1"; filename="evil.mp4',
+        duration_s=8,
+        transcript="x",
+        lang="zh",
+    ))
+    resp = fastapi_client.get("/api/media/1/export/srt")
+    assert resp.status_code == 200
+    cd = resp.headers["content-disposition"]
+    # Single physical header line, latin-1-safe, no raw CR/LF leaked through.
+    cd.encode("latin-1")
+    assert "\r" not in cd and "\n" not in cd
+    # The only Set-Cookie the client sees must not come from our filename.
+    assert "set-cookie" not in {k.lower() for k in resp.headers}
+
+
 def _insert_media_with_segments(sample_record):
     import json as _json
     db = importlib.import_module("db")


### PR DESCRIPTION
## What

`export_media` set `Content-Disposition: filename="{stem}.{ext}"` with the raw filename stem. Starlette **latin-1-encodes** response headers, so any CJK stem (e.g. `黑沙灘.mov`) raised `UnicodeEncodeError` → **500**.

This broke:
- single-clip export `GET /api/media/{id}/export/{fmt}` (all 5 formats)
- **batch export `POST /api/export/batch` (#111)** — reuses the same builder

…for essentially **every clip in a CJK-named library** (黑沙灘, 恬馨幼兒園, …).

## Fix

Add `_attachment_headers(stem, ext)` (RFC 6266/5987): an ASCII-only `filename` fallback (non-ASCII + quote/backslash → `_`) plus a percent-encoded `filename*=UTF-8''…` carrying the true name. Modern browsers and the Tauri WKWebView both prefer `filename*`. Applied to txt/srt/vtt/edl/fcpxml.

## How it was found

2026-06-29 **M2 on-device verification** of the 5-PR merge (#108/#110/#111/#112/#106). Real GPU ingest of `黑沙灘.mov` (qwen3-vl:8b @100% GPU, 0 NULL frames) → `POST /api/export/batch` returned 500. Root-caused to the header encode.

## Tests

- Update the now-outdated `endswith(...srt")` assertion (an ASCII `filename` is still emitted, but `filename*` is appended).
- Add `test_export_cjk_filename_does_not_crash_header`: all 5 formats + batch, asserting the header is latin-1-encodable and the zip member is the correct UTF-8 name.
- **Full suite: 668 passed, 5 skipped.**

## ⚠️ Before merge

Production server code — recommend a Codex / agent-teams audit pass before merging, per repo discipline. Verified on-device (M2 Max) but not yet independently audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)