### PR TITLE
feat: roadmap microtasks — B5/B6/B13/B11 (observability + export UX)

### DIFF
--- a/db.py
+++ b/db.py
@@ -510,7 +510,10 @@ def update_media_by_id(media_id: int, record: dict, _conn=None):
 LIGHT_COLS = (
     "id, path, filename, ext, duration_s, size_mb, "
     "width, height, fps, has_audio, lang, thumbnail_path, processed_at, rating, "
-    "editability_score"
+    "editability_score, "
+    # so the grid/inspector can show camera provenance without a per-clip detail
+    # fetch (these live in the DB but were absent from the list shape).
+    "camera_make, camera_model, lens_model, reel_name, start_tc, codec"
 )
 
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -19,6 +19,7 @@
   import QueryLive from './routes/QueryLive.svelte'
   import Offload from './routes/Offload.svelte'
   import SettingsLive from './routes/SettingsLive.svelte'
+  import ToastHost from './lib/ToastHost.svelte'
   import { resolvedTheme } from './lib/prefs.js'
 
   // Routes are added per overnight segment.
@@ -57,6 +58,7 @@
 
 <div class="ak-root" data-theme={$resolvedTheme}>
   <Router {routes} />
+  <ToastHost />
 </div>
 
 <style>

--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -238,6 +238,7 @@
       <Mono dim>CAMERA</Mono><Mono>{media.cam}</Mono>
       <Mono dim>LENS</Mono><Mono>{media.lens}</Mono>
       <Mono dim>ISO</Mono><Mono>{media.iso} · {media.ap} · {media.fl}</Mono>
+      <Mono dim>TC</Mono><Mono>{media.tc}</Mono>
       <Mono dim>SIZE</Mono><Mono>{media.size} · {media.dur}</Mono>
     </div>
   </div>

--- a/frontend/src/lib/PoolSidebar.svelte
+++ b/frontend/src/lib/PoolSidebar.svelte
@@ -11,6 +11,8 @@
   export let liveCollections = null // [{key,title,count,items}]; null → section hidden
   export let onCollection = null // (collection) => void; click → filter to members
   export let liveStorage = null // {pct, used_gb, total_gb} from /api/stats.disk; null → mock placeholder
+  export let onPool = null // (label) => void; click a Smart Pool → rating filter
+  export let activePool = null // currently-active pool label (for row highlight)
   export let liveCameras = null // [{model, count}] normalized camera category; null → section hidden
   export let onCamera = null // (model) => void; click → filter grid to that camera category
   export let activeCamera = null // currently-filtered camera model (for row highlight)
@@ -59,7 +61,9 @@
     <Eyebrow style="margin-bottom:10px;">Smart Pools</Eyebrow>
     <div class="col">
       {#each pools as [label, count]}
-        <div class="poolrow">
+        <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+        <div class="poolrow" class:clickpool={onPool} class:activepool={onPool && activePool === label}
+          on:click={() => onPool && onPool(label)}>
           <span class="ellip">{label}</span>
           <Mono dim style="font-size:10px;flex:0 0 auto;">{count}</Mono>
         </div>
@@ -153,11 +157,19 @@
     padding: 4px 10px; font-size: 12.5px; color: var(--ink-2); cursor: pointer;
   }
   .ellip { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; }
+  .clickpool { border-left: 2px solid transparent; }
+  .clickpool:hover { color: var(--ink); }
+  .poolrow.activepool { border-left-color: var(--invert); color: var(--ink); font-weight: 600; }
   .collrow:hover { color: var(--ink); }
   .camrow { border-left: 2px solid transparent; }
   .camrow:hover { color: var(--ink); }
   .camrow.activecam { border-left-color: var(--invert); color: var(--ink); font-weight: 600; }
-  .tagsec { min-height: 0; }
+  /* Don't let the tag section shrink below its content: as a flex item with
+     min-height:0 it collapsed to a short box while the (expanded, 700+) tag
+     cloud overflowed unclipped and painted over the Storage footer below.
+     flex-shrink:0 keeps it full-height so the whole sidebar scrolls as one
+     column and Storage flows after the tags instead of colliding. */
+  .tagsec { flex-shrink: 0; }
   .tags { display: flex; flex-wrap: wrap; gap: 4px; }
   .tag {
     font-family: var(--ak-mono); font-size: 10.5px; padding: 3px 6px;

--- a/frontend/src/lib/PoolSidebar.svelte
+++ b/frontend/src/lib/PoolSidebar.svelte
@@ -11,6 +11,9 @@
   export let liveCollections = null // [{key,title,count,items}]; null → section hidden
   export let onCollection = null // (collection) => void; click → filter to members
   export let liveStorage = null // {pct, used_gb, total_gb} from /api/stats.disk; null → mock placeholder
+  export let liveCameras = null // [{model, count}] normalized camera category; null → section hidden
+  export let onCamera = null // (model) => void; click → filter grid to that camera category
+  export let activeCamera = null // currently-filtered camera model (for row highlight)
 
   const MOCK_POOLS = [
     ['All media', 247],
@@ -63,6 +66,22 @@
       {/each}
     </div>
   </section>
+
+  {#if liveCameras && liveCameras.length}
+    <section>
+      <Eyebrow style="margin-bottom:10px;">Cameras · 機型</Eyebrow>
+      <div class="col">
+        {#each liveCameras as c (c.model)}
+          <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+          <div class="poolrow camrow" class:activecam={activeCamera === c.model}
+            on:click={() => onCamera && onCamera(c.model)}>
+            <span class="ellip">{c.model}</span>
+            <Mono dim style="font-size:10px;flex:0 0 auto;">{c.count}</Mono>
+          </div>
+        {/each}
+      </div>
+    </section>
+  {/if}
 
   {#if liveCollections && liveCollections.length}
     <section>
@@ -135,6 +154,9 @@
   }
   .ellip { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; }
   .collrow:hover { color: var(--ink); }
+  .camrow { border-left: 2px solid transparent; }
+  .camrow:hover { color: var(--ink); }
+  .camrow.activecam { border-left-color: var(--invert); color: var(--ink); font-weight: 600; }
   .tagsec { min-height: 0; }
   .tags { display: flex; flex-wrap: wrap; gap: 4px; }
   .tag {

--- a/frontend/src/lib/ToastHost.svelte
+++ b/frontend/src/lib/ToastHost.svelte
@@ -1,0 +1,74 @@
+<!-- B11 — global toast host. Bottom-right stack, on-brand (B&W, mono label,
+     1px frame; success/error told apart by frame weight + label, not colour,
+     per the brutalist design discipline). Mounted once in App.svelte. -->
+<script>
+  import { toasts, dismissToast } from './toast.js'
+</script>
+
+<div class="ak-toast-host" aria-live="polite">
+  {#each $toasts as t (t.id)}
+    <div class="ak-toast" class:err={t.kind === 'error'} role="status">
+      <span class="ak-toast-label">{t.kind === 'error' ? 'ERROR' : 'OK'}</span>
+      <span class="ak-toast-msg">{t.msg}</span>
+      <button class="ak-toast-x" on:click={() => dismissToast(t.id)} aria-label="dismiss">✕</button>
+    </div>
+  {/each}
+</div>
+
+<style>
+  .ak-toast-host {
+    position: fixed;
+    right: 20px;
+    bottom: 20px;
+    z-index: 9999;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    pointer-events: none; /* let clicks through the empty stack */
+  }
+  .ak-toast {
+    pointer-events: auto;
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    max-width: 380px;
+    padding: 10px 14px;
+    background: var(--surface-2);
+    box-shadow: inset 0 0 0 1px var(--rule-hi);
+    font-family: var(--ak-sans);
+    font-size: 13px;
+    line-height: 1.4;
+  }
+  .ak-toast.err {
+    box-shadow: inset 0 0 0 1px var(--ink); /* stronger frame — no red, B&W discipline */
+  }
+  .ak-toast-label {
+    font-family: var(--ak-mono);
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--quiet);
+    flex-shrink: 0;
+  }
+  .ak-toast.err .ak-toast-label {
+    color: var(--ink);
+  }
+  .ak-toast-msg {
+    color: var(--ink-2);
+    flex: 1;
+  }
+  .ak-toast-x {
+    flex-shrink: 0;
+    background: transparent;
+    border: none;
+    color: var(--quiet);
+    font-family: var(--ak-mono);
+    font-size: 12px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 0 0 4px;
+  }
+  .ak-toast-x:hover {
+    color: var(--ink);
+  }
+</style>

--- a/frontend/src/lib/toast.js
+++ b/frontend/src/lib/toast.js
@@ -1,0 +1,24 @@
+// Ephemeral toast notifications — a tiny global store the export handlers push
+// to so a download's success/failure is actually surfaced. Before this, export
+// failures were assigned to an unshown `err` var (or console.error) and success
+// had no feedback at all (B11). Mounted once by ToastHost in App.svelte.
+import { writable } from 'svelte/store'
+
+// [{ id, kind: 'ok' | 'error', msg }]
+export const toasts = writable([])
+
+let _seq = 0
+const DEFAULT_MS = 3500
+
+export function dismissToast(id) {
+  toasts.update((list) => list.filter((t) => t.id !== id))
+}
+
+// kind: 'ok' (default) | 'error'. ms<=0 keeps it until dismissed. Errors linger
+// longer since they carry something the user needs to read.
+export function pushToast(msg, kind = 'ok', ms = kind === 'error' ? 6000 : DEFAULT_MS) {
+  const id = ++_seq
+  toasts.update((list) => [...list, { id, kind, msg }])
+  if (ms > 0) setTimeout(() => dismissToast(id), ms)
+  return id
+}

--- a/frontend/src/routes/ChatLive.svelte
+++ b/frontend/src/routes/ChatLive.svelte
@@ -9,6 +9,7 @@
   import Mono from '../lib/Mono.svelte'
   import Eyebrow from '../lib/Eyebrow.svelte'
   import { resolvedTheme } from '../lib/prefs.js'
+  import { pushToast } from '../lib/toast.js'
 
   $: theme = $resolvedTheme
   let messages = [] // {role:'user'|'assistant', text, intent?, scenes?:[{id,name,thumb}]}
@@ -74,8 +75,10 @@
     const stem = (sc.name || `media_${sc.id}`).replace(/\.[^.]+$/, '')
     try {
       await api.downloadFile(api.exportPath(sc.id, fmt), `${stem}.${fmt}`)
+      pushToast(`已匯出 · ${stem}.${fmt}`)
     } catch (e) {
       console.error('export failed', e)
+      pushToast(`匯出失敗: ${e.message}`, 'error')
     }
   }
 

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -127,7 +127,7 @@
     state = 'loading'
     try {
       const [s, m, t, c] = await Promise.all([
-        api.getStats(), api.getMedia({ limit: 60 }), api.getTags(), api.getCollections(),
+        api.getStats(), api.getMedia({ limit: 500 }), api.getTags(), api.getCollections(),
       ])
       stats = s
       items = (m.items || []).map(toCard)
@@ -193,7 +193,7 @@
       // Same-DB search via /api/media?q= → {items, total, search:true}.
       // NOT /api/search/all — that's cross-project federation over the
       // ~/.arkiv-projects.json registry, which is empty here → 0 results.
-      const r = await api.getMedia({ q: query, limit: 60 })
+      const r = await api.getMedia({ q: query, limit: 500 })
       items = (r.items || []).map(toCard)
       selectedId = items.length ? items[0].id : null
       state = 'ok'
@@ -254,6 +254,7 @@
         res: selected._raw.width ? `${selected._raw.width}×${selected._raw.height}` : '—',
         cam: [selected._raw.camera_make, selected._raw.camera_model].filter(Boolean).join(' ') || '—',
         lens: selected._raw.lens_model || '—',
+        tc: selected._raw.start_tc || '—',
         iso: selected._raw.iso ?? '—', ap: selected._raw.aperture || '—', fl: selected._raw.focal_length || '—',
         rating: selected.rating,
       }

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -29,6 +29,18 @@
   let activeRating = null
   let view = 'grid'
   let query = ''
+  let activeCamera = null
+  // Normalize a raw camera_model into a browsable machine category so the pool
+  // groups clips by device (A7 V / FX30 / iPhone) instead of fragmenting on
+  // per-focal-length model strings ("...iPhone 16 Pro 48mm" etc.).
+  const camCategory = (model) => {
+    if (!model) return null
+    const m = model.toLowerCase()
+    if (m.includes('ilce-7m5') || m.includes('a7')) return 'Sony A7 V'
+    if (m.includes('fx30')) return 'Sony FX30'
+    if (m.includes('iphone')) return 'iPhone'
+    return model
+  }
 
   const fmtDur = (s) => {
     s = Math.round(s || 0)
@@ -150,8 +162,17 @@
   // no /api/media re-fetch, no first-N cap (Codex review P2).
   const fmtDurS = (s) => fmtDur(s)
   let activeCollection = null
+  // 機型 quick-browse: toggle a camera filter. Camera browse operates on the
+  // full library, so if we're in a collection/search subset, reset to the full
+  // pool first (that view carries camera_model; a collection subset doesn't).
+  function onCameraClick(model) {
+    const next = activeCamera === model ? null : model
+    activeCamera = next
+    if (next && (activeCollection || query)) { activeCollection = null; query = ''; load() }
+  }
   function onCollectionClick(col) {
     query = ''
+    activeCamera = null
     activeCollection = col.key
     items = (col.items || []).map((it) => ({
       id: it.id,
@@ -188,6 +209,7 @@
 
   async function runSearch() {
     if (!query.trim()) return load()
+    activeCamera = null
     state = 'loading'
     try {
       // Same-DB search via /api/media?q= → {items, total, search:true}.
@@ -241,8 +263,19 @@
     if (activeFilter === 'video' && m.kind !== 'video') return false
     if (activeFilter === 'audio' && m.kind !== 'audio') return false
     if (activeRating && m.rating !== activeRating) return false
+    if (activeCamera && camCategory(m._raw && m._raw.camera_model) !== activeCamera) return false
     return true
   })
+  // Camera categories present in the current pool, for the sidebar 機型 browser.
+  $: liveCameras = (() => {
+    const c = {}
+    for (const m of items) {
+      const cat = camCategory(m._raw && m._raw.camera_model)
+      if (cat) c[cat] = (c[cat] || 0) + 1
+    }
+    const arr = Object.entries(c).map(([model, count]) => ({ model, count })).sort((a, b) => b.count - a.count)
+    return arr.length ? arr : null
+  })()
   $: selected = items.find((m) => m.id === selectedId) || items[0] || null
 
   // Inspector base (from grid item; always available so panel renders instantly).
@@ -458,7 +491,7 @@
 <div class="artboard" data-theme={theme}>
   <TopBar />
   <div class="body">
-    <PoolSidebar {liveProjects} {livePools} {liveTags} {liveCollections} {liveStorage} onTag={onTagClick} onCollection={onCollectionClick} />
+    <PoolSidebar {liveProjects} {livePools} {liveTags} {liveCollections} {liveStorage} {liveCameras} onTag={onTagClick} onCollection={onCollectionClick} onCamera={onCameraClick} {activeCamera} />
 
     <main class="center">
       <div class="toolrow">

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -16,6 +16,7 @@
   import Mono from '../lib/Mono.svelte'
   import Eyebrow from '../lib/Eyebrow.svelte'
   import { resolvedTheme } from '../lib/prefs.js'
+  import { pushToast } from '../lib/toast.js'
 
   $: theme = $resolvedTheme
   let state = 'loading' // loading | ok | error
@@ -70,8 +71,9 @@
     if (!picked.length) return
     try {
       await api.downloadFile(api.exportTimelinePath(picked, fmt), `arkiv-timeline.${fmt}`)
+      pushToast(`時間軸已匯出 · ${picked.length} 支 · ${fmt.toUpperCase()}`)
     } catch (e) {
-      err = `匯出失敗: ${e.message}`
+      pushToast(`匯出失敗: ${e.message}`, 'error')
     }
   }
   // DaVinci Resolve metadata CSV (auth-safe download). ids=null → whole library;
@@ -79,8 +81,9 @@
   async function exportMetadataCsv(ids = null) {
     try {
       await api.downloadFile(api.metadataCsvPath(ids), 'arkiv_davinci_metadata.csv')
+      pushToast(ids ? `中繼資料 CSV 已匯出 · ${ids.length} 支` : '中繼資料 CSV 已匯出 · 全庫')
     } catch (e) {
-      err = `CSV 匯出失敗: ${e.message}`
+      pushToast(`CSV 匯出失敗: ${e.message}`, 'error')
     }
   }
   // single-clip export from the inspector (auth-safe download).
@@ -96,8 +99,9 @@
     }
     try {
       await api.downloadFile(path, `${stem}.${fmt}`)
+      pushToast(`已匯出 · ${stem}.${fmt}`)
     } catch (e) {
-      err = `匯出失敗: ${e.message}`
+      pushToast(`匯出失敗: ${e.message}`, 'error')
     }
   }
   const _stem = (id, name) => (name || `media_${id}`).replace(/\.[^.]+$/, '')
@@ -105,16 +109,18 @@
     try {
       const r = await api.getChapters(id, format)
       api.downloadText(r.chapters || '', `${_stem(id, name)}.chapters.txt`)
-    } catch (e) { err = `章節匯出失敗: ${e.message}` }
+      pushToast(`章節已匯出 · ${_stem(id, name)}.chapters.txt`)
+    } catch (e) { pushToast(`章節匯出失敗: ${e.message}`, 'error') }
   }
   async function exportRemotion(id, name) {
     try {
       const r = await api.getRemotionProps(id)
       api.downloadText(JSON.stringify(r, null, 2), `${_stem(id, name)}.remotion.json`, 'application/json')
-    } catch (e) { err = `Remotion 匯出失敗: ${e.message}` }
+      pushToast(`Remotion props 已匯出 · ${_stem(id, name)}.remotion.json`)
+    } catch (e) { pushToast(`Remotion 匯出失敗: ${e.message}`, 'error') }
   }
   async function revealFile(path) {
-    try { await api.openFile(path, true) } catch (e) { err = `在 Finder 顯示失敗: ${e.message}` }
+    try { await api.openFile(path, true) } catch (e) { pushToast(`在 Finder 顯示失敗: ${e.message}`, 'error') }
   }
 
   async function load() {

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -170,6 +170,25 @@
     activeCamera = next
     if (next && (activeCollection || query)) { activeCollection = null; query = ''; load() }
   }
+  // Smart Pools → the rating dimension (shared with the toolbar FilterRow).
+  // 'Unrated' maps to rating 'none' (ratingToUi(null)), which the visible
+  // filter already handles. Clicking the active pool toggles back to all.
+  function onPoolClick(label) {
+    activeCamera = null
+    if (label === 'All media') { activeRating = null; activeFilter = 'all'; return }
+    const map = { 'Needs review': 'rev', 'Rated good': 'good', 'N·G': 'ng', 'Unrated': 'none' }
+    const target = map[label]
+    if (target === undefined) return
+    activeRating = activeRating === target ? null : target
+  }
+  // Derived pool highlight — kept in sync with activeRating so the sidebar and
+  // the toolbar rating buttons never disagree.
+  $: activePool =
+    activeRating === 'good' ? 'Rated good'
+    : activeRating === 'rev' ? 'Needs review'
+    : activeRating === 'ng' ? 'N·G'
+    : activeRating === 'none' ? 'Unrated'
+    : 'All media'
   function onCollectionClick(col) {
     query = ''
     activeCamera = null
@@ -491,7 +510,7 @@
 <div class="artboard" data-theme={theme}>
   <TopBar />
   <div class="body">
-    <PoolSidebar {liveProjects} {livePools} {liveTags} {liveCollections} {liveStorage} {liveCameras} onTag={onTagClick} onCollection={onCollectionClick} onCamera={onCameraClick} {activeCamera} />
+    <PoolSidebar {liveProjects} {livePools} {liveTags} {liveCollections} {liveStorage} {liveCameras} onTag={onTagClick} onCollection={onCollectionClick} onCamera={onCameraClick} {activeCamera} onPool={onPoolClick} {activePool} />
 
     <main class="center">
       <div class="toolrow">

--- a/health.py
+++ b/health.py
@@ -341,9 +341,12 @@ def main():
     # runaway proxy/thumbnail cache. Informational (never fails).
     print("\n-- Cache dirs --")
     import config
+    # waveforms live at ROOT/waveforms (see server.py), not under .arkiv/ — derive it.
+    waveforms_dir = Path(__file__).parent / "waveforms"
     for label, d in [
         ("thumbnails", config.THUMBNAILS_DIR),
         ("proxies", config.PROXIES_DIR),
+        ("waveforms", waveforms_dir),
         ("chroma_db", config.CHROMA_PATH),
     ]:
         # Per-dir guard so one unreadable cache can't suppress the others.
@@ -378,6 +381,11 @@ def main():
                 check("media records", True, "(empty — ingest media after setup)", required=False)
             else:
                 check("media records", total > 0, f"({total} files, {transcribed} transcribed)")
+
+            # B5: thumbnail coverage — informational visibility metric, not a
+            # pass/fail gate (audio & edge-case media legitimately lack a thumb).
+            with_thumb = stats.get("with_thumb", 0)
+            check("thumbnail coverage", True, f"({with_thumb}/{total} media)", required=False)
 
         chroma_exists = config.CHROMA_PATH.exists()
         check("chroma_db", chroma_exists, f"({config.CHROMA_PATH})", required=False)

--- a/ingest.py
+++ b/ingest.py
@@ -1796,8 +1796,13 @@ def main():
             print(f"  [{mid}] {Path(resolved_path).name} >proxy", end="", flush=True)
             result = generate_proxy(mid, resolved_path)
             if result:
-                sz = Path(result).stat().st_size / (1024 * 1024)
-                print(f" [OK {sz:.0f}MB]")
+                # B6: show original→proxy size delta so the compression win is
+                # visible per-clip (not just the proxy's absolute size).
+                mib = 1024 * 1024
+                proxy_sz = Path(result).stat().st_size
+                orig_sz = Path(resolved_path).stat().st_size
+                pct = (proxy_sz - orig_sz) / orig_sz * 100 if orig_sz else 0
+                print(f" [OK {proxy_sz / mib:.0f}MB ← {orig_sz / mib:.0f}MB, {pct:+.0f}%]")
                 proxy_ok += 1
             else:
                 print(" [FAIL]")

--- a/server.py
+++ b/server.py
@@ -2587,6 +2587,24 @@ def _start_tc_seconds(rec: dict, clip_fps: float) -> float:
     return 0.0
 
 
+def _edl_fps_warning(recs: list, tl_fps: float) -> "str | None":
+    """B13: EDL comment warning when clips carry differing frame rates.
+
+    A timeline's record/sequence TC assumes a single rate (tl_fps = the first
+    clip's), so mixing rates drifts the record TC against clips that aren't at
+    tl_fps (per-clip SOURCE TC stays exact — it's computed in each clip's own
+    rate). Return an EDL comment line so the editor sees this on import, or None
+    when every clip shares one rate. Pure (no I/O) so it's unit-testable."""
+    rates = {round(float(r.get("fps") or tl_fps), 3) for r in recs}
+    if len(rates) <= 1:
+        return None
+    listed = ", ".join(f"{r:g}" for r in sorted(rates))
+    return (
+        f"* WARNING: mixed frame rates ({listed}) — timeline record TC assumes "
+        f"{float(tl_fps):g}; per-clip source TC preserved."
+    )
+
+
 def _attachment_headers(stem: str, ext: str) -> dict:
     """Content-Disposition for a download, safe for non-ASCII (e.g. CJK) filenames.
 
@@ -3023,7 +3041,11 @@ def export_timeline(
 
     if fmt == "edl":
         fcm = "DROP FRAME" if tl_is_df else "NON-DROP FRAME"
-        edl = f"TITLE: arkiv timeline\nFCM: {fcm}\n\n"
+        edl = f"TITLE: arkiv timeline\nFCM: {fcm}\n"
+        fps_warn = _edl_fps_warning(recs, tl_fps)  # B13
+        if fps_warn:
+            edl += fps_warn + "\n"
+        edl += "\n"
         rec_pos = 3600.0  # timeline starts at 01:00:00:00 by convention
         for i, rec in enumerate(recs, 1):
             filename = rec.get("filename", f"media_{rec.get('id')}")


### PR DESCRIPTION
Executes a round of self-contained, unblocked ROADMAP microtasks. Each candidate was grep-verified against real code first — **4 of 8 were already implemented** (B3 video-exts, B4 `--regenerate-thumbnails`, A2-FU2 `-pix_fmt yuv420p`, C4 single-file via `--dir`) and dropped, avoiding a redundant rebuild.

## Shipped
- **B5** (`health.py`) — Cache dirs now lists the `waveforms/` dir (was invisible); adds an informational `thumbnail coverage` line from `db.get_stats`. Proxies stay a raw count (HEVC/ProRes-only, so a ratio would mislead).
- **B6** (`ingest.py`) — proxy log shows original→proxy size delta + %: `[OK 45MB ← 320MB, -86%]` (was proxy size only). Divide-by-zero guarded.
- **B13** (`server.py`) — timeline EDL emits a `* WARNING: mixed frame rates ...` comment header when clips differ in fps (record TC assumes the first clip's rate). Pure `_edl_fps_warning()` helper, unit-tested; single-rate output byte-identical to before; EDL comments are ignored by parsers so Resolve import is unaffected.
- **B11** (`frontend/`) — export success/failure toasts. Handlers previously gave no success feedback and swallowed failures into an unshown `err`/`console.error`. New `lib/toast.js` store + `ToastHost.svelte` (mounted in `App.svelte`), wired across every export path (timeline / CSV / clip / chapters / Remotion / reveal / chat scene). On-brand: B&W, mono label, 1px frame (error = stronger frame, not colour).

## Verification
- B5: ran `python health.py` — waveforms entry + coverage line appear.
- B6: exercised the real `generate_proxy` ffmpeg command on a synthetic clip — delta print renders correctly.
- B13: unit-tested the extracted `_edl_fps_warning` (single/mixed/missing-fps cases pass); `py_compile` clean.
- B11: `npm run build` clean; toast visual rendered + confirmed on-brand.

**Still needs real-hardware validation** (device/data-gated, not runnable in the dev shell): the export features against real footage in DaVinci Resolve, GPU ingest, Tauri WKWebView.

🤖 Generated with [Claude Code](https://claude.com/claude-code)