### PR TITLE
chore: audit hygiene — ak-btn root-fix, route code-split, lifespan migration

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,15 +1,6 @@
 <script>
   import Router from 'svelte-spa-router'
-  import Home from './routes/Home.svelte'
-  import Gallery from './routes/Gallery.svelte'
-  import MainDark from './routes/MainDark.svelte'
-  import MainStates from './routes/MainStates.svelte'
-  import InspectorFull from './routes/InspectorFull.svelte'
-  import Search from './routes/Search.svelte'
-  import Ingest from './routes/Ingest.svelte'
-  import Settings from './routes/Settings.svelte'
-  import Flows from './routes/Flows.svelte'
-  import Edge from './routes/Edge.svelte'
+  import { wrap } from 'svelte-spa-router/wrap'
   import Live from './routes/Live.svelte'
   import MainLive from './routes/MainLive.svelte'
   import IngestLive from './routes/IngestLive.svelte'
@@ -42,16 +33,16 @@
     '/settings': SettingsLive, // settings — live theme switcher + real system/about (engine config deferred)
 
     // ── design reference (Claude-design mock artboards; not the product) ──────
-    '/_design/home': Home, // design scaffold kept for reference (was '/')
-    '/_design/gallery': Gallery, // seg 1 — shared-primitive gallery
-    '/_design/main': MainDark, // seg 2 — hero (interactive)
-    '/_design/states': MainStates, // seg 3 — state variants
-    '/_design/inspector': InspectorFull, // seg 4 — inspector full
-    '/_design/search': Search, // seg 5 — cross-project search
-    '/_design/ingest': Ingest, // seg 6 — ingest progress
-    '/_design/settings': Settings, // seg 7 — settings modal
-    '/_design/flows': Flows, // seg 8 — round-3 flows
-    '/_design/edge': Edge, // seg 9 — round-4 edge
+    '/_design/home': wrap({ asyncComponent: () => import('./routes/Home.svelte') }), // design scaffold kept for reference (was '/')
+    '/_design/gallery': wrap({ asyncComponent: () => import('./routes/Gallery.svelte') }), // seg 1 — shared-primitive gallery
+    '/_design/main': wrap({ asyncComponent: () => import('./routes/MainDark.svelte') }), // seg 2 — hero (interactive)
+    '/_design/states': wrap({ asyncComponent: () => import('./routes/MainStates.svelte') }), // seg 3 — state variants
+    '/_design/inspector': wrap({ asyncComponent: () => import('./routes/InspectorFull.svelte') }), // seg 4 — inspector full
+    '/_design/search': wrap({ asyncComponent: () => import('./routes/Search.svelte') }), // seg 5 — cross-project search
+    '/_design/ingest': wrap({ asyncComponent: () => import('./routes/Ingest.svelte') }), // seg 6 — ingest progress
+    '/_design/settings': wrap({ asyncComponent: () => import('./routes/Settings.svelte') }), // seg 7 — settings modal
+    '/_design/flows': wrap({ asyncComponent: () => import('./routes/Flows.svelte') }), // seg 8 — round-3 flows
+    '/_design/edge': wrap({ asyncComponent: () => import('./routes/Edge.svelte') }), // seg 9 — round-4 edge
     // 360 (.insv/.360): ingest reproject shipped (Phase 8.3b) — no dedicated SPA viewer route yet
   }
 </script>

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -182,7 +182,7 @@ body { margin: 0; padding: 0; min-height: 100%; }
 .ak-rule { height: 1px; background: var(--rule); }
 .ak-rule-v { width: 1px; background: var(--rule); }
 
-button.ak-btn {
+.ak-btn {
   font-family: var(--ak-mono);
   font-size: var(--fs-tiny);
   text-transform: uppercase;
@@ -193,10 +193,13 @@ button.ak-btn {
   padding: 6px 10px;
   cursor: pointer;
   line-height: 1;
+  text-decoration: none; /* <a class="ak-btn"> — kill UA link underline */
+  display: inline-block; /* <a>/<span> are inline; needed for vertical padding */
+  white-space: nowrap;
 }
-button.ak-btn:hover { background: var(--surface-2); border-color: var(--ink); }
-button.ak-btn--primary { background: var(--invert); color: var(--invert-ink); border-color: var(--invert); }
-button.ak-btn--primary:hover { background: var(--ink-2); border-color: var(--ink-2); color: var(--invert-ink); }
+.ak-btn:hover { background: var(--surface-2); border-color: var(--ink); }
+.ak-btn--primary { background: var(--invert); color: var(--invert-ink); border-color: var(--invert); }
+.ak-btn--primary:hover { background: var(--ink-2); border-color: var(--ink-2); color: var(--invert-ink); }
 
 input.ak-input {
   font-family: var(--ak-mono);

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -663,7 +663,7 @@
   .proj { min-width: 0; }
   .projtitle { font-size: 28px; letter-spacing: -0.04em; line-height: 1; color: var(--ink); }
   .livesearch { flex: 1; max-width: 360px; font-size: 12px; }
-  .ranked { font-size: 10px; padding: 6px 10px; text-decoration: none; white-space: nowrap; }
+  .ranked { font-size: 10px; padding: 6px 10px; }
   .metacsv { font-size: 10px; padding: 6px 10px; white-space: nowrap; }
   .gridwrap { flex: 1; overflow: auto; position: relative; }
   /* G9: prototype card width = 198px (runtime-measured from the 1400px design canvas).

--- a/frontend/src/routes/QueryLive.svelte
+++ b/frontend/src/routes/QueryLive.svelte
@@ -235,7 +235,6 @@
   .artboard { width: 100%; max-width: 1920px; height: 100vh; height: 100dvh; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 1fr; overflow: hidden; margin: 0 auto; }
   .grow { flex: 1; }
   .topbar { display: flex; align-items: center; border-bottom: 1px solid var(--rule); padding: 0 16px; gap: 16px; }
-  .topbar a { text-decoration: none; }
   .main { display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
   .builder { padding: 22px 64px 16px; border-bottom: 1px solid var(--rule); }
   .matchrow { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }

--- a/frontend/src/routes/SearchLive.svelte
+++ b/frontend/src/routes/SearchLive.svelte
@@ -227,7 +227,6 @@
   .artboard { width: 100%; max-width: 1920px; height: 100vh; height: 100dvh; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 1fr; overflow: hidden; margin: 0 auto; }
   .grow { flex: 1; }
   .topbar { display: flex; align-items: center; border-bottom: 1px solid var(--rule); padding: 0 16px; gap: 16px; }
-  .topbar a { text-decoration: none; }
   .main { display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
   .hero { padding: 24px 64px 18px; border-bottom: 1px solid var(--rule); }
   .queryrow { display: flex; align-items: center; gap: 16px; margin-bottom: 12px; }

--- a/server.py
+++ b/server.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, List, Literal, Optional, Set
 
@@ -137,7 +138,13 @@ class _RedactTokenFilter(_logging.Filter):
         return True
 _logging.getLogger("uvicorn.access").addFilter(_RedactTokenFilter())
 
-app = FastAPI(title="Media Asset Manager API")
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    _bootstrap_admin_token()  # late-bound; defined below near the admin routes
+    yield
+    # no shutdown work today; add teardown after the yield when needed
+
+app = FastAPI(title="Media Asset Manager API", lifespan=_lifespan)
 _ALLOWED_ORIGINS = [
     "http://localhost:8501",
     "http://127.0.0.1:8501",
@@ -366,7 +373,6 @@ def _split_csv(value: Optional[str]) -> Optional[List[str]]:
     return parts or None
 
 
-@app.on_event("startup")
 def _bootstrap_admin_token():
     raw = admin.bootstrap_admin_token_if_empty()
     if raw:


### PR DESCRIPTION
First round of the Fable-audit hygiene cleanup. Ships 3 of 4 planned items; the 4th (search-box merge) is held for a visual/UX sign-off (see below).

**Pipeline note (試行 tiered flow)**: planned by Fable → executed by Opus (item 1) + Sonnet (items 3, 4) → Codex audit to follow.

## Items shipped
### 1. `fix(ui)`: de-qualify `.ak-btn` (Opus)
`app.css` styled `button.ak-btn` (element-qualified) — so `<a class="ak-btn">` / `<span class="ak-btn">` got **no** styling, worked around per-route. De-qualified to `.ak-btn` (+ `text-decoration/display/white-space` for inline use) and removed the `SearchLive`/`QueryLive` `.topbar a{}` and `MainLive` `.ranked` workarounds.
- **6 anchor/span sites now render as proper bordered buttons** (intended — the plain-text look was an accidental side-effect of the qualified selector): SearchLive topbar ×2, QueryLive topbar ×2, MainLive `排名 →`, and the `Open →` result chips.
- All ~70 `<button class="ak-btn">` usages are **visually unchanged** (same rule, lower specificity).
- ⚠️ **Needs a visual sign-off**: eyeball `#/search-live`, `#/query-live`, `#/main-live` on the running dev server. If any of the 6 should stay plain text, we add an `ak-btn--bare` opt-out.
- Note: `ChatLive`'s equivalent workaround lives in PR #116 (branched before this) → becomes redundant once both merge; harmless meanwhile.

### 3. `perf(build)`: code-split `/_design/*` mock routes (Sonnet)
The 10 design-reference artboards were statically bundled. Wrapped with `wrap({asyncComponent})` → lazy-loaded. **~217 kB (~40%) off the main JS chunk**, 10 new lazy chunks. Live routes untouched. Verified: build green.

### 4. `refactor(server)`: `on_event` → lifespan (Sonnet)
FastAPI's `@app.on_event` is deprecated; the sole startup handler now runs via an `asynccontextmanager` lifespan. Verified: **pytest 672 passed / 5 skipped**, `grep on_event = 0`.

## Held for next wave
- **Item 2 (two-search-box merge on MainLive)**: needs a UX call (Fable's Option C: TopBar search = type→filter grid, Enter→ranked) + it depends on Item 1 landing first (both touch MainLive's toolrow). Deferred until Item 1 is signed off.

## Verification
`npm run build` green (only pre-existing ArkivLogo/Thumb warnings); `pytest` 672 passed; `grep button.ak-btn` = 0. `vite.config.js` local-only tweak excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)