### PR TITLE
fix(ingest): recover Sony XAVC camera identity from embedded XML (closes #115)

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -344,6 +344,12 @@ def exiftool_extract(path: str, fps: Optional[float] = None) -> dict:
     cmd = [
         config.EXIFTOOL_PATH, "-json",
         "-Make", "-Model", "-LensModel",
+        # issue #115: Sony XAVC (A7 V / FX30) leaves the standard Make/Model
+        # blank and puts device identity in the embedded XML (NRT) block as
+        # DeviceManufacturer / DeviceModelName. Read them in the SAME exiftool
+        # call so sidecar-less clips still populate camera_make/model. Non-Sony
+        # files simply don't have these tags → d.get() returns None → no effect.
+        "-DeviceManufacturer", "-DeviceModelName", "-LensZoomModelName",
         "-GPSLatitude", "-GPSLongitude",
         "-ColorSpace",
         "-ISO",
@@ -439,9 +445,12 @@ def exiftool_extract(path: str, fps: Optional[float] = None) -> dict:
     cdate_str = str(cdate) if cdate else None
 
     return {
-        "camera_make": d.get("Make"),
-        "camera_model": d.get("Model"),
-        "lens_model": d.get("LensModel") or d.get("Blackmagic-designCameraLensType"),
+        # issue #115: fall back to embedded-XML device identity when the
+        # standard EXIF Make/Model are blank (Sony XAVC without an M01.XML
+        # sidecar). Standard tags still win when present.
+        "camera_make": d.get("Make") or d.get("DeviceManufacturer"),
+        "camera_model": d.get("Model") or d.get("DeviceModelName"),
+        "lens_model": d.get("LensModel") or d.get("Blackmagic-designCameraLensType") or d.get("LensZoomModelName"),
         "gps_lat": d.get("GPSLatitude"),
         "gps_lon": d.get("GPSLongitude"),
         "color_space": str(d.get("ColorSpace")) if d.get("ColorSpace") else None,

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -38,6 +38,67 @@ def test_parse_xavc_sidecar_malformed(tmp_path):
     assert ingest.parse_xavc_sidecar(str(mp4)) == {}
 
 
+# issue #115: Sony XAVC embedded-XML (NRT) camera identity fallback
+
+def test_exiftool_camera_falls_back_to_embedded_xml_device(monkeypatch):
+    """Sony XAVC without an M01.XML sidecar leaves standard Make/Model blank but
+    carries device identity in the embedded XML as DeviceManufacturer /
+    DeviceModelName. Read them in the same exiftool call so camera_make/model
+    populate instead of staying NULL (445/480 恬馨 clips were empty for this)."""
+    import sys, os, json
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    import ingest
+
+    fake_stdout = json.dumps([{
+        "SourceFile": "C0042.MP4",
+        # standard EXIF Make/Model/LensModel intentionally absent (Sony XAVC)
+        "DeviceManufacturer": "Sony",
+        "DeviceModelName": "ILCE-7M5",
+        "LensZoomModelName": "FE 24-70mm F2.8 GM",
+    }])
+
+    class _FakeProc:
+        returncode = 0
+        stdout = fake_stdout
+        stderr = ""
+
+    monkeypatch.setattr(ingest.subprocess, "run", lambda *a, **kw: _FakeProc())
+    result = ingest.exiftool_extract("C0042.MP4")
+    assert result["camera_make"] == "Sony"
+    assert result["camera_model"] == "ILCE-7M5"
+    assert result["lens_model"] == "FE 24-70mm F2.8 GM"
+
+
+def test_exiftool_camera_prefers_standard_over_embedded_xml(monkeypatch):
+    """When both the standard EXIF Make/Model and the embedded-XML device tags
+    are present, the standard tags win — the embedded fallback only fills gaps."""
+    import sys, os, json
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    import ingest
+
+    fake_stdout = json.dumps([{
+        "SourceFile": "C0042.MP4",
+        "Make": "SONY",
+        "Model": "ILME-FX30",
+        "LensModel": "E 17-70mm F2.8 B070",
+        # stale/duplicate embedded values that must NOT override standard tags
+        "DeviceManufacturer": "Sony Corporation",
+        "DeviceModelName": "wrong-model",
+        "LensZoomModelName": "wrong-lens",
+    }])
+
+    class _FakeProc:
+        returncode = 0
+        stdout = fake_stdout
+        stderr = ""
+
+    monkeypatch.setattr(ingest.subprocess, "run", lambda *a, **kw: _FakeProc())
+    result = ingest.exiftool_extract("C0042.MP4")
+    assert result["camera_make"] == "SONY"
+    assert result["camera_model"] == "ILME-FX30"
+    assert result["lens_model"] == "E 17-70mm F2.8 B070"
+
+
 # B10b2: Blackmagic Cam app (iOS) per-vendor lens tag
 
 def test_exiftool_lens_falls_back_to_bmd_camera_lens_type(monkeypatch):


### PR DESCRIPTION
## Problem

Sony XAVC clips (A7 V / FX30 / A7 IV) leave the standard EXIF `Make`/`Model` blank and put device identity in the embedded XML (NRT) block as `DeviceManufacturer` / `DeviceModelName`. `exiftool_extract` (`ingest.py`) only queried the standard tags, and `parse_xavc_sidecar` only recovered identity from a co-located `<stem>M01.XML` sidecar. Clips copied/imported **without** their sidecars stored `camera_make`/`camera_model` as `NULL` — the 恬馨 library had 445/480 clips empty, and "機型" pool browsing / camera filters showed them as unknown.

Fixes #115.

## Fix

Add `-DeviceManufacturer -DeviceModelName -LensZoomModelName` to the **same** exiftool call and use them as a fallback **only when the standard tags are blank**:

- `camera_make: d.get("Make") or d.get("DeviceManufacturer")`
- `camera_model: d.get("Model") or d.get("DeviceModelName")`
- `lens_model: … or d.get("LensZoomModelName")`

Standard EXIF still wins when present. Non-Sony files don't carry these tags → `d.get()` returns `None` → no behavior change. Same subprocess, a few extra tags — low risk.

## Verification

- **Real end-to-end**: ran `exiftool_extract()` against a real sidecar-less Sony A7 IV clip (`A74_*.MP4`, no M01.XML). Raw `-Make -Model` blank; function now returns `camera_make='Sony'`, `camera_model='ILCE-7M4'` (was `None`).
- **Unit**: 2 new tests — embedded-XML fallback populates when standard tags absent; standard tags win when both present.
- **Regression**: 674 passed / 5 skipped locally.

## Out of scope

`start_tc` extraction already exists (`ingest.py`) — the 恬馨 clips' empty timecodes were a legacy-ingest artifact, not a current gap. Camera metadata only. Backfilling already-ingested rows is a separate `--refresh` concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)