### PR TITLE
fix(ingest): bench summary reports effective vision model, not config default

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -72,6 +72,16 @@ def _stage(marker: str, stage: str) -> None:
         print(f" >{marker}", end="", flush=True)
 
 
+def _bench_pipeline_desc():
+    """Human-readable pipeline string for the benchmark summary. Reports the
+    *effective* vision model (settings.vision_model(), = config.VISION_MODEL
+    when unset) so a `vision.model` override isn't misreported — warmup and the
+    real vision calls both consume settings.vision_model()."""
+    import settings as _settings
+    return "faster-whisper {0} + Silero VAD + {1}".format(
+        config.WHISPER_MODEL, _settings.vision_model())
+
+
 def _warm_up_vision_model():
     """Send a dummy request to ensure the vision model is loaded in VRAM."""
     import urllib.request
@@ -1845,10 +1855,14 @@ def main():
             print("[embed] run `python embed.py` manually; ingest itself succeeded.")
 
     if bench_log:
+        # Report the *effective* vision model, not config.VISION_MODEL — a
+        # `vision.model` override would otherwise misreport the model actually
+        # used for this run (see _bench_pipeline_desc).
+        _pipeline_desc = _bench_pipeline_desc()
         print(f"\n{'='*60}")
         print(f"BENCHMARK SUMMARY — {datetime.now().strftime('%Y-%m-%d %H:%M')}")
         print(f"{'='*60}")
-        print(f"Pipeline: faster-whisper {config.WHISPER_MODEL} + Silero VAD + {config.VISION_MODEL}")
+        print(f"Pipeline: {_pipeline_desc}")
         print(f"{'─'*60}")
         print(f"{'File':<20} {'Duration':>8} {'Process':>8} {'Speed':>8}")
         print(f"{'─'*60}")
@@ -1864,7 +1878,7 @@ def main():
         bench_path = config.BASE_DIR / "bench_ingest.json"
         bench_data = {
             "timestamp": datetime.now().isoformat(),
-            "pipeline": f"faster-whisper {config.WHISPER_MODEL} + Silero VAD + {config.VISION_MODEL}",
+            "pipeline": _pipeline_desc,
             "gpu": detect_gpu(),
             "total_duration_s": round(total_dur, 1),
             "total_process_s": round(batch_elapsed, 1),

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -38,6 +38,25 @@ def test_parse_xavc_sidecar_malformed(tmp_path):
     assert ingest.parse_xavc_sidecar(str(mp4)) == {}
 
 
+# bench summary footer must report the *effective* vision model, not the
+# config default (todo: override active 時誤報模型 cosmetic bug)
+
+def test_bench_pipeline_desc_reports_effective_vision_model(monkeypatch):
+    import sys, os
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    import ingest, settings
+
+    # No override → equals config default (behavior-preserving)
+    monkeypatch.setattr(settings, "vision_model", lambda project=None: ingest.config.VISION_MODEL)
+    assert ingest.config.VISION_MODEL in ingest._bench_pipeline_desc()
+
+    # vision.model override active → footer reports the override, not the default
+    monkeypatch.setattr(settings, "vision_model", lambda project=None: "qwen3-vl:8b")
+    desc = ingest._bench_pipeline_desc()
+    assert "qwen3-vl:8b" in desc
+    assert ingest.config.WHISPER_MODEL in desc
+
+
 # issue #115: Sony XAVC embedded-XML (NRT) camera identity fallback
 
 def test_exiftool_camera_falls_back_to_embedded_xml_device(monkeypatch):


### PR DESCRIPTION
## Problem

The benchmark summary footer and `bench_ingest.json` printed `config.VISION_MODEL`, but warmup (`_warm_up_vision_model`) and the real vision calls consume `settings.vision_model()` — the *effective* model (equals `config.VISION_MODEL` when unset, the override otherwise). So when a `vision.model` override is active (e.g. `settings.put("vision.model", "qwen3-vl:8b")`), the footer/JSON misreported the model actually used for the run.

Surfaced as a known cosmetic finding during the 2026-06-29 M2 real-GPU ingest verification.

## Fix

Extract `_bench_pipeline_desc()` which resolves the effective vision model via `settings.vision_model()`, and use it for both the printed footer and the saved `bench_ingest.json` `pipeline` field. Behavior-preserving when no override is set.

## Verification

- **Runtime**: `_bench_pipeline_desc()` with no override resolves to `config.VISION_MODEL` (`qwen2.5vl:7b`) — matches prior output.
- **Unit**: new test covers both the default (== config) and override (reports the override) paths.
- **Regression**: 675 passed / 5 skipped locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)