### PR TITLE
feat(ingest): source vision model picker from installed Ollama models (brick 4b)

### DIFF
--- a/server.py
+++ b/server.py
@@ -1912,6 +1912,17 @@ def ingest_engines(
         {"mode": k, "name": config.WHISPER_GUARD_LAYERS[k].get("name", str(k))}
         for k in sorted(config.WHISPER_GUARD_LAYERS)
     ]
+    # brick 4b: the vision picker's options come from the installed Ollama models
+    # (queried live, vision-capable only), so the setup dialog is driven by
+    # backend truth instead of a hardcoded list. Empty when Ollama is unreachable
+    # → the UI falls back to a free-text field. Always include the current
+    # effective model so the active selection shows even if detection missed it
+    # (or Ollama is down).
+    import vision as _vision
+    cur_vision = settings_store.effective("vision.model")
+    vision_models = _vision.list_vision_models()
+    if cur_vision and cur_vision not in vision_models:
+        vision_models = sorted(set(vision_models) | {cur_vision})
     # Phase 9.7 G5③: the dialog's defaults come from the persisted settings
     # (library default), falling back to config. These are genuinely consumed —
     # IngestSetup pre-fills its pickers from them, and the vision model/num_ctx
@@ -1921,7 +1932,8 @@ def ingest_engines(
         "default_mode": settings_store.effective("transcription.default_mode"),
         "default_language": settings_store.effective("transcription.default_language"),
         "default_recursive": settings_store.effective("ingest.recursive"),
-        "vision_model": settings_store.effective("vision.model"),
+        "vision_model": cur_vision,
+        "vision_models": vision_models,
         "vision_num_ctx": settings_store.effective("vision.num_ctx"),
         "languages": _INGEST_LANGUAGES,
     }

--- a/tests/test_ingest_options.py
+++ b/tests/test_ingest_options.py
@@ -57,10 +57,92 @@ def test_brick4_invalid_values_dropped():
     assert "--whisper-guard" not in opts and "--language" not in opts
 
 
-def test_brick4_engines_endpoint_shape(fastapi_client):
+def test_brick4_engines_endpoint_shape(fastapi_client, monkeypatch):
+    # keep the endpoint deterministic + offline — don't let it hit a real Ollama
+    import vision
+    monkeypatch.setattr(vision, "list_vision_models", lambda: ["qwen3-vl:8b"])
     r = fastapi_client.get("/api/ingest/engines")
     assert r.status_code == 200
     data = r.json()
     assert data["default_mode"] in {m["mode"] for m in data["whisper_modes"]}
     assert data["whisper_modes"] and all("name" in m for m in data["whisper_modes"])
     assert {lang["code"] for lang in data["languages"]} >= {"zh", "en"}
+
+
+# ── brick 4b: vision model picker sourced from installed Ollama models ─────────
+
+class _FakeResp:
+    def __init__(self, payload, ok=True):
+        self._payload = payload
+        self.ok = ok
+
+    def json(self):
+        return self._payload
+
+
+def _clear_vision_caches():
+    import vision
+    vision._vision_capable_cache.clear()
+
+
+def test_brick4b_is_vision_model_prefers_ollama_capabilities(monkeypatch):
+    import vision
+    _clear_vision_caches()
+    # Ollama reports capabilities → trust them over the name (a "vision" model
+    # named plainly is still detected; a "vl"-named model reported non-vision is
+    # correctly excluded).
+    caps = {"qwen3-vl:8b": ["completion", "vision"], "text-only:latest": ["completion"]}
+    monkeypatch.setattr(vision.requests, "post",
+                        lambda url, json, timeout: _FakeResp({"capabilities": caps[json["name"]]}))
+    assert vision._is_vision_model("qwen3-vl:8b") is True
+    assert vision._is_vision_model("text-only:latest") is False
+
+
+def test_brick4b_is_vision_model_falls_back_to_name_heuristic(monkeypatch):
+    import vision
+    _clear_vision_caches()
+    # /api/show unreachable (older Ollama / down) → name heuristic decides
+    def _boom(*a, **k):
+        raise Exception("no /api/show")
+    monkeypatch.setattr(vision.requests, "post", _boom)
+    assert vision._is_vision_model("qwen2.5-vl:7b") is True
+    assert vision._is_vision_model("qwen2.5vl:7b") is True  # no separator before "vl"
+    assert vision._is_vision_model("llama3.2-vision:11b") is True
+    assert vision._is_vision_model("llava:13b") is True
+    assert vision._is_vision_model("moondream:latest") is True
+    assert vision._is_vision_model("llama3:8b") is False
+    assert vision._is_vision_model("mistral:7b") is False
+
+
+def test_brick4b_list_vision_models_filters_and_sorts(monkeypatch):
+    import vision
+    _clear_vision_caches()
+    tags = {"models": [
+        {"name": "qwen3-vl:8b"}, {"name": "llama3:8b"}, {"name": "qwen2.5vl:7b"},
+        {"name": "llava:13b"}, {"name": "nomic-embed-text:latest"},
+    ]}
+    monkeypatch.setattr(vision.requests, "get", lambda url, timeout: _FakeResp(tags))
+    # no capabilities from /api/show → name heuristic (incl. the no-separator
+    # "qwen2.5vl" case that only the widened heuristic catches)
+    monkeypatch.setattr(vision.requests, "post", lambda url, json, timeout: _FakeResp({}, ok=False))
+    out = vision.list_vision_models()
+    assert out == ["llava:13b", "qwen2.5vl:7b", "qwen3-vl:8b"]  # vision-only, sorted
+
+
+def test_brick4b_list_vision_models_empty_when_ollama_down(monkeypatch):
+    import vision
+    _clear_vision_caches()
+    def _boom(*a, **k):
+        raise Exception("connection refused")
+    monkeypatch.setattr(vision.requests, "get", _boom)
+    assert vision.list_vision_models() == []  # graceful → UI falls back to free text
+
+
+def test_brick4b_engines_includes_current_model_even_if_undetected(fastapi_client, monkeypatch):
+    import vision, settings as settings_store
+    monkeypatch.setattr(vision, "list_vision_models", lambda: ["llava:13b"])
+    monkeypatch.setattr(settings_store, "effective",
+                        lambda key, *a, **k: "custom-vl:latest" if key == "vision.model" else "x")
+    data = fastapi_client.get("/api/ingest/engines").json()
+    assert "custom-vl:latest" in data["vision_models"]  # active selection always present
+    assert data["vision_model"] == "custom-vl:latest"

--- a/vision.py
+++ b/vision.py
@@ -33,6 +33,54 @@ def model_available(name: str) -> bool:
         avail = False
     _model_avail_cache[name] = avail
     return avail
+
+
+# Vision-capable model name families — used as a fallback when Ollama's
+# /api/show doesn't report capabilities (older Ollama) or is unreachable.
+_VISION_NAME_RE = re.compile(
+    r"(?:^|[-_/.\d])v(?:l|ision)(?:[-_.:]|$)"   # …vl / …-vision (qwen2.5vl, qwen3-vl, llama3.2-vision)
+    r"|llava|bakllava|moondream|minicpm-v|granite[\d.]*-vision|cogvlm",
+    re.IGNORECASE,
+)
+
+_vision_capable_cache: Dict[str, bool] = {}
+
+
+def _is_vision_model(name: str) -> bool:
+    """Best-effort vision-capability check for an installed Ollama model. Prefers
+    Ollama's own reported capabilities (POST /api/show → capabilities: [...]),
+    falling back to a name heuristic when capabilities are absent (older Ollama)
+    or the show call fails. Cached per process."""
+    if not name:
+        return False
+    if name in _vision_capable_cache:
+        return _vision_capable_cache[name]
+    result = None
+    try:
+        r = requests.post(f"{config.OLLAMA_URL}/api/show", json={"name": name}, timeout=5)
+        if r.ok:
+            caps = r.json().get("capabilities")
+            if isinstance(caps, list):
+                result = "vision" in caps
+    except Exception:
+        result = None  # fall through to the name heuristic
+    if result is None:
+        result = bool(_VISION_NAME_RE.search(name))
+    _vision_capable_cache[name] = result
+    return result
+
+
+def list_vision_models() -> List[str]:
+    """Installed Ollama models that can do vision, for the ingest-setup picker so
+    the UI is driven by backend truth instead of a hardcoded list. Returns a
+    sorted list of model tags; empty when Ollama is unreachable (the UI then
+    falls back to a free-text vision-model field)."""
+    try:
+        r = requests.get(f"{config.OLLAMA_URL}/api/tags", timeout=5)
+        installed = [m.get("name", "") for m in r.json().get("models", []) if m.get("name")]
+    except Exception:
+        return []
+    return sorted(n for n in installed if _is_vision_model(n))
 PROMPT = (
     "請用繁體中文分析這個影片畫面，回傳嚴格的 JSON 格式（不要加 markdown 標記）：\n"
     "{\n"


### PR DESCRIPTION
## Context

The ingest setup dialog's **"Vision tagging · ollama"** picker (brick 4b) was pending because `/api/ingest/engines` only returned the single current `vision_model` — there was no source of *selectable* models to build a picker from. The whisper picker got backend-truth options (`whisper_modes`) in #77; this does the same for vision.

## Change

`vision.list_vision_models()`:
- Queries Ollama `/api/tags` for installed models, keeps the vision-capable ones.
- Vision capability is decided by Ollama's own `/api/show` `capabilities` array (accurate — catches names a heuristic would miss, e.g. `qwen2.5vl` with no separator), falling back to a **name heuristic** when `/api/show` doesn't report capabilities (older Ollama) or is unreachable. Per-model cached.
- Returns `[]` when Ollama is down → the UI degrades to a free-text field.

`/api/ingest/engines` now returns `vision_models`, always unioned with the current effective `vision.model` so the active selection is present even if detection missed it or Ollama is down.

## Verification

- **Real local Ollama** (6 models installed): `list_vision_models()` returns exactly the 3 vision models (`minicpm-v`, `qwen2.5vl`, `qwen3-vl`), excluding the embedding (`nomic-embed-text`, `bge-m3`) and text-only (`qwen2.5:14b`) models.
- **Unit** (5 new): capabilities-preferred detection, name-heuristic fallback (incl. no-separator `qwen2.5vl`), filter+sort, empty-when-Ollama-down, engines includes current model even if undetected.
- **Regression**: 680 passed / 5 skipped locally; endpoint test mocks `list_vision_models` so CI stays offline/deterministic.

## Scope

Backend unblock only (the documented step 1: "先加 ollama 安裝模型清單來源"). The **frontend IngestSetup picker** that consumes `vision_models` is the remaining half of brick 4b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)