### PR TITLE
chore(frontend): source dev-server allowedHosts from env, not a hardcoded landmine

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,18 +1,34 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 
 // arkiv frontend — Svelte 4 + Vite 5. Backend (FastAPI) runs on :8501;
 // dev proxy forwards /api + /thumbnails so the SPA can call it during `npm run dev`.
-export default defineConfig({
-  plugins: [svelte()],
-  server: {
-    port: 5173,
-    proxy: {
-      // explicit IPv4 — `localhost` resolves to ::1 first on dual-stack macOS,
-      // but the backend binds 127.0.0.1, so localhost would ECONNREFUSED.
-      '/api': 'http://127.0.0.1:8501',
-      '/thumbnails': 'http://127.0.0.1:8501',
-      '/ws': { target: 'ws://127.0.0.1:8501', ws: true },
+export default defineConfig(({ mode }) => {
+  // Extra dev-server Host-header allowlist, sourced from the environment so it stays
+  // out of git. Vite blocks non-localhost Host headers (anti DNS-rebinding); to view
+  // the dev server over e.g. Tailscale serve, set in a gitignored frontend/.env.local:
+  //   ARKIV_DEV_ALLOWED_HOSTS=.ts.net
+  // Leading-dot entries match a domain and all its subdomains. Empty = Vite default.
+  // Read via loadEnv (Vite does NOT populate process.env from .env files); the
+  // non-VITE_ prefix keeps it server-side only, out of the client bundle.
+  const env = loadEnv(mode, process.cwd(), '')
+  const extraAllowedHosts = (env.ARKIV_DEV_ALLOWED_HOSTS ?? '')
+    .split(',')
+    .map((h) => h.trim())
+    .filter(Boolean)
+
+  return {
+    plugins: [svelte()],
+    server: {
+      port: 5173,
+      allowedHosts: extraAllowedHosts,
+      proxy: {
+        // explicit IPv4 — `localhost` resolves to ::1 first on dual-stack macOS,
+        // but the backend binds 127.0.0.1, so localhost would ECONNREFUSED.
+        '/api': 'http://127.0.0.1:8501',
+        '/thumbnails': 'http://127.0.0.1:8501',
+        '/ws': { target: 'ws://127.0.0.1:8501', ws: true },
+      },
     },
-  },
+  }
 })


### PR DESCRIPTION
## What

The dev-server Host allowlist for viewing arkiv over **Tailscale serve** was being added as a hardcoded line marked *"LOCAL-ONLY — do not commit / revert before committing"*:

```js
allowedHosts: ['.ts.net'],   // do not commit
```

A `git add -A` sweeps that into a commit, weakening Vite's anti-DNS-rebinding protection for every environment. This replaces it with an env-sourced allowlist that is **safe to commit** and needs no manual reverting.

## How

- Read `ARKIV_DEV_ALLOWED_HOSTS` via `loadEnv()` in a config function.
  - Vite does **not** populate `process.env` from `.env` files — the first naive `process.env.*` attempt read `undefined` and the allowlist silently stayed empty (caught in testing, see below).
  - Non-`VITE_` prefix keeps it server-side only, out of the client bundle.
- Local usage — put in a gitignored `frontend/.env.local`:
  ```
  ARKIV_DEV_ALLOWED_HOSTS=.ts.net
  ```
- Committed default = empty allowlist = Vite's stock protection.

## Verification

`npm run dev` + Host-header probes against the running dev server:

| Host header | Expected | Result |
|---|---|---|
| `foo.<tailnet>.ts.net` (env set) | allow | `200` ✅ |
| `evil.example.com` | block | `403` ✅ |
| `bar.ts.net.evil.com` (prefix trick) | block | `403` ✅ |
| `ts.net` (base domain) | allow | `200` ✅ |
| `foo.<tailnet>.ts.net` (**empty** env) | block | `403` ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)