### PR TITLE
chore: versioned pre-commit hooks — do-not-commit + Vite allowedHosts guards

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# arkiv — pre-commit hook (versioned; enable with scripts/install-hooks.sh)
+#
+# Guards against two classes of landmine that a routine `git add -A` would sweep
+# into a commit:
+#   §1  do-not-commit sentinel markers left in code/config
+#   §2  a hardcoded / wide-open Vite dev-server allowedHosts (must be env-sourced)
+#
+# Enable once per clone:  bash scripts/install-hooks.sh   (sets core.hooksPath=.githooks)
+# Emergency bypass (NOT recommended):  git commit --no-verify
+set -uo pipefail
+
+FAIL=0
+STAGED=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null || true)
+
+# ============================================================================
+# §1 do-not-commit sentinel guard
+# 掃非 markdown 的 staged 檔含 sentinel token。.md 排除（docs 本來就會提及）；
+# .githooks/ 排除（hook 定義本身合法引用 token）。
+# ============================================================================
+if [ -n "$STAGED" ]; then
+  while IFS= read -r file; do
+    case "$file" in
+      *.md|*.markdown) continue ;;
+      .githooks/*) continue ;;
+      *.png|*.jpg|*.jpeg|*.gif|*.ico|*.svg|*.woff*|*.ttf|*.eot|*.mp4|*.mov|*.mp3|*.wav|*.pdf) continue ;;
+    esac
+    [ -f "$file" ] || continue
+    content=$(git show ":$file" 2>/dev/null || true)
+    [ -z "$content" ] && continue
+    if printf '%s' "$content" | grep -qiE -- "(DO[[:space:]]+NOT[[:space:]]+COMMIT|@?NOCOMMIT)"; then
+      echo "❌ BLOCKED: do-not-commit marker left in $file"
+      echo "   → remove the temporary change, or source it from a gitignored .env.local"
+      FAIL=1
+    fi
+  done <<< "$STAGED"
+fi
+
+# ============================================================================
+# §2 Vite allowedHosts guard
+# committed vite config 的 dev-server host 白名單必須 env-source（見 frontend/vite.config.js
+# 的 ARKIV_DEV_ALLOWED_HOSTS + .env.local）。擋 `allowedHosts: true`（全開）與
+# `allowedHosts: [ ...literal... ]`（硬編碼 host）——兩者都會跨環境削弱反 DNS-rebinding 保護。
+# ============================================================================
+if [ -n "$STAGED" ]; then
+  while IFS= read -r file; do
+    case "$file" in
+      *.js|*.mjs|*.cjs|*.ts) ;;
+      *) continue ;;
+    esac
+    [ -f "$file" ] || continue
+    content=$(git show ":$file" 2>/dev/null || true)
+    [ -z "$content" ] && continue
+    # match `allowedHosts:` followed by `true` or `[` (array literal); the env-sourced
+    # form `allowedHosts: <variable>` does not match either.
+    if printf '%s' "$content" | grep -qE -- "allowedHosts[[:space:]]*:[[:space:]]*(true|\[)"; then
+      echo "❌ BLOCKED: hardcoded / wide-open Vite allowedHosts in $file"
+      echo "   → source it from env instead, e.g.:"
+      echo "       const hosts = (loadEnv(mode, process.cwd(), '').ARKIV_DEV_ALLOWED_HOSTS ?? '')"
+      echo "         .split(',').map(s=>s.trim()).filter(Boolean)"
+      echo "       server: { allowedHosts: hosts }"
+      echo "     and put your local hosts in a gitignored frontend/.env.local"
+      FAIL=1
+    fi
+  done <<< "$STAGED"
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+  echo ""
+  echo "Pre-commit checks failed. Fix the issues above."
+  echo "Emergency bypass (NOT recommended): git commit --no-verify"
+  exit 1
+fi
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,19 @@ python health.py
 uvicorn server:app --host 0.0.0.0 --port 8501 --reload
 ```
 
+### Git hooks
+
+Enable the repo's pre-commit checks once per clone:
+
+```bash
+bash scripts/install-hooks.sh   # points core.hooksPath at .githooks/
+```
+
+The pre-commit hook blocks two easy-to-miss landmines: `DO NOT COMMIT` / `NOCOMMIT`
+markers left in code, and a hardcoded or wide-open Vite dev-server `allowedHosts`
+(it must be sourced from a gitignored `frontend/.env.local` — see `frontend/vite.config.js`).
+Bypass in an emergency with `git commit --no-verify`.
+
 ## How to Contribute
 
 ### Reporting Bugs

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# arkiv — enable the versioned git hooks in .githooks/
+# Run once per clone:  bash scripts/install-hooks.sh
+#
+# Git does not auto-enable repo-tracked hooks (.git/hooks is local + untracked),
+# so each contributor points core.hooksPath at the versioned .githooks/ directory.
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
+
+git config core.hooksPath .githooks
+chmod +x .githooks/* 2>/dev/null || true
+
+echo "✓ core.hooksPath → .githooks (hooks enabled for this clone)"
+echo "  active hooks: $(ls -1 .githooks 2>/dev/null | tr '\n' ' ')"


### PR DESCRIPTION
## What

arkiv had **no hook infrastructure** (bare `.git/hooks`, untracked). This adds a versioned `.githooks/pre-commit` that blocks two easy-to-miss landmines a routine `git add -A` would sweep into a commit:

- **§1 do-not-commit sentinel** — `DO NOT COMMIT` / `NOCOMMIT` / `@nocommit` left in code/config. Excludes `.md` (docs mention them) + `.githooks/` (the hook itself defines them).
- **§2 Vite allowedHosts** — a hardcoded (`allowedHosts: ['..']`) or wide-open (`allowedHosts: true`) dev-server host allowlist. It must be env-sourced from a gitignored `frontend/.env.local` (see #125, `ARKIV_DEV_ALLOWED_HOSTS`). Committing a literal re-opens the anti-DNS-rebinding hole across **every** environment. The env-sourced variable form (`allowedHosts: hosts`) passes.

## Enable

Git does not auto-enable repo-tracked hooks (`.git/hooks` is local + untracked), so once per clone:

```bash
bash scripts/install-hooks.sh   # sets core.hooksPath=.githooks
```

Documented in `CONTRIBUTING.md`. **Deliberately no npm `prepare` auto-wire** — fragile, and misses Python-only backend contributors.

## Verification (end-to-end against the real hook)

| Case | Expected | Result |
|---|---|---|
| sentinel in `.js` | block | ✅ |
| clean `.js` | pass | ✅ |
| sentinel in `.md` | exempt | ✅ |
| `allowedHosts: true` | block | ✅ |
| `allowedHosts: ['.ts.net']` | block | ✅ |
| `allowedHosts: <var>` (env-sourced) | pass | ✅ |
| own deliverables staged | pass (no self-trip) | ✅ |

## Companion

Pairs with #125 (env-sourced `allowedHosts`) — that fixes the current landmine, this stops the next one. Mirrors the OS-level rule codified in hevin-ai-os (private).

🤖 Generated with [Claude Code](https://claude.com/claude-code)