### PR TITLE
feat(search): wire cross-project federation into live search UI

### DIFF
--- a/frontend/src/lib/TopBar.svelte
+++ b/frontend/src/lib/TopBar.svelte
@@ -9,10 +9,15 @@
 
   let query = ''
   let searchEl
-  // Enter → ranked search screen; SearchLive reads ?q= on mount.
+  // Enter → ranked search screen; SearchLive reads ?q= (+ ?all=1) on mount, so the
+  // "All projects" toggle here seeds federation mode over there.
   function runSearch() {
     const q = query.trim()
-    push(q ? `/search-live?q=${encodeURIComponent(q)}` : '/search-live')
+    const p = new URLSearchParams()
+    if (q) p.set('q', q)
+    if (crossProject) p.set('all', '1')
+    const qs = p.toString()
+    push(qs ? `/search-live?${qs}` : '/search-live')
   }
   // ⌘K / Ctrl-K focuses the search box (the shortcut the hint advertises).
   function onGlobalKey(e) {

--- a/frontend/src/routes/SearchLive.svelte
+++ b/frontend/src/routes/SearchLive.svelte
@@ -1,9 +1,11 @@
-<!-- Search screen wired to LIVE semantic search (/api/media?q=). The mock
-     Search.svelte stays a design baseline; this is its functional twin.
-     Same-DB semantic + lexical ranking (score + excerpt come from the backend);
-     cross-project federation (the mock's multi-group view) needs a populated
-     ~/.arkiv-projects.json registry and is out of scope here — we show the one
-     active project. -->
+<!-- Search screen wired to LIVE search. Two modes:
+     • Current project (default) — same-DB semantic + lexical via /api/media?q=.
+     • All projects — cross-project federation via /api/search/all, fanned out
+       read-only across every project in ~/.arkiv-projects.json (managed in
+       Settings). Federated rows live in OTHER projects' DBs, so this server can't
+       stream/thumbnail/open them — they render read-only (no Open, placeholder
+       thumb) and grouped by project. Toggle with the facet or arrive with ?all=1
+       (the TopBar "All projects" button seeds it). -->
 <script>
   import { onMount } from 'svelte'
   import * as api from '../lib/api.js'
@@ -17,19 +19,30 @@
   let query = ''
   let state = 'idle' // idle | loading | ok | error
   let err = ''
-  let results = []
-  let total = 0
   let elapsedMs = 0
+  // Unified render model: one group in current-project mode, N in federation mode.
+  // { name, path, items:[…], count, openable, live }
+  let groups = []
+  let total = 0
+  $: shown = groups.reduce((a, g) => a + g.items.length, 0)
   // Derived from the project registry when available; neutral label otherwise,
   // so results outside the demo project aren't mislabeled (Codex review P3).
   let projectName = '目前專案'
 
+  // Cross-project federation. Off = current project only (/api/media). On = fan out
+  // read-only across the registry (/api/search/all). Federation errors (a stalled
+  // NAS mount, an unreadable project.db) surface per-project instead of failing the
+  // whole search.
+  let crossProject = false
+  let projectCount = 0 // registered projects, for the "All projects · N" label
+  let fedErrors = []
+  let projectsQueried = 0
+  let projectsFailed = 0
+
   // Media-type facet — wired to /api/media?media_type= (real backend filter; audit
   // H14 made it apply on the semantic-search branch too). 'all' omits the param.
-  // The mock's "Transcript only / Tags only" facets are intentionally dropped:
-  // /api/media has no such toggle, and faking one would violate evidence discipline.
-  // Cross-project federation ("All projects") stays deferred — needs a populated
-  // ~/.arkiv-projects.json; we scope to the current project ("Current only").
+  // /api/search/all has no media_type filter, so the facet is disabled (not silently
+  // ignored) in federation mode — evidence discipline over a fake toggle.
   let mediaType = 'all' // all | video | audio
   let counts = { all: null, video: null, audio: null } // library totals for labels
   const FACETS = [
@@ -52,45 +65,91 @@
     return i === -1 ? { b: text, m: '', a: '' } : { b: text.slice(0, i), m: q, a: text.slice(i + q.length) }
   }
 
-  // Update the hash so a query+facet is shareable/reloadable (the existing ?q=
-  // seed plus the new ?type=). replaceState avoids spamming history per keystroke.
+  // Update the hash so a query+facet+mode is shareable/reloadable (?q= seed plus
+  // ?type= and ?all=1). replaceState avoids spamming history per keystroke.
   function syncHash() {
     const p = new URLSearchParams()
     if (query.trim()) p.set('q', query.trim())
-    if (mediaType !== 'all') p.set('type', mediaType)
+    if (!crossProject && mediaType !== 'all') p.set('type', mediaType)
+    if (crossProject) p.set('all', '1')
     const qs = p.toString()
     history.replaceState(null, '', `#/search-live${qs ? '?' + qs : ''}`)
   }
 
   function setType(key) {
-    if (mediaType === key) return
+    if (crossProject || mediaType === key) return // media_type doesn't apply to federation
     mediaType = key
     syncHash()
     if (query.trim()) runSearch()
   }
 
+  function setCrossProject(on) {
+    if (crossProject === on) return
+    crossProject = on
+    syncHash()
+    if (query.trim()) runSearch()
+  }
+
+  // Current-project search (/api/media?q=) → one group of openable rows.
+  async function runCurrent(q) {
+    const params = { q, limit: 40 }
+    if (mediaType !== 'all') params.media_type = mediaType
+    const r = await api.getMedia(params)
+    total = r.total ?? (r.items || []).length
+    const items = (r.items || []).map((it) => ({
+      id: it.id,
+      name: it.filename || `#${it.id}`,
+      dur: fmtDur(it.duration_s),
+      score: typeof it.score === 'number' ? it.score : null,
+      excerpt: it.excerpt || it.transcript || '',
+      lang: it.lang || '',
+      thumb: api.thumbUrlFromPath(it.thumbnail_path),
+      tags: (it.tags || []).map((t) => t.name).slice(0, 4),
+    }))
+    groups = [{ name: projectName, path: '', items, count: total, openable: true, live: true }]
+    fedErrors = []
+    projectsQueried = 0
+    projectsFailed = 0
+  }
+
+  // Federated search (/api/search/all) → one group per project, read-only rows.
+  async function runFederated(q) {
+    const r = await api.search(q, { limit: 40 })
+    total = r.total_results ?? (r.items || []).length
+    projectsQueried = r.projects_queried ?? 0
+    projectsFailed = r.projects_failed ?? 0
+    // The "no matching projects" preflight error means an empty registry — surface
+    // it as guidance, not as a per-project failure row.
+    fedErrors = (r.errors || []).filter((e) => e.stage !== 'preflight' || e.project_name)
+    const byProject = new Map()
+    for (const it of r.items || []) {
+      const name = it.project_name || '（未命名專案）'
+      if (!byProject.has(name)) byProject.set(name, { name, path: it.project_path || '', items: [], count: 0, openable: false, live: false })
+      byProject.get(name).items.push({
+        id: it.media_id,
+        name: it.filename || `#${it.media_id}`,
+        dur: fmtDur(it.duration_s),
+        score: typeof it.score === 'number' ? it.score : null,
+        excerpt: it.excerpt || '',
+        lang: it.lang || '',
+        thumb: null, // cross-project: this server can't serve another project's thumbs
+        tags: [],
+      })
+    }
+    for (const g of byProject.values()) g.count = g.items.length
+    groups = [...byProject.values()]
+  }
+
   async function runSearch() {
     const q = query.trim()
-    if (!q) { state = 'idle'; results = []; total = 0; return }
+    if (!q) { state = 'idle'; groups = []; total = 0; fedErrors = []; return }
     state = 'loading'
     syncHash()
     const t0 = performance.now()
     try {
-      const params = { q, limit: 40 }
-      if (mediaType !== 'all') params.media_type = mediaType
-      const r = await api.getMedia(params)
+      if (crossProject) await runFederated(q)
+      else await runCurrent(q)
       elapsedMs = Math.round(performance.now() - t0)
-      total = r.total ?? (r.items || []).length
-      results = (r.items || []).map((it) => ({
-        id: it.id,
-        name: it.filename || `#${it.id}`,
-        dur: fmtDur(it.duration_s),
-        score: typeof it.score === 'number' ? it.score : null,
-        excerpt: it.excerpt || it.transcript || '',
-        thumb: api.thumbUrlFromPath(it.thumbnail_path),
-        // first few tag names (raw per-result tags); keep it light
-        tags: (it.tags || []).map((t) => t.name).slice(0, 4),
-      }))
       state = 'ok'
     } catch (e) {
       state = 'error'
@@ -112,20 +171,22 @@
   }
 
   onMount(async () => {
-    // label the result group from the active project registry, if any
+    // label the current-project group + count the registry for the "All projects" facet
     try {
       const r = await api.getProjects()
+      projectCount = r?.total ?? (r?.projects?.length ?? 0)
       const name = r?.projects?.[0]?.name
       if (name) projectName = name
-    } catch (e) { /* no registry → keep neutral label */ }
+    } catch (e) { /* no registry → keep neutral label, projectCount 0 */ }
     loadCounts()
-    // seed from the hash, e.g. #/search-live?q=餐廳&type=video
+    // seed from the hash, e.g. #/search-live?q=餐廳&type=video  or  ?q=…&all=1
     const h = window.location.hash
     const qi = h.indexOf('?')
     if (qi !== -1) {
       const p = new URLSearchParams(h.slice(qi + 1))
+      if (p.get('all') === '1') crossProject = true
       const t = p.get('type')
-      if (t === 'video' || t === 'audio') mediaType = t
+      if (!crossProject && (t === 'video' || t === 'audio')) mediaType = t
       const q = p.get('q')
       if (q) { query = q; runSearch() }
     }
@@ -143,7 +204,9 @@
 
   <div class="main">
     <div class="hero">
-      <Eyebrow style="margin-bottom:10px;">Search · 語意 + 關鍵字（current project）</Eyebrow>
+      <Eyebrow style="margin-bottom:10px;">
+        Search · 語意 + 關鍵字（{crossProject ? '跨專案聯邦' : 'current project'}）
+      </Eyebrow>
       <div class="queryrow">
         <Mono dim style="font-size:26px;font-weight:400;">⌕</Mono>
         <input
@@ -156,15 +219,32 @@
       </div>
       <div class="facets">
         {#each FACETS as f}
-          <button class="facet" class:active={mediaType === f.key} on:click={() => setType(f.key)}>
+          <button
+            class="facet" class:active={!crossProject && mediaType === f.key}
+            disabled={crossProject}
+            title={crossProject ? '跨專案搜尋不支援媒體類型過濾' : ''}
+            on:click={() => setType(f.key)}
+          >
             {f.label}{#if counts[f.key] != null} · {counts[f.key]}{/if}
           </button>
         {/each}
         <div class="fvrule"></div>
-        <button class="facet active" disabled title="跨專案聯邦搜尋待 ~/.arkiv-projects.json registry（暫未啟用）">Current only</button>
+        <button
+          class="facet" class:active={!crossProject}
+          title="只搜尋目前開啟的專案"
+          on:click={() => setCrossProject(false)}
+        >Current only</button>
+        <button
+          class="facet" class:active={crossProject}
+          title="跨專案聯邦搜尋 · 讀取 ~/.arkiv-projects.json 登記的所有專案（在設定新增）"
+          on:click={() => setCrossProject(true)}
+        >All projects{#if projectCount} · {projectCount}{/if}</button>
         <div class="fvrule"></div>
         {#if state === 'ok'}
-          <Mono dim style="font-size:10.5px;">{total} matches · {elapsedMs}ms · semantic + lexical</Mono>
+          <Mono dim style="font-size:10.5px;">
+            {total} matches · {elapsedMs}ms
+            {#if crossProject}· {projectsQueried - projectsFailed}/{projectsQueried} 專案{:else}· semantic + lexical{/if}
+          </Mono>
         {:else if state === 'loading'}
           <Mono dim style="font-size:10.5px;">searching…</Mono>
         {:else if state === 'error'}
@@ -176,48 +256,78 @@
     </div>
 
     <div class="results">
-      {#if state === 'ok' && results.length === 0}
-        <div class="emptyresult">沒有符合「{query}」的素材</div>
-      {:else if results.length}
-        <section class="rgroup">
-          <div class="ghead">
-            <Mono dim style="font-size:10px;letter-spacing:0.1em;">PROJECT</Mono>
-            <div class="ak-display gproj">{projectName}</div>
-            <Mono dim style="font-size:10.5px;">{results.length} of {total}</Mono>
-            <div class="grow"></div>
-            <Mono dim style="font-size:9.5px;letter-spacing:0.08em;">● LIVE</Mono>
-          </div>
+      {#if crossProject && state === 'ok' && projectsQueried === 0}
+        <div class="emptyresult">
+          尚未登記任何專案 — 到 <a href="#/settings">設定 → 跨庫專案</a> 新增要一起搜尋的素材庫
+        </div>
+      {/if}
 
-          <div class="rows">
-            {#each results as r, i (r.id)}
-              {@const p = hl(r.excerpt, query.trim())}
-              <a class="rrow" class:first={i === 0} href={`#/main-live?sel=${r.id}`}>
-                <div class="rthumb">
-                  {#if r.thumb}
-                    <img class="rthumbimg" src={r.thumb} alt={r.name} loading="lazy" />
-                  {:else}
-                    <Thumb seed={r.id} kind="video" {theme} />
-                  {/if}
-                  <Mono style="position:absolute;bottom:2px;right:3px;font-size:9px;color:#f3f2ee;background:rgba(10,10,12,.78);padding:1px 3px;">{r.dur}</Mono>
-                </div>
-                <div class="rcontent">
-                  <div class="rtop">
-                    <Mono style="font-size:11.5px;font-weight:500;color:var(--ink);">{r.name}</Mono>
-                    <div class="rtags">{#each r.tags as t}<span class="rtag">{t}</span>{/each}</div>
+      {#if crossProject && fedErrors.length}
+        <div class="fedbanner">
+          <Mono style="font-size:10px;letter-spacing:0.08em;color:var(--cyan);">⚠ {fedErrors.length} 專案查詢失敗</Mono>
+          {#each fedErrors as e}
+            <Mono dim style="font-size:10px;">· {e.project_name || e.project_path || '?'}: {e.error}</Mono>
+          {/each}
+        </div>
+      {/if}
+
+      {#if state === 'ok' && shown === 0 && !(crossProject && projectsQueried === 0)}
+        <div class="emptyresult">沒有符合「{query}」的素材</div>
+      {:else if shown}
+        {#each groups as g (g.name)}
+          <section class="rgroup">
+            <div class="ghead">
+              <Mono dim style="font-size:10px;letter-spacing:0.1em;">PROJECT</Mono>
+              <div class="ak-display gproj">{g.name}</div>
+              <Mono dim style="font-size:10.5px;">{g.items.length}{#if g.live} of {g.count}{/if}</Mono>
+              <div class="grow"></div>
+              {#if g.live}
+                <Mono dim style="font-size:9.5px;letter-spacing:0.08em;">● LIVE</Mono>
+              {:else}
+                <Mono dim style="font-size:9.5px;letter-spacing:0.08em;" title="結果在其他專案的資料庫 · 唯讀，無法在此開啟/播放">唯讀 · 跨庫</Mono>
+              {/if}
+            </div>
+
+            <div class="rows">
+              {#each g.items as r, i (g.name + ':' + r.id)}
+                {@const p = hl(r.excerpt, query.trim())}
+                <svelte:element
+                  this={g.openable ? 'a' : 'div'}
+                  class="rrow" class:first={i === 0} class:readonly={!g.openable}
+                  href={g.openable ? `#/main-live?sel=${r.id}` : undefined}
+                >
+                  <div class="rthumb">
+                    {#if r.thumb}
+                      <img class="rthumbimg" src={r.thumb} alt={r.name} loading="lazy" />
+                    {:else}
+                      <Thumb seed={r.id} kind="video" {theme} />
+                    {/if}
+                    <Mono style="position:absolute;bottom:2px;right:3px;font-size:9px;color:#f3f2ee;background:rgba(10,10,12,.78);padding:1px 3px;">{r.dur}</Mono>
                   </div>
-                  {#if r.excerpt}<div class="snippet">{p.b}<span class="mark">{p.m}</span>{p.a}</div>{/if}
-                </div>
-                <div class="rscore">
-                  {#if r.score != null}
-                    <Mono style="font-size:13px;font-weight:600;color:var(--ink);">{r.score.toFixed(2)}</Mono>
-                    <Mono dim style="font-size:9px;display:block;margin-top:1px;letter-spacing:0.08em;">SCORE</Mono>
-                  {/if}
-                </div>
-                <div class="raction"><span class="ak-btn openbtn">Open →</span></div>
-              </a>
-            {/each}
-          </div>
-        </section>
+                  <div class="rcontent">
+                    <div class="rtop">
+                      <Mono style="font-size:11.5px;font-weight:500;color:var(--ink);">{r.name}</Mono>
+                      <div class="rtags">
+                        {#each r.tags as t}<span class="rtag">{t}</span>{/each}
+                        {#if !g.openable && r.lang}<span class="rtag">{r.lang}</span>{/if}
+                      </div>
+                    </div>
+                    {#if r.excerpt}<div class="snippet">{p.b}<span class="mark">{p.m}</span>{p.a}</div>{/if}
+                  </div>
+                  <div class="rscore">
+                    {#if r.score != null}
+                      <Mono style="font-size:13px;font-weight:600;color:var(--ink);">{r.score.toFixed(2)}</Mono>
+                      <Mono dim style="font-size:9px;display:block;margin-top:1px;letter-spacing:0.08em;">SCORE</Mono>
+                    {/if}
+                  </div>
+                  <div class="raction">
+                    {#if g.openable}<span class="ak-btn openbtn">Open →</span>{/if}
+                  </div>
+                </svelte:element>
+              {/each}
+            </div>
+          </section>
+        {/each}
       {/if}
     </div>
   </div>
@@ -235,16 +345,20 @@
   .facet { font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; padding: 5px 10px; background: transparent; color: var(--ink-2); border: 1px solid var(--rule); cursor: pointer; line-height: 1; }
   .facet:hover:not(.active):not(:disabled) { border-color: var(--rule-hi); }
   .facet.active { background: var(--invert); color: var(--invert-ink); border-color: var(--invert); }
-  .facet:disabled { cursor: default; }
+  .facet:disabled { cursor: default; opacity: 0.5; }
   .fvrule { width: 1px; height: 14px; background: var(--rule); margin: 0 4px; }
   .results { flex: 1; overflow: auto; padding: 14px 64px 18px; }
+  .fedbanner { display: flex; flex-direction: column; gap: 2px; margin-bottom: 12px; padding: 8px 10px; border: 1px solid var(--rule); background: var(--surface-2); }
   .rgroup { margin-bottom: 16px; }
   .ghead { display: flex; align-items: baseline; gap: 12px; margin-bottom: 8px; padding-bottom: 6px; border-bottom: 1px solid var(--rule); }
   .gproj { font-size: 18px; letter-spacing: -0.03em; line-height: 1; color: var(--ink); }
   .emptyresult { padding: 24px 16px; font-family: var(--ak-mono); font-size: 11px; color: var(--quiet); text-align: center; letter-spacing: 0.05em; }
+  .emptyresult a { color: var(--ink-2); }
   .rrow { display: grid; grid-template-columns: 100px 1fr 60px 78px; gap: 14px; align-items: center; padding: 5px 0; border-top: 1px solid var(--rule); cursor: pointer; text-decoration: none; color: inherit; }
   .rrow.first { border-top: none; }
   .rrow:hover { background: var(--surface-2); }
+  .rrow.readonly { cursor: default; }
+  .rrow.readonly:hover { background: transparent; }
   .rthumb { position: relative; aspect-ratio: 16 / 9; background: var(--surface-2); overflow: hidden; }
   .rthumbimg { width: 100%; height: 100%; object-fit: cover; display: block; }
   .rcontent { min-width: 0; }


### PR DESCRIPTION
## What

Activates the multi-project **federation search** in the live UI — the greenlit "多專案先" step. The backend (`/api/search/all` + `/api/projects` registry) has been built, merged and tested since Phase 8.0c, but the frontend was deliberately stubbed: `api.search()` had **zero callers** and SearchLive's "Current only" facet was a `disabled` placeholder.

`SearchLive` now has two modes:
- **Current project** (default, unchanged) — `/api/media?q=`, openable rows.
- **All projects** — `/api/search/all`, fanned out read-only across the registry, results grouped by project.

## Cross-project safety (red lines)

Federated rows live in **other projects' DBs**, so this server can't stream/thumbnail/open them:
- Rendered **read-only**: no Open button, placeholder thumb, a `唯讀·跨庫` marker, and **not anchor elements** — you cannot click through to a non-local media id.
- Media-type facet is **disabled** (not silently ignored) in federation mode, since `/api/search/all` has no such filter — evidence discipline over a fake toggle.
- Per-project errors (stalled NAS mount, unreadable `project.db`) surface in a **banner** instead of failing the whole search.
- Empty registry shows **guidance to Settings**, not fake results.
- Path sanitization (Phase 16.2) is backend-side and **untouched**.

Mode is shareable via `?all=1`; the TopBar "All projects" toggle seeds it.

## Verification

End-to-end against **two registered projects** on a live backend (Playwright, headless):
- Federation renders **2 read-only groups**, 0 anchor rows, no Open affordance, media facets disabled, `All projects · 2` active.
- Current-only renders **openable rows** with thumbnails + `● LIVE`.
- Toggle swaps modes, updates the hash (`all=1` ↔ removed), re-runs the search.
- Empty registry → Settings guidance, no fake results.
- **0 console errors**; `npm run build` clean.

## Scope

Frontend-only (2 files). The cross-library **精選集 / bin** (copy clips into a new project) remains greenfield — a separate Phase 2 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)