### PR TITLE
feat(bins): cross-library 精選集 + copy-into-project (multi-project Phase 2)

### DIFF
--- a/bins.py
+++ b/bins.py
@@ -1,0 +1,373 @@
+"""Cross-library 精選集 (curated bins) — persistent, named selections of clips that
+live scattered across MULTIPLE registered projects.
+
+A bin references clips *by identity* — the (project_name, media_id) pair that
+survives federation's Phase-16.2 path sanitization — and never moves or mutates
+the source library (cross-library is forever read-only, W2.2 spec §0.3). The
+payoff action "copy selected clips into a new project" lives in server.py; this
+module owns the persistence + a per-item reachability gate.
+
+Storage mirrors the project registry (projects.py): a versioned, lock-guarded,
+atomically-written JSON that lives OUTSIDE any single project's .arkiv (a bin
+spans projects, so it can't belong to one project.db). Default
+~/.arkiv-bins.json, overridable via ARKIV_BINS_PATH.
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+BINS_VERSION = 1
+
+# Serializes bins read-modify-write so two concurrent add/remove calls (FastAPI
+# runs sync handlers in a threadpool) can't lose-update each other — same reason
+# projects.py serializes the registry.
+_BINS_LOCK = threading.Lock()
+
+
+class BinsError(Exception):
+    pass
+
+
+# Per-item reachability, surfaced in GET /api/bins/{id} and gated before copy.
+# OK plus the HealthStatus values (passed through) plus three bin-specific ones.
+STATUS_OK = "ok"
+STATUS_PROJECT_UNREGISTERED = "project_unregistered"  # project_name no longer in the registry
+STATUS_ROW_MISSING = "row_missing"                    # clip deleted from the source project.db
+STATUS_FILE_MISSING = "file_missing"                  # source file gone from disk
+STATUS_ERROR = "error"                                # unexpected failure probing the source
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _default_bins_path() -> Path:
+    return Path(
+        os.getenv("ARKIV_BINS_PATH", str(Path.home() / ".arkiv-bins.json"))
+    ).expanduser().resolve(strict=False)
+
+
+def _item_key(project_name: str, media_id: Any) -> tuple:
+    # Dedup key inside a bin. media_id is per-project auto-increment, so it must
+    # be qualified by the project name (federation's cross-project identity).
+    return (str(project_name), str(media_id))
+
+
+@dataclass
+class BinItem(object):
+    project_name: str
+    media_id: str
+    filename: str = ""
+    added_at: Optional[str] = None
+
+    @classmethod
+    def from_mapping(cls, data: Dict[str, Any]) -> "BinItem":
+        if not isinstance(data, dict):
+            raise BinsError("bin item must be an object")
+        project_name = data.get("project_name")
+        media_id = data.get("media_id")
+        if not project_name or media_id in (None, ""):
+            raise BinsError("bin item missing project_name or media_id")
+        return cls(
+            project_name=str(project_name),
+            media_id=str(media_id),
+            filename=str(data.get("filename") or ""),
+            added_at=data.get("added_at"),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "project_name": self.project_name,
+            "media_id": self.media_id,
+            "filename": self.filename,
+            "added_at": self.added_at,
+        }
+
+    def key(self) -> tuple:
+        return _item_key(self.project_name, self.media_id)
+
+
+@dataclass
+class Bin(object):
+    id: str
+    name: str
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    items: List[BinItem] = field(default_factory=list)
+
+    @classmethod
+    def from_mapping(cls, data: Dict[str, Any]) -> "Bin":
+        if not isinstance(data, dict):
+            raise BinsError("bin entry must be an object")
+        bin_id = data.get("id")
+        name = data.get("name")
+        if not bin_id or not name:
+            raise BinsError("bin entry missing id or name")
+        raw_items = data.get("items") or []
+        if not isinstance(raw_items, list):
+            raise BinsError("bin items must be a list")
+        return cls(
+            id=str(bin_id),
+            name=str(name),
+            created_at=data.get("created_at"),
+            updated_at=data.get("updated_at"),
+            items=[BinItem.from_mapping(item) for item in raw_items],
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "items": [item.to_dict() for item in self.items],
+        }
+
+    def summary(self) -> Dict[str, Any]:
+        # List view — no items payload (cheap; the detail view resolves statuses).
+        return {
+            "id": self.id,
+            "name": self.name,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "item_count": len(self.items),
+        }
+
+
+def load_bins() -> Dict[str, Any]:
+    path = _default_bins_path()
+    if not path.exists():
+        data = {"version": BINS_VERSION, "bins": []}
+        save_bins(data)
+        return data
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except ValueError as exc:
+        raise BinsError("bins JSON is corrupt") from exc
+    if not isinstance(data, dict):
+        raise BinsError("bins root must be an object")
+    bins = data.get("bins", [])
+    if not isinstance(bins, list):
+        raise BinsError("bins must be a list")
+    version = data.get("version", BINS_VERSION)
+    if version != BINS_VERSION:
+        raise BinsError("unsupported bins version")
+    data["version"] = version
+    data["bins"] = bins
+    return data
+
+
+def save_bins(data: Dict[str, Any]) -> None:
+    path = _default_bins_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": int(data.get("version", BINS_VERSION)),
+        "bins": data.get("bins", []),
+    }
+    # Unique tmp name per writer + atomic os.replace — see projects.save_registry
+    # for why a shared "<file>.tmp" corrupts under concurrent writers.
+    tmp_path = path.with_suffix(path.suffix + f".{os.getpid()}.{threading.get_ident()}.tmp")
+    try:
+        with tmp_path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+        tmp_path.replace(path)
+    finally:
+        if tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+
+
+def _load_bin_objects() -> List[Bin]:
+    return [Bin.from_mapping(raw) for raw in load_bins().get("bins", [])]
+
+
+def _find(bins: Iterable[Bin], bin_id: str) -> Optional[Bin]:
+    for b in bins:
+        if b.id == bin_id:
+            return b
+    return None
+
+
+def _persist(bins: List[Bin]) -> None:
+    data = load_bins()
+    data["bins"] = [b.to_dict() for b in bins]
+    save_bins(data)
+
+
+def list_bins() -> List[Bin]:
+    return _load_bin_objects()
+
+
+def get_bin(bin_id: str) -> Bin:
+    b = _find(_load_bin_objects(), bin_id)
+    if b is None:
+        raise BinsError("bin not found: {0}".format(bin_id))
+    return b
+
+
+def create_bin(name: str) -> Bin:
+    name = (name or "").strip()
+    if not name:
+        raise BinsError("bin name required")
+    with _BINS_LOCK:
+        bins = _load_bin_objects()
+        now = _now_iso()
+        new = Bin(id=uuid.uuid4().hex[:12], name=name, created_at=now, updated_at=now, items=[])
+        bins.append(new)
+        _persist(bins)
+        return new
+
+
+def rename_bin(bin_id: str, name: str) -> Bin:
+    name = (name or "").strip()
+    if not name:
+        raise BinsError("bin name required")
+    with _BINS_LOCK:
+        bins = _load_bin_objects()
+        target = _find(bins, bin_id)
+        if target is None:
+            raise BinsError("bin not found: {0}".format(bin_id))
+        target.name = name
+        target.updated_at = _now_iso()
+        _persist(bins)
+        return target
+
+
+def delete_bin(bin_id: str) -> Bin:
+    with _BINS_LOCK:
+        bins = _load_bin_objects()
+        target = _find(bins, bin_id)
+        if target is None:
+            raise BinsError("bin not found: {0}".format(bin_id))
+        _persist([b for b in bins if b.id != bin_id])
+        return target
+
+
+def add_items(bin_id: str, items: List[Dict[str, Any]]) -> Bin:
+    """Add items (dedup by (project_name, media_id), preserving add order). Accepts
+    a list of {project_name, media_id, filename?}."""
+    with _BINS_LOCK:
+        bins = _load_bin_objects()
+        target = _find(bins, bin_id)
+        if target is None:
+            raise BinsError("bin not found: {0}".format(bin_id))
+        existing = {item.key() for item in target.items}
+        now = _now_iso()
+        added = 0
+        for raw in items or []:
+            item = BinItem.from_mapping(raw)
+            if item.key() in existing:
+                continue
+            item.added_at = now
+            target.items.append(item)
+            existing.add(item.key())
+            added += 1
+        if added:
+            target.updated_at = now
+            _persist(bins)
+        return target
+
+
+def remove_item(bin_id: str, project_name: str, media_id: Any) -> Bin:
+    with _BINS_LOCK:
+        bins = _load_bin_objects()
+        target = _find(bins, bin_id)
+        if target is None:
+            raise BinsError("bin not found: {0}".format(bin_id))
+        drop = _item_key(project_name, media_id)
+        kept = [item for item in target.items if item.key() != drop]
+        if len(kept) != len(target.items):
+            target.items = kept
+            target.updated_at = _now_iso()
+            _persist(bins)
+        return target
+
+
+def bin_item_status(project_name: str, media_id: Any) -> str:
+    """Reference-integrity gate for one bin item. Composes the primitives that
+    already exist but that nothing wires together for a cross-project item:
+    registry lookup → library health → row-in-db → file-on-disk. Returns a status
+    string (STATUS_* / a HealthStatus value). The resolved absolute path is used
+    ONLY here (server-side); it is never returned to the client (Phase 16.2)."""
+    # federation drags chromadb at import; keep it lazy so pure-CRUD callers and
+    # tests don't pay for it.
+    from projects import discover_projects
+    from health import project_health, HealthStatus
+    from federation import _connect_project_db, _fetch_media_row, _resolve_paths
+
+    project = None
+    for candidate in discover_projects():
+        if candidate.name == project_name:
+            project = candidate
+            break
+    if project is None:
+        return STATUS_PROJECT_UNREGISTERED
+
+    health = project_health(project)
+    if health != HealthStatus.OK:
+        return health.value if isinstance(health, HealthStatus) else str(health)
+
+    conn = None
+    try:
+        conn = _connect_project_db(project)
+        row = _fetch_media_row(conn, media_id)
+        if row is None:
+            return STATUS_ROW_MISSING
+        _relative, absolute = _resolve_paths(project, row.get("path") or "")
+        if not absolute or not os.path.exists(absolute):
+            return STATUS_FILE_MISSING
+        return STATUS_OK
+    except Exception:
+        return STATUS_ERROR
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+def resolve_source(project_name: str, media_id: Any) -> Optional[Dict[str, Any]]:
+    """Server-side ONLY: (project_name, media_id) → {absolute_path, filename,
+    status}. The absolute path is for the copy orchestrator (server.py); never
+    hand it to a client. Returns None only if the project is unregistered."""
+    from projects import discover_projects
+    from federation import _connect_project_db, _fetch_media_row, _resolve_paths
+
+    project = None
+    for candidate in discover_projects():
+        if candidate.name == project_name:
+            project = candidate
+            break
+    if project is None:
+        return None
+
+    status = bin_item_status(project_name, media_id)
+    absolute = ""
+    filename = ""
+    if status == STATUS_OK:
+        conn = None
+        try:
+            conn = _connect_project_db(project)
+            row = _fetch_media_row(conn, media_id)
+            if row is not None:
+                _relative, absolute = _resolve_paths(project, row.get("path") or "")
+                filename = row.get("filename") or ""
+        finally:
+            if conn is not None:
+                conn.close()
+    return {
+        "project_name": project_name,
+        "media_id": str(media_id),
+        "status": status,
+        "absolute_path": absolute,
+        "filename": filename,
+    }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -10,6 +10,7 @@
   import QueryLive from './routes/QueryLive.svelte'
   import Offload from './routes/Offload.svelte'
   import SettingsLive from './routes/SettingsLive.svelte'
+  import Bins from './routes/Bins.svelte'
   import ToastHost from './lib/ToastHost.svelte'
   import { resolvedTheme } from './lib/prefs.js'
 
@@ -30,6 +31,7 @@
     '/chat-live': ChatLive, // E2 — chat wired to live /api/chat
     '/search-live': SearchLive, // search wired to live /api/media?q=
     '/query-live': QueryLive, // G6 — structured query builder, live /api/search/query
+    '/bins': Bins, // 多專案 Phase 2 — cross-library 精選集 (persistent named selections spanning projects)
     '/settings': SettingsLive, // settings — live theme switcher + real system/about (engine config deferred)
 
     // ── design reference (Claude-design mock artboards; not the product) ──────

--- a/frontend/src/lib/PoolSidebar.svelte
+++ b/frontend/src/lib/PoolSidebar.svelte
@@ -10,6 +10,8 @@
   export let onTag = null // (name) => void; live tag-click → filter
   export let liveCollections = null // [{key,title,count,items}]; null → section hidden
   export let onCollection = null // (collection) => void; click → filter to members
+  export let liveBins = null // [{id,name,item_count}] cross-library 精選集; null → section hidden
+  export let onBin = null // (bin) => void; click → open the bin
   export let liveStorage = null // {pct, used_gb, total_gb} from /api/stats.disk; null → mock placeholder
   export let onPool = null // (label) => void; click a Smart Pool → rating filter
   export let activePool = null // currently-active pool label (for row highlight)
@@ -96,6 +98,21 @@
           <div class="poolrow collrow" on:click={() => onCollection && onCollection(c)}>
             <span class="ellip">{c.title}</span>
             <Mono dim style="font-size:10px;flex:0 0 auto;">{c.count}</Mono>
+          </div>
+        {/each}
+      </div>
+    </section>
+  {/if}
+
+  {#if liveBins && liveBins.length}
+    <section>
+      <Eyebrow style="margin-bottom:10px;">精選集 · 跨庫</Eyebrow>
+      <div class="col">
+        {#each liveBins as bn (bn.id)}
+          <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+          <div class="poolrow collrow" on:click={() => onBin && onBin(bn)}>
+            <span class="ellip">★ {bn.name}</span>
+            <Mono dim style="font-size:10px;flex:0 0 auto;">{bn.item_count}</Mono>
           </div>
         {/each}
       </div>

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -36,6 +36,11 @@ async function req(path, { method = 'GET', body, signal } = {}) {
     headers,
     body: body !== undefined ? JSON.stringify(body) : undefined,
     signal,
+    // API responses are live data (reachability status, search hits, project
+    // health) — never let the browser serve a heuristically-cached copy, or a
+    // re-opened 精選集 shows stale reachability and the whole point (surfacing a
+    // moved/offline source) is defeated.
+    cache: 'no-store',
   })
   if (!res.ok) {
     let detail = null
@@ -67,6 +72,24 @@ export const addProject = (body, opts) => req('/api/projects', { method: 'POST',
 export const deleteProject = (name, opts) => req(`/api/projects/${encodeURIComponent(name)}`, { method: 'DELETE', ...opts })
 // POST /api/projects/sync → {projects, total} (refresh last_indexed_at from DB).
 export const syncProjects = (opts) => req('/api/projects/sync', { method: 'POST', ...opts })
+// ---- cross-library 精選集 (bins): persistent named selections spanning projects ----
+// A bin references clips by (project_name, media_id) — the identity that survives
+// federation's path sanitization. GET /api/bins/{id} returns each item with a
+// reachability `status` (ok | project_unregistered | db_missing | nas_unmounted |
+// row_missing | file_missing | …) — never an absolute path (Phase 16.2).
+export const getBins = (opts) => req('/api/bins', opts)
+export const createBin = (name, opts) => req('/api/bins', { method: 'POST', body: { name }, ...opts })
+export const getBin = (id, opts) => req(`/api/bins/${encodeURIComponent(id)}`, opts)
+export const renameBin = (id, name, opts) =>
+  req(`/api/bins/${encodeURIComponent(id)}`, { method: 'PATCH', body: { name }, ...opts })
+export const deleteBin = (id, opts) =>
+  req(`/api/bins/${encodeURIComponent(id)}`, { method: 'DELETE', ...opts })
+// items = [{project_name, media_id, filename?}] — deduped server-side by (project,media).
+export const addBinItems = (id, items, opts) =>
+  req(`/api/bins/${encodeURIComponent(id)}/items`, { method: 'POST', body: { items }, ...opts })
+export const removeBinItem = (id, project_name, media_id, opts) =>
+  req(`/api/bins/${encodeURIComponent(id)}/items`, { method: 'DELETE', body: { project_name, media_id }, ...opts })
+
 export const getTags = (opts) => req('/api/tags', opts)
 // /api/collections → {collections:[{key,title,category,count,items:[{id,filename,thumb,score}]}], total}
 export const getCollections = (opts) => req('/api/collections', opts)

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -89,6 +89,23 @@ export const addBinItems = (id, items, opts) =>
   req(`/api/bins/${encodeURIComponent(id)}/items`, { method: 'POST', body: { items }, ...opts })
 export const removeBinItem = (id, project_name, media_id, opts) =>
   req(`/api/bins/${encodeURIComponent(id)}/items`, { method: 'DELETE', body: { project_name, media_id }, ...opts })
+// Copy a bin's reachable clips into a project → ndjson stream of
+// {type:"gate"|"copy"|"index"|"log"|"registered"|"done", …}. req() can't stream,
+// so return the raw Response for the caller to read line-by-line (same as offloadRun).
+// body: {dest, create_new, dest_name?, mode:'reference'|'copy', skip_vision?, no_embed?}
+export async function copyBin(id, body, { signal } = {}) {
+  const headers = { 'Content-Type': 'application/json' }
+  if (_token) headers['Authorization'] = `Bearer ${_token}`
+  const res = await fetch(`${BASE}/api/bins/${encodeURIComponent(id)}/copy`, {
+    method: 'POST', headers, body: JSON.stringify(body), signal, cache: 'no-store',
+  })
+  if (!res.ok) {
+    let detail = null
+    try { detail = await res.json() } catch { /* non-json */ }
+    throw new ApiError(res.status, `/api/bins/${id}/copy`, detail)
+  }
+  return res
+}
 
 export const getTags = (opts) => req('/api/tags', opts)
 // /api/collections → {collections:[{key,title,category,count,items:[{id,filename,thumb,score}]}], total}

--- a/frontend/src/routes/Bins.svelte
+++ b/frontend/src/routes/Bins.svelte
@@ -85,6 +85,73 @@
     } catch (e) { pushToast('移除失敗: ' + e.message, 'error') }
   }
 
+  // ── copy-into-project dialog ──
+  let copyOpen = false
+  let copyMode = 'reference' // reference | copy
+  let destKind = 'new' // new | existing
+  let destPath = ''
+  let destName = ''
+  let existingProj = ''
+  let projList = []
+  let fastMode = false // skip vision + embedding (clips are already analysed in source)
+  let copyRunning = false
+  let copyLog = []
+  let copySummary = null
+
+  async function openCopy() {
+    copyOpen = true
+    copyLog = []; copySummary = null
+    try { projList = (await api.getProjects()).projects || [] } catch (e) { projList = [] }
+    if (!existingProj && projList.length) existingProj = projList[0].name
+  }
+
+  function _pushLog(line) { copyLog = [...copyLog.slice(-80), line] }
+
+  function handleCopyEvent(ev) {
+    if (ev.type === 'gate') _pushLog(`${ev.action === 'skipped' ? '⤫ 跳過' : '＋ 排入'} ${ev.project_name}#${ev.media_id}${ev.action === 'skipped' ? ' · ' + ev.status : ''}`)
+    else if (ev.type === 'copy') _pushLog(ev.error ? `✗ 複製失敗 ${ev.file}: ${ev.error}` : `⇄ 複製 ${ev.file} (${ev.done}/${ev.total})`)
+    else if (ev.type === 'index') _pushLog(ev.status === 'start' ? `▸ 索引 ${ev.files} 檔…` : `▸ 索引完成 (code ${ev.code})`)
+    else if (ev.type === 'log' && ev.line) _pushLog(ev.line)
+    else if (ev.type === 'registered') _pushLog(ev.error ? `註冊: ${ev.error}` : `✓ 已註冊新專案「${ev.name}」`)
+    else if (ev.type === 'done') copySummary = ev.summary
+  }
+
+  async function runCopy() {
+    const body = { mode: copyMode, create_new: destKind === 'new', skip_vision: fastMode, no_embed: fastMode }
+    if (destKind === 'new') {
+      if (!destPath.trim()) { pushToast('請填新專案路徑', 'error'); return }
+      body.dest = destPath.trim()
+      if (destName.trim()) body.dest_name = destName.trim()
+    } else {
+      if (!existingProj) { pushToast('請選目的專案', 'error'); return }
+      body.dest = existingProj
+    }
+    copyRunning = true; copyLog = []; copySummary = null
+    try {
+      const res = await api.copyBin(activeId, body)
+      const reader = res.body.getReader()
+      const dec = new TextDecoder()
+      let buf = ''
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buf += dec.decode(value, { stream: true })
+        let nl
+        while ((nl = buf.indexOf('\n')) >= 0) {
+          const line = buf.slice(0, nl).trim()
+          buf = buf.slice(nl + 1)
+          if (line) { try { handleCopyEvent(JSON.parse(line)) } catch (e) { /* skip */ } }
+        }
+      }
+      if (copySummary) {
+        const s = copySummary
+        pushToast(`複製完成 → ${s.dest}：${s.copied} 支${s.skipped.length ? '，略過 ' + s.skipped.length : ''}`)
+      }
+      loadBins(); if (activeId) select(activeId)
+    } catch (e) { pushToast('複製失敗: ' + e.message, 'error') }
+    copyRunning = false
+  }
+
   async function del(id, name) {
     if (!confirm(`刪除精選集「${name}」？（只刪清單，不動任何原始素材）`)) return
     try {
@@ -138,8 +205,65 @@
           <div class="ak-display dname">{detail.name}</div>
           <Mono dim style="font-size:10.5px;">{detail.reachable}/{detail.item_count} 可達</Mono>
           <div class="grow"></div>
+          {#if detail.item_count}
+            <button class="ak-btn ak-btn--primary" on:click={openCopy}>複製進新案 →</button>
+          {/if}
           <button class="ak-btn danger" on:click={() => del(detail.id, detail.name)}>刪除精選集</button>
         </div>
+
+        {#if copyOpen}
+          <div class="copypanel">
+            <div class="cprow">
+              <Mono dim style="font-size:10px;letter-spacing:0.08em;">目的地</Mono>
+              <label class="radio"><input type="radio" bind:group={destKind} value="new" /> 新專案</label>
+              <label class="radio"><input type="radio" bind:group={destKind} value="existing" /> 現有專案</label>
+            </div>
+            {#if destKind === 'new'}
+              <div class="cprow">
+                <input class="ak-input" style="flex:1" placeholder="新專案資料夾路徑（例 /Volumes/NAS/新案）" bind:value={destPath} />
+                <input class="ak-input" style="flex:0 1 160px" placeholder="專案名稱（選填）" bind:value={destName} />
+              </div>
+            {:else}
+              <div class="cprow">
+                <select class="ak-input" style="flex:1" bind:value={existingProj}>
+                  {#each projList as p}<option value={p.name}>{p.name}</option>{/each}
+                </select>
+              </div>
+            {/if}
+            <div class="cprow">
+              <Mono dim style="font-size:10px;letter-spacing:0.08em;">方式</Mono>
+              <label class="radio" title="新案索引舊庫原始檔路徑，不搬 bytes（原檔不動、省空間；舊庫離線則讀不到）">
+                <input type="radio" bind:group={copyMode} value="reference" /> 索引引用（原檔不動）
+              </label>
+              <label class="radio" title="驗證複製 bytes 進新案（自足可攜、防舊庫離線；佔額外空間）">
+                <input type="radio" bind:group={copyMode} value="copy" /> 實體複製 bytes
+              </label>
+            </div>
+            <div class="cprow">
+              <label class="radio" title="略過 vision/embedding 重分析（來源已分析過，較快；新案暫無語意搜尋直到補跑）">
+                <input type="checkbox" bind:checked={fastMode} /> 快速（略過重分析）
+              </label>
+              <div class="grow"></div>
+              <button class="ak-btn" on:click={() => (copyOpen = false)} disabled={copyRunning}>取消</button>
+              <button class="ak-btn ak-btn--primary" on:click={runCopy} disabled={copyRunning}>
+                {copyRunning ? '複製中…' : '開始複製'}
+              </button>
+            </div>
+            {#if copyLog.length || copySummary}
+              <div class="cplog">
+                {#each copyLog as l}<div class="cplogline">{l}</div>{/each}
+              </div>
+            {/if}
+            {#if copySummary}
+              <div class="cpsummary">
+                <Mono style="font-size:11px;font-weight:600;">完成 → {copySummary.dest}：複製 {copySummary.copied} 支（{copySummary.mode === 'copy' ? '實體複製' : '索引引用'}）</Mono>
+                {#if copySummary.skipped.length}
+                  <Mono style="font-size:10px;color:var(--cyan);">略過 {copySummary.skipped.length}：{copySummary.skipped.map((s) => s.project_name + '#' + s.media_id + '(' + s.status + ')').join('、')}</Mono>
+                {/if}
+              </div>
+            {/if}
+          </div>
+        {/if}
 
         {#if loading}
           <Mono dim style="font-size:10.5px;">載入中…</Mono>
@@ -213,4 +337,11 @@
   .xbtn { padding: 3px 8px; }
   .danger { color: #e0533d; border-color: #e0533d; }
   .danger:hover { background: #e0533d; color: #fff; }
+  .copypanel { border: 1px solid var(--rule-hi); background: var(--surface-2); padding: 12px 14px; margin-bottom: 16px; display: flex; flex-direction: column; gap: 10px; }
+  .cprow { display: flex; align-items: center; gap: 12px; }
+  .radio { display: flex; align-items: center; gap: 5px; font-family: var(--ak-mono); font-size: 11px; color: var(--ink-2); cursor: pointer; }
+  .radio input { cursor: pointer; accent-color: var(--invert); }
+  .cplog { max-height: 160px; overflow: auto; background: var(--bg); border: 1px solid var(--rule); padding: 6px 8px; font-family: var(--ak-mono); font-size: 10px; line-height: 1.5; color: var(--ink-2); }
+  .cplogline { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .cpsummary { display: flex; flex-direction: column; gap: 2px; padding-top: 4px; }
 </style>

--- a/frontend/src/routes/Bins.svelte
+++ b/frontend/src/routes/Bins.svelte
@@ -152,6 +152,20 @@
     copyRunning = false
   }
 
+  let renaming = false
+  let renameVal = ''
+  function startRename() { renameVal = detail.name; renaming = true }
+  async function saveRename() {
+    const name = renameVal.trim()
+    if (!name || name === detail.name) { renaming = false; return }
+    try {
+      await api.renameBin(activeId, name)
+      renaming = false
+      await loadBins(); await select(activeId)
+      pushToast('已改名')
+    } catch (e) { pushToast('改名失敗: ' + e.message, 'error') }
+  }
+
   async function del(id, name) {
     if (!confirm(`刪除精選集「${name}」？（只刪清單，不動任何原始素材）`)) return
     try {
@@ -202,7 +216,14 @@
         <div class="empty">選一個精選集，或先建立一個</div>
       {:else}
         <div class="dhead">
-          <div class="ak-display dname">{detail.name}</div>
+          {#if renaming}
+            <input class="ak-input renameinput" bind:value={renameVal} autofocus
+                   on:keydown={(e) => { if (e.key === 'Enter') saveRename(); if (e.key === 'Escape') renaming = false }} />
+            <button class="ak-btn" on:click={saveRename}>存</button>
+          {:else}
+            <div class="ak-display dname">{detail.name}</div>
+            <button class="ak-btn renamebtn" title="改名" on:click={startRename}>✎</button>
+          {/if}
           <Mono dim style="font-size:10.5px;">{detail.reachable}/{detail.item_count} 可達</Mono>
           <div class="grow"></div>
           {#if detail.item_count}
@@ -320,6 +341,9 @@
   .detail { padding: 18px 40px; overflow: auto; }
   .dhead { display: flex; align-items: baseline; gap: 12px; margin-bottom: 14px; padding-bottom: 8px; border-bottom: 1px solid var(--rule); }
   .dname { font-size: 22px; letter-spacing: -0.03em; color: var(--ink); }
+  .renamebtn { padding: 3px 7px; opacity: 0.6; }
+  .renamebtn:hover { opacity: 1; }
+  .renameinput { font-size: 18px; padding: 4px 8px; min-width: 220px; }
   .empty { padding: 40px 16px; font-family: var(--ak-mono); font-size: 11px; color: var(--quiet); text-align: center; letter-spacing: 0.05em; }
   .empty a, .detail a { color: var(--ink-2); }
   .rgroup { margin-bottom: 16px; }

--- a/frontend/src/routes/Bins.svelte
+++ b/frontend/src/routes/Bins.svelte
@@ -1,0 +1,216 @@
+<!-- 精選集 (cross-library bins) — persistent named selections that reference clips
+     scattered across MULTIPLE registered projects. Originals never move; a bin is
+     pure reference (cross-library is read-only). Each item shows a reachability
+     badge (✓ / ⚠ 庫離線 / ✗ 檔案不在 …) so a moved/offline source is never
+     silently trusted. Rows are read-only — the clip lives in another project's DB,
+     so this server can't stream/open it. Add items from the search screen's
+     "加入精選集". Copy-into-project (the payoff) lands in the next PR. -->
+<script>
+  import { onMount } from 'svelte'
+  import * as api from '../lib/api.js'
+  import ArkivLogo from '../lib/ArkivLogo.svelte'
+  import Mono from '../lib/Mono.svelte'
+  import Eyebrow from '../lib/Eyebrow.svelte'
+  import Thumb from '../lib/Thumb.svelte'
+  import { pushToast } from '../lib/toast.js'
+  import { resolvedTheme } from '../lib/prefs.js'
+
+  $: theme = $resolvedTheme
+  let bins = []
+  let activeId = null
+  let detail = null // { id, name, item_count, reachable, items:[{project_name, media_id, filename, status}] }
+  let loading = false
+  let newName = ''
+
+  // status → { label, sev }. sev: ok | warn | bad. Drives the badge colour.
+  const STATUS = {
+    ok: { label: '✓', sev: 'ok' },
+    project_unregistered: { label: '未登記', sev: 'warn' },
+    db_missing: { label: '庫無索引', sev: 'warn' },
+    chroma_missing: { label: '庫無向量', sev: 'warn' },
+    nas_unmounted: { label: '庫離線', sev: 'warn' },
+    path_not_found: { label: '庫不存在', sev: 'bad' },
+    timeout: { label: '逾時', sev: 'warn' },
+    row_missing: { label: '已從庫刪除', sev: 'bad' },
+    file_missing: { label: '檔案不在', sev: 'bad' },
+    error: { label: '錯誤', sev: 'warn' },
+  }
+  const badge = (s) => STATUS[s] || { label: s || '?', sev: 'warn' }
+
+  // group a bin's items by project_name for display
+  $: groups = (() => {
+    if (!detail) return []
+    const by = new Map()
+    for (const it of detail.items || []) {
+      if (!by.has(it.project_name)) by.set(it.project_name, { name: it.project_name, items: [] })
+      by.get(it.project_name).items.push(it)
+    }
+    return [...by.values()]
+  })()
+
+  async function loadBins() {
+    try {
+      const r = await api.getBins()
+      bins = r.bins || []
+      if (!activeId && bins.length) select(bins[0].id)
+      else if (activeId && !bins.find((b) => b.id === activeId)) { activeId = null; detail = null }
+    } catch (e) { pushToast('讀取精選集失敗: ' + e.message, 'error') }
+  }
+
+  async function select(id) {
+    activeId = id
+    loading = true
+    try {
+      detail = await api.getBin(id)
+    } catch (e) { pushToast('讀取精選集失敗: ' + e.message, 'error'); detail = null }
+    loading = false
+  }
+
+  async function create() {
+    const name = newName.trim()
+    if (!name) return
+    try {
+      const b = await api.createBin(name)
+      newName = ''
+      await loadBins()
+      select(b.id)
+      pushToast('已建立精選集「' + name + '」')
+    } catch (e) { pushToast('建立失敗: ' + e.message, 'error') }
+  }
+
+  async function removeItem(it) {
+    try {
+      detail = await api.removeBinItem(activeId, it.project_name, it.media_id)
+      loadBins() // refresh counts
+    } catch (e) { pushToast('移除失敗: ' + e.message, 'error') }
+  }
+
+  async function del(id, name) {
+    if (!confirm(`刪除精選集「${name}」？（只刪清單，不動任何原始素材）`)) return
+    try {
+      await api.deleteBin(id)
+      if (activeId === id) { activeId = null; detail = null }
+      await loadBins()
+      pushToast('已刪除精選集')
+    } catch (e) { pushToast('刪除失敗: ' + e.message, 'error') }
+  }
+
+  onMount(loadBins)
+</script>
+
+<div class="artboard" data-theme={theme}>
+  <div class="topbar">
+    <ArkivLogo size={16} />
+    <Mono dim style="font-size:10px;">精選集</Mono>
+    <div class="grow"></div>
+    <a class="ak-btn" href="#/search-live">⌕ 搜尋加片</a>
+    <a class="ak-btn" href="#/main-live">← back to grid</a>
+  </div>
+
+  <div class="body">
+    <!-- left: bin list + create -->
+    <aside class="side">
+      <Eyebrow style="margin-bottom:10px;">精選集 · 跨庫引用</Eyebrow>
+      <div class="createrow">
+        <input class="ak-input newname" placeholder="新精選集名稱…" bind:value={newName}
+               on:keydown={(e) => e.key === 'Enter' && create()} />
+        <button class="ak-btn" on:click={create}>＋</button>
+      </div>
+      <div class="binlist">
+        {#each bins as b (b.id)}
+          <button class="binrow" class:on={activeId === b.id} on:click={() => select(b.id)}>
+            <span class="bname">{b.name}</span>
+            <Mono dim style="font-size:10px;">{b.item_count}</Mono>
+          </button>
+        {/each}
+        {#if !bins.length}
+          <Mono dim style="font-size:10.5px;display:block;padding:8px 2px;">尚無精選集 — 上方新建，或到搜尋頁把片加入</Mono>
+        {/if}
+      </div>
+    </aside>
+
+    <!-- right: active bin detail -->
+    <main class="detail">
+      {#if !detail}
+        <div class="empty">選一個精選集，或先建立一個</div>
+      {:else}
+        <div class="dhead">
+          <div class="ak-display dname">{detail.name}</div>
+          <Mono dim style="font-size:10.5px;">{detail.reachable}/{detail.item_count} 可達</Mono>
+          <div class="grow"></div>
+          <button class="ak-btn danger" on:click={() => del(detail.id, detail.name)}>刪除精選集</button>
+        </div>
+
+        {#if loading}
+          <Mono dim style="font-size:10.5px;">載入中…</Mono>
+        {:else if !detail.item_count}
+          <div class="empty">這個精選集還沒有片 — 到 <a href="#/search-live">搜尋頁</a> 選片「加入精選集」</div>
+        {:else}
+          {#each groups as g (g.name)}
+            <section class="rgroup">
+              <div class="ghead">
+                <Mono dim style="font-size:10px;letter-spacing:0.1em;">PROJECT</Mono>
+                <div class="ak-display gproj">{g.name}</div>
+                <Mono dim style="font-size:10.5px;">{g.items.length}</Mono>
+                <div class="grow"></div>
+                <Mono dim style="font-size:9.5px;letter-spacing:0.08em;" title="結果在其他專案的資料庫 · 唯讀，無法在此開啟/播放">唯讀 · 跨庫</Mono>
+              </div>
+              <div class="rows">
+                {#each g.items as it (it.project_name + ':' + it.media_id)}
+                  {@const bd = badge(it.status)}
+                  <div class="rrow">
+                    <div class="rthumb"><Thumb seed={it.media_id} kind="video" {theme} /></div>
+                    <div class="rcontent">
+                      <Mono style="font-size:11.5px;font-weight:500;color:var(--ink);">{it.filename || ('#' + it.media_id)}</Mono>
+                    </div>
+                    <div class="rbadge">
+                      <span class="badge {bd.sev}" title={it.status}>{bd.label}</span>
+                    </div>
+                    <div class="raction">
+                      <button class="ak-btn xbtn" title="從精選集移除（不動原檔）" on:click={() => removeItem(it)}>×</button>
+                    </div>
+                  </div>
+                {/each}
+              </div>
+            </section>
+          {/each}
+        {/if}
+      {/if}
+    </main>
+  </div>
+</div>
+
+<style>
+  .artboard { width: 100%; max-width: 1920px; height: 100vh; height: 100dvh; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 1fr; overflow: hidden; margin: 0 auto; }
+  .grow { flex: 1; }
+  .topbar { display: flex; align-items: center; border-bottom: 1px solid var(--rule); padding: 0 16px; gap: 16px; }
+  .body { display: grid; grid-template-columns: 260px 1fr; min-height: 0; overflow: hidden; }
+  .side { border-right: 1px solid var(--rule); padding: 18px 16px; overflow: auto; }
+  .createrow { display: flex; gap: 6px; margin-bottom: 12px; }
+  .newname { flex: 1; font-size: 12px; }
+  .binlist { display: flex; flex-direction: column; gap: 2px; }
+  .binrow { display: flex; align-items: center; justify-content: space-between; gap: 8px; width: 100%; text-align: left; padding: 7px 8px; background: transparent; border: 1px solid transparent; cursor: pointer; color: var(--ink-2); }
+  .binrow:hover { background: var(--surface-2); }
+  .binrow.on { background: var(--surface-2); border-color: var(--rule-hi); color: var(--ink); }
+  .bname { font-size: 12.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .detail { padding: 18px 40px; overflow: auto; }
+  .dhead { display: flex; align-items: baseline; gap: 12px; margin-bottom: 14px; padding-bottom: 8px; border-bottom: 1px solid var(--rule); }
+  .dname { font-size: 22px; letter-spacing: -0.03em; color: var(--ink); }
+  .empty { padding: 40px 16px; font-family: var(--ak-mono); font-size: 11px; color: var(--quiet); text-align: center; letter-spacing: 0.05em; }
+  .empty a, .detail a { color: var(--ink-2); }
+  .rgroup { margin-bottom: 16px; }
+  .ghead { display: flex; align-items: baseline; gap: 12px; margin-bottom: 8px; padding-bottom: 6px; border-bottom: 1px solid var(--rule); }
+  .gproj { font-size: 18px; letter-spacing: -0.03em; line-height: 1; color: var(--ink); }
+  .rrow { display: grid; grid-template-columns: 100px 1fr 96px 40px; gap: 14px; align-items: center; padding: 5px 0; border-top: 1px solid var(--rule); }
+  .rthumb { position: relative; aspect-ratio: 16 / 9; background: var(--surface-2); overflow: hidden; }
+  .rcontent { min-width: 0; }
+  .rbadge { text-align: right; }
+  .badge { font-family: var(--ak-mono); font-size: 9.5px; letter-spacing: 0.05em; padding: 2px 6px; border: 1px solid var(--rule); white-space: nowrap; }
+  .badge.ok { color: var(--ink-2); border-color: var(--rule-hi); }
+  .badge.warn { color: var(--cyan); border-color: var(--cyan); }
+  .badge.bad { color: #e0533d; border-color: #e0533d; }
+  .raction { display: flex; justify-content: flex-end; }
+  .xbtn { padding: 3px 8px; }
+  .danger { color: #e0533d; border-color: #e0533d; }
+  .danger:hover { background: #e0533d; color: #fff; }
+</style>

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -78,6 +78,39 @@
     picked = picked.includes(id) ? picked.filter((x) => x !== id) : [...picked, id]
   }
   const clearPicks = () => (picked = [])
+
+  // Add the multi-selection to a cross-library 精選集 (bin). A bin item is keyed by
+  // (registry project name, media_id); the current project's REGISTRY name comes
+  // from stats.project_registered_name — null when this library isn't registered,
+  // in which case a bin item couldn't be resolved back, so the add is disabled.
+  let binList = []
+  let targetBinId = ''
+  let newBinName = ''
+  $: projectRegName = stats && stats.project_registered_name
+  async function loadBins() {
+    try { binList = (await api.getBins()).bins || [] } catch (e) { /* none yet */ }
+  }
+  async function addPicksToBin() {
+    if (!projectRegName) { pushToast('本專案未登記，無法加入精選集 — 先到設定登記', 'error'); return }
+    const byId = new Map((items || []).map((m) => [m.id, m]))
+    const refs = picked.map((id) => ({
+      project_name: projectRegName,
+      media_id: String(id),
+      filename: (byId.get(id) || {}).name || `#${id}`,
+    }))
+    let binId = targetBinId
+    try {
+      if (!binId && newBinName.trim()) {
+        const b = await api.createBin(newBinName.trim())
+        binId = b.id; newBinName = ''; await loadBins(); targetBinId = binId
+      }
+      if (!binId) { pushToast('先選一個精選集或輸入新名稱', 'error'); return }
+      const r = await api.addBinItems(binId, refs)
+      const name = (binList.find((b) => b.id === binId) || {}).name || '精選集'
+      pushToast(`已加入「${name}」（共 ${r.item_count} 支）`)
+      clearPicks(); loadBins()
+    } catch (e) { pushToast('加入精選集失敗: ' + e.message, 'error') }
+  }
   const EXPORT_FMTS = ['edl', 'fcpxml', 'srt']
   async function exportTimeline(fmt) {
     if (!picked.length) return
@@ -310,6 +343,7 @@
     }
     await selectFromParam()
     loadEngines()
+    loadBins()
   })
 
   $: visible = items.filter((m) => {
@@ -544,7 +578,7 @@
 <div class="artboard" data-theme={theme}>
   <TopBar />
   <div class="body">
-    <PoolSidebar {liveProjects} {livePools} {liveTags} {liveCollections} {liveStorage} {liveCameras} onTag={onTagClick} onCollection={onCollectionClick} onCamera={onCameraClick} {activeCamera} onPool={onPoolClick} {activePool} />
+    <PoolSidebar {liveProjects} {livePools} {liveTags} {liveCollections} {liveStorage} {liveCameras} onTag={onTagClick} onCollection={onCollectionClick} onCamera={onCameraClick} {activeCamera} onPool={onPoolClick} {activePool} liveBins={binList} onBin={() => (window.location.hash = '#/bins')} />
 
     <main class="center">
       <div class="toolrow">
@@ -576,12 +610,26 @@
 
       {#if picked.length}
         <div class="exportbar">
-          <Mono style="font-size:11px;letter-spacing:0.04em;">已選 {picked.length} 支 → 合成一條時間軸</Mono>
+          <Mono style="font-size:11px;letter-spacing:0.04em;">已選 {picked.length} 支</Mono>
           <div class="expbtns">
+            <span class="barlabel">時間軸</span>
             {#each EXPORT_FMTS as fmt}
               <button class="ak-btn expbtn" on:click={() => exportTimeline(fmt)}>{fmt.toUpperCase()}</button>
             {/each}
             <button class="ak-btn expbtn" on:click={() => exportMetadataCsv(picked)} title="匯出所選 metadata CSV">CSV</button>
+            <div class="barvrule"></div>
+            <span class="barlabel">精選集</span>
+            <select class="ak-input binsel" bind:value={targetBinId} disabled={!projectRegName}
+                    title={projectRegName ? '' : '本專案未登記，無法加入精選集'}>
+              <option value="">選精選集…</option>
+              {#each binList as b}<option value={b.id}>{b.name}（{b.item_count}）</option>{/each}
+            </select>
+            <input class="ak-input binnew" placeholder="新精選集…" bind:value={newBinName} disabled={!projectRegName}
+                   on:keydown={(e) => e.key === 'Enter' && addPicksToBin()} />
+            <button class="ak-btn expbtn" on:click={addPicksToBin} disabled={!projectRegName}
+                    title={projectRegName ? '加入跨庫精選集' : '本專案未登記（設定→跨庫專案）'}>加入精選集</button>
+            <a class="ak-btn expbtn" href="#/bins" title="檢視精選集">★</a>
+            <div class="barvrule"></div>
             <button class="ak-btn expbtn clear" on:click={clearPicks}>清除</button>
           </div>
         </div>
@@ -735,7 +783,13 @@
     display: flex; align-items: center; justify-content: space-between; gap: 14px;
     padding: 9px 22px; border-bottom: 1px solid var(--rule); background: var(--surface-2);
   }
-  .expbtns { display: flex; gap: 6px; }
+  .expbtns { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
   .expbtn { font-size: 10px; padding: 5px 10px; text-decoration: none; }
   .expbtn.clear { opacity: 0.7; }
+  .expbtn:disabled { opacity: 0.4; cursor: default; }
+  .barlabel { font-family: var(--ak-mono); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--quiet); }
+  .barvrule { width: 1px; height: 16px; background: var(--rule-hi); margin: 0 4px; }
+  .binsel, .binnew { font-size: 10px; padding: 4px 6px; }
+  .binnew { width: 110px; }
+  .binsel:disabled, .binnew:disabled { opacity: 0.4; }
 </style>

--- a/frontend/src/routes/SearchLive.svelte
+++ b/frontend/src/routes/SearchLive.svelte
@@ -13,6 +13,7 @@
   import Mono from '../lib/Mono.svelte'
   import Eyebrow from '../lib/Eyebrow.svelte'
   import Thumb from '../lib/Thumb.svelte'
+  import { pushToast } from '../lib/toast.js'
   import { resolvedTheme } from '../lib/prefs.js'
 
   $: theme = $resolvedTheme
@@ -38,6 +39,47 @@
   let fedErrors = []
   let projectsQueried = 0
   let projectsFailed = 0
+
+  // Multi-select of federated results → 加入精選集 (a cross-library bin). Only in
+  // federation mode: an item's (project_name, media_id) is the identity a bin
+  // stores. Ordered array (add order) + derived Set for O(1) membership — same
+  // shape as MainLive's `picked`.
+  let picks = [] // [{project_name, media_id, filename}]
+  $: pickKeys = new Set(picks.map((p) => p.project_name + ':' + p.media_id))
+  let binList = [] // [{id, name, item_count}]
+  let targetBinId = ''
+  let newBinName = ''
+
+  function togglePick(project_name, media_id, filename) {
+    const key = project_name + ':' + media_id
+    picks = pickKeys.has(key)
+      ? picks.filter((p) => p.project_name + ':' + p.media_id !== key)
+      : [...picks, { project_name, media_id, filename }]
+  }
+  const clearPicks = () => (picks = [])
+
+  async function loadBins() {
+    try { binList = (await api.getBins()).bins || [] } catch (e) { /* no bins yet */ }
+  }
+
+  async function addPicksToBin() {
+    let binId = targetBinId
+    try {
+      if (!binId && newBinName.trim()) {
+        const b = await api.createBin(newBinName.trim())
+        binId = b.id
+        newBinName = ''
+        await loadBins()
+        targetBinId = binId
+      }
+      if (!binId) { pushToast('先選一個精選集或輸入新名稱', 'error'); return }
+      const r = await api.addBinItems(binId, picks)
+      const name = (binList.find((b) => b.id === binId) || {}).name || '精選集'
+      pushToast(`已加入「${name}」（共 ${r.item_count} 支）`)
+      clearPicks()
+      loadBins()
+    } catch (e) { pushToast('加入精選集失敗: ' + e.message, 'error') }
+  }
 
   // Media-type facet — wired to /api/media?media_type= (real backend filter; audit
   // H14 made it apply on the semantic-search branch too). 'all' omits the param.
@@ -179,6 +221,7 @@
       if (name) projectName = name
     } catch (e) { /* no registry → keep neutral label, projectCount 0 */ }
     loadCounts()
+    loadBins()
     // seed from the hash, e.g. #/search-live?q=餐廳&type=video  or  ?q=…&all=1
     const h = window.location.hash
     const qi = h.indexOf('?')
@@ -199,6 +242,7 @@
     <Mono dim style="font-size:10px;">live</Mono>
     <div class="grow"></div>
     <a class="ak-btn" href="#/query-live">⊞ query builder</a>
+    <a class="ak-btn" href="#/bins">★ 精選集</a>
     <a class="ak-btn" href="#/main-live">← back to grid</a>
   </div>
 
@@ -271,6 +315,21 @@
         </div>
       {/if}
 
+      {#if crossProject && picks.length}
+        <div class="pickbar">
+          <Mono style="font-size:11px;font-weight:500;">已選 {picks.length} 支 →</Mono>
+          <select class="ak-input binsel" bind:value={targetBinId}>
+            <option value="">選精選集…</option>
+            {#each binList as b}<option value={b.id}>{b.name}（{b.item_count}）</option>{/each}
+          </select>
+          <Mono dim style="font-size:10px;">或</Mono>
+          <input class="ak-input newbin" placeholder="新精選集名稱…" bind:value={newBinName}
+                 on:keydown={(e) => e.key === 'Enter' && addPicksToBin()} />
+          <button class="ak-btn ak-btn--primary" on:click={addPicksToBin}>加入精選集</button>
+          <button class="ak-btn" on:click={clearPicks}>清除</button>
+        </div>
+      {/if}
+
       {#if state === 'ok' && shown === 0 && !(crossProject && projectsQueried === 0)}
         <div class="emptyresult">沒有符合「{query}」的素材</div>
       {:else if shown}
@@ -301,6 +360,13 @@
                       <img class="rthumbimg" src={r.thumb} alt={r.name} loading="lazy" />
                     {:else}
                       <Thumb seed={r.id} kind="video" {theme} />
+                    {/if}
+                    {#if !g.openable}
+                      <!-- federated rows are read-only but pickable → 精選集 -->
+                      <label class="pickbox" title="選取加入精選集">
+                        <input type="checkbox" checked={pickKeys.has(g.name + ':' + r.id)}
+                               on:change={() => togglePick(g.name, r.id, r.name)} />
+                      </label>
                     {/if}
                     <Mono style="position:absolute;bottom:2px;right:3px;font-size:9px;color:#f3f2ee;background:rgba(10,10,12,.78);padding:1px 3px;">{r.dur}</Mono>
                   </div>
@@ -349,6 +415,11 @@
   .fvrule { width: 1px; height: 14px; background: var(--rule); margin: 0 4px; }
   .results { flex: 1; overflow: auto; padding: 14px 64px 18px; }
   .fedbanner { display: flex; flex-direction: column; gap: 2px; margin-bottom: 12px; padding: 8px 10px; border: 1px solid var(--rule); background: var(--surface-2); }
+  .pickbar { position: sticky; top: 0; z-index: 5; display: flex; align-items: center; gap: 10px; margin-bottom: 12px; padding: 8px 12px; border: 1px solid var(--rule-hi); background: var(--bg); }
+  .binsel, .newbin { font-size: 12px; padding: 4px 6px; }
+  .newbin { flex: 0 1 180px; }
+  .pickbox { position: absolute; top: 4px; left: 4px; z-index: 2; display: flex; }
+  .pickbox input { width: 15px; height: 15px; cursor: pointer; accent-color: var(--invert); }
   .rgroup { margin-bottom: 16px; }
   .ghead { display: flex; align-items: baseline; gap: 12px; margin-bottom: 8px; padding-bottom: 6px; border-bottom: 1px solid var(--rule); }
   .gproj { font-size: 18px; letter-spacing: -0.03em; line-height: 1; color: var(--ink); }

--- a/ingest.py
+++ b/ingest.py
@@ -1334,7 +1334,8 @@ def main():
         except (AttributeError, ValueError):
             pass
     parser = argparse.ArgumentParser(description="Ingest media files into SQLite DB")
-    parser.add_argument("--dir", help="Media directory to scan (required unless --migrate-* / --regenerate-proxies / --vision-only)")
+    parser.add_argument("--dir", help="Media directory to scan (required unless --migrate-* / --regenerate-proxies / --vision-only / --files)")
+    parser.add_argument("--files", nargs="+", metavar="F", help="Ingest an explicit list of files instead of scanning a --dir. Used by the cross-library 精選集 'copy into project' flow to index clips gathered from several source libraries in one run (one model warmup). Files outside PROJECT_ROOT store an absolute media.path (still resolvable).")
     parser.add_argument("--limit", type=int, default=0, help="Max files to process (0=all)")
     parser.add_argument("--skip-vision", action="store_true", help="Skip llava frame description")
     parser.add_argument("--refresh", action="store_true", help="Re-process already-indexed files — re-extracts thumbnail + frames (not reusing cached ones, so changed extraction logic like 360 reproject re-applies) + re-runs vision (issue #53)")
@@ -1393,8 +1394,8 @@ def main():
         or args.propose_aliases or args.apply_aliases
         or bool(args.queue) or args.status
     )
-    if not maintenance_mode and not args.dir:
-        parser.error("--dir is required unless using --migrate-storage / --migrate-relative / --regenerate-proxies / --vision-only")
+    if not maintenance_mode and not args.dir and not args.files:
+        parser.error("--dir (or --files) is required unless using --migrate-storage / --migrate-relative / --regenerate-proxies / --vision-only")
 
     if args.db:
         db.DB_PATH = Path(args.db)
@@ -1469,24 +1470,45 @@ def main():
     # audit M7: a relative --dir (e.g. `--dir clips`) used to flow cwd-relative
     # paths into the DB — a third path form besides abs/rel-to-PROJECT_ROOT,
     # breaking dedupe and resolve_path. Canonicalize before any DB interaction.
-    media_dir = Path(args.dir).expanduser().resolve()
-    if not media_dir.exists():
-        print(f"Error: {media_dir} does not exist")
-        sys.exit(1)
-
-    if media_dir.is_file():
-        # Single-file mode (used by watch.py for new-arrival ingest)
-        files = [media_dir] if media_dir.suffix.lower() in SUPPORTED else []
-    elif args.recursive:
-        files = sorted(
-            f for f in media_dir.rglob("*")
-            if f.is_file() and f.suffix.lower() in SUPPORTED
-        )
+    if args.files:
+        # Explicit file list (精選集 copy-into-project) — resolve + filter to
+        # SUPPORTED, dedup preserving order, then fall through to the same batch
+        # pipeline as --dir. Missing files are dropped with a note (the copy
+        # orchestrator already gated reachability, but be defensive).
+        files = []
+        seen = set()
+        for raw in args.files:
+            fp = Path(raw).expanduser().resolve()
+            key = str(fp)
+            if key in seen:
+                continue
+            seen.add(key)
+            if fp.suffix.lower() not in SUPPORTED:
+                print(f"Skip (unsupported): {fp}")
+                continue
+            if not fp.exists():
+                print(f"Skip (missing): {fp}")
+                continue
+            files.append(fp)
     else:
-        files = sorted(
-            f for f in media_dir.iterdir()
-            if f.is_file() and f.suffix.lower() in SUPPORTED
-        )
+        media_dir = Path(args.dir).expanduser().resolve()
+        if not media_dir.exists():
+            print(f"Error: {media_dir} does not exist")
+            sys.exit(1)
+
+        if media_dir.is_file():
+            # Single-file mode (used by watch.py for new-arrival ingest)
+            files = [media_dir] if media_dir.suffix.lower() in SUPPORTED else []
+        elif args.recursive:
+            files = sorted(
+                f for f in media_dir.rglob("*")
+                if f.is_file() and f.suffix.lower() in SUPPORTED
+            )
+        else:
+            files = sorted(
+                f for f in media_dir.iterdir()
+                if f.is_file() and f.suffix.lower() in SUPPORTED
+            )
 
     total = len(files)
 

--- a/server.py
+++ b/server.py
@@ -1653,7 +1653,24 @@ def get_stats(
     # library instead of a hardcoded demo name. Multi-library installs (one .arkiv
     # per project) each report their own name.
     stats["project"] = config.PROJECT_ROOT.name if config.PROJECT_ROOT else None
+    # The REGISTRY name for the currently-loaded project (may differ from the dir
+    # basename — a library registered as "恬馨庫" can live in a dir named "tianxin").
+    # A cross-library 精選集 item is keyed by registry name, so the grid's
+    # "加入精選集" needs this — null when the current project isn't registered
+    # (then a grid-added item couldn't be resolved back → the UI disables the add).
+    stats["project_registered_name"] = _current_project_registry_name()
     return stats
+
+
+def _current_project_registry_name():
+    try:
+        root_key = str(config.PROJECT_ROOT.expanduser().resolve(strict=False)).casefold()
+        for p in project_registry.discover_projects():
+            if p.key() == root_key:
+                return p.name
+    except Exception:
+        pass
+    return None
 
 
 @app.get("/api/tags")

--- a/server.py
+++ b/server.py
@@ -350,6 +350,18 @@ class BinAddItems(BaseModel):
     items: List[BinItemRef]
 
 
+class BinCopyRequest(BaseModel):
+    # dest = an existing registered project name, OR (create_new) a filesystem path
+    # for a brand-new project. mode: 'reference' indexes the original files in place
+    # (no bytes moved — 原檔不動); 'copy' verified-copies bytes into the dest first.
+    dest: str
+    create_new: bool = False
+    dest_name: Optional[str] = None  # registry name when create_new (default = dir basename)
+    mode: Literal["reference", "copy"] = "reference"
+    skip_vision: bool = False
+    no_embed: bool = False
+
+
 class CreateTokenRequest(BaseModel):
     name: str
     scopes: List[str]
@@ -678,6 +690,28 @@ def projects_health(
 # Storage is ~/.arkiv-bins.json (bins.py), separate from any project.db. Items
 # reference clips by (project_name, media_id) — never mutating the source library.
 
+def _copy_clip_verified(src_path: str, dst_dir: Path) -> Path:
+    """Verified copy of one clip into dst_dir (hash both sides, atomic rename, NEVER
+    deletes the source). offload.run_offload is card/dir-oriented (its rel math
+    breaks for a lone file), so this reuses offload's hash primitive on a simple
+    single-file copy. Raises on hash mismatch. (ascMHL provenance is a follow-up —
+    not load-bearing for copy-into-project.)"""
+    import shutil
+    import offload as _offload
+    src = Path(src_path)
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    final = dst_dir / src.name
+    partial = final.with_name(final.name + ".partial")
+    if partial.exists():
+        partial.unlink()
+    shutil.copyfile(str(src), str(partial))  # bytes only; never touches the source
+    if _offload._hash_file(src, _offload.DEFAULT_HASH) != _offload._hash_file(partial, _offload.DEFAULT_HASH):
+        partial.unlink()
+        raise ValueError("hash mismatch copying {0}".format(src.name))
+    os.replace(str(partial), str(final))
+    return final
+
+
 def _bin_detail_payload(b) -> dict:
     """Bin + per-item reachability status. The status probe re-resolves the source
     server-side; only the enum + basename filename + project_name reach the client
@@ -765,6 +799,128 @@ def remove_bin_item(bin_id: str, body: BinItemRef, _tok: dict = Depends(require_
     except bins_store.BinsError as exc:
         raise HTTPException(status_code=404, detail=str(exc))
     return _bin_detail_payload(b)
+
+
+@app.post("/api/bins/{bin_id}/copy")
+def copy_bin(bin_id: str, body: BinCopyRequest, _tok: dict = Depends(require_scopes("videos_write"))):
+    """Copy a bin's reachable clips into a project (existing or brand-new), then
+    index them so they're searchable there. Streams ndjson progress. RED LINE: each
+    item is re-gated for reachability server-side; unreachable ones are SKIPPED and
+    listed in the summary (never silently dropped), the source library is never
+    mutated, and in 'copy' mode the verified-copy engine never deletes the source.
+
+    mode='reference' indexes the original absolute paths in place (no bytes moved);
+    mode='copy' verified-copies (hash + MHL) bytes into the dest first."""
+    import subprocess, sys as _sys, json as _json
+
+    try:
+        b = bins_store.get_bin(bin_id)
+    except bins_store.BinsError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    # Resolve destination project root + registry name.
+    if body.create_new:
+        dest_root = Path(body.dest).expanduser().resolve(strict=False)
+        # refuse to bootstrap into an existing NON-empty project dir (avoid clobber)
+        if (dest_root / ".arkiv" / "project.db").exists():
+            raise HTTPException(400, "目的地已是既有專案（含 .arkiv/project.db）；請改選現有專案或換新路徑")
+        dest_root.mkdir(parents=True, exist_ok=True)
+        dest_name = (body.dest_name or dest_root.name).strip() or dest_root.name
+    else:
+        proj = None
+        for p in project_registry.discover_projects():
+            if p.name == body.dest:
+                proj = p
+                break
+        if proj is None:
+            raise HTTPException(400, "找不到目的專案：{0}".format(body.dest))
+        dest_root = Path(proj.path).expanduser().resolve(strict=False)
+        dest_name = proj.name
+
+    dest_db = dest_root / ".arkiv" / "project.db"
+    (dest_root / ".arkiv").mkdir(parents=True, exist_ok=True)
+    dest_media_dir = dest_root / "media"
+
+    def _stream():
+        skipped = []
+        reachable = []  # (project_name, media_id, absolute_path)
+        # ── gate: re-resolve every item server-side; skip unreachable (fail-loud) ──
+        for item in b.items:
+            info = bins_store.resolve_source(item.project_name, item.media_id)
+            status = (info or {}).get("status") or bins_store.STATUS_PROJECT_UNREGISTERED
+            if status != bins_store.STATUS_OK or not (info or {}).get("absolute_path"):
+                skipped.append({"project_name": item.project_name, "media_id": item.media_id, "status": status})
+                yield _json.dumps({"type": "gate", "project_name": item.project_name,
+                                   "media_id": item.media_id, "status": status, "action": "skipped"},
+                                  ensure_ascii=False) + "\n"
+                continue
+            reachable.append((item.project_name, item.media_id, info["absolute_path"]))
+            yield _json.dumps({"type": "gate", "project_name": item.project_name,
+                               "media_id": item.media_id, "status": status, "action": "queued"},
+                              ensure_ascii=False) + "\n"
+
+        # ── copy phase (mode=copy only): verified byte-copy into the dest ──
+        ingest_paths = []
+        if body.mode == "copy" and reachable:
+            dest_media_dir.mkdir(parents=True, exist_ok=True)
+            for idx, (pn, mid, src) in enumerate(reachable):
+                try:
+                    copied = _copy_clip_verified(src, dest_media_dir)
+                    ingest_paths.append(str(copied))
+                    yield _json.dumps({"type": "copy", "file": Path(src).name,
+                                       "done": idx + 1, "total": len(reachable)}, ensure_ascii=False) + "\n"
+                except Exception as exc:  # a copy failure must not fake success
+                    skipped.append({"project_name": pn, "media_id": mid, "status": "copy_failed: {0}".format(exc)})
+                    yield _json.dumps({"type": "copy", "file": Path(src).name, "error": str(exc)},
+                                      ensure_ascii=False) + "\n"
+        else:
+            ingest_paths = [src for (_pn, _mid, src) in reachable]
+
+        # ── index phase: one ingest run over the gathered files (one model warmup) ──
+        if ingest_paths:
+            cmd = [_sys.executable, str(ROOT / "ingest.py"), "--files", *ingest_paths,
+                   "--db", str(dest_db)]
+            if body.skip_vision:
+                cmd.append("--skip-vision")
+            if body.no_embed:
+                cmd.append("--no-embed")
+            yield _json.dumps({"type": "index", "status": "start", "files": len(ingest_paths)},
+                              ensure_ascii=False) + "\n"
+            # Run ingest AS the dest project: ARKIV_PROJECT_ROOT=dest_root so paths
+            # relativize against the dest, not the server's own project. In
+            # reference mode the sources sit OUTSIDE dest_root, so this stores an
+            # absolute media.path (resolvable from the dest); in copy mode the
+            # copied files sit under dest_root/media, so they store relative. cwd
+            # points at the dest .arkiv so ingest's bench_ingest.json / state don't
+            # dirty the install dir (mirrors /api/offload's state_cwd).
+            ingest_env = dict(os.environ)
+            ingest_env["ARKIV_PROJECT_ROOT"] = str(dest_root)
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                    text=True, bufsize=1, env=ingest_env,
+                                    cwd=str(dest_root / ".arkiv"))
+            try:
+                for line in proc.stdout:
+                    yield _json.dumps({"type": "log", "line": line.rstrip("\n")}, ensure_ascii=False) + "\n"
+                proc.wait()
+            finally:
+                if proc.stdout and not proc.stdout.closed:
+                    proc.stdout.close()
+            yield _json.dumps({"type": "index", "status": "done", "code": proc.returncode},
+                              ensure_ascii=False) + "\n"
+
+        # ── bootstrap: register the new project (path now exists) ──
+        if body.create_new:
+            try:
+                project_registry.add_project(dest_name, str(dest_root))
+                yield _json.dumps({"type": "registered", "name": dest_name}, ensure_ascii=False) + "\n"
+            except project_registry.RegistryError as exc:
+                yield _json.dumps({"type": "registered", "error": str(exc)}, ensure_ascii=False) + "\n"
+
+        yield _json.dumps({"type": "done", "summary": {
+            "copied": len(ingest_paths), "skipped": skipped, "dest": dest_name, "mode": body.mode,
+        }}, ensure_ascii=False) + "\n"
+
+    return StreamingResponse(_stream(), media_type="application/x-ndjson")
 
 
 # --- Phase 9.7 G5②: persisted settings (curated key/value overrides) ---

--- a/server.py
+++ b/server.py
@@ -21,6 +21,7 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, field_validator
 
 import admin
+import bins as bins_store
 import chat
 import codec
 import auth
@@ -320,6 +321,33 @@ class ProjectCreate(BaseModel):
         if "/" in cleaned or "\\" in cleaned:
             raise ValueError("project name must not contain path separators")
         return cleaned
+
+
+class BinCreate(BaseModel):
+    name: str
+
+    @field_validator("name")
+    @classmethod
+    def _clean_bin_name(cls, v: str) -> str:
+        cleaned = " ".join(
+            "".join(c for c in (v or "") if c == " " or (ord(c) >= 0x20 and c != "\x7f")).split()
+        )
+        if not cleaned:
+            raise ValueError("bin name must not be empty")
+        if len(cleaned) > 100:
+            raise ValueError("bin name too long (max 100)")
+        return cleaned
+
+
+class BinItemRef(BaseModel):
+    project_name: str
+    media_id: str
+    filename: Optional[str] = None
+
+
+class BinAddItems(BaseModel):
+    # Accept one ref or a batch — the frontend adds a multi-selection at once.
+    items: List[BinItemRef]
 
 
 class CreateTokenRequest(BaseModel):
@@ -644,6 +672,99 @@ def projects_health(
     projects = project_registry.health_projects()
     ok_count = sum(1 for item in projects if item["status"] == "ok")
     return {"projects": projects, "total": len(projects), "ok": ok_count}
+
+
+# --- Cross-library 精選集 (bins): persistent named selections spanning projects ---
+# Storage is ~/.arkiv-bins.json (bins.py), separate from any project.db. Items
+# reference clips by (project_name, media_id) — never mutating the source library.
+
+def _bin_detail_payload(b) -> dict:
+    """Bin + per-item reachability status. The status probe re-resolves the source
+    server-side; only the enum + basename filename + project_name reach the client
+    (Phase 16.2 — no absolute path ever leaves the backend)."""
+    items = []
+    for item in b.items:
+        status = bins_store.bin_item_status(item.project_name, item.media_id)
+        items.append({
+            "project_name": item.project_name,
+            "media_id": item.media_id,
+            "filename": _basename_safe(item.filename) if item.filename else "",
+            "added_at": item.added_at,
+            "status": status,
+        })
+    payload = b.summary()
+    payload["items"] = items
+    payload["reachable"] = sum(1 for it in items if it["status"] == bins_store.STATUS_OK)
+    return payload
+
+
+@app.get("/api/bins")
+def list_bins(_tok: dict = Depends(require_scopes("collections_read"))):
+    try:
+        rows = [b.summary() for b in bins_store.list_bins()]
+    except bins_store.BinsError as exc:
+        raise HTTPException(status_code=500, detail="bins store unreadable: {0}".format(exc))
+    return {"bins": rows, "total": len(rows)}
+
+
+@app.post("/api/bins")
+def create_bin(body: BinCreate, _tok: dict = Depends(require_scopes("collections_write"))):
+    try:
+        b = bins_store.create_bin(body.name)
+    except bins_store.BinsError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return b.summary()
+
+
+@app.get("/api/bins/{bin_id}")
+def get_bin(bin_id: str, _tok: dict = Depends(require_scopes("collections_read"))):
+    try:
+        b = bins_store.get_bin(bin_id)
+    except bins_store.BinsError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return _bin_detail_payload(b)
+
+
+@app.patch("/api/bins/{bin_id}")
+def rename_bin(bin_id: str, body: BinCreate, _tok: dict = Depends(require_scopes("collections_write"))):
+    try:
+        b = bins_store.rename_bin(bin_id, body.name)
+    except bins_store.BinsError as exc:
+        code = 404 if "not found" in str(exc) else 400
+        raise HTTPException(status_code=code, detail=str(exc))
+    return b.summary()
+
+
+@app.delete("/api/bins/{bin_id}")
+def delete_bin(bin_id: str, _tok: dict = Depends(require_scopes("collections_write"))):
+    try:
+        b = bins_store.delete_bin(bin_id)
+    except bins_store.BinsError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return b.summary()
+
+
+@app.post("/api/bins/{bin_id}/items")
+def add_bin_items(bin_id: str, body: BinAddItems, _tok: dict = Depends(require_scopes("collections_write"))):
+    payload = [
+        {"project_name": it.project_name, "media_id": it.media_id, "filename": it.filename}
+        for it in body.items
+    ]
+    try:
+        b = bins_store.add_items(bin_id, payload)
+    except bins_store.BinsError as exc:
+        code = 404 if "not found" in str(exc) else 400
+        raise HTTPException(status_code=code, detail=str(exc))
+    return _bin_detail_payload(b)
+
+
+@app.delete("/api/bins/{bin_id}/items")
+def remove_bin_item(bin_id: str, body: BinItemRef, _tok: dict = Depends(require_scopes("collections_write"))):
+    try:
+        b = bins_store.remove_item(bin_id, body.project_name, body.media_id)
+    except bins_store.BinsError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return _bin_detail_payload(b)
 
 
 # --- Phase 9.7 G5②: persisted settings (curated key/value overrides) ---

--- a/tests/test_bin_copy.py
+++ b/tests/test_bin_copy.py
@@ -1,0 +1,176 @@
+"""Copy-into-project orchestration (POST /api/bins/{id}/copy). The reachability
+gate + reference/copy modes + create_new bootstrap are tested here with the ingest
+subprocess stubbed (deterministic, no ffmpeg/Whisper/Ollama in CI); the real
+`ingest --files` indexing path is covered by an end-to-end live-server run."""
+import importlib
+import io
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _parse_ndjson(text):
+    import json
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+class _FakePopen:
+    """Stand-in for the ingest subprocess — records the command, emits a couple of
+    log lines, exits 0. Captured into `calls` so tests can assert the built cmd."""
+    def __init__(self, calls):
+        self._calls = calls
+
+    def __call__(self, cmd, **kwargs):
+        self._calls.append({"cmd": cmd, "env": kwargs.get("env"), "cwd": kwargs.get("cwd")})
+        inst = _FakePopen(self._calls)
+        inst.returncode = 0
+        inst.stdout = io.StringIO("Ingesting files\n[1/1] clip done\n")
+        return inst
+
+    def wait(self):
+        self.returncode = 0
+
+
+def _setup(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARKIV_BINS_PATH", str(tmp_path / "bins.json"))
+    monkeypatch.setenv("ARKIV_PROJECTS_REGISTRY", str(tmp_path / "registry.json"))
+    monkeypatch.delenv("ARKIV_PROJECT_ROOTS", raising=False)
+    bins = importlib.import_module("bins")
+    return bins
+
+
+def _stub_ingest(monkeypatch):
+    calls = []
+    monkeypatch.setattr(subprocess, "Popen", _FakePopen(calls))
+    return calls
+
+
+def _stub_resolve(monkeypatch, mapping):
+    """mapping: (project_name, media_id) -> {status, absolute_path, filename}."""
+    import bins as bins_mod
+    def fake(project_name, media_id):
+        return mapping.get((project_name, str(media_id)))
+    monkeypatch.setattr(bins_mod, "resolve_source", fake)
+
+
+def test_copy_reference_gates_unreachable_and_registers_new(fastapi_client, tmp_path, monkeypatch):
+    bins = _setup(tmp_path, monkeypatch)
+    calls = _stub_ingest(monkeypatch)
+
+    # one real reachable source file, one unreachable (ghost) item
+    src = tmp_path / "src" / "clip.mp4"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b"video-bytes")
+    _stub_resolve(monkeypatch, {
+        ("libA", "1"): {"status": "ok", "absolute_path": str(src), "filename": "clip.mp4"},
+        ("libGhost", "9"): {"status": "project_unregistered", "absolute_path": "", "filename": "gone.mp4"},
+    })
+
+    b = bins.create_bin("copybin")
+    bins.add_items(b.id, [
+        {"project_name": "libA", "media_id": "1", "filename": "clip.mp4"},
+        {"project_name": "libGhost", "media_id": "9", "filename": "gone.mp4"},
+    ])
+
+    dest = tmp_path / "newproj"
+    r = fastapi_client.post(
+        "/api/bins/{0}/copy".format(b.id),
+        json={"dest": str(dest), "create_new": True, "dest_name": "新案",
+              "mode": "reference", "skip_vision": True, "no_embed": True},
+    )
+    assert r.status_code == 200, r.text
+    events = _parse_ndjson(r.text)
+    kinds = [e.get("type") for e in events]
+    assert "gate" in kinds and "done" in kinds
+
+    done = [e for e in events if e["type"] == "done"][0]["summary"]
+    assert done["copied"] == 1  # only the reachable one
+    assert done["mode"] == "reference"
+    # RED LINE: the unreachable item is SKIPPED and named (never silently dropped)
+    assert done["skipped"] == [{"project_name": "libGhost", "media_id": "9", "status": "project_unregistered"}]
+
+    # reference mode indexes the ORIGINAL absolute path (no copy) → ingest --files <src>
+    assert len(calls) == 1
+    cmd = calls[0]["cmd"]
+    assert "--files" in cmd and str(src) in cmd
+    assert "--db" in cmd and str(dest / ".arkiv" / "project.db") in cmd
+    assert "--skip-vision" in cmd and "--no-embed" in cmd
+    # ingest runs AS the dest project (paths relativize against the dest, not the server)
+    assert calls[0]["env"]["ARKIV_PROJECT_ROOT"] == str(dest.resolve())
+    # source file untouched
+    assert src.exists() and src.read_bytes() == b"video-bytes"
+
+    # create_new registered the project
+    import projects
+    assert any(p.name == "新案" for p in projects.list_registry_projects())
+
+
+def test_copy_mode_copies_verified_bytes_and_keeps_source(fastapi_client, tmp_path, monkeypatch):
+    bins = _setup(tmp_path, monkeypatch)
+    calls = _stub_ingest(monkeypatch)
+
+    src = tmp_path / "src" / "clip.mp4"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b"the-real-bytes-1234567890")
+    _stub_resolve(monkeypatch, {
+        ("libA", "1"): {"status": "ok", "absolute_path": str(src), "filename": "clip.mp4"},
+    })
+
+    b = bins.create_bin("copybin")
+    bins.add_items(b.id, [{"project_name": "libA", "media_id": "1", "filename": "clip.mp4"}])
+
+    dest = tmp_path / "newproj_copy"
+    r = fastapi_client.post(
+        "/api/bins/{0}/copy".format(b.id),
+        json={"dest": str(dest), "create_new": True, "mode": "copy",
+              "skip_vision": True, "no_embed": True},
+    )
+    assert r.status_code == 200, r.text
+    events = _parse_ndjson(r.text)
+    assert any(e.get("type") == "copy" and e.get("done") == 1 for e in events)
+
+    # bytes landed under dest/media, identical to source, and the SOURCE is intact
+    copied = dest / "media" / "clip.mp4"
+    assert copied.exists()
+    assert copied.read_bytes() == b"the-real-bytes-1234567890"
+    assert src.exists() and src.read_bytes() == b"the-real-bytes-1234567890"  # never deleted
+    # ingest indexes the COPIED file (not the original)
+    assert str(copied) in calls[0]["cmd"]
+
+
+def test_copy_into_existing_project(fastapi_client, tmp_path, monkeypatch):
+    bins = _setup(tmp_path, monkeypatch)
+    _stub_ingest(monkeypatch)
+
+    # an existing registered destination project
+    existing = tmp_path / "existing"
+    (existing / ".arkiv").mkdir(parents=True)
+    import projects
+    projects.add_project("已存在專案", str(existing))
+
+    src = tmp_path / "src" / "clip.mp4"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b"x")
+    _stub_resolve(monkeypatch, {("libA", "1"): {"status": "ok", "absolute_path": str(src), "filename": "clip.mp4"}})
+
+    b = bins.create_bin("cb")
+    bins.add_items(b.id, [{"project_name": "libA", "media_id": "1", "filename": "clip.mp4"}])
+
+    r = fastapi_client.post(
+        "/api/bins/{0}/copy".format(b.id),
+        json={"dest": "已存在專案", "create_new": False, "mode": "reference",
+              "skip_vision": True, "no_embed": True},
+    )
+    assert r.status_code == 200, r.text
+    done = [e for e in _parse_ndjson(r.text) if e["type"] == "done"][0]["summary"]
+    assert done["copied"] == 1 and done["dest"] == "已存在專案"
+
+
+def test_copy_unknown_dest_project_400(fastapi_client, tmp_path, monkeypatch):
+    bins = _setup(tmp_path, monkeypatch)
+    b = bins.create_bin("cb")
+    r = fastapi_client.post(
+        "/api/bins/{0}/copy".format(b.id),
+        json={"dest": "沒有這個專案", "create_new": False, "mode": "reference"},
+    )
+    assert r.status_code == 400

--- a/tests/test_bins.py
+++ b/tests/test_bins.py
@@ -205,3 +205,21 @@ def test_bins_api_crud_and_no_path_leak(fastapi_client, tmp_path, monkeypatch):
 def test_bins_api_get_missing_404(fastapi_client, tmp_path, monkeypatch):
     monkeypatch.setenv("ARKIV_BINS_PATH", str(tmp_path / "api-bins2.json"))
     assert fastapi_client.get("/api/bins/nope").status_code == 404
+
+
+def test_stats_reports_current_project_registry_name(fastapi_client, tmp_path, monkeypatch):
+    """stats.project_registered_name = the REGISTRY name of the loaded project (may
+    differ from the dir basename); null when unregistered. The grid's 加入精選集
+    needs this so grid-added bin items are keyed by a resolvable name."""
+    import config
+    import projects
+    monkeypatch.setenv("ARKIV_PROJECTS_REGISTRY", str(tmp_path / "reg.json"))
+    monkeypatch.delenv("ARKIV_PROJECT_ROOTS", raising=False)
+
+    # unregistered → null
+    assert fastapi_client.get("/api/stats").json().get("project_registered_name") is None
+
+    # register the CURRENT project root under a name != its dir basename
+    projects.add_project("我的素材庫", str(config.PROJECT_ROOT))
+    got = fastapi_client.get("/api/stats").json().get("project_registered_name")
+    assert got == "我的素材庫"

--- a/tests/test_bins.py
+++ b/tests/test_bins.py
@@ -1,0 +1,207 @@
+"""Cross-library 精選集 (bins): persistence CRUD + per-item reference-integrity
+status. The status probe is the RED LINE — a source library going offline / a
+clip deleted / a file removed from disk must surface, never silently 'ok'."""
+import importlib
+import sqlite3
+from pathlib import Path
+
+
+def _fresh_bins(tmp_path, monkeypatch):
+    # _default_bins_path() reads ARKIV_BINS_PATH live on every call, so setting the
+    # env is enough — do NOT reload the module (reloading rebinds ProjectMeta and
+    # contaminates federation's isinstance checks in other tests).
+    monkeypatch.setenv("ARKIV_BINS_PATH", str(tmp_path / "bins.json"))
+    return importlib.import_module("bins")
+
+
+def _make_project(tmp_path, name, with_db=True, with_chroma=True, media_path="clips/a.mp4", make_file=True):
+    """A registrable project: <root>/.arkiv/{project.db,chroma_db}. Media row 1
+    points at media_path (relative → resolves under root); optionally create the
+    real file so file_missing can be exercised by omitting it."""
+    root = tmp_path / name
+    arkiv = root / ".arkiv"
+    arkiv.mkdir(parents=True, exist_ok=True)
+    if with_chroma:
+        (arkiv / "chroma_db").mkdir(exist_ok=True)
+    if with_db:
+        conn = sqlite3.connect(str(arkiv / "project.db"))
+        conn.execute(
+            "CREATE TABLE media (id INTEGER PRIMARY KEY, path TEXT, filename TEXT, "
+            "duration_s REAL, rating TEXT, lang TEXT, ext TEXT, transcript TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO media (id, path, filename, duration_s, rating, lang, ext, transcript) "
+            "VALUES (1, ?, '黑沙灘.mov', 7.9, 'good', 'zh', '.mov', 'iceland')",
+            (media_path,),
+        )
+        conn.commit()
+        conn.close()
+    if make_file and media_path:
+        target = root / media_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"stub-media")
+    return root
+
+
+# --- CRUD ---
+
+def test_bin_crud_round_trip(tmp_path, monkeypatch):
+    bins = _fresh_bins(tmp_path, monkeypatch)
+    b = bins.create_bin("單車紀錄片選片")
+    assert b.name == "單車紀錄片選片" and b.id
+    assert [x.name for x in bins.list_bins()] == ["單車紀錄片選片"]
+
+    renamed = bins.rename_bin(b.id, "改名了")
+    assert renamed.name == "改名了"
+    assert bins.get_bin(b.id).name == "改名了"
+
+    bins.delete_bin(b.id)
+    assert bins.list_bins() == []
+
+
+def test_add_items_dedupes_and_preserves_order(tmp_path, monkeypatch):
+    bins = _fresh_bins(tmp_path, monkeypatch)
+    b = bins.create_bin("selection")
+    bins.add_items(b.id, [
+        {"project_name": "projA", "media_id": "1", "filename": "a.mov"},
+        {"project_name": "projB", "media_id": "5", "filename": "b.mov"},
+        {"project_name": "projA", "media_id": "1", "filename": "dup-ignored"},  # dup key
+    ])
+    got = bins.get_bin(b.id)
+    assert [(i.project_name, i.media_id) for i in got.items] == [("projA", "1"), ("projB", "5")]
+    # dedup keeps the FIRST filename
+    assert got.items[0].filename == "a.mov"
+
+
+def test_remove_item(tmp_path, monkeypatch):
+    bins = _fresh_bins(tmp_path, monkeypatch)
+    b = bins.create_bin("s")
+    bins.add_items(b.id, [{"project_name": "p", "media_id": "1"}, {"project_name": "p", "media_id": "2"}])
+    bins.remove_item(b.id, "p", "1")
+    assert [i.media_id for i in bins.get_bin(b.id).items] == ["2"]
+
+
+def test_get_missing_bin_raises(tmp_path, monkeypatch):
+    bins = _fresh_bins(tmp_path, monkeypatch)
+    try:
+        bins.get_bin("nope")
+        assert False, "should raise"
+    except bins.BinsError as exc:
+        assert "not found" in str(exc)
+
+
+def test_save_bins_uses_unique_tmp_and_cleans_up(tmp_path, monkeypatch):
+    bins = _fresh_bins(tmp_path, monkeypatch)
+    bins.save_bins({"version": 1, "bins": []})
+    assert not (tmp_path / "bins.json.tmp").exists()
+    assert (tmp_path / "bins.json").exists()
+
+
+def test_corrupt_bins_json_raises_clean(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARKIV_BINS_PATH", str(tmp_path / "bins.json"))
+    (tmp_path / "bins.json").write_text("{ not valid", encoding="utf-8")
+    bins = importlib.import_module("bins")
+    try:
+        bins.list_bins()
+        assert False, "should raise"
+    except bins.BinsError as exc:
+        assert "corrupt" in str(exc)
+
+
+# --- reference-integrity status (the RED LINE) ---
+
+def _register(tmp_path, monkeypatch, name, root):
+    monkeypatch.setenv("ARKIV_PROJECTS_REGISTRY", str(tmp_path / "registry.json"))
+    monkeypatch.delenv("ARKIV_PROJECT_ROOTS", raising=False)
+    projects = importlib.import_module("projects")  # env read live; no reload
+    projects.add_project(name, str(root))
+    return projects
+
+
+def test_status_ok_for_reachable_clip(tmp_path, monkeypatch):
+    bins = _fresh_bins(tmp_path, monkeypatch)
+    root = _make_project(tmp_path, "libA", make_file=True)
+    _register(tmp_path, monkeypatch, "libA", root)
+    assert bins.bin_item_status("libA", "1") == bins.STATUS_OK
+
+
+def test_status_project_unregistered(tmp_path, monkeypatch):
+    bins = _fresh_bins(tmp_path, monkeypatch)
+    monkeypatch.setenv("ARKIV_PROJECTS_REGISTRY", str(tmp_path / "registry.json"))
+    monkeypatch.delenv("ARKIV_PROJECT_ROOTS", raising=False)
+    assert bins.bin_item_status("ghost", "1") == bins.STATUS_PROJECT_UNREGISTERED
+
+
+def test_status_row_missing(tmp_path, monkeypatch):
+    bins = _fresh_bins(tmp_path, monkeypatch)
+    root = _make_project(tmp_path, "libB", make_file=True)
+    _register(tmp_path, monkeypatch, "libB", root)
+    assert bins.bin_item_status("libB", "999") == bins.STATUS_ROW_MISSING
+
+
+def test_status_file_missing(tmp_path, monkeypatch):
+    bins = _fresh_bins(tmp_path, monkeypatch)
+    # row exists but the referenced file is never created on disk
+    root = _make_project(tmp_path, "libC", make_file=False)
+    _register(tmp_path, monkeypatch, "libC", root)
+    assert bins.bin_item_status("libC", "1") == bins.STATUS_FILE_MISSING
+
+
+def test_status_db_missing_passes_through_health(tmp_path, monkeypatch):
+    bins = _fresh_bins(tmp_path, monkeypatch)
+    # project dir + chroma but NO project.db → health returns db_missing
+    root = _make_project(tmp_path, "libD", with_db=False, with_chroma=True, make_file=False)
+    _register(tmp_path, monkeypatch, "libD", root)
+    assert bins.bin_item_status("libD", "1") == "db_missing"
+
+
+# --- API endpoints ---
+
+def test_bins_api_crud_and_no_path_leak(fastapi_client, tmp_path, monkeypatch):
+    monkeypatch.setenv("ARKIV_BINS_PATH", str(tmp_path / "api-bins.json"))
+    monkeypatch.setenv("ARKIV_PROJECTS_REGISTRY", str(tmp_path / "api-registry.json"))
+    monkeypatch.delenv("ARKIV_PROJECT_ROOTS", raising=False)
+
+    # create
+    r = fastapi_client.post("/api/bins", json={"name": "跨庫選片"})
+    assert r.status_code == 200, r.text
+    bid = r.json()["id"]
+
+    # list
+    r = fastapi_client.get("/api/bins")
+    assert r.status_code == 200
+    assert [b["name"] for b in r.json()["bins"]] == ["跨庫選片"]
+
+    # add items — filename carries an absolute path; the detail view MUST basename it
+    r = fastapi_client.post(
+        "/api/bins/{0}/items".format(bid),
+        json={"items": [{"project_name": "ghostlib", "media_id": "7",
+                          "filename": "/Users/secret/vault/黑沙灘.mov"}]},
+    )
+    assert r.status_code == 200, r.text
+    detail = r.json()
+    assert detail["item_count"] == 1
+    item = detail["items"][0]
+    # reachability surfaced (project not registered here)
+    assert item["status"] == "project_unregistered"
+    # Phase 16.2: no absolute path leaks — filename basenamed, no absolute_path field
+    assert item["filename"] == "黑沙灘.mov"
+    assert "absolute_path" not in item
+    assert "/Users/secret" not in r.text
+
+    # remove item
+    r = fastapi_client.request(
+        "DELETE", "/api/bins/{0}/items".format(bid),
+        json={"project_name": "ghostlib", "media_id": "7"},
+    )
+    assert r.status_code == 200
+    assert r.json()["item_count"] == 0
+
+    # delete bin
+    assert fastapi_client.delete("/api/bins/{0}".format(bid)).status_code == 200
+    assert fastapi_client.get("/api/bins").json()["total"] == 0
+
+
+def test_bins_api_get_missing_404(fastapi_client, tmp_path, monkeypatch):
+    monkeypatch.setenv("ARKIV_BINS_PATH", str(tmp_path / "api-bins2.json"))
+    assert fastapi_client.get("/api/bins/nope").status_code == 404


### PR DESCRIPTION
**Stacked on #127** (base = `feat/federation-search-ui`). Multi-project workflow **Phase 2** — the complete cross-library 精選集 + copy-into-project feature, delivered "一次到位" per Hevin's decision. Two commits: PR A (persistence + reference-integrity) · PR B (copy-into-project).

Hevin's 拍板 (AskUserQuestion): scope = bin **+ copy in one go**; copy semantics = **both** (index-by-reference / verified-copy, chosen per-copy); **multiple named bins**.

## What it does
A 精選集 is a persistent, named selection of clips scattered across registered projects, referenced by `(project_name, media_id)` — the identity that survives federation's Phase-16.2 sanitization. Add clips from federated search, see each clip's reachability, then **copy the selection into a project** (new or existing) to actually edit from it ("開新專案撈多個舊庫"). Cross-library is **read-only** — the source libraries are never moved or mutated (W2.2 §0.3).

## PR A — persistence + reference-integrity
- **`bins.py`** — versioned, lock-guarded, atomic JSON at `~/.arkiv-bins.json` (env `ARKIV_BINS_PATH`), mirroring `projects.py`. Multiple named bins; items deduped by `(project_name, media_id)`, add-order preserved.
- **`bin_item_status()`** — the RED-LINE gate: registry lookup → `health.project_health` → federation row fetch → `os.path.exists`, collapsed to one status (`ok` / `project_unregistered` / `db_missing` / `nas_unmounted` / `path_not_found` / `row_missing` / `file_missing`). Absolute path is **server-side only**; client gets status enum + basenamed filename.
- **`/api/bins`** CRUD (reusing `collections_read`/`collections_write`).
- Frontend: multi-select federated results + "加入精選集"; a `/bins` route with per-item reachability badges (✓ / ⚠ 庫離線 / ✗ 檔案不在). `req()` now sends `cache:'no-store'` (a browser-cached copy showed stale reachability — caught in verification).

## PR B — copy-into-project
`POST /api/bins/{id}/copy` (streams ndjson):
- **Gate**: each item re-resolved server-side; unreachable → **skipped + named in the summary** (fail-loud), never silently dropped.
- **`mode='reference'`**: indexes the original absolute paths in place (原檔不動, no bytes moved).
- **`mode='copy'`**: verified byte-copy into `dest/media` (hash both sides, atomic rename, **never deletes the source**), then indexes the copies (self-contained).
- **`create_new`**: bootstraps a fresh project dir → ingests → registers it; refuses to clobber an existing project.
- Indexing runs one **`ingest --files …`** (new flag) AS the dest project (`ARKIV_PROJECT_ROOT=dest_root`) so paths relativize against the dest — reference→absolute, copy→relative.
- Frontend: a copy dialog (new/existing dest, reference/copy, fast "skip re-analysis" toggle) with live progress + summary; `api.copyBin` streams the ndjson.

## Verification (end-to-end, live server + Playwright)
- **Reference** copy into a new project → original absolute path stored, no bytes moved, source untouched, project registered.
- **Copy** mode → verified identical bytes under `dest/media`, relative path, source intact (hash IDENTICAL).
- **Red line**: moving a source project's dir flips its bin badge to 庫不存在 (`path_not_found`) and reachable → 1/2; a mixed-reachability bin copies the reachable clip and lists the unreachable one as skipped.
- UI copy dialog drives it all with a live log + summary; **0 console errors**; no absolute path leaks in any `/api/bins` response.
- Suite **697 passed / 5 skipped** (13 bins + 4 copy tests, incl. all status paths, no-leak assertion, verified-copy-keeps-source); frontend build clean; `ingest --files` smoke-tested for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)