### PR TITLE
fix(concurrency): ingest single-flight — cover copy_bin + retranscribe-all (fable-audit HIGH)

### DIFF
--- a/server.py
+++ b/server.py
@@ -877,6 +877,7 @@ def copy_bin(bin_id: str, body: BinCopyRequest, _tok: dict = Depends(require_sco
             ingest_paths = [src for (_pn, _mid, src) in reachable]
 
         # ── index phase: one ingest run over the gathered files (one model warmup) ──
+        index_skipped_busy = False
         if ingest_paths:
             cmd = [_sys.executable, str(ROOT / "ingest.py"), "--files", *ingest_paths,
                    "--db", str(dest_db)]
@@ -884,29 +885,52 @@ def copy_bin(bin_id: str, body: BinCopyRequest, _tok: dict = Depends(require_sco
                 cmd.append("--skip-vision")
             if body.no_embed:
                 cmd.append("--no-embed")
-            yield _json.dumps({"type": "index", "status": "start", "files": len(ingest_paths)},
-                              ensure_ascii=False) + "\n"
-            # Run ingest AS the dest project: ARKIV_PROJECT_ROOT=dest_root so paths
-            # relativize against the dest, not the server's own project. In
-            # reference mode the sources sit OUTSIDE dest_root, so this stores an
-            # absolute media.path (resolvable from the dest); in copy mode the
-            # copied files sit under dest_root/media, so they store relative. cwd
-            # points at the dest .arkiv so ingest's bench_ingest.json / state don't
-            # dirty the install dir (mirrors /api/offload's state_cwd).
-            ingest_env = dict(os.environ)
-            ingest_env["ARKIV_PROJECT_ROOT"] = str(dest_root)
-            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                                    text=True, bufsize=1, env=ingest_env,
-                                    cwd=str(dest_root / ".arkiv"))
-            try:
-                for line in proc.stdout:
-                    yield _json.dumps({"type": "log", "line": line.rstrip("\n")}, ensure_ascii=False) + "\n"
-                proc.wait()
-            finally:
-                if proc.stdout and not proc.stdout.closed:
-                    proc.stdout.close()
-            yield _json.dumps({"type": "index", "status": "done", "code": proc.returncode},
-                              ensure_ascii=False) + "\n"
+            # fable-audit 2026-07-12 (#2/#5): this launches a full whisper+vision
+            # pipeline — it MUST share the H3 single-flight slot, or a concurrent
+            # /api/ingest runs a second pipeline → double-whisper OOM. If the slot
+            # is busy, the bytes are already copied; skip indexing (fail-loud) so
+            # the user can re-ingest later rather than risk the OOM.
+            if not _acquire_ingest_slot():
+                index_skipped_busy = True
+                yield _json.dumps({"type": "index", "status": "busy",
+                                   "error": "已有匯入任務進行中，已複製檔案但略過索引；請稍後手動 ingest"},
+                                  ensure_ascii=False) + "\n"
+            else:
+                yield _json.dumps({"type": "index", "status": "start", "files": len(ingest_paths)},
+                                  ensure_ascii=False) + "\n"
+                # Run ingest AS the dest project: ARKIV_PROJECT_ROOT=dest_root so paths
+                # relativize against the dest, not the server's own project. In
+                # reference mode the sources sit OUTSIDE dest_root, so this stores an
+                # absolute media.path (resolvable from the dest); in copy mode the
+                # copied files sit under dest_root/media, so they store relative. cwd
+                # points at the dest .arkiv so ingest's bench_ingest.json / state don't
+                # dirty the install dir (mirrors /api/offload's state_cwd).
+                ingest_env = dict(os.environ)
+                ingest_env["ARKIV_PROJECT_ROOT"] = str(dest_root)
+                proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                        text=True, bufsize=1, env=ingest_env,
+                                        cwd=str(dest_root / ".arkiv"))
+                try:
+                    for line in proc.stdout:
+                        yield _json.dumps({"type": "log", "line": line.rstrip("\n")}, ensure_ascii=False) + "\n"
+                    proc.wait()
+                except GeneratorExit:
+                    # fable-audit 2026-07-12 (#6/#7): client disconnected — terminate
+                    # the child (mirrors offload_run) so a multi-minute whisper/vision
+                    # pass doesn't run orphaned with the slot held.
+                    proc.terminate()
+                    try:
+                        proc.wait(timeout=10)
+                    except subprocess.TimeoutExpired:
+                        proc.kill()
+                        proc.wait()
+                    raise
+                finally:
+                    if proc.stdout and not proc.stdout.closed:
+                        proc.stdout.close()
+                    _release_ingest_slot()
+                yield _json.dumps({"type": "index", "status": "done", "code": proc.returncode},
+                                  ensure_ascii=False) + "\n"
 
         # ── bootstrap: register the new project (path now exists) ──
         if body.create_new:
@@ -918,6 +942,7 @@ def copy_bin(bin_id: str, body: BinCopyRequest, _tok: dict = Depends(require_sco
 
         yield _json.dumps({"type": "done", "summary": {
             "copied": len(ingest_paths), "skipped": skipped, "dest": dest_name, "mode": body.mode,
+            "index_skipped_busy": index_skipped_busy,
         }}, ensure_ascii=False) + "\n"
 
     return StreamingResponse(_stream(), media_type="application/x-ndjson")
@@ -4109,6 +4134,12 @@ def retranscribe_all(
     with _retranscribe_lock:  # refuse concurrent batch runs (mirrors embed M8)
         if _retranscribe_active:
             raise HTTPException(409, "批次重轉錄已在進行中，請稍候")
+        # fable-audit 2026-07-12 (#11): this batch runs whisper IN-PROCESS over the
+        # whole library — it must also hold the shared H3 ingest slot, or a
+        # concurrent /api/ingest loads a second whisper → double-whisper OOM. The
+        # background worker releases it in its finally.
+        if not _acquire_ingest_slot():
+            raise HTTPException(409, "已有匯入任務進行中，請稍候")
         _retranscribe_active = True
         _retranscribe_progress.update({
             "total": len(targets), "done": 0, "failed": 0,
@@ -4178,6 +4209,7 @@ def _run_retranscribe_all(targets, language, backup):
         _retranscribe_progress["current"] = None
         with _retranscribe_lock:
             _retranscribe_active = False
+        _release_ingest_slot()  # fable-audit 2026-07-12 (#11): free the shared H3 slot
 
 
 @app.get("/api/retranscribe-all/status")

--- a/tests/test_bin_copy.py
+++ b/tests/test_bin_copy.py
@@ -53,6 +53,47 @@ def _stub_resolve(monkeypatch, mapping):
     monkeypatch.setattr(bins_mod, "resolve_source", fake)
 
 
+def test_copy_skips_index_when_ingest_slot_busy(fastapi_client, tmp_path, monkeypatch):
+    """fable-audit 2026-07-12 (#2/#5): copy_bin's index phase must share the H3
+    single-flight slot. If a full ingest already holds it, copy_bin copies/gates the
+    files but must NOT spawn a second whisper+vision pipeline — it skips indexing and
+    says so, rather than risking the double-whisper OOM the guard exists to prevent."""
+    import server
+
+    bins = _setup(tmp_path, monkeypatch)
+    calls = _stub_ingest(monkeypatch)  # if a subprocess spawns, it lands here
+
+    src = tmp_path / "src" / "clip.mp4"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b"video-bytes")
+    _stub_resolve(monkeypatch, {
+        ("libA", "1"): {"status": "ok", "absolute_path": str(src), "filename": "clip.mp4"},
+    })
+    b = bins.create_bin("busybin")
+    bins.add_items(b.id, [{"project_name": "libA", "media_id": "1", "filename": "clip.mp4"}])
+
+    assert server._acquire_ingest_slot() is True  # simulate a concurrent ingest holding the slot
+    try:
+        r = fastapi_client.post(
+            "/api/bins/{0}/copy".format(b.id),
+            json={"dest": str(tmp_path / "np"), "create_new": True, "dest_name": "忙案",
+                  "mode": "reference", "skip_vision": True, "no_embed": True},
+        )
+        assert r.status_code == 200, r.text
+        events = _parse_ndjson(r.text)
+        # the index phase reported busy and was skipped — NO ingest subprocess spawned
+        assert any(e.get("type") == "index" and e.get("status") == "busy" for e in events)
+        assert calls == []
+        done = [e for e in events if e["type"] == "done"][0]["summary"]
+        assert done["index_skipped_busy"] is True
+    finally:
+        server._release_ingest_slot()
+
+    # slot is free again → a normal copy now DOES index (proves we didn't wedge it)
+    assert server._acquire_ingest_slot() is True
+    server._release_ingest_slot()
+
+
 def test_copy_reference_gates_unreachable_and_registers_new(fastapi_client, tmp_path, monkeypatch):
     bins = _setup(tmp_path, monkeypatch)
     calls = _stub_ingest(monkeypatch)

--- a/tests/test_hardening_concurrency.py
+++ b/tests/test_hardening_concurrency.py
@@ -1,0 +1,48 @@
+"""Regression tests for the fable-audit 2026-07-12 concurrency-guard fixes.
+
+Pins that whole-library retranscribe now shares the H3 single-flight ingest slot
+(#11) so a concurrent /api/ingest can't load a second whisper → double-whisper OOM.
+(copy_bin's slot sharing #2/#5 is covered in test_bin_copy.py.)
+"""
+import importlib
+
+
+def _seed_audio_row(sample_record):
+    db = importlib.import_module("db")
+    db.upsert(sample_record(path="/tmp/ghost-audio.mp3", filename="ghost-audio.mp3",
+                            ext=".mp3", has_audio=1))
+
+
+def test_retranscribe_all_409_when_ingest_slot_busy(fastapi_client, sample_record):
+    import server
+    _seed_audio_row(sample_record)
+    assert server._acquire_ingest_slot() is True  # a concurrent ingest holds the slot
+    try:
+        resp = fastapi_client.post("/api/retranscribe-all", json={"backup": False})
+        assert resp.status_code == 409
+    finally:
+        server._release_ingest_slot()
+
+
+def test_retranscribe_all_releases_slot_after_run(fastapi_client, sample_record):
+    import server
+    _seed_audio_row(sample_record)
+    # slot free → the batch is queued; TestClient runs the background task
+    # synchronously, and its finally must release the shared slot.
+    resp = fastapi_client.post("/api/retranscribe-all", json={"backup": False})
+    assert resp.status_code == 200
+    assert resp.json()["queued"] == 1
+    # the slot was released — a subsequent ingest can acquire it
+    assert server._acquire_ingest_slot() is True
+    server._release_ingest_slot()
+
+
+def test_retranscribe_all_no_audio_returns_early_without_taking_slot(fastapi_client):
+    # empty library (no has_audio rows) → returns before touching the slot
+    import server
+    resp = fastapi_client.post("/api/retranscribe-all", json={"backup": False})
+    assert resp.status_code == 200
+    assert resp.json()["queued"] == 0
+    # slot untouched / free
+    assert server._acquire_ingest_slot() is True
+    server._release_ingest_slot()


### PR DESCRIPTION
## What & why

Second PR from the **fable self-check baseline audit** (2026-07-12, see PR #129 + `docs/2026-07-12-fable-self-check-baseline.md`). Closes the HIGH-severity **ingest single-flight guard bypasses**.

The audit-H3 guard's own docstring claims it covers *"ALL ingest entry points"* — but only 3 of the ingest-spawn sites actually acquire it. Two heavy pipelines bypassed it, and running a second whisper+vision concurrently reproduces the exact **double-whisper OOM / DB-lock** the guard was written to prevent.

| # | Finding | Fix |
|---|---|---|
| **#2/#5** | `copy_bin` (`/api/bins/{id}/copy`) spawns a full `ingest.py` pipeline with **no slot** | Acquire `_acquire_ingest_slot` before the index phase; if busy, bytes are already copied → skip indexing fail-loud (`index status "busy"` + `summary.index_skipped_busy`) rather than launch a 2nd pipeline |
| **#6/#7** | `copy_bin`'s streaming generator has no `GeneratorExit` handling → child runs orphaned on client disconnect (with the slot held) | `terminate()` → `wait(10)` → `kill()`, mirroring the existing `offload_run` fix |
| **#11** | `/api/retranscribe-all` runs whisper **in-process** over the whole library, guarded only by its own lock — never the shared slot | Also hold the shared slot (409 if an ingest is running); release in the worker's `finally` |

## Tests
- `tests/test_hardening_concurrency.py` (+3): retranscribe-all → 409 when slot busy / releases slot after run / no-audio early-return.
- `tests/test_bin_copy.py` (+1): copy skips index when slot busy, spawns no 2nd subprocess, doesn't wedge the slot.
- **Full suite: 702 passed, 5 skipped, zero regressions.** 3.9-safe.

## Follow-up (not in this PR)
**#12** — server-side `/api/ingest` + `/reingest` use plain `subprocess.run(timeout=)`, which on `TimeoutExpired` kills only the direct child, orphaning ffmpeg grandchildren. `watch.py` already solved this with a process-group kill (`run_tree`); tracked as a separate reliability PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)