### PR TITLE
ci: coverage floor + frontend-build + dependency-audit gates (fable-audit round)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,70 @@ jobs:
 
       - name: Run tests
         run: pytest -q
+
+  coverage:
+    name: coverage
+    # Coverage floor as a regression RATCHET (not a quality claim — the conftest
+    # backend fakes flatter the number). Kept as its OWN job and NON-BLOCKING for
+    # now: a pre-existing intermittent flake in a subprocess-CLI test surfaces
+    # under `--cov`, so we don't import that instability into the correctness legs
+    # above. Floor is set conservatively below the measured ~63%. Flip to blocking
+    # once the flaky test is fixed (see CONTRIBUTING / follow-up).
+    runs-on: macos-latest  # same as `test`: mlx-whisper has no Linux wheel
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install \
+            "fastapi>=0.100.0" "uvicorn>=0.20.0" "pydantic>=2.0,<3" \
+            "pillow>=9.0" "requests>=2.28" "xxhash>=2.0.0" "nanoid>=2.0.0" \
+            "psutil>=5.9" "whisper-guard>=0.3" numpy mlx-whisper "mcp>=1.2"
+      - name: Coverage
+        run: pytest -q --cov=. --cov-config=pyproject.toml --cov-report=term:skip-covered --cov-fail-under=55
+
+  frontend:
+    name: frontend-build
+    runs-on: ubuntu-latest
+    # Nothing in CI touched frontend/ before this — a broken Svelte build could
+    # merge silently. Build-only for now; lint/svelte-check are a follow-up.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install + build
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+
+  audit:
+    name: dependency-audit
+    runs-on: ubuntu-latest
+    # Non-blocking: surfaces known-vuln deps without gating merges. Flip to
+    # blocking once the initial findings are triaged (expect transitive noise).
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: pip-audit
+        run: |
+          python -m pip install --upgrade pip pip-audit
+          pip-audit -r requirements.txt -r requirements-dev.txt || true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: npm audit
+        working-directory: frontend
+        run: npm audit --omit=dev --audit-level=high || true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+# Tool configuration for arkiv.
+#
+# Deliberately config-only — NO [project] / build metadata. arkiv installs via
+# requirements.txt with a flat module layout at the repo root; adding packaging
+# metadata here would change the import story. This file exists so CI has a home
+# for coverage (and, later, ruff/mypy) config.
+
+[tool.coverage.run]
+source = ["."]
+omit = [
+    "tests/*",
+    "scripts/*",
+    "bench_*.py",
+    "resource_probe.py",
+    "temp/*",
+    "waveforms/*",
+    ".claude/*",
+    "src-tauri/*",
+]
+
+[tool.coverage.report]
+# An offload test writes into temp/ and cleans it up; that file can vanish before
+# the report runs. Don't let a missing-source artifact fail the coverage gate.
+ignore_errors = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest>=7.4
 pytest-asyncio>=0.21
+pytest-cov>=4.1
 httpx>=0.24


### PR DESCRIPTION
## What & why

Wires the missing **品質閘門** (CI quality gates) the fable self-check flagged. **No source/runtime changes** — config + CI only.

- **`pyproject.toml`** — `[tool.coverage]` config (omit tests/scripts/bench/temp; `ignore_errors` for the stray offload-temp artifact). Deliberately config-only, no `[project]`/build metadata (flat module layout).
- **`requirements-dev.txt`** — `+ pytest-cov`.
- **`ci.yml`** — three new jobs:
  | Job | What | Blocking? |
  |---|---|---|
  | `coverage` | 55% floor (regression ratchet, measured baseline ~63%), macos/3.12 | **No** (see note) |
  | `frontend-build` | `npm ci && npm run build` — nothing in CI touched `frontend/` before, a broken Svelte build could merge silently | **Yes** (verified locally ✓) |
  | `dependency-audit` | `pip-audit` + `npm audit` | **No** (surfaces vulns, doesn't gate) |

### Why coverage is its own non-blocking job
Adding `--cov` to the existing 3.12 correctness leg surfaced a **pre-existing intermittent flake** — `test_auth.py::test_cli_revoke_removes_token` (a subprocess-CLI token-id parse) fails ~1 in 2 full-suite runs under coverage, passes alone and on rerun. Rather than import that instability into the correctness gate, coverage is a separate `continue-on-error` job. **Flip it to blocking after the flake is fixed** (tracked follow-up).

## Deferred to dedicated PRs (per audit)
**ruff + mypy.** ruff shows **~1,600** findings dominated by `UP007`/`UP006` (`Optional`→`X | Y`) — **auto-fixing those would inject 3.10+ union syntax and break the 3.9 deploy floor** — plus `B008` false-positives on FastAPI's idiomatic `Depends()`. That needs a careful 3.9-safe rule set on its own branch, not a blanket sweep (which would also conflict with the in-flight #129/#130 that touch `server.py`).

Part of the fable-audit hardening round (see #129, #130, `docs/2026-07-12-fable-self-check-baseline.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)