### PR TITLE
fix(security): scope absolute project paths to admin callers (fable-audit #22)

### DIFF
--- a/server.py
+++ b/server.py
@@ -621,6 +621,25 @@ def search_all(
     return JSONResponse(content=payload, status_code=status_code)
 
 
+def _project_paths_visible(tok: dict) -> bool:
+    """fable-audit 2026-07-12 (#22): absolute project roots leave the backend only
+    for admin-scoped callers. Loopback-trust already grants all scopes (incl.
+    'admin'), so the LOCAL operator's registry / mount UI is unaffected (case a);
+    a remote admin token also sees full paths (case c); a remote projects_read-only
+    token gets basenames — so a browse-only LAN/Tailscale client can't map the
+    operator's home layout, drive structure, or other clients' folder names."""
+    return "admin" in (tok.get("scopes") or ())
+
+
+def _sanitize_project_paths(projects: list, tok: dict) -> list:
+    if _project_paths_visible(tok):
+        return projects
+    for p in projects:
+        if p.get("path"):
+            p["path"] = _basename_safe(p["path"])
+    return projects
+
+
 @app.get("/api/projects")
 def list_projects(
     _tok: dict = Depends(require_scopes("projects_read")),
@@ -631,6 +650,7 @@ def list_projects(
         projects = [project.to_dict() for project in project_registry.list_registry_projects()]
     except project_registry.RegistryError as exc:
         raise HTTPException(status_code=500, detail="project registry unreadable: {0}".format(exc))
+    _sanitize_project_paths(projects, _tok)
     return {"projects": projects, "total": len(projects)}
 
 
@@ -682,6 +702,7 @@ def projects_health(
     _tok: dict = Depends(require_scopes("projects_read")),
 ):
     projects = project_registry.health_projects()
+    _sanitize_project_paths(projects, _tok)  # fable-audit #22 — see list_projects
     ok_count = sum(1 for item in projects if item["status"] == "ok")
     return {"projects": projects, "total": len(projects), "ok": ok_count}
 

--- a/tests/test_hardening_projpath.py
+++ b/tests/test_hardening_projpath.py
@@ -1,0 +1,78 @@
+"""Regression: /api/projects[/health] must not leak absolute project roots to a
+remote projects_read-only token (fable-audit 2026-07-12 #22).
+
+(a)+(c) model: full paths only when the caller is admin-scoped. Loopback-trust
+grants all scopes, so the LOCAL operator UI keeps full paths (a); a remote admin
+token keeps them (c); a remote read-only token gets basenames.
+
+A forwarded header (X-Forwarded-For) is what trips auth._looks_proxied, which
+disables loopback-trust and forces real token-scope validation — the only way to
+exercise a non-admin caller against the in-process TestClient (which is loopback).
+"""
+import importlib
+import json
+from pathlib import Path
+
+REMOTE = {"X-Forwarded-For": "203.0.113.9"}  # → treated as proxied/remote
+
+
+def _register_secret_project(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARKIV_PROJECTS_REGISTRY", str(tmp_path / "registry.json"))
+    root = tmp_path / "影片專案" / "機密客戶A"
+    root.mkdir(parents=True)
+    projects = importlib.import_module("projects")
+    projects.add_project("機密客戶A", str(root))
+    return str(root)
+
+
+def _token(scopes):
+    admin = importlib.import_module("admin")
+    return admin.create_token(name="t-" + "-".join(scopes), scopes=scopes)["raw_token"]
+
+
+def test_projects_basenamed_for_remote_readonly_token(fastapi_client, tmp_path, monkeypatch):
+    root = _register_secret_project(tmp_path, monkeypatch)
+    ro = _token(["projects_read"])
+    resp = fastapi_client.get(
+        "/api/projects",
+        headers={"Authorization": f"Bearer {ro}", **REMOTE},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["projects"][0]["path"] == "機密客戶A"          # basenamed
+    blob = json.dumps(data, ensure_ascii=False)
+    assert root not in blob                                     # no absolute path
+    assert str(tmp_path) not in blob
+
+
+def test_projects_health_basenamed_for_remote_readonly_token(fastapi_client, tmp_path, monkeypatch):
+    root = _register_secret_project(tmp_path, monkeypatch)
+    ro = _token(["projects_read"])
+    resp = fastapi_client.get(
+        "/api/projects/health",
+        headers={"Authorization": f"Bearer {ro}", **REMOTE},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["projects"][0]["path"] == "機密客戶A"
+    assert root not in json.dumps(data, ensure_ascii=False)
+
+
+def test_projects_full_path_for_remote_admin_token(fastapi_client, tmp_path, monkeypatch):
+    root = _register_secret_project(tmp_path, monkeypatch)
+    adm = _token(["admin", "projects_read"])
+    resp = fastapi_client.get(
+        "/api/projects",
+        headers={"Authorization": f"Bearer {adm}", **REMOTE},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["projects"][0]["path"] == str(Path(root).expanduser())
+
+
+def test_projects_full_path_for_local_loopback(fastapi_client, tmp_path, monkeypatch):
+    # default TestClient = loopback, no forwarded header → all scopes → full path
+    # (the local operator's registry/mount UI is unaffected).
+    root = _register_secret_project(tmp_path, monkeypatch)
+    resp = fastapi_client.get("/api/projects")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["projects"][0]["path"] == str(Path(root).expanduser())


### PR DESCRIPTION
## What & why

Closes fable-audit finding **#22** (deferred item (1) of the Phase 16.2 path-leak triage, still live).

`GET /api/projects` + `/api/projects/health` returned each project's **full absolute filesystem path** to any `projects_read` token. A remote/LAN browse client (e.g. over Tailscale) could map the operator's home layout, drive structure, and other clients' folder names — **no write privilege required**.

## Fix: (a)+(c) combined — authorization-based, not network-based

Absolute paths leave the backend **only for admin-scoped callers**, else basename. Because loopback-trust already grants *all* scopes (incl. `admin`), this collapses to a single check `"admin" in tok["scopes"]`:

| Caller | Result | |
|---|---|---|
| Local operator (loopback) | **full path** | case (a) — registry/mount UI unaffected |
| Remote **admin** token | **full path** | case (c) |
| Remote `projects_read`-only | **basename** | ← the leak, fixed |

### Why this shape (per the discussion)
- **Not unconditional-basename**: the local registry/mount UI (`Flows.svelte`, `SettingsLive.svelte`) legitimately renders the full path.
- **Not a loopback/remote split**: in a **multi-team DIT** scenario everyone connects remotely, so *authorization* (admin scope), not network position, is the right trust axis. This model covers solo-local **and** multi-team from one code path.

## Tests
`tests/test_hardening_projpath.py` (+4): remote read-only → basename (list + health), remote admin → full, local loopback → full. Uses `X-Forwarded-For` to trip `auth._looks_proxied` and force real token-scope validation against the loopback TestClient. **Full suite: 702 passed, 5 skipped, zero regressions.** 3.9-safe.

## Note
True multi-tenant use (per-token *project isolation* — which team sees which projects) is a larger design question beyond this leak fix, tracked separately.

Part of the fable-audit hardening round (#129, #130, #131, `docs/2026-07-12-fable-self-check-baseline.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)