### PR TITLE
refactor(server): extract state.py — ingest slot + WS broadcaster (APIRouter-split foundation, PR7)

### DIFF
--- a/server.py
+++ b/server.py
@@ -37,27 +37,24 @@ import tag_aliases
 import tag_quality
 
 
-# ── Ingest single-flight guard ───────────────────────────────────────────────
-# One guard for ALL ingest entry points (REST /api/ingest, reingest, WS) so two
-# full pipelines can't run at once → DB-lock contention + double whisper + OOM on a
-# 16GB box (audit H3). threading.Lock because REST runs in the threadpool while the
-# WS variant runs on the event loop.
+# ── Ingest single-flight guard + WS broadcaster ──────────────────────────────
+# Extracted to state.py (fable-audit 2026-07-12) as the APIRouter-split foundation:
+# the ingest single-flight slot and the WS IngestBroadcaster are shared runtime
+# state that a future per-router split must import as ONE instance (forking them
+# would silently break the H3 double-whisper-OOM guard). Re-exported here so
+# existing call sites + tests keep referencing server._acquire_ingest_slot /
+# server.ingest_ws unchanged.
 import threading as _threading
-_ingest_lock = _threading.Lock()
-_ingest_active = False
+from state import (  # noqa: F401  (re-exported for backward compat)
+    IngestBroadcaster,
+    _acquire_ingest_slot,
+    _release_ingest_slot,
+    ingest_ws,
+)
 
-def _acquire_ingest_slot() -> bool:
-    global _ingest_active
-    with _ingest_lock:
-        if _ingest_active:
-            return False
-        _ingest_active = True
-        return True
-
-def _release_ingest_slot() -> None:
-    global _ingest_active
-    with _ingest_lock:
-        _ingest_active = False
+# The remaining guards stay here for now — their flags are rebound via `global`
+# inside route handlers (and a test writes the raw flag), so they need a
+# mutable-container refactor rather than a plain import to move to state.py.
 
 # audit M9 (partial): vision.VISION_MODEL is module-global, so two concurrent
 # retry-vision calls could interleave their save/swap/restore and permanently
@@ -76,44 +73,6 @@ _embed_rebuild_active = False
 _retranscribe_lock = _threading.Lock()
 _retranscribe_active = False
 _retranscribe_progress = {"total": 0, "done": 0, "failed": 0, "current": None, "running": False, "backup": None}
-
-# ── WebSocket connection manager ────────────────────────────────────────────
-_MAX_WS_CONNECTIONS = 32  # cap concurrent progress listeners (DoS guard)
-
-
-class IngestBroadcaster:
-    """Manages WebSocket connections for ingest progress updates."""
-    def __init__(self):
-        self.connections: Set[WebSocket] = set()
-
-    async def connect(self, ws: WebSocket) -> bool:
-        if len(self.connections) >= _MAX_WS_CONNECTIONS:
-            await ws.close(code=1013)  # try again later
-            return False
-        await ws.accept()
-        # audit L6: re-check after the await — concurrent handshakes can all pass
-        # the pre-accept check before any of them is added to the set (TOCTOU).
-        if len(self.connections) >= _MAX_WS_CONNECTIONS:
-            await ws.close(code=1013)
-            return False
-        self.connections.add(ws)
-        return True
-
-    def disconnect(self, ws: WebSocket):
-        self.connections.discard(ws)
-
-    async def broadcast(self, data: dict):
-        dead = set()
-        # snapshot: send_json awaits, so a concurrent connect/disconnect mutating
-        # the live set mid-iteration would raise "Set changed size" (audit H9).
-        for ws in list(self.connections):
-            try:
-                await ws.send_json(data)
-            except Exception:
-                dead.add(ws)
-        self.connections -= dead
-
-ingest_ws = IngestBroadcaster()
 
 # ── Init ─────────────────────────────────────────────────────────────────────
 db.init_db()

--- a/state.py
+++ b/state.py
@@ -1,0 +1,84 @@
+"""Shared process-wide runtime state for the API server.
+
+Extracted from server.py (fable-audit 2026-07-12) as the APIRouter-split
+foundation: when server.py's ~80 routes are peeled into per-concern routers, each
+router must import ONE instance of the ingest single-flight guard and the WS
+broadcaster from here — forking them per router would silently break the H3 guard
+(the double-whisper-OOM protection). server.py re-exports these names, so existing
+call sites and tests that reference `server._acquire_ingest_slot` / `server.ingest_ws`
+keep working unchanged.
+
+Scope note: the embed-rebuild / retranscribe / vision-fallback guards deliberately
+stay in server.py for now. Their flags are rebound via `global` inside route
+handlers (and a test writes the raw flag), so moving them needs a mutable-container
+refactor rather than a plain import — tracked as a follow-up.
+"""
+import threading as _threading
+from typing import Set
+
+from fastapi import WebSocket
+
+# ── Ingest single-flight guard ────────────────────────────────────────────────
+# One guard for ALL ingest entry points (REST /api/ingest, reingest, WS, bin-copy,
+# retranscribe-all) so two full pipelines can't run at once → DB-lock contention +
+# double whisper + OOM on a 16GB box (audit H3). threading.Lock because REST runs in
+# the threadpool while the WS variant runs on the event loop. The flag + its
+# mutators live together here so the `global` rebinding stays intra-module and
+# server.py can import the FUNCTIONS without a stale value-copy of the flag.
+_ingest_lock = _threading.Lock()
+_ingest_active = False
+
+
+def _acquire_ingest_slot() -> bool:
+    global _ingest_active
+    with _ingest_lock:
+        if _ingest_active:
+            return False
+        _ingest_active = True
+        return True
+
+
+def _release_ingest_slot() -> None:
+    global _ingest_active
+    with _ingest_lock:
+        _ingest_active = False
+
+
+# ── WebSocket connection manager ──────────────────────────────────────────────
+_MAX_WS_CONNECTIONS = 32  # cap concurrent progress listeners (DoS guard)
+
+
+class IngestBroadcaster:
+    """Manages WebSocket connections for ingest progress updates."""
+    def __init__(self):
+        self.connections: Set[WebSocket] = set()
+
+    async def connect(self, ws: WebSocket) -> bool:
+        if len(self.connections) >= _MAX_WS_CONNECTIONS:
+            await ws.close(code=1013)  # try again later
+            return False
+        await ws.accept()
+        # audit L6: re-check after the await — concurrent handshakes can all pass
+        # the pre-accept check before any of them is added to the set (TOCTOU).
+        if len(self.connections) >= _MAX_WS_CONNECTIONS:
+            await ws.close(code=1013)
+            return False
+        self.connections.add(ws)
+        return True
+
+    def disconnect(self, ws: WebSocket):
+        self.connections.discard(ws)
+
+    async def broadcast(self, data: dict):
+        dead = set()
+        # snapshot: send_json awaits, so a concurrent connect/disconnect mutating
+        # the live set mid-iteration would raise "Set changed size" (audit H9).
+        for ws in list(self.connections):
+            try:
+                await ws.send_json(data)
+            except Exception:
+                dead.add(ws)
+        self.connections -= dead
+
+
+ingest_ws = IngestBroadcaster()

--- a/tests/test_state_extraction.py
+++ b/tests/test_state_extraction.py
@@ -1,0 +1,51 @@
+"""Guards the APIRouter-split foundation (fable-audit 2026-07-12 PR7).
+
+1. Route parity: the app must register every route exactly once, with no duplicate
+   (path, method) pair. This is the safety net for the FUTURE per-router split PRs
+   — moving routes into APIRouters must not drop or double-register any endpoint.
+2. Single-instance guard: server.py re-exports the ingest slot from state.py; the
+   flag must be ONE shared instance, or a per-module copy would silently defeat the
+   H3 double-whisper-OOM guard.
+"""
+import importlib
+
+
+def test_no_duplicate_route_registrations(server_module):
+    seen = set()
+    dupes = []
+    for r in server_module.app.routes:
+        methods = tuple(sorted(getattr(r, "methods", None) or ()))
+        key = (getattr(r, "path", None), methods)
+        if key in seen:
+            dupes.append(key)
+        seen.add(key)
+    assert not dupes, f"duplicate route registrations: {dupes}"
+    # sanity: the app actually has a substantial route surface (guards an empty/half
+    # -wired app slipping past a future split)
+    api_routes = [r for r in server_module.app.routes if getattr(r, "path", "").startswith("/api/")]
+    assert len(api_routes) >= 50
+
+
+def test_critical_routes_present(server_module):
+    paths = {getattr(r, "path", "") for r in server_module.app.routes}
+    for p in ("/api/projects", "/api/bins/{bin_id}/copy", "/api/offload",
+              "/api/cache/clear", "/api/retranscribe-all", "/api/search/all"):
+        assert p in paths, f"missing route {p}"
+
+
+def test_ingest_slot_is_single_shared_instance(server_module):
+    state = importlib.import_module("state")
+    # server re-exports the SAME function objects
+    assert server_module._acquire_ingest_slot is state._acquire_ingest_slot
+    assert server_module._release_ingest_slot is state._release_ingest_slot
+    assert server_module.ingest_ws is state.ingest_ws
+
+    # acquiring through server is visible through state (one flag, not two copies)
+    assert server_module._acquire_ingest_slot() is True
+    try:
+        assert state._acquire_ingest_slot() is False        # blocked — same slot
+        assert server_module._acquire_ingest_slot() is False
+    finally:
+        state._release_ingest_slot()
+    assert server_module._acquire_ingest_slot() is True     # freed
+    server_module._release_ingest_slot()


### PR DESCRIPTION
## What

Extracts the process-wide **ingest single-flight guard** (`_acquire_ingest_slot`/`_release_ingest_slot`) and the **WS `IngestBroadcaster`** out of `server.py` into a new `state.py`. `server.py` re-exports the names, so every existing call site and test that references `server._acquire_ingest_slot` / `server.ingest_ws` keeps working unchanged (net `server.py` −41 lines).

This is the **de-risking foundation** for the future per-router APIRouter split (fable-audit HIGH #9 `server.py` god-file / module split-brain). When ~80 routes get peeled into per-concern routers, each router must import **one** instance of the ingest slot + broadcaster — forking the slot per-router would silently defeat the **H3 double-whisper-OOM guard**.

## Deliberately left in `server.py`

The `retranscribe` / `embed-rebuild` / `vision-fallback` guards stay put. Their flags are rebound via `global` inside route handlers (and a test writes the raw flag), so they need a **mutable-container refactor**, not a plain `from state import X` (which would import a stale value-copy of the flag and break rebinding). Tracked as a follow-up. This is the "mutable module-global re-export footgun" — moving only the functions-accessed slot is the safe subset.

## Tests (`tests/test_state_extraction.py`, +3)

- **route-parity net** — no duplicate `(path, method)` registration, critical routes present, ≥50 `/api` routes. This is the safety net that locks route surface behaviour for the *future* route-moving PRs (before/after `app.routes` must be identical).
- **single-shared-instance** — `server` re-exports the SAME function/instance objects as `state`, and acquiring the slot through `server` blocks re-acquiring through `state` (proves one shared flag, not two copies).

## Verification

- `python -m pytest -q`: **727 passed, 5 skipped** (main was 724; +3 new).
- `server._acquire_ingest_slot.__module__ == 'state'`; `server.ingest_ws is state.ingest_ws` → `True`.
- Zero behaviour change — pure relocation + re-export.

Part of the 2026-07-12 fable self-check hardening round (baseline: `docs/2026-07-12-fable-self-check-baseline.md`). Follows merged #129/#130/#131/#132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)