### PR TITLE
fix(bins): never clobber same-basename clips on copy-into-project (round-5 critical #3)

### DIFF
--- a/server.py
+++ b/server.py
@@ -670,17 +670,40 @@ def projects_health(
 # Storage is ~/.arkiv-bins.json (bins.py), separate from any project.db. Items
 # reference clips by (project_name, media_id) — never mutating the source library.
 
-def _copy_clip_verified(src_path: str, dst_dir: Path) -> Path:
+def _unique_dest(dst_dir: Path, name: str, taken=None) -> Path:
+    """Pick a path in dst_dir for `name` that overwrites NOTHING. If the name already
+    exists on disk OR was already used this run (casefolded — macOS/exFAT are
+    case-insensitive), append ' (n)' before the extension until free.
+
+    fable-audit 2026-07-12 critical #3: two clips sharing a basename (e.g. C0001.MP4
+    from two source projects) both resolved to dst_dir/C0001.MP4 and the second
+    os.replace silently destroyed the first's bytes while verified-copy reported
+    success. The casefolded `taken` set closes the sequential-run window before the
+    first file lands on disk (codex footgun: check BOTH on-disk and per-run names)."""
+    n = 1
+    candidate = name
+    stem, ext = os.path.splitext(name)
+    while (dst_dir / candidate).exists() or (taken is not None and candidate.casefold() in taken):
+        n += 1
+        candidate = "{0} ({1}){2}".format(stem, n, ext)
+    if taken is not None:
+        taken.add(candidate.casefold())
+    return dst_dir / candidate
+
+
+def _copy_clip_verified(src_path: str, dst_dir: Path, taken=None) -> Path:
     """Verified copy of one clip into dst_dir (hash both sides, atomic rename, NEVER
-    deletes the source). offload.run_offload is card/dir-oriented (its rel math
-    breaks for a lone file), so this reuses offload's hash primitive on a simple
-    single-file copy. Raises on hash mismatch. (ascMHL provenance is a follow-up —
-    not load-bearing for copy-into-project.)"""
+    deletes the source, NEVER overwrites an existing/colliding dest — see
+    _unique_dest). offload.run_offload is card/dir-oriented (its rel math breaks for
+    a lone file), so this reuses offload's hash primitive on a simple single-file
+    copy. Raises on hash mismatch. Returns the actual final path (which may be a
+    ' (n)'-suffixed rename); the caller reads .name to detect a rename. (ascMHL
+    provenance is a follow-up — not load-bearing for copy-into-project.)"""
     import shutil
     import offload as _offload
     src = Path(src_path)
     dst_dir.mkdir(parents=True, exist_ok=True)
-    final = dst_dir / src.name
+    final = _unique_dest(dst_dir, src.name, taken)
     partial = final.with_name(final.name + ".partial")
     if partial.exists():
         partial.unlink()
@@ -843,12 +866,16 @@ def copy_bin(bin_id: str, body: BinCopyRequest, _tok: dict = Depends(require_sco
         ingest_paths = []
         if body.mode == "copy" and reachable:
             dest_media_dir.mkdir(parents=True, exist_ok=True)
+            taken = set()  # casefolded dest names claimed this run (critical #3)
             for idx, (pn, mid, src) in enumerate(reachable):
                 try:
-                    copied = _copy_clip_verified(src, dest_media_dir)
+                    copied = _copy_clip_verified(src, dest_media_dir, taken)
                     ingest_paths.append(str(copied))
-                    yield _json.dumps({"type": "copy", "file": Path(src).name,
-                                       "done": idx + 1, "total": len(reachable)}, ensure_ascii=False) + "\n"
+                    evt = {"type": "copy", "file": Path(src).name,
+                           "done": idx + 1, "total": len(reachable)}
+                    if copied.name != Path(src).name:  # basename collision → renamed, not clobbered
+                        evt["renamed_to"] = copied.name
+                    yield _json.dumps(evt, ensure_ascii=False) + "\n"
                 except Exception as exc:  # a copy failure must not fake success
                     skipped.append({"project_name": pn, "media_id": mid, "status": "copy_failed: {0}".format(exc)})
                     yield _json.dumps({"type": "copy", "file": Path(src).name, "error": str(exc)},

--- a/tests/test_bin_copy.py
+++ b/tests/test_bin_copy.py
@@ -179,6 +179,62 @@ def test_copy_mode_copies_verified_bytes_and_keeps_source(fastapi_client, tmp_pa
     assert str(copied) in calls[0]["cmd"]
 
 
+def test_copy_same_basename_never_clobbers(fastapi_client, tmp_path, monkeypatch):
+    """fable-audit 2026-07-12 CRITICAL #3: two clips sharing a basename (C0001.MP4
+    from two different source projects) must both survive the copy — the second must
+    NOT os.replace over the first. Pre-fix, verified-copy reported `copied: 2` while
+    only one file's bytes existed on disk; if the operator then trusted the copy and
+    wiped the source card, a clip was gone."""
+    bins = _setup(tmp_path, monkeypatch)
+    calls = _stub_ingest(monkeypatch)
+
+    # two DISTINCT clips that happen to share the camera-original basename
+    srcA = tmp_path / "cardA" / "C0001.MP4"
+    srcB = tmp_path / "cardB" / "C0001.MP4"
+    srcA.parent.mkdir(parents=True)
+    srcB.parent.mkdir(parents=True)
+    srcA.write_bytes(b"AAAA-distinct-bytes-from-card-A")
+    srcB.write_bytes(b"BBBB-different-bytes-from-card-B")
+    _stub_resolve(monkeypatch, {
+        ("libA", "1"): {"status": "ok", "absolute_path": str(srcA), "filename": "C0001.MP4"},
+        ("libB", "2"): {"status": "ok", "absolute_path": str(srcB), "filename": "C0001.MP4"},
+    })
+
+    b = bins.create_bin("collide")
+    bins.add_items(b.id, [
+        {"project_name": "libA", "media_id": "1", "filename": "C0001.MP4"},
+        {"project_name": "libB", "media_id": "2", "filename": "C0001.MP4"},
+    ])
+
+    dest = tmp_path / "proj_collide"
+    r = fastapi_client.post(
+        "/api/bins/{0}/copy".format(b.id),
+        json={"dest": str(dest), "create_new": True, "mode": "copy",
+              "skip_vision": True, "no_embed": True},
+    )
+    assert r.status_code == 200, r.text
+    events = _parse_ndjson(r.text)
+
+    media = dest / "media"
+    files = sorted(p.name for p in media.iterdir() if not p.name.endswith(".partial"))
+    # BOTH clips landed under distinct names — nothing was overwritten
+    assert len(files) == 2, "expected 2 files, got {0}".format(files)
+    all_bytes = {(media / f).read_bytes() for f in files}
+    assert all_bytes == {b"AAAA-distinct-bytes-from-card-A", b"BBBB-different-bytes-from-card-B"}
+
+    # the second clip was renamed (not clobbered) and the stream said so
+    assert any(e.get("type") == "copy" and e.get("renamed_to") for e in events)
+    done = [e for e in events if e["type"] == "done"][0]["summary"]
+    assert done["copied"] == 2  # both counted, both real on disk
+
+    # ingest indexes BOTH distinct copied paths (ingest_paths correctly remapped)
+    cmd = calls[0]["cmd"]
+    assert str(media / files[0]) in cmd and str(media / files[1]) in cmd
+    # sources untouched
+    assert srcA.read_bytes() == b"AAAA-distinct-bytes-from-card-A"
+    assert srcB.read_bytes() == b"BBBB-different-bytes-from-card-B"
+
+
 def test_copy_into_existing_project(fastapi_client, tmp_path, monkeypatch):
     bins = _setup(tmp_path, monkeypatch)
     _stub_ingest(monkeypatch)


### PR DESCRIPTION
## Round-5 Wave 1 · R5-02 · the one CRITICAL

`_copy_clip_verified` did `os.replace(partial, dst_dir/src.name)` with **no existence check**, and `copy_bin` flattens every clip into one dest media dir. Two clips sharing a camera-original basename (`C0001.MP4` from two source projects) both resolved to the same dest path — the second `os.replace` **silently destroyed the first's bytes** while verified-copy reported `copied: 2, skipped: []`. Trust the copy, wipe the source card → a clip is gone.

Independently confirmed by both the fable adversarial skeptics and the Codex cross-validation pass.

## Fix

New `_unique_dest()` picks a dest that overwrites **nothing**: if the name exists on disk **or** was already claimed this run (casefolded — macOS/exFAT are case-insensitive, per Codex's footgun note), it appends ` (n)` before the extension.

- `copy_bin` passes a per-run `taken` set and emits `renamed_to` in the ndjson stream.
- `ingest_paths` gets the **actual** final paths, so indexing points at the right bytes (Codex footgun: skipped/renamed files correctly remapped).
- Renames on collision rather than skipping — no clip is dropped from the copy.

## Test

`test_copy_same_basename_never_clobbers`: two distinct clips sharing a basename → both land under distinct names with their own bytes, the stream reports the rename, ingest indexes both distinct paths, sources untouched. Fails pre-fix (only one file survives).

Full suite: **725 passed, 5 skipped**. 3.9-safe.

Part of the round-5 review (docs PR #134, finding #3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)