### PR TITLE
fix(proxy): atomic writes + non-empty consumer gate + diagnostics (round-5 #1/#60/C1)

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -518,9 +518,21 @@ def generate_proxy(media_id: int, path: str, force: bool = False) -> Optional[st
     proxy_dir.mkdir(parents=True, exist_ok=True)
     proxy_path = config.proxy_path_for(media_id, path)
     if proxy_path.exists() and not force:
-        return str(proxy_path)
+        # fable-audit round-5 #1: a truncated proxy from a prior kill/power-loss is
+        # otherwise served forever. Treat an empty file as absent so it gets rebuilt.
+        if proxy_path.stat().st_size > 0:
+            return str(proxy_path)
+        proxy_path.unlink(missing_ok=True)
     if force:
         proxy_path.unlink(missing_ok=True)
+    # Encode to a same-dir tmp with the REAL .mp4 suffix, then os.replace onto the
+    # final path only after a clean, non-empty encode (mirrors frames.py _extract_to).
+    # A kill/power-loss mid-encode then leaves the tmp — never a half-written final
+    # that every consumer would accept by bare existence (fable-audit round-5 #1).
+    # Tmp keeps .mp4 (codex footgun: ffmpeg infers the muxer from the extension) and
+    # sits beside the final so os.replace stays on one filesystem.
+    tmp_path = proxy_path.with_name("{0}.tmp.{1}{2}".format(proxy_path.stem, os.getpid(), proxy_path.suffix))
+    tmp_path.unlink(missing_ok=True)
     cmd = [
         config.FFMPEG_PATH, "-y", "-i", path,
         "-c:v", "libx264", "-preset", "fast", "-crf", "28",
@@ -530,19 +542,33 @@ def generate_proxy(media_id: int, path: str, force: bool = False) -> Optional[st
         "-vf", "scale=-2:720",
         "-c:a", "aac", "-b:a", "128k",
         "-movflags", "+faststart",
-        str(proxy_path),
+        str(tmp_path),
     ]
     try:
         # encoding pinned: Windows zh-TW default cp950 can't decode ffmpeg's
         # utf-8 stderr → UnicodeDecodeError crashes proxy gen on headless ingest.
         r = subprocess.run(cmd, capture_output=True, text=True,
                            encoding="utf-8", errors="replace", timeout=600)
-        if r.returncode == 0 and proxy_path.exists():
+        if r.returncode == 0 and tmp_path.exists() and tmp_path.stat().st_size > 0:
+            os.replace(str(tmp_path), str(proxy_path))
             return str(proxy_path)
-        proxy_path.unlink(missing_ok=True)
+        tmp_path.unlink(missing_ok=True)
+        # fable-audit round-5 #60: say WHY (ffmpeg-missing vs disk-full vs bad codec)
+        # instead of a silent None that reads as a mystery 409 downstream.
+        tail = (r.stderr or "")[-300:]
+        print("[proxy] ffmpeg rc={0} for {1}: {2}".format(r.returncode, path, tail))
         return None
-    except Exception:
-        proxy_path.unlink(missing_ok=True)
+    except FileNotFoundError as exc:  # ffmpeg binary itself missing — distinct failure
+        tmp_path.unlink(missing_ok=True)
+        print("[proxy] ffmpeg not found ({0}); check FFMPEG_PATH".format(exc))
+        return None
+    except subprocess.TimeoutExpired:
+        tmp_path.unlink(missing_ok=True)
+        print("[proxy] timeout after 600s: {0}".format(path))
+        return None
+    except Exception as exc:
+        tmp_path.unlink(missing_ok=True)
+        print("[proxy] failed {0}: {1}: {2}".format(path, type(exc).__name__, exc))
         return None
 
 

--- a/server.py
+++ b/server.py
@@ -3867,6 +3867,18 @@ async def ingest_media_ws(
 
 import mimetypes
 
+
+def _proxy_ready(p: Path) -> bool:
+    """A proxy counts as present only if it exists AND is non-empty. A zero/truncated
+    file left by a killed encode must not be served as valid nor block a rebuild
+    (fable-audit round-5 C1 — the consumer side of the atomic-write fix in
+    ingest.generate_proxy)."""
+    try:
+        return p.exists() and p.stat().st_size > 0
+    except OSError:
+        return False
+
+
 @app.get("/api/stream/{media_id}")
 def stream_media(media_id: int, _tok: dict = Depends(require_scopes("videos_read"))):
     """Stream a media file with range request support for seeking.
@@ -3880,7 +3892,7 @@ def stream_media(media_id: int, _tok: dict = Depends(require_scopes("videos_read
     # user's content under the same media_id.
     resolved_src = _resolve_media_path(rec["path"])
     proxy_path = config.proxy_path_for(media_id, resolved_src)
-    if proxy_path.exists():
+    if _proxy_ready(proxy_path):
         return FileResponse(
             path=str(proxy_path),
             media_type="video/mp4",
@@ -3964,7 +3976,7 @@ def proxy_status(_tok: dict = Depends(require_scopes("videos_read"))):
         rows = conn.execute("SELECT id, path FROM media").fetchall()
     proxied = sum(
         1 for r in rows
-        if config.proxy_path_for(r["id"], _resolve_media_path(r["path"])).exists()
+        if _proxy_ready(config.proxy_path_for(r["id"], _resolve_media_path(r["path"])))
     )
     size_mb = round(sum(p.stat().st_size for p in proxy_dir.glob("*.mp4")) / 1048576, 1)
     return {"total": len(rows), "proxied": proxied, "size_mb": size_mb}
@@ -3980,7 +3992,7 @@ def proxy_build(request: Request, background_tasks: BackgroundTasks, _tok: dict 
         rows = conn.execute("SELECT id, path FROM media").fetchall()
     to_build = [
         dict(r) for r in rows
-        if not config.proxy_path_for(r["id"], _resolve_media_path(r["path"])).exists()
+        if not _proxy_ready(config.proxy_path_for(r["id"], _resolve_media_path(r["path"])))
     ]
     if not to_build:
         return {"message": "全部 proxy 已存在", "queued": 0}
@@ -3999,7 +4011,7 @@ def proxy_build_one(media_id: int, request: Request, background_tasks: Backgroun
     if not rec:
         raise HTTPException(404, "找不到媒體")
     src = _resolve_media_path(rec["path"])
-    if config.proxy_path_for(media_id, src).exists():
+    if _proxy_ready(config.proxy_path_for(media_id, src)):
         return {"message": "proxy 已存在", "queued": 0, "media_id": media_id}
     background_tasks.add_task(_build_proxies, [{"id": media_id, "path": rec["path"]}])
     return {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -801,6 +801,89 @@ def test_proxy_build_one_skips_when_proxy_already_exists(
     assert queued == []
 
 
+def test_proxy_build_one_rebuilds_when_existing_proxy_is_empty(
+    fastapi_client, sample_record, tmp_path, monkeypatch
+):
+    """fable-audit round-5 C1: a zero-byte proxy left by a killed encode must be
+    treated as ABSENT, not served/counted as valid nor allowed to block a rebuild.
+    Pre-fix `proxy_path.exists()` said 'done' for a 0-byte file → the truncated
+    proxy was permanent."""
+    db = importlib.import_module("db")
+    config = importlib.import_module("config")
+
+    src = tmp_path / "src.mov"
+    src.write_bytes(b"hevc-bytes")
+    db.upsert(sample_record(path=str(src), filename="src.mov", ext=".mov"))
+    proxies_dir = tmp_path / "proxies"; proxies_dir.mkdir()
+    monkeypatch.setattr(config, "PROXIES_DIR", proxies_dir)
+    # a truncated (empty) proxy from a prior killed encode
+    config.proxy_path_for(1, str(src)).write_bytes(b"")
+
+    import server
+    queued = []
+    monkeypatch.setattr(server, "_build_proxies", lambda items: queued.extend(items))
+
+    resp = fastapi_client.post("/api/proxy/build/1")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["queued"] == 1  # empty proxy treated as missing → rebuilt
+    assert queued and queued[0]["id"] == 1
+
+
+def test_generate_proxy_failed_encode_leaves_no_final(tmp_path, monkeypatch):
+    """fable-audit round-5 #1: a mid-encode failure must NOT leave a half-written
+    final proxy. ffmpeg writes to a same-dir tmp; only a clean, non-empty encode is
+    os.replace'd onto the final path."""
+    from pathlib import Path
+    ingest = importlib.import_module("ingest")
+    config = importlib.import_module("config")
+    proxies = tmp_path / "proxies"; proxies.mkdir()
+    monkeypatch.setattr(config, "PROXIES_DIR", proxies)
+    src = tmp_path / "clip.mov"; src.write_bytes(b"src")
+
+    class _R:
+        returncode = 1
+        stderr = "ffmpeg: Conversion failed!"
+        stdout = ""
+
+    def fake_run(cmd, **kw):
+        Path(cmd[-1]).write_bytes(b"\x00\x00")  # ffmpeg wrote a truncated tmp, then died
+        return _R()
+    monkeypatch.setattr(ingest.subprocess, "run", fake_run)
+
+    assert ingest.generate_proxy(1, str(src)) is None
+    assert not config.proxy_path_for(1, str(src)).exists()   # no half-written final
+    assert list(proxies.glob("*.tmp.*")) == []               # tmp cleaned up
+
+
+def test_generate_proxy_success_replaces_atomically(tmp_path, monkeypatch):
+    """A clean encode lands as the final proxy via os.replace; a pre-existing empty
+    proxy (killed prior run) is discarded and rebuilt (round-5 #1 writer-side gate)."""
+    from pathlib import Path
+    ingest = importlib.import_module("ingest")
+    config = importlib.import_module("config")
+    proxies = tmp_path / "proxies"; proxies.mkdir()
+    monkeypatch.setattr(config, "PROXIES_DIR", proxies)
+    src = tmp_path / "clip.mov"; src.write_bytes(b"src")
+    config.proxy_path_for(1, str(src)).write_bytes(b"")  # stale empty proxy — must be rebuilt
+
+    class _R:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def fake_run(cmd, **kw):
+        Path(cmd[-1]).write_bytes(b"real-proxy-bytes")
+        return _R()
+    monkeypatch.setattr(ingest.subprocess, "run", fake_run)
+
+    result = ingest.generate_proxy(1, str(src))
+    final = config.proxy_path_for(1, str(src))
+    assert result == str(final)
+    assert final.read_bytes() == b"real-proxy-bytes"
+    assert list(proxies.glob("*.tmp.*")) == []
+
+
 def test_stream_returns_409_when_hevc_source_has_no_proxy(
     fastapi_client, sample_record, tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Round-5 Wave 1 · R5-01 · closes #1, #60, and Codex C1

`generate_proxy` wrote ffmpeg output **straight to the final proxy path** (no tmp+replace), and every consumer accepted the proxy by bare `exists()`. A kill / power-loss / Ctrl-C mid-encode left a **truncated .mp4 that was served forever and blocked any rebuild** — playback proxy silently corrupt, no self-heal.

## Fix

- **Atomic write (#1):** encode to a same-dir `.tmp.<pid>.mp4` sibling, `os.replace` onto the final path only after `rc==0` **and** a non-empty result (mirrors `frames.py` `_extract_to`). Tmp keeps `.mp4` so ffmpeg infers the muxer and `os.replace` stays on one filesystem (**Codex footgun**). A kill mid-encode leaves only the tmp — never a half-written final.
- **Consumer gate (Codex C1):** new `_proxy_ready(p)` = exists **and** size > 0, applied at `/api/stream`, `/api/proxy/status`, `/api/proxy/build`, `/api/proxy/build/{id}`. A zero-byte proxy from a prior kill is treated as absent → rebuilt, not served/counted. `generate_proxy` applies the same empty-check on its early return.
- **Diagnostics (#60):** narrow the `except` into `FileNotFoundError` (ffmpeg missing) / `TimeoutExpired` / generic, each printing *why* + the ffmpeg stderr tail — instead of a silent `None` that surfaced as a mystery 409.

## Tests (+3)

- `test_generate_proxy_failed_encode_leaves_no_final` — rc≠0 → returns None, no final, tmp cleaned.
- `test_generate_proxy_success_replaces_atomically` — clean encode lands via os.replace; a stale empty proxy is discarded first.
- `test_proxy_build_one_rebuilds_when_existing_proxy_is_empty` — zero-byte proxy → queued for rebuild.

Full suite **727 passed, 5 skipped**. 3.9-safe.

Part of the round-5 review (docs PR #134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)