### PR TITLE
fix(ingest): route /api/ingest + reingest through tree-killing run_tree (round-5 #2/#12)

### DIFF
--- a/proctree.py
+++ b/proctree.py
@@ -1,0 +1,74 @@
+"""Process-tree-safe subprocess dispatch.
+
+`run_tree` is `subprocess.run` that kills the WHOLE process tree on timeout, not
+just the direct child. Extracted from watch.py (fable-audit round-5 #2) so the
+long-lived watcher AND the /api/ingest + /api/media/{id}/reingest HTTP routes share
+one implementation: those routes used plain `subprocess.run(timeout=)`, which on
+timeout kills only `ingest.py` and orphans its ffmpeg/whisper grandchildren — they
+keep running (and, mid-encode, keep writing) with the H3 ingest slot already
+released (audit H8, deferred #12).
+
+POSIX: the child gets its own session (`start_new_session`) and the timeout path
+`killpg`s the group. Windows: a new process group + `taskkill /T /F`.
+"""
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+from typing import Mapping, Optional, Sequence
+
+
+def run_tree(
+    cmd: Sequence[str],
+    timeout: float,
+    cwd: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
+    text: bool = True,
+    encoding: Optional[str] = None,
+    errors: Optional[str] = None,
+) -> "subprocess.CompletedProcess":
+    """subprocess.run that kills the whole process tree on timeout.
+
+    Mirrors subprocess.run's capture semantics (stdout/stderr piped) and honours
+    cwd / env / text / encoding / errors so it is a drop-in for the existing HTTP
+    call sites (codex footgun: preserve cwd, env and text/encoding behaviour, plus
+    the Windows tree-kill). On TimeoutExpired the entire group is killed and the
+    exception is re-raised with whatever output was captured.
+    """
+    popen_kwargs: dict = {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": text,
+    }
+    if cwd is not None:
+        popen_kwargs["cwd"] = cwd
+    if env is not None:
+        popen_kwargs["env"] = env
+    if encoding is not None:
+        popen_kwargs["encoding"] = encoding
+    if errors is not None:
+        popen_kwargs["errors"] = errors
+    if os.name == "posix":
+        popen_kwargs["start_new_session"] = True
+    else:
+        popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+
+    proc = subprocess.Popen(list(cmd), **popen_kwargs)
+    try:
+        out, err = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        if os.name == "posix":
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                proc.kill()
+        else:
+            subprocess.run(["taskkill", "/F", "/T", "/PID", str(proc.pid)], capture_output=True)
+            proc.kill()
+        try:
+            out, err = proc.communicate(timeout=10)
+        except Exception:
+            out, err = ("" if text else b""), ("" if text else b"")
+        raise subprocess.TimeoutExpired(list(cmd), timeout, output=out, stderr=err)
+    return subprocess.CompletedProcess(list(cmd), proc.returncode, out, err)

--- a/server.py
+++ b/server.py
@@ -2349,7 +2349,10 @@ def ingest_media(
     if not _acquire_ingest_slot():  # audit H3
         raise HTTPException(409, "已有匯入任務進行中，請稍候")
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=1800, cwd=str(ROOT))
+        # run_tree, not subprocess.run: on timeout the whole ingest.py→ffmpeg/whisper
+        # tree is killed, not just the direct child (fable-audit round-5 #2 / #12).
+        import proctree
+        result = proctree.run_tree(cmd, timeout=1800, cwd=str(ROOT))
         payload = {
             "ok": result.returncode == 0,
             "stdout": result.stdout[-2000:] if result.stdout else "",
@@ -2761,16 +2764,18 @@ def reingest_media(
             media_id, rec["lang"], rec["transcript"],
             rec.get("segments_json"), rec.get("words_json"),
         )
-    import subprocess, sys
+    import subprocess, sys, proctree
     if not _acquire_ingest_slot():  # audit H3 — don't run concurrently with another ingest
         raise HTTPException(409, "已有匯入任務進行中，請稍候")
     try:
         # Single-file mode (ingest.py handles a file path as --dir). The old
         # `--dir <parent> --limit 1` re-processed the alphabetically-first file of
         # the folder, not this media — silently refreshing the WRONG row (audit H4).
-        result = subprocess.run(
+        # run_tree kills the whole tree on timeout (round-5 #2 / #12), so an orphaned
+        # ffmpeg can't keep writing after the 600s cap with the slot released.
+        result = proctree.run_tree(
             [sys.executable, str(ROOT / "ingest.py"), "--dir", media_path, "--refresh"],
-            capture_output=True, text=True, timeout=600, cwd=str(ROOT)
+            timeout=600, cwd=str(ROOT),
         )
         payload = {
             "ok": result.returncode == 0,

--- a/tests/test_audit_20260612.py
+++ b/tests/test_audit_20260612.py
@@ -79,7 +79,10 @@ def test_h4_reingest_targets_single_file(
         captured["cmd"] = cmd
         return types.SimpleNamespace(returncode=0, stdout="", stderr="")
 
-    monkeypatch.setattr(subprocess, "run", fake_run)
+    # reingest now dispatches through proctree.run_tree (round-5 #2: tree-kill on
+    # timeout) rather than a bare subprocess.run — stub the shared helper.
+    import proctree
+    monkeypatch.setattr(proctree, "run_tree", fake_run)
     r = fastapi_client.post("/api/media/%d/reingest" % mid)
     assert r.status_code == 200
     cmd = captured["cmd"]

--- a/tests/test_proctree.py
+++ b/tests/test_proctree.py
@@ -1,0 +1,67 @@
+"""proctree.run_tree — process-tree-safe subprocess.run (fable-audit round-5 #2/#12).
+
+The load-bearing property: on timeout the WHOLE tree dies, not just the direct
+child. Pre-fix, /api/ingest's plain subprocess.run(timeout=) killed ingest.py but
+orphaned its ffmpeg/whisper grandchildren, which kept writing after the slot was
+released.
+"""
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+import proctree
+
+
+def test_run_tree_basic_capture_and_returncode(tmp_path):
+    r = proctree.run_tree([sys.executable, "-c", "print('hi'); import sys; sys.exit(3)"], timeout=30)
+    assert r.returncode == 3
+    assert "hi" in r.stdout
+
+
+def test_run_tree_honours_cwd_and_env(tmp_path):
+    (tmp_path / "marker.txt").write_text("x")
+    env = dict(os.environ)
+    env["ARKIV_PROCTREE_TEST"] = "sentinel-value"
+    r = proctree.run_tree(
+        [sys.executable, "-c",
+         "import os; print(os.path.exists('marker.txt')); print(os.environ.get('ARKIV_PROCTREE_TEST'))"],
+        timeout=30, cwd=str(tmp_path), env=env,
+    )
+    assert r.returncode == 0
+    lines = r.stdout.splitlines()
+    assert lines[0] == "True"                 # ran in cwd
+    assert lines[1] == "sentinel-value"       # env passed through
+
+
+def test_watch_reexports_proctree_run_tree():
+    import watch
+    assert watch.run_tree is proctree.run_tree
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX session/killpg tree-kill assertion")
+def test_run_tree_kills_grandchild_on_timeout():
+    # parent spawns a long-sleeping grandchild, prints its pid, then sleeps too.
+    parent = (
+        "import subprocess,sys,time;"
+        "g=subprocess.Popen([sys.executable,'-c','import time;time.sleep(60)']);"
+        "print(g.pid,flush=True);"
+        "time.sleep(60)"
+    )
+    with pytest.raises(subprocess.TimeoutExpired) as ei:
+        proctree.run_tree([sys.executable, "-c", parent], timeout=1.0)
+    out = ei.value.output or ""
+    gpid = int(out.strip().splitlines()[0])
+
+    # the grandchild must be gone — killpg took the whole session, not just ingest.py
+    dead = False
+    for _ in range(50):
+        try:
+            os.kill(gpid, 0)
+        except ProcessLookupError:
+            dead = True
+            break
+        time.sleep(0.1)
+    assert dead, "grandchild {0} survived the timeout kill".format(gpid)

--- a/watch.py
+++ b/watch.py
@@ -94,40 +94,11 @@ class StabilityTracker:
         return list(self._seen.keys())
 
 
-# ── subprocess dispatch (kept from the polling watcher) ──────────────────────
-
-def run_tree(cmd: Sequence[str], timeout: float) -> subprocess.CompletedProcess:
-    """subprocess.run that kills the whole process tree on timeout.
-
-    audit H8: plain subprocess.run(timeout=) only kills the direct child;
-    ffmpeg/whisper grandchildren orphan and (on Windows) hold the pipes open so
-    communicate() hangs. POSIX: new session + killpg. Windows: taskkill /T /F.
-    """
-    kwargs: dict = {}
-    if os.name == "posix":
-        kwargs["start_new_session"] = True
-    else:
-        kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
-    proc = subprocess.Popen(
-        list(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, **kwargs,
-    )
-    try:
-        out, err = proc.communicate(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        if os.name == "posix":
-            try:
-                os.killpg(proc.pid, signal.SIGKILL)
-            except (ProcessLookupError, PermissionError):
-                proc.kill()
-        else:
-            subprocess.run(["taskkill", "/F", "/T", "/PID", str(proc.pid)], capture_output=True)
-            proc.kill()
-        try:
-            out, err = proc.communicate(timeout=10)
-        except Exception:
-            out, err = "", ""
-        raise subprocess.TimeoutExpired(list(cmd), timeout, output=out, stderr=err)
-    return subprocess.CompletedProcess(list(cmd), proc.returncode, out, err)
+# ── subprocess dispatch ──────────────────────────────────────────────────────
+# run_tree (process-tree-safe subprocess.run) moved to the shared proctree module
+# (fable-audit round-5 #2) so the /api/ingest + reingest HTTP routes reuse the same
+# tree-kill instead of the plain subprocess.run that orphaned their ffmpeg children.
+from proctree import run_tree  # noqa: F401,E402 (re-exported for existing callers)
 
 
 def ingest_file(path: Path, timeout: float = 600.0) -> bool:


### PR DESCRIPTION
## Round-5 Wave 1 · R5-05 · closes #2 and deferred #12

`/api/ingest` (timeout=1800) and `/api/media/{id}/reingest` (timeout=600) used plain `subprocess.run(timeout=)`. On timeout CPython kills only the direct child — `ingest.py` — and **orphans its ffmpeg/whisper grandchildren**, which keep running (and, mid-encode, keep writing to the proxy file) after the shared H3 ingest slot is already released. `watch.py` already fixed exactly this with `run_tree()` (start_new_session+killpg / taskkill /T), but the HTTP routes never adopted it (audit H8).

## Fix

- Extracted `run_tree()` from `watch.py` into a shared **`proctree`** module, enhanced to honour `cwd` / `env` / `text` / `encoding` / `errors` so it's a drop-in for the HTTP sites (**Codex footgun**: preserve cwd/env/encoding + Windows tree-kill). `watch.py` re-exports it — its callers unchanged.
- `/api/ingest` and `reingest` now call `proctree.run_tree(cmd, timeout, cwd=ROOT)`.

## Tests (`tests/test_proctree.py`, +4)

- basic capture + returncode, `cwd`/`env` passthrough, `watch.run_tree is proctree.run_tree` parity, and the load-bearing one: **a POSIX assertion that a timeout kills a grandchild process**, not just the direct child.
- Updated the H4 reingest test to stub `proctree.run_tree` (the mechanism it now uses).

Full suite **728 passed, 5 skipped**. 3.9-safe. Also lays a shared-helper stone for the router split.

Part of the round-5 review (docs PR #134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)