### PR TITLE
fix(db): H5 merge re-parents transcripts before media DELETE (round-5 #7)

### DIFF
--- a/db.py
+++ b/db.py
@@ -424,6 +424,17 @@ def migrate_to_relative():
                     conn.execute("DELETE FROM frames WHERE media_id=?", (row["id"],))
                     conn.execute("UPDATE OR IGNORE tags SET media_id=? WHERE media_id=?", (sid, row["id"]))
                     conn.execute("DELETE FROM tags WHERE media_id=?", (row["id"],))
+                    # fable-audit round-5 #7: transcripts.media_id is ON DELETE
+                    # CASCADE, so the media DELETE below would wipe the loser's
+                    # per-language transcript archive. These abs/rel rows are the
+                    # SAME physical file, so re-parent every language the survivor
+                    # LACKS (UPDATE OR IGNORE); a shared-language conflict keeps the
+                    # survivor's authoritative copy (identical content) and the
+                    # cascade drops the redundant loser row. Without this, a language
+                    # present only on the loser (survivor zh, loser en) was silently
+                    # destroyed by the cascade.
+                    conn.execute("UPDATE OR IGNORE transcripts SET media_id=? WHERE media_id=?", (sid, row["id"]))
+                    conn.execute("DELETE FROM transcripts WHERE media_id=?", (row["id"],))
                     conn.execute("DELETE FROM media WHERE id=?", (row["id"],))
                     merged_count += 1
                     print(f"[migrate] merged duplicate media id={row['id']} into id={sid} ({new_path})")

--- a/tests/test_v081_edges.py
+++ b/tests/test_v081_edges.py
@@ -82,6 +82,38 @@ def test_h5_merge_frame_collision_keeps_survivor_copy(tmp_db):
         assert c.execute("PRAGMA foreign_key_check").fetchall() == []
 
 
+# ── H5 + round-5 #7: the merge must NOT cascade-delete the loser's per-language
+#    transcript archive. A language present only on the abs (loser) row must be
+#    re-parented onto the survivor, not destroyed by the media DELETE's FK cascade.
+def test_h5_merge_preserves_loser_only_transcript_language(tmp_db):
+    db = importlib.import_module("db")
+    config = importlib.import_module("config")
+
+    rel = "h5tr/clip.mp4"
+    abspath = str(Path(config.PROJECT_ROOT) / rel)
+    with db.get_conn() as c:
+        c.execute("INSERT INTO media (path, filename, ext) VALUES (?,?,?)", (rel, "clip.mp4", ".mp4"))
+        survivor_id = c.execute("SELECT id FROM media WHERE path=?", (rel,)).fetchone()["id"]
+        c.execute("INSERT INTO media (path, filename, ext) VALUES (?,?,?)", (abspath, "clip.mp4", ".mp4"))
+        legacy_id = c.execute("SELECT id FROM media WHERE path=?", (abspath,)).fetchone()["id"]
+    # survivor has a zh transcript; the legacy (abs) row is the ONLY holder of en
+    db.upsert_transcript(survivor_id, "zh", "中文逐字稿", None, None)
+    db.upsert_transcript(legacy_id, "en", "english transcript", None, None)
+
+    db.migrate_to_relative()
+
+    with db.get_conn() as c:
+        langs = {r["lang"]: r["transcript"]
+                 for r in c.execute("SELECT lang, transcript FROM transcripts WHERE media_id=?",
+                                    (survivor_id,)).fetchall()}
+        # BOTH languages survive on the survivor — the loser-only 'en' was rescued,
+        # not cascade-deleted
+        assert langs == {"zh": "中文逐字稿", "en": "english transcript"}
+        # nothing left dangling on the deleted loser id
+        assert c.execute("SELECT COUNT(*) AS n FROM transcripts WHERE media_id=?", (legacy_id,)).fetchone()["n"] == 0
+        assert c.execute("PRAGMA foreign_key_check").fetchall() == []
+
+
 # ── scene_ids: chat_messages.scene_ids_json is a TEXT JSON blob, NOT a FK, so
 #    an H5 merge that deletes a cited media id leaves a dangling reference. The
 #    refinement resolution (`SELECT ... WHERE id IN (prior_ids)`) must drop the


### PR DESCRIPTION
## Round-5 Wave 1 · R5-03 · closes #7

`migrate_to_relative`'s abs/rel duplicate merge moved `frames` + `tags` to the survivor, then `DELETE FROM media WHERE id=loser`. `transcripts.media_id` is **ON DELETE CASCADE**, so that DELETE silently wiped the loser row's per-language transcript archive. When a language lived **only** on the loser (survivor `zh`, legacy-abs `en`), the merge destroyed it. Confirmed by the fable skeptics and the Codex pass (against `test_transcripts_g2` proving the cascade).

## Fix

The abs/rel rows are the **same physical file**, so re-parent every language the survivor lacks (`UPDATE OR IGNORE transcripts SET media_id=survivor`); a shared-language conflict keeps the survivor's authoritative copy (identical content) and the cascade drops the redundant loser row — an **explicit conflict policy, no silent loss** (Codex footgun: `UPDATE OR IGNORE` alone still drops a same-lang conflict, which here is a redundant duplicate of one file, so that's correct and now documented).

## Test

`test_h5_merge_preserves_loser_only_transcript_language`: survivor holds `zh`, legacy-abs holds only `en` → after migrate the survivor carries **both**; nothing dangles on the deleted id; `PRAGMA foreign_key_check` clean. Fails pre-fix (the `en` cascade-deletes).

Full suite **725 passed, 5 skipped**. 3.9-safe.

Part of the round-5 review (docs PR #134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)