### PR TITLE
fix(transcribe): retranscribe integrity — lang backup, revert, archive-outgoing (round-5 #14/#17/C2)

### DIFF
--- a/corrections.py
+++ b/corrections.py
@@ -371,14 +371,20 @@ def revert(backup_name: Optional[str] = None) -> Dict:
     except (OSError, ValueError):
         return {"restored": 0, "backup": name, "error": "backup unreadable"}
     media = payload.get("media", [])
+    # fable-audit round-5 #14: restore lang too, but tolerate OLD backups that predate
+    # the lang field — COALESCE(?, lang) keeps the current lang when the backup has
+    # none, instead of nulling/guessing it (codex footgun). retranscribe-all backups
+    # now carry lang; correction-apply backups don't (apply never changes lang), so
+    # COALESCE leaves lang untouched there — correct in both cases.
     rows = [
-        (m.get("transcript"), m.get("segments_json"), m.get("words_json"), m["id"])
+        (m.get("transcript"), m.get("segments_json"), m.get("words_json"), m.get("lang"), m["id"])
         for m in media if isinstance(m, dict) and "id" in m
     ]
     if rows:
         with db.get_conn() as conn:
             conn.executemany(
-                "UPDATE media SET transcript=?, segments_json=?, words_json=? WHERE id=?",
+                "UPDATE media SET transcript=?, segments_json=?, words_json=?, "
+                "lang=COALESCE(?, lang) WHERE id=?",
                 rows,
             )
     return {"restored": len(rows), "backup": name}

--- a/server.py
+++ b/server.py
@@ -2546,6 +2546,20 @@ def retranscribe_media(
     active_lang = lang or body.language
     seg_json = json.dumps(segments, ensure_ascii=False) if segments else None
     words_json = json.dumps(words, ensure_ascii=False) if words else None
+    # fable-audit round-5 #17: when retranscribing into the SAME language, the G2
+    # archive-outgoing below writes the old text to transcripts[(id, lang)] and then
+    # the new-active archive overwrites that very row — so a hand-corrected transcript
+    # would be destroyed with no recoverable copy. Snapshot it to the durable
+    # correction-backups first (restorable via the same revert). Cross-language
+    # retranscribes are already safe (the outgoing language's archive row survives).
+    backup_name = None
+    if active_lang == rec.get("lang") and (rec.get("transcript") or "").strip():
+        backup_name = corrections._write_backup(
+            [{"id": media_id, "transcript": rec.get("transcript"),
+              "segments_json": rec.get("segments_json"),
+              "words_json": rec.get("words_json"), "lang": rec.get("lang")}],
+            [{"op": "retranscribe", "language": active_lang}],
+        )
     with db.get_conn() as conn:
         # G2: archive the OUTGOING transcript first so retranscribing into a
         # different language preserves the previous one (else zh→en would lose zh).
@@ -2558,7 +2572,7 @@ def retranscribe_media(
         )
         # archive the new active language too (its row mirrors media.*).
         db.upsert_transcript(media_id, active_lang, text, seg_json, words_json, _conn=conn)
-    return {"ok": True, "transcript_length": len(text), "language": active_lang}
+    return {"ok": True, "transcript_length": len(text), "language": active_lang, "backup": backup_name}
 
 
 class ActivateLangRequest(BaseModel):
@@ -4242,7 +4256,10 @@ def _run_retranscribe_all(targets, language, backup):
             with db.get_conn() as conn:
                 for mid, _ in targets:
                     r = conn.execute(
-                        "SELECT id, transcript, segments_json, words_json FROM media WHERE id=?",
+                        # fable-audit round-5 #14: include lang so revert restores the
+                        # language too — else a zh→en batch, reverted, leaves zh text
+                        # tagged lang='en', which later archives cross-contaminate.
+                        "SELECT id, transcript, segments_json, words_json, lang FROM media WHERE id=?",
                         (mid,),
                     ).fetchone()
                     if r:
@@ -4274,6 +4291,13 @@ def _run_retranscribe_all(targets, language, backup):
             _sj = json.dumps(segments, ensure_ascii=False) if segments else None
             _wj = json.dumps(words, ensure_ascii=False) if words else None
             with db.get_conn() as conn:
+                # fable-audit round-5 C2: archive the OUTGOING transcript first, like
+                # the single-clip retranscribe does — else a batch zh→en overwrites
+                # media's zh with en and, if the per-run backup is off/lost, the prior
+                # active text is gone from the archive too.
+                if (rec.get("transcript") or "").strip() and rec.get("lang"):
+                    db.upsert_transcript(mid, rec["lang"], rec.get("transcript"),
+                                         rec.get("segments_json"), rec.get("words_json"), _conn=conn)
                 conn.execute(
                     "UPDATE media SET transcript=?, lang=?, segments_json=?, words_json=? WHERE id=?",
                     (

--- a/tests/test_retranscribe_all.py
+++ b/tests/test_retranscribe_all.py
@@ -123,3 +123,73 @@ def test_api_refuses_concurrent_run(fastapi_client, server_module, tmp_path, mon
         assert r.status_code == 409
     finally:
         server_module._retranscribe_active = False
+
+
+def test_batch_backup_and_revert_restore_lang(srv, tmp_path, monkeypatch):
+    """fable-audit round-5 #14: the batch backup must carry lang, and revert must
+    restore it — else a zh→en batch, reverted, leaves the zh text tagged lang='en',
+    which later per-language archives cross-contaminate."""
+    db = importlib.import_module("db")
+    transcribe = importlib.import_module("transcribe")
+    corrections = importlib.import_module("corrections")
+    id1, p1 = _seed_audio(tmp_path, "中文逐字稿")
+    with db.get_conn() as c:
+        c.execute("UPDATE media SET lang='zh' WHERE id=?", (id1,))
+    monkeypatch.setattr(transcribe, "transcribe",
+                        lambda path, language=None: ("english text", "en", [], []))
+
+    srv._run_retranscribe_all([(id1, p1)], "en", True)
+    with db.get_conn() as c:
+        row = c.execute("SELECT transcript, lang FROM media WHERE id=?", (id1,)).fetchone()
+    assert row["transcript"] == "english text" and row["lang"] == "en"
+
+    corrections.revert()
+    with db.get_conn() as c:
+        row = c.execute("SELECT transcript, lang FROM media WHERE id=?", (id1,)).fetchone()
+    assert row["transcript"] == "中文逐字稿"
+    assert row["lang"] == "zh"  # pre-fix: stayed 'en' (text/lang mismatch)
+
+
+def test_batch_archives_outgoing_language(srv, tmp_path, monkeypatch):
+    """fable-audit round-5 C2: even with per-run backup OFF, the batch must archive
+    the OUTGOING transcript before overwriting media — like the single-clip path —
+    so the prior active language survives in the per-language archive."""
+    db = importlib.import_module("db")
+    transcribe = importlib.import_module("transcribe")
+    id1, p1 = _seed_audio(tmp_path, "原始中文")
+    with db.get_conn() as c:
+        c.execute("UPDATE media SET lang='zh' WHERE id=?", (id1,))
+    monkeypatch.setattr(transcribe, "transcribe",
+                        lambda path, language=None: ("english", "en", [], []))
+
+    srv._run_retranscribe_all([(id1, p1)], "en", False)  # backup OFF → archive is the only safety net
+    with db.get_conn() as c:
+        archived = {r["lang"]: r["transcript"]
+                    for r in c.execute("SELECT lang, transcript FROM transcripts WHERE media_id=?", (id1,))}
+    assert archived.get("zh") == "原始中文"  # outgoing zh preserved (C2)
+    assert archived.get("en") == "english"  # new active also archived
+
+
+def test_single_clip_same_lang_retranscribe_backs_up(fastapi_client, srv, tmp_path, monkeypatch):
+    """fable-audit round-5 #17: retranscribing into the SAME language would let the
+    G2 archive-outgoing be immediately overwritten by the new-active archive,
+    destroying a hand-corrected transcript with no recoverable copy. A durable
+    correction-backup must be written first."""
+    db = importlib.import_module("db")
+    transcribe = importlib.import_module("transcribe")
+    corrections = importlib.import_module("corrections")
+    id1, p1 = _seed_audio(tmp_path, "手動修正過的逐字稿")
+    with db.get_conn() as c:
+        c.execute("UPDATE media SET lang='zh' WHERE id=?", (id1,))
+    monkeypatch.setattr(transcribe, "transcribe",
+                        lambda path, language=None: ("機器重轉的較差版本", "zh", [], []))
+
+    r = fastapi_client.post("/api/media/%d/retranscribe" % id1, json={"language": "zh"})
+    assert r.status_code == 200, r.text
+    assert r.json()["backup"]  # a backup was written (round-5 #17)
+    with db.get_conn() as c:
+        assert c.execute("SELECT transcript FROM media WHERE id=?", (id1,)).fetchone()[0] == "機器重轉的較差版本"
+
+    corrections.revert()  # the hand-corrected original is recoverable
+    with db.get_conn() as c:
+        assert c.execute("SELECT transcript FROM media WHERE id=?", (id1,)).fetchone()[0] == "手動修正過的逐字稿"


### PR DESCRIPTION
## Round-5 Wave 1 · R5-04 · closes #14, #17, and Codex C2

Three ways a retranscribe destroyed transcript data — all confirmed by the fable skeptics and the Codex pass:

- **#17 (single-clip, same language):** the G2 archive-outgoing writes the old text to `transcripts[(id, lang)]`, then the new-active archive **overwrites that very row** — so retranscribing zh→zh destroyed a hand-corrected transcript with no recoverable copy. Now a durable correction-backup is written first when `active_lang == rec['lang']` (restorable via the same revert); the backup name is returned.
- **#14 (batch backup omits lang):** `retranscribe-all`'s backup SELECT lacked `lang`, so revert restored text but not language — a zh→en batch, reverted, left zh text tagged `lang='en'`, which later archives cross-contaminate. Backup now carries `lang`; `corrections.revert` restores it via `COALESCE(?, lang)` so **old lang-less backups (and correction-apply backups, which never touch lang) are tolerated, not nulled** (Codex footgun).
- **C2 (batch skips archive-outgoing):** unlike the single-clip path, the batch worker overwrote media without first archiving the outgoing transcript, so with per-run backup off the prior active language was lost from the archive too. It now archives the outgoing transcript before the overwrite.

**C3** (correction backups don't sync the `transcripts` active-lang row) is a separate medium-severity staleness in `corrections.apply` — **deferred to its own follow-up** to keep this PR atomic.

## Tests (+3)

batch lang restore round-trip; batch archive-outgoing with backup **off**; single-clip same-lang backup + revert recovers the hand-corrected original.

Full suite **726 passed** — the single failure is `test_cli_revoke_removes_token`, a **pre-existing order/timing flake** (passes in isolation, tracked separately); untouched by this PR. 3.9-safe.

Part of the round-5 review (docs PR #134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)