### PR TITLE
fix(bins): release ingest slot on copy_bin index-phase failure (round-5 #58)

### DIFF
--- a/server.py
+++ b/server.py
@@ -903,41 +903,50 @@ def copy_bin(bin_id: str, body: BinCopyRequest, _tok: dict = Depends(require_sco
                                    "error": "已有匯入任務進行中，已複製檔案但略過索引；請稍後手動 ingest"},
                                   ensure_ascii=False) + "\n"
             else:
-                yield _json.dumps({"type": "index", "status": "start", "files": len(ingest_paths)},
-                                  ensure_ascii=False) + "\n"
-                # Run ingest AS the dest project: ARKIV_PROJECT_ROOT=dest_root so paths
-                # relativize against the dest, not the server's own project. In
-                # reference mode the sources sit OUTSIDE dest_root, so this stores an
-                # absolute media.path (resolvable from the dest); in copy mode the
-                # copied files sit under dest_root/media, so they store relative. cwd
-                # points at the dest .arkiv so ingest's bench_ingest.json / state don't
-                # dirty the install dir (mirrors /api/offload's state_cwd).
-                ingest_env = dict(os.environ)
-                ingest_env["ARKIV_PROJECT_ROOT"] = str(dest_root)
-                proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                                        text=True, bufsize=1, env=ingest_env,
-                                        cwd=str(dest_root / ".arkiv"))
+                # fable-audit round-5 #58: the slot is now held. The FIRST yield below
+                # and the Popen sit BEFORE the inner try, so a GeneratorExit at that
+                # yield (client disconnects) or a Popen failure used to escape the
+                # release → every ingest endpoint 409s until restart. Wrap everything
+                # from here in an outer try whose finally always releases the slot.
+                proc = None
                 try:
-                    for line in proc.stdout:
-                        yield _json.dumps({"type": "log", "line": line.rstrip("\n")}, ensure_ascii=False) + "\n"
-                    proc.wait()
-                except GeneratorExit:
-                    # fable-audit 2026-07-12 (#6/#7): client disconnected — terminate
-                    # the child (mirrors offload_run) so a multi-minute whisper/vision
-                    # pass doesn't run orphaned with the slot held.
-                    proc.terminate()
+                    yield _json.dumps({"type": "index", "status": "start", "files": len(ingest_paths)},
+                                      ensure_ascii=False) + "\n"
+                    # Run ingest AS the dest project: ARKIV_PROJECT_ROOT=dest_root so
+                    # paths relativize against the dest, not the server's own project.
+                    # In reference mode the sources sit OUTSIDE dest_root, so this
+                    # stores an absolute media.path (resolvable from the dest); in copy
+                    # mode the copied files sit under dest_root/media, so they store
+                    # relative. cwd points at the dest .arkiv so ingest's
+                    # bench_ingest.json / state don't dirty the install dir (mirrors
+                    # /api/offload's state_cwd).
+                    ingest_env = dict(os.environ)
+                    ingest_env["ARKIV_PROJECT_ROOT"] = str(dest_root)
+                    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                            text=True, bufsize=1, env=ingest_env,
+                                            cwd=str(dest_root / ".arkiv"))
                     try:
-                        proc.wait(timeout=10)
-                    except subprocess.TimeoutExpired:
-                        proc.kill()
+                        for line in proc.stdout:
+                            yield _json.dumps({"type": "log", "line": line.rstrip("\n")}, ensure_ascii=False) + "\n"
                         proc.wait()
-                    raise
+                    except GeneratorExit:
+                        # fable-audit 2026-07-12 (#6/#7): client disconnected —
+                        # terminate the child (mirrors offload_run) so a multi-minute
+                        # whisper/vision pass doesn't run orphaned with the slot held.
+                        proc.terminate()
+                        try:
+                            proc.wait(timeout=10)
+                        except subprocess.TimeoutExpired:
+                            proc.kill()
+                            proc.wait()
+                        raise
+                    finally:
+                        if proc.stdout and not proc.stdout.closed:
+                            proc.stdout.close()
+                    yield _json.dumps({"type": "index", "status": "done", "code": proc.returncode},
+                                      ensure_ascii=False) + "\n"
                 finally:
-                    if proc.stdout and not proc.stdout.closed:
-                        proc.stdout.close()
                     _release_ingest_slot()
-                yield _json.dumps({"type": "index", "status": "done", "code": proc.returncode},
-                                  ensure_ascii=False) + "\n"
 
         # ── bootstrap: register the new project (path now exists) ──
         if body.create_new:

--- a/tests/test_bin_copy.py
+++ b/tests/test_bin_copy.py
@@ -263,6 +263,44 @@ def test_copy_into_existing_project(fastapi_client, tmp_path, monkeypatch):
     assert done["copied"] == 1 and done["dest"] == "已存在專案"
 
 
+def test_copy_bin_releases_slot_when_popen_fails(fastapi_client, tmp_path, monkeypatch):
+    """fable-audit round-5 #58: the ingest slot is acquired before the index-phase
+    Popen. If Popen raises (or the client disconnects at the first yield), the slot
+    must STILL be released — pre-fix it leaked and every ingest endpoint 409'd until
+    restart."""
+    import server
+    bins = _setup(tmp_path, monkeypatch)
+
+    src = tmp_path / "src" / "clip.mp4"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b"x")
+    _stub_resolve(monkeypatch, {
+        ("libA", "1"): {"status": "ok", "absolute_path": str(src), "filename": "clip.mp4"},
+    })
+    b = bins.create_bin("slotbin")
+    bins.add_items(b.id, [{"project_name": "libA", "media_id": "1", "filename": "clip.mp4"}])
+
+    assert server._acquire_ingest_slot() is True  # confirm free, then release for the run
+    server._release_ingest_slot()
+
+    def boom(*a, **k):
+        raise OSError("popen failed during index phase")
+    monkeypatch.setattr(subprocess, "Popen", boom)
+
+    try:
+        fastapi_client.post(
+            "/api/bins/{0}/copy".format(b.id),
+            json={"dest": str(tmp_path / "np"), "create_new": True, "mode": "reference",
+                  "skip_vision": True, "no_embed": True},
+        )
+    except Exception:
+        pass  # the stream errors out — that's fine; the slot must be free regardless
+
+    # the slot was released despite the Popen failure (not wedged)
+    assert server._acquire_ingest_slot() is True
+    server._release_ingest_slot()
+
+
 def test_copy_unknown_dest_project_400(fastapi_client, tmp_path, monkeypatch):
     bins = _setup(tmp_path, monkeypatch)
     b = bins.create_bin("cb")


### PR DESCRIPTION
## Round-5 Wave 1 · R5-06 · closes #58

`copy_bin`'s index phase acquired the shared H3 ingest slot, then ran the first `yield` (index-start) and `subprocess.Popen` **before** the `try` whose `finally` releases it. A GeneratorExit at that yield (client disconnects) or a Popen failure **escaped the release** — the slot stayed held and every ingest endpoint (`/api/ingest`, reingest, retranscribe-all, copy_bin) returned 409 **until the server restarted**. Confirmed by both audit passes.

## Fix

Wrap everything from immediately after the successful acquire in an outer `try/finally` that always releases the slot (**Codex footgun**: cover the first yield + Popen, not just the streaming loop). The inner `try` still handles child termination on disconnect + stdout close.

## Test

`test_copy_bin_releases_slot_when_popen_fails`: Popen raises during the index phase → the stream errors, but the slot is **free afterward** (pre-fix it wedged, and `_acquire_ingest_slot()` would return False).

Full suite **725 passed, 5 skipped**. 3.9-safe.

Part of the round-5 review (docs PR #134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)