### PR TITLE
fix(mhl): exclude *.partial from ascMHL manifest (round-5 #18)

### DIFF
--- a/mhl.py
+++ b/mhl.py
@@ -268,6 +268,13 @@ def _compute_directory_hashes(
 def _should_ignore(path: Path, rel_dir: str) -> bool:
     if path.name == ".DS_Store":
         return True
+    # fable-audit round-5 #18: a killed offload leaves a truncated "<name>.partial"
+    # (offload writes bytes there, then os.replace's onto the final name on success).
+    # It must NEVER be hashed into the manifest — otherwise ascMHL records the
+    # truncated bytes as verified original content and every future verify passes on
+    # a broken clip. Excluding it here means a leftover .partial is simply ignored.
+    if path.name.endswith(".partial"):
+        return True
     parts = path.parts
     if "ascmhl" in parts:
         return True

--- a/tests/test_mhl.py
+++ b/tests/test_mhl.py
@@ -128,6 +128,30 @@ def test_create_writes_v2_hashlist_and_chain():
     assert len(c4_value) == 90
 
 
+def test_partial_files_excluded_from_manifest():
+    """fable-audit round-5 #18: a truncated <name>.partial left by a killed offload
+    must NOT be hashed into the manifest — else ascMHL records it as verified
+    original content and verify passes forever on a broken clip."""
+    fixture = REPO_ROOT / "temp" / "mhl-partial-evidence"
+    ensure_clean(fixture)
+    fixture = make_fixture(fixture)
+    # a killed offload's leftover truncated temp file
+    (fixture / "A001" / "clip_003.mp4.partial").write_bytes(b"trunc")
+
+    result = run_cli(["create", "--source", str(fixture)], cwd=fixture)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    mhl_path = sorted((fixture / "ascmhl").glob("0001_*.mhl"))[0]
+    root = parse_xml(mhl_path)
+    hashes = root.find("m:hashes", MHL_NS)
+    paths = [h.findtext("m:path", namespaces=MHL_NS) for h in hashes.findall("m:hash", MHL_NS)]
+    # the two real clips are hashed; the .partial is not
+    assert "A001/clip_001.mp4" in paths
+    assert "A001/clip_002.mp4" in paths
+    assert not any((p or "").endswith(".partial") for p in paths)
+    ensure_clean(fixture)
+
+
 def test_verify_detects_tamper():
     fixture = REPO_ROOT / "temp" / "mhl-verify-evidence"
     ensure_clean(fixture)


### PR DESCRIPTION
## Round-5 Wave 1 · R5-07 · closes #18

A killed offload leaves a truncated `<name>.partial` (offload copies bytes there, then `os.replace`s onto the final name on success). `mhl._should_ignore` only skipped `.DS_Store` and the `ascmhl` dir, so the **next card's manifest hashed the truncated `.partial` in as verified ORIGINAL content** — and every future ascMHL verify then passed forever on a broken clip.

## Fix

`_should_ignore` now excludes any `*.partial`, so a leftover temp file is never recorded as content.

The **on-disk stale-partial sweep** the audit also suggested is **deferred**: Codex flagged that a naive sweep could delete a *concurrent* offload's live `.partial`. The manifest exclusion alone fully fixes the "verified truncated content" bug and leaves the leftover as harmless clutter — the safe, complete fix.

## Test

`test_partial_files_excluded_from_manifest`: fixture with two real clips + one `.partial` → the manifest hashes the clips, never the `.partial`.

Full suite **725 passed, 5 skipped**. 3.9-safe.

Part of the round-5 review (docs PR #134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)