### PR TITLE
fix(query): date end-day inclusive, tag eq case-insensitive, sort tiebreakers (round-5 #10/#11/#12)

### DIFF
--- a/db.py
+++ b/db.py
@@ -896,12 +896,17 @@ def _build_filter_clause(
     return " AND ".join(clauses), params
 
 
+# fable-audit round-5 #12: every sort has a unique `, id` tiebreaker. Without it,
+# non-unique sort keys (hundreds of C0001.MP4 filenames, equal durations, NULL
+# processed_at) leave row order undefined, so LIMIT/OFFSET pagination can repeat or
+# drop rows across page fetches — and media_position (the "next/prev in this sort")
+# can disagree with the grid. id is the PK, so it's a total order.
 SORT_MAP = {
-    "date": "processed_at DESC",
-    "name": "filename ASC",
-    "duration": "duration_s DESC",
-    "size": "size_mb DESC",
-    "rating": "CASE rating WHEN 'good' THEN 1 WHEN 'review' THEN 2 WHEN 'ng' THEN 3 ELSE 4 END",
+    "date": "processed_at DESC, id DESC",
+    "name": "filename ASC, id ASC",
+    "duration": "duration_s DESC, id DESC",
+    "size": "size_mb DESC, id DESC",
+    "rating": "CASE rating WHEN 'good' THEN 1 WHEN 'review' THEN 2 WHEN 'ng' THEN 3 ELSE 4 END, id DESC",
 }
 
 

--- a/query_builder.py
+++ b/query_builder.py
@@ -48,7 +48,7 @@ _FIELDS: Dict[str, Tuple[Optional[str], set, str]] = {
     "rating": ("rating", {"eq"}, "enum"),
     "iso": ("iso", {"range"}, "numeric"),
     "duration": ("duration_s", {"range"}, "numeric"),
-    "date": ("processed_at", {"range"}, "numeric"),
+    "date": ("processed_at", {"range"}, "daterange"),
     "media_type": (None, {"eq"}, "bucket"),
     "semantic": (None, {"contains"}, "semantic"),
 }
@@ -85,7 +85,10 @@ def _one_condition(cond: Dict[str, Any]) -> Tuple[Optional[str], List[Any], Opti
         if not v:
             raise QueryError("tag condition needs a non-empty value")
         if op == "eq":
-            return "id IN (SELECT media_id FROM tags WHERE name = ?)", [v], None
+            # add_tag stores names lowercased; an eq bind of 'Interview' would miss
+            # the stored 'interview' (SQLite = is case-sensitive). Normalize to match
+            # the write path (fable-audit round-5 #11). CJK is unaffected by lower().
+            return "id IN (SELECT media_id FROM tags WHERE name = ?)", [v.lower()], None
         return "id IN (SELECT media_id FROM tags WHERE name LIKE ?)", ["%{0}%".format(v)], None
 
     if kind == "bucket":
@@ -112,6 +115,27 @@ def _one_condition(cond: Dict[str, Any]) -> Tuple[Optional[str], List[Any], Opti
         if op == "eq":
             return "{0} = ?".format(column), [v], None
         return "{0} LIKE ?".format(column), ["%{0}%".format(v)], None
+
+    if kind == "daterange":  # value = [start, end] date strings (either may be null)
+        if not isinstance(value, (list, tuple)) or len(value) != 2:
+            raise QueryError("{0} range needs a [start, end] pair".format(field))
+        lo, hi = value
+        frags, params = [], []
+        if lo is not None:
+            frags.append("{0} >= ?".format(column))
+            params.append(lo)
+        if hi is not None:
+            # processed_at is a full ISO timestamp; a date-only upper bound like
+            # '2026-07-12' would exclude everything ON the 12th ('…T14:30:00' sorts
+            # after '2026-07-12'). Compare against the NEXT day exclusively so the
+            # end day is fully included (fable-audit round-5 #10; chat.py does the
+            # same day-ceiling). date() on the bound (not the column) keeps the
+            # processed_at index usable.
+            frags.append("{0} < date(?, '+1 day')".format(column))
+            params.append(hi)
+        if not frags:
+            raise QueryError("{0} range needs at least one bound".format(field))
+        return "(" + " AND ".join(frags) + ")", params, None
 
     if kind == "numeric":  # range, value = [min, max] (either may be null)
         if not isinstance(value, (list, tuple)) or len(value) != 2:

--- a/tests/test_query_builder_g6.py
+++ b/tests/test_query_builder_g6.py
@@ -54,6 +54,16 @@ def test_numeric_range_open_upper():
     assert c["params"] == [10]
 
 
+def test_date_range_upper_bound_is_day_inclusive():
+    # fable-audit round-5 #10: processed_at is a full timestamp, so the end-day bound
+    # must compare against the next day exclusively (not <= the date-only string).
+    c = qb.compile_spec({"conditions": [
+        {"field": "date", "op": "range", "value": ["2026-05-01", "2026-05-03"]},
+    ]})
+    assert c["where"] == "(processed_at >= ? AND processed_at < date(?, '+1 day'))"
+    assert c["params"] == ["2026-05-01", "2026-05-03"]
+
+
 def test_media_type_bucket():
     c = qb.compile_spec({"conditions": [
         {"field": "media_type", "op": "eq", "value": "video"},
@@ -186,3 +196,47 @@ def test_query_invalid_spec_is_422(fastapi_client):
         "conditions": [{"field": "bogus", "op": "eq", "value": 1}],
     })
     assert r.status_code == 422
+
+
+def test_date_range_includes_end_day(fastapi_client, server_module):
+    """fable-audit round-5 #10: the clip processed at 2026-05-03T09:00 must be
+    returned when the range END is '2026-05-03' — pre-fix `<= '2026-05-03'` dropped
+    every clip processed after midnight on the end day."""
+    db = importlib.import_module("db")
+    _seed(db)
+    r = fastapi_client.post("/api/search/query", json={
+        "conditions": [{"field": "date", "op": "range", "value": ["2026-05-01", "2026-05-03"]}],
+    })
+    assert r.status_code == 200, r.text
+    assert {it["filename"] for it in r.json()["items"]} == {"a.mp4", "b.mov", "c.mp3"}
+
+
+def test_date_range_single_day_not_empty(fastapi_client, server_module):
+    """A single-day range [d, d] must return that day's clips, not nothing."""
+    db = importlib.import_module("db")
+    _seed(db)
+    r = fastapi_client.post("/api/search/query", json={
+        "conditions": [{"field": "date", "op": "range", "value": ["2026-05-03", "2026-05-03"]}],
+    })
+    assert {it["filename"] for it in r.json()["items"]} == {"c.mp3"}
+
+
+def test_tag_eq_is_case_insensitive(fastapi_client, server_module):
+    """fable-audit round-5 #11: add_tag stores lowercased, so an eq bind of a
+    mixed-case tag must normalize to match (else 'Interview' finds nothing)."""
+    db = importlib.import_module("db")
+    _seed(db)
+    db.add_tag(1, "Interview")  # stored as 'interview'
+    r = fastapi_client.post("/api/search/query", json={
+        "conditions": [{"field": "tag", "op": "eq", "value": "Interview"}],
+    })
+    assert {it["filename"] for it in r.json()["items"]} == {"a.mp4"}
+
+
+def test_sort_map_entries_have_unique_tiebreaker():
+    """fable-audit round-5 #12: every sort ends with an id tiebreaker so LIMIT/OFFSET
+    pagination is a total order (no repeat/drop across pages)."""
+    db = importlib.import_module("db")
+    for key, val in db.SORT_MAP.items():
+        tail = val.rstrip()
+        assert tail.endswith("id DESC") or tail.endswith("id ASC"), (key, val)


### PR DESCRIPTION
## Round-5 Wave 1 · R5-09 · closes #10, #11, #12

Three query-correctness defects that silently returned the **wrong result set** (data-integrity dimension — a DIT operator trusts search to find their footage):

- **#10 — date range drops the end day.** `processed_at` is a full ISO timestamp, so a date-only upper bound `'2026-07-12'` excluded everything ingested after midnight on the 12th (`…T14:30:00` > `'2026-07-12'`) — a single-day range was **always empty**. New `daterange` field kind compares `< date(?, '+1 day')` so the end day is fully included (date() on the bound, not the column, keeps the index usable).
- **#11 — tag `eq` is case-sensitive.** `add_tag` stores names `.strip().lower()`, but the `eq` leg bound the raw value, so `{field:tag, op:eq, value:'Interview'}` matched nothing despite clips tagged `interview`. Normalize the eq bind to `lower()`.
- **#12 — pagination repeats/drops rows.** `SORT_MAP` had no unique tiebreaker, so equal sort keys (hundreds of `C0001.MP4`, equal durations, NULL `processed_at`) left row order undefined and LIMIT/OFFSET could repeat or skip rows across page fetches. Append `, id` to every sort for a total order.

## Tests (+5)

date-range SQL shape + end-day-inclusive + single-day integration; tag eq mixed-case; SORT_MAP tiebreaker invariant.

Full suite **729 passed, 5 skipped**. 3.9-safe.

Part of the round-5 review (docs PR #134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)