### PR TITLE
fix(db): recognise + migrate backslash-relative paths in dedup (round-5 #9)

### DIFF
--- a/db.py
+++ b/db.py
@@ -79,6 +79,34 @@ def to_relative(abs_path: str) -> str:
         return abs_path
 
 
+def dedup_path_variants(path: str) -> List[str]:
+    """Every stored form a file could match on for dedup: its absolute path, the
+    forward-slash relative form (what new ingests write), and the BACKSLASH relative
+    form a pre-fix Windows ingest wrote (fable-audit round-5 #9). Without the
+    backslash form, a NAS DB written by old Windows ingest and opened on mac looked
+    entirely unprocessed and re-ingested the whole library as duplicates."""
+    abs_path = str(path)
+    rel = to_relative(abs_path)
+    variants = [abs_path, rel]
+    back = rel.replace("/", "\\")
+    if back != rel:
+        variants.append(back)
+    return variants
+
+
+def canonical_stored_path(stored: str) -> str:
+    """Canonicalise a STORED path value to forward-slash relative. to_relative alone
+    can't convert a backslash-relative path ('media\\clip.mp4' is neither absolute
+    nor under PROJECT_ROOT, so it's returned unchanged), which is why migrate_to_
+    relative never reconciled pre-fix Windows rows (fable-audit round-5 #9)."""
+    if not stored:
+        return stored
+    p = Path(stored)
+    if not p.is_absolute() and "\\" in stored:
+        return stored.replace("\\", "/")
+    return to_relative(stored)
+
+
 def resolve_path(rel_path: str) -> str:
     """Relative path -> absolute under PROJECT_ROOT. Idempotent.
 
@@ -395,8 +423,10 @@ def migrate_to_relative():
     with get_conn() as conn:
         rows = conn.execute("SELECT id, path, thumbnail_path FROM media").fetchall()
         for row in rows:
-            new_path = to_relative(row["path"]) if row["path"] else row["path"]
-            new_thumb = to_relative(row["thumbnail_path"]) if row["thumbnail_path"] else row["thumbnail_path"]
+            # canonical_stored_path (not to_relative) so a pre-fix Windows
+            # backslash-relative row is also normalised, not just abs→rel (#9).
+            new_path = canonical_stored_path(row["path"]) if row["path"] else row["path"]
+            new_thumb = canonical_stored_path(row["thumbnail_path"]) if row["thumbnail_path"] else row["thumbnail_path"]
             if new_path != row["path"] or new_thumb != row["thumbnail_path"]:
                 try:
                     conn.execute(
@@ -459,11 +489,12 @@ def migrate_to_relative():
 
 
 def is_processed(path: str) -> bool:
-    rel = to_relative(str(path))
+    variants = dedup_path_variants(str(path))  # abs / forward-rel / backslash-rel (#9)
+    placeholders = ",".join("?" * len(variants))
     with get_conn() as conn:
         row = conn.execute(
-            "SELECT id FROM media WHERE path=? OR path=?",
-            (str(path), rel),
+            "SELECT id FROM media WHERE path IN ({0})".format(placeholders),
+            variants,
         ).fetchone()
         return row is not None
 

--- a/ingest.py
+++ b/ingest.py
@@ -1546,7 +1546,9 @@ def main():
         _known_paths = {r[0] for r in conn.execute("SELECT path FROM media").fetchall()}
 
     def _is_known(p) -> bool:
-        return str(p) in _known_paths or db.to_relative(str(p)) in _known_paths
+        # abs / forward-rel / backslash-rel — matches is_processed so a pre-fix
+        # Windows (backslash) DB row isn't re-ingested as a duplicate (round-5 #9).
+        return any(v in _known_paths for v in db.dedup_path_variants(str(p)))
 
     if args.limit and not args.refresh:
         # Filter out already-processed files before applying limit

--- a/tests/test_v081_edges.py
+++ b/tests/test_v081_edges.py
@@ -112,6 +112,26 @@ def test_h5_merge_preserves_loser_only_transcript_language(tmp_db):
         # nothing left dangling on the deleted loser id
         assert c.execute("SELECT COUNT(*) AS n FROM transcripts WHERE media_id=?", (legacy_id,)).fetchone()["n"] == 0
         assert c.execute("PRAGMA foreign_key_check").fetchall() == []
+# ── round-5 #9: a pre-fix Windows ingest stored backslash-relative paths that
+#    to_relative can't convert, so dedup missed them (whole-library re-ingest as
+#    duplicates) and migrate never reconciled them.
+def test_backslash_relative_row_is_deduped_and_migrated(tmp_db):
+    db = importlib.import_module("db")
+    config = importlib.import_module("config")
+    with db.get_conn() as c:
+        c.execute("INSERT INTO media (path, filename, ext) VALUES (?,?,?)",
+                  ("media\\clip.mp4", "clip.mp4", ".mp4"))
+    abspath = str(Path(config.PROJECT_ROOT) / "media" / "clip.mp4")
+
+    # dedup recognises the backslash row via its abs path → not re-ingested
+    assert db.is_processed(abspath) is True
+    assert db.dedup_path_variants(abspath).count("media\\clip.mp4") == 1
+
+    # migrate normalises it to forward-slash (pre-fix it was left untouched)
+    db.migrate_to_relative()
+    with db.get_conn() as c:
+        paths = [r["path"] for r in c.execute("SELECT path FROM media")]
+    assert paths == ["media/clip.mp4"]
 
 
 # ── scene_ids: chat_messages.scene_ids_json is a TEXT JSON blob, NOT a FK, so


### PR DESCRIPTION
## Round-5 Wave 1 · R5-10 · closes #9

A pre-fix Windows ingest wrote **backslash-relative** media paths (`media\clip.mp4`). `to_relative` can't convert them (not absolute, not under `PROJECT_ROOT` → returned unchanged), so on mac:

- **dedup** (`is_processed` / `ingest._is_known`) compared only the abs and forward-slash forms and **missed the backslash rows** — a NAS DB written by old Windows ingest re-ingested the **entire library as duplicates** (old rows kept their ratings/tags but pointed at dead paths; stats double-counted).
- **`migrate_to_relative`** also skipped them — it "reported success, fixed nothing".

## Fix

- `db.dedup_path_variants(path)` → `[abs, forward-rel, backslash-rel]`; `is_processed` and `ingest._is_known` match against all three.
- `db.canonical_stored_path(stored)` normalises a backslash-relative stored value to forward-slash; `migrate_to_relative` uses it so those rows are finally reconciled (and merged via the existing H5 path if a forward-slash twin already exists).

## Test

`test_backslash_relative_row_is_deduped_and_migrated`: a backslash row is recognised by `is_processed(abs)` and normalised to forward-slash by migrate. Fails pre-fix.

Full suite **725 passed, 5 skipped**. 3.9-safe.

Part of the round-5 review (docs PR #134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)