### PR TITLE
fix(watch): back off + quarantine a permanently-failing file (round-5 #5)

### DIFF
--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -87,7 +87,36 @@ def test_failed_dispatch_not_marked_known(tmp_path):
     _make_file(f)
     w = watch.Watcher([root], debounce_s=0.0, dispatch=lambda p: False)  # ingest fails
     assert w.tick(now=1.0) == []          # dispatch ran but returned False
-    assert str(f) not in w.known           # so it can be retried next tick
+    assert str(f) not in w.known           # so it can be retried (after back-off)
+
+
+def test_failing_file_backs_off_then_quarantines(tmp_path):
+    """fable-audit round-5 #5: a permanently-failing file must NOT be re-dispatched
+    every tick. It backs off exponentially and, after QUARANTINE_AFTER failures,
+    stops retrying — until its signature changes (re-copied / fixed)."""
+    root = tmp_path / "inbox"
+    root.mkdir()
+    f = root / "corrupt.mp4"
+    _make_file(f, size=1000)
+    calls = []
+    w = watch.Watcher([root], debounce_s=0.0, dispatch=lambda p: calls.append(p) or False)
+    assert w.QUARANTINE_AFTER == 3 and w.BASE_BACKOFF_S == 30.0  # pin the constants this test assumes
+
+    w.tick(now=0.0)                 # fail #1 → back off until t=30
+    assert len(calls) == 1
+    w.tick(now=10.0)                # inside back-off → NOT retried
+    assert len(calls) == 1
+    w.tick(now=30.0)               # fail #2 → back off until t=90
+    assert len(calls) == 2
+    w.tick(now=90.0)               # fail #3 → now quarantined
+    assert len(calls) == 3
+    w.tick(now=100_000.0)          # quarantined: never retried, however long we wait
+    assert len(calls) == 3
+
+    # the file is re-copied (new signature) → quarantine clears, dispatched again
+    _make_file(f, size=2000)
+    w.tick(now=100_001.0)
+    assert len(calls) == 4
 
 
 def test_non_media_ignored(tmp_path):

--- a/watch.py
+++ b/watch.py
@@ -128,6 +128,14 @@ class Watcher:
     """Ties roots → candidate files → stability → dispatch. `tick()` is the pure
     polling step (also reused to drain candidates queued by watchdog events)."""
 
+    # fable-audit round-5 #5: a file whose dispatch keeps failing (corrupt .MP4)
+    # was retried every tick forever — whisper warm-up + log spam + RAM pressure,
+    # 24/7. Back off exponentially and quarantine after N failures; a signature
+    # change (the file was re-copied / fixed) clears the record for a fresh attempt.
+    QUARANTINE_AFTER = 3
+    BASE_BACKOFF_S = 30.0
+    MAX_BACKOFF_S = 3600.0
+
     def __init__(
         self,
         roots: Sequence[Path],
@@ -141,6 +149,8 @@ class Watcher:
         self.clock = clock
         self.known: Set[str] = set()         # already-ingested resolved paths
         self._candidates: Set[str] = set()    # paths flagged by watchdog events
+        # path -> (fail_count, next_retry_at, signature_at_failure)
+        self._failures: Dict[str, Tuple[int, float, Signature]] = {}
 
     def load_known(self) -> None:
         """Seed `known` from the DB so we never re-ingest existing media."""
@@ -198,11 +208,30 @@ class Watcher:
             if not p.exists():
                 self.tracker.forget(key)
                 continue
+            # Back-off / quarantine gate (round-5 #5): a file that keeps failing
+            # dispatch must not be retried every tick. A signature change means the
+            # file was re-copied/fixed → clear the record and try fresh.
+            fail = self._failures.get(key)
+            if fail is not None:
+                fcount, retry_at, fsig = fail
+                if fsig == sig:
+                    if fcount >= self.QUARANTINE_AFTER:
+                        continue  # quarantined until the file changes
+                    if now < retry_at:
+                        continue  # still inside the back-off window
+                else:
+                    self._failures.pop(key, None)
             ok = self.dispatch(p)
             self.tracker.forget(key)
             if ok:
                 self.known.add(key)
+                self._failures.pop(key, None)
                 dispatched.append(p)
+            else:
+                prev = self._failures.get(key)
+                fcount = prev[0] + 1 if (prev and prev[2] == sig) else 1
+                backoff = min(self.MAX_BACKOFF_S, self.BASE_BACKOFF_S * (2 ** (fcount - 1)))
+                self._failures[key] = (fcount, now + backoff, sig)
         return dispatched
 
     # --- run loop (I/O shell; verified on-device, not in unit tests) ---


### PR DESCRIPTION
## Round-5 Wave 1 · R5-12 · closes #5

`watch.tick` re-dispatched a file whose ingest kept failing on **every tick**: a corrupt `.MP4` sitting in the inbox triggered a whisper warm-up + log spam + RAM pressure 24/7, because a failed dispatch never enters `known` and the safety scan re-observes it each poll.

## Fix

The `Watcher` tracks per-path `(fail_count, next_retry_at, signature)`:
- a failed dispatch is backed off exponentially (30s, 60s, 120s…, capped at 1h),
- after `QUARANTINE_AFTER=3` failures it stops retrying entirely,
- a **signature change** (the file was re-copied / fixed) clears the record for a fresh attempt.

## Test

`test_failing_file_backs_off_then_quarantines`: an always-failing file is dispatched once, skipped inside the back-off window, retried after it, quarantined after 3 failures (never retried however long we wait), then re-dispatched once its signature changes.

Full suite **725 passed, 5 skipped**. 3.9-safe (pure watch.py).

Part of the round-5 review (docs PR #134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)