### PR TITLE
fix(cache): protect thumbnails + invalidate chromadb client cache (round-5 #15/#16)

### DIFF
--- a/server.py
+++ b/server.py
@@ -2873,14 +2873,24 @@ def clear_cache(
     target: str = Query("app", description="app|thumbnails|chromadb|waveforms|all"),
     _tok: dict = Depends(require_scopes("videos_write")),
 ):
-    """Clear caches. target: app (pycache+thumbnails+waveforms), thumbnails, chromadb, waveforms, all."""
+    """Clear caches. target: app (pycache+waveforms — cheap regenerables only),
+    thumbnails, chromadb, waveforms, all.
+
+    fable-audit round-5 #16: 'app' NO LONGER clears thumbnails. media.thumbnail_path
+    and the vision frame images (*_frame*.jpg) live in the thumbnails dir and are
+    DB-referenced — a casual 'clear app cache' used to blank the whole grid + frame
+    strips and need an hours-long --refresh. Thumbnails now clear only on an explicit
+    target of 'thumbnails' or 'all'."""
     # fable-audit 2026-07-12 (#4): this is the only heavy mutating route missing the
     # M14 guard — target=chromadb/all rmtree's the whole semantic index, and as a
     # no-preflight simple POST a cross-site page could fire it under loopback-trust.
     _assert_same_site(request)
     import shutil
+    # #15: never rmtree the index out from under an active rebuild.
+    if target in ("chromadb", "all") and _embed_rebuild_active:
+        raise HTTPException(409, "語意索引重建進行中，請待完成後再清除")
     cleared = []
-    if target in ("app", "thumbnails", "all"):
+    if target in ("thumbnails", "all"):
         thumbs = config.THUMBNAILS_DIR
         if thumbs.exists():
             files = list(thumbs.iterdir())
@@ -2901,8 +2911,20 @@ def clear_cache(
             cleared.append("__pycache__")
     if target in ("chromadb", "all"):
         if config.CHROMA_PATH.exists():
-            shutil.rmtree(config.CHROMA_PATH, ignore_errors=True)
+            try:
+                # #15: drop ignore_errors — a failed clear must surface, not be
+                # silently reported as done.
+                shutil.rmtree(config.CHROMA_PATH)
+            except OSError as exc:
+                raise HTTPException(500, "清除 chromadb 失敗：{0}".format(exc))
             cleared.append("chromadb")
+        # #15: invalidate chromadb's in-process System cache so a subsequent rebuild
+        # is actually served, instead of the cached (now-deleted) index all session.
+        try:
+            import vectordb
+            vectordb.clear_client_cache()
+        except Exception:
+            pass
     return {"ok": True, "cleared": cleared}
 
 

--- a/tests/test_hardening_round4.py
+++ b/tests/test_hardening_round4.py
@@ -156,3 +156,49 @@ def test_retranscribe_all_accepts_null_language(fastapi_client):
     # null is valid (auto-detect); must not 422 at the validation layer
     resp = fastapi_client.post("/api/retranscribe-all", json={"language": None})
     assert resp.status_code != 422
+
+
+# ── round-5 #16: 'app' cache-clear must NOT nuke DB-referenced thumbnails ─────
+
+def test_cache_clear_app_preserves_thumbnails(fastapi_client, tmp_path, monkeypatch):
+    config = importlib.import_module("config")
+    thumbs = tmp_path / "thumbnails"; thumbs.mkdir()
+    (thumbs / "clip_thumb.jpg").write_bytes(b"jpg")
+    (thumbs / "clip_frame0.jpg").write_bytes(b"jpg")
+    monkeypatch.setattr(config, "THUMBNAILS_DIR", thumbs)
+
+    # 'app' clears cheap regenerables only — thumbnails survive (grid + vision intact)
+    r = fastapi_client.post("/api/cache/clear", params={"target": "app"})
+    assert r.status_code == 200
+    assert (thumbs / "clip_thumb.jpg").exists()
+    assert not any("thumbnails" in c for c in r.json()["cleared"])
+
+    # explicit target='thumbnails' still clears them
+    r = fastapi_client.post("/api/cache/clear", params={"target": "thumbnails"})
+    assert r.status_code == 200
+    assert list(thumbs.iterdir()) == []
+    assert any("thumbnails" in c for c in r.json()["cleared"])
+
+
+# ── round-5 #15: chromadb clear invalidates the in-process client cache ───────
+
+def test_cache_clear_chromadb_invalidates_client_cache(fastapi_client, tmp_path, monkeypatch):
+    config = importlib.import_module("config")
+    vectordb = importlib.import_module("vectordb")
+    chroma = tmp_path / "chroma"; chroma.mkdir()
+    (chroma / "index.bin").write_bytes(b"x")
+    monkeypatch.setattr(config, "CHROMA_PATH", chroma)
+    called = {"n": 0}
+    monkeypatch.setattr(vectordb, "clear_client_cache", lambda: called.__setitem__("n", called["n"] + 1))
+
+    r = fastapi_client.post("/api/cache/clear", params={"target": "chromadb"})
+    assert r.status_code == 200
+    assert not chroma.exists()          # index removed
+    assert called["n"] == 1             # cached System dropped so a rebuild is seen
+
+
+def test_cache_clear_refuses_chromadb_during_embed_rebuild(fastapi_client, monkeypatch):
+    import server
+    monkeypatch.setattr(server, "_embed_rebuild_active", True)  # a rebuild is mid-flight
+    r = fastapi_client.post("/api/cache/clear", params={"target": "chromadb"})
+    assert r.status_code == 409

--- a/vectordb.py
+++ b/vectordb.py
@@ -190,6 +190,21 @@ def _assert_collection_compatible(col) -> None:
 _CHROMA_LOCK = threading.Lock()
 
 
+def clear_client_cache():
+    """Drop chromadb's process-global System cache so the NEXT PersistentClient(path)
+    rebuilds from the on-disk dir. After rmtree'ing CHROMA_PATH, the cached System
+    still serves the DELETED index in-process until the server restarts — so a
+    rebuild is invisible and search returns the old deleted index all session
+    (fable-audit round-5 #15). Best-effort: a chromadb version without this API just
+    means the pre-existing restart-to-see-it behaviour, never a crash."""
+    with _CHROMA_LOCK:
+        try:
+            from chromadb.api.shared_system_client import SharedSystemClient
+            SharedSystemClient.clear_system_cache()
+        except Exception:
+            pass
+
+
 def get_collection(reset: bool = False):
     with _CHROMA_LOCK:  # audit M11
         client = chromadb.PersistentClient(path=str(CHROMA_PATH))


### PR DESCRIPTION
## Round-5 Wave 1 · R5-08 · closes #15, #16

Two ways the cache-clear button destroyed working state:

- **#16 — default 'app' nuked DB-referenced images.** The `app` target rmtree'd the thumbnails dir, which holds `media.thumbnail_path` **and** the vision frame images (`*_frame*.jpg`) — both DB-referenced. One click of "清 app 快取" blanked the whole grid + frame strips and needed an hours-long `ingest --refresh` to rebuild the frame images. `app` now clears only cheap regenerables (pycache + waveforms); thumbnails clear only on an explicit `thumbnails`/`all` target.
- **#15 — chromadb clear served the deleted index.** Clearing rmtree'd `CHROMA_PATH` but left chromadb's process-global System cache pointing at the deleted dir, so search returned the **deleted index all session** and a rebuild was invisible until restart. Now `vectordb.clear_client_cache()` drops the cached System after the rmtree; the clear is **409 while an embed rebuild is active**; and rmtree no longer passes `ignore_errors`, so a failed clear surfaces instead of falsely reporting success.

**#47** (frontend confirm on '清全部') is a UI guard — moved to the frontend wave.

## Tests (+3)

'app' preserves thumbnails while 'thumbnails' clears them; chromadb clear removes the dir **and** calls `clear_client_cache`; chromadb clear returns 409 during a rebuild.

Full suite **727 passed, 5 skipped**. 3.9-safe.

Part of the round-5 review (docs PR #134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)