### PR TITLE
feat(ingest): content-hash move-detection dedup (round-5 #8)

### DIFF
--- a/db.py
+++ b/db.py
@@ -220,7 +220,10 @@ def init_db():
         # migrations: add columns if upgrading from older schema
         for col, typ in [
             ("file_hash", "TEXT"),
-            ("hash_algo", "TEXT DEFAULT 'xxh3-128'"),
+            # fable-audit round-5 #8: the default was a bogus 'xxh3-128' — arkiv hashes
+            # with xxh3 (xxh3_64, offload.DEFAULT_HASH). ingest now writes hash_algo
+            # explicitly, so the column default only labels legacy NULL-hash rows.
+            ("hash_algo", "TEXT DEFAULT 'xxh3'"),
             ("hash_verified_at", "TEXT"),
             ("thumbnail_path", "TEXT"),
             ("rating", "TEXT"),
@@ -497,6 +500,42 @@ def is_processed(path: str) -> bool:
             variants,
         ).fetchone()
         return row is not None
+
+
+def find_moved_row(file_hash: str) -> Optional[Dict]:
+    """A media row with this content hash whose stored path NO LONGER exists on disk
+    — i.e. the file was moved/renamed, not a genuine second copy (fable-audit
+    round-5 #8, move-detection semantics). Returned so ingest can re-point the row
+    instead of re-transcribing/re-visioning the whole library after a reorg. A hash
+    match whose path STILL exists is a real duplicate and is NOT returned (it gets
+    ingested as a new row, so the original is never silently abandoned)."""
+    if not file_hash:
+        return None
+    with get_conn() as conn:
+        rows = conn.execute("SELECT * FROM media WHERE file_hash=?", (file_hash,)).fetchall()
+    for r in rows:
+        try:
+            stored = resolve_path(r["path"])
+        except ValueError:
+            continue  # a poisoned/escaping legacy path — skip, don't re-point onto it
+        if not Path(stored).exists():
+            return dict(r)
+    return None
+
+
+def repoint_media_path(media_id: int, new_abs_path: str, _conn=None) -> None:
+    """Point an existing row at a new location (the file moved). Preserves the row's
+    ratings / tags / transcript / frames — only the path changes (round-5 #8). Stored
+    in the same relative form a fresh ingest would use."""
+    new_stored = to_relative(new_abs_path)
+
+    def _do(c):
+        c.execute("UPDATE media SET path=? WHERE id=?", (new_stored, media_id))
+    if _conn is not None:
+        _do(_conn)
+    else:
+        with get_conn() as conn:
+            _do(conn)
 
 
 _ALLOWED_COLS = {

--- a/ingest.py
+++ b/ingest.py
@@ -623,11 +623,25 @@ def _apply_vision_to_frame_data(frame_data: List[Dict], frame_results: List[Dict
     return scores
 
 
-def process_file(path: Path, skip_vision: bool, existing: Optional[Dict] = None, refresh: bool = False) -> Dict:
+def _file_hash(path: Path) -> Optional[str]:
+    """xxh3 content hash of a file (offload's primitive), or None if unreadable.
+    Content-addresses each clip so a moved/renamed file is recognised instead of
+    re-ingested as a duplicate (fable-audit round-5 #8)."""
+    try:
+        import offload as _offload
+        return _offload._hash_file(path, "xxh3")
+    except OSError:
+        return None
+
+
+def process_file(path: Path, skip_vision: bool, existing: Optional[Dict] = None,
+                 refresh: bool = False, file_hash: Optional[str] = None) -> Dict:
     """
     Process one media file.
     If `existing` is provided (refresh mode), skip transcription and reuse existing
     transcript/lang — only re-run thumbnail + vision.
+    `file_hash` may be passed in (already computed for move-detection) to avoid
+    hashing the file twice; if None it is computed here.
     """
     _stage("probe", "probe")
     meta = probe(str(path))
@@ -656,6 +670,14 @@ def process_file(path: Path, skip_vision: bool, existing: Optional[Dict] = None,
         # the record below / in Phase 2 only when a real value exists.
         "processed_at": datetime.now(timezone.utc).isoformat(),
     }
+
+    # Content hash for move-detection + integrity (round-5 #8). Reuse a hash the
+    # caller already computed (move-detection pass), else compute it now. On a
+    # refresh this backfills legacy rows whose file_hash was NULL.
+    fhash = file_hash if file_hash is not None else _file_hash(path)
+    if fhash:
+        record["file_hash"] = fhash
+        record["hash_algo"] = "xxh3"
 
     # Audio transcription (skip on refresh — reuse existing)
     if meta["has_audio"] and not existing:
@@ -1564,7 +1586,7 @@ def main():
 
     import time as _time
 
-    ok, skipped, failed = 0, 0, 0
+    ok, skipped, failed, moved = 0, 0, 0, 0
     refreshed_ids = set()  # already-indexed ids re-processed this run → force re-embed
     bench_log = []  # per-file benchmark records
     batch_start = _time.time()
@@ -1583,6 +1605,23 @@ def main():
             skipped += 1
             continue
 
+        # Move-detection (round-5 #8): an UNKNOWN path whose content hash matches a
+        # row whose stored path is GONE is a moved/renamed file — re-point the
+        # existing row (keeping its ratings/tags/transcript) instead of re-ingesting
+        # the whole library as duplicates after a folder reorg. A hash match whose
+        # path still exists is a genuine second copy → fall through to a fresh
+        # ingest. The hash is reused by process_file so the file is read once.
+        file_hash = None
+        if not already and not args.refresh:
+            file_hash = _file_hash(f)
+            if file_hash:
+                mrow = db.find_moved_row(file_hash)
+                if mrow is not None:
+                    db.repoint_media_path(mrow["id"], str(f))
+                    print(f"[{i}/{len(files)}] MOVED {f.name} → re-pointed id={mrow['id']}")
+                    moved += 1
+                    continue
+
         existing = None
         if already and args.refresh:
             existing = _get_media_row_for_path(f)
@@ -1593,8 +1632,10 @@ def main():
             print(f"[{i}/{len(files)}] {f.name}", end="", flush=True)
         file_start = _time.time()
         try:
-            # Phase 1: always skip vision — will run in Phase 2
-            record = process_file(f, skip_vision=True, existing=existing, refresh=args.refresh)
+            # Phase 1: always skip vision — will run in Phase 2. Pass the hash we
+            # already computed for move-detection so the file isn't read twice.
+            record = process_file(f, skip_vision=True, existing=existing,
+                                  refresh=args.refresh, file_hash=file_hash)
             file_elapsed = _time.time() - file_start
             if record:
                 frames = record.pop("_frames", [])
@@ -1883,7 +1924,8 @@ def main():
     batch_elapsed = _time.time() - batch_start
     total_dur = sum(b["duration_s"] for b in bench_log)
 
-    print(f"\nDone. OK={ok}  skip={skipped}  fail={failed}")
+    _moved_suffix = f"  moved={moved}" if moved else ""
+    print(f"\nDone. OK={ok}  skip={skipped}  fail={failed}{_moved_suffix}")
     print(f"DB: {db.DB_PATH}")
 
     # Auto-build the vector index so semantic search + chat work immediately.

--- a/tests/test_move_detection.py
+++ b/tests/test_move_detection.py
@@ -1,0 +1,62 @@
+"""Content-hash move-detection (fable-audit round-5 #8).
+
+A moved/renamed file (unknown path, content hash matches a row whose stored path is
+GONE) must re-point the existing row — preserving its ratings/tags/transcript —
+instead of re-ingesting the whole library as duplicates after a reorg. A hash match
+whose path STILL exists is a genuine second copy and must NOT be re-pointed (the
+original is never silently abandoned) — that is the move-detection semantics Hevin
+chose over blanket content-dedup.
+"""
+import importlib
+
+
+def test_find_moved_row_detects_and_repoint_preserves_metadata(tmp_db, tmp_path, monkeypatch):
+    db = importlib.import_module("db")
+    config = importlib.import_module("config")
+    monkeypatch.setattr(config, "PROJECT_ROOT", tmp_path)  # resolve_path roots here
+
+    # a row whose stored file no longer exists on disk (the clip was moved away)
+    with db.get_conn() as c:
+        c.execute(
+            "INSERT INTO media (path, filename, ext, file_hash, hash_algo, rating) "
+            "VALUES (?,?,?,?,?,?)",
+            ("old/clip.mp4", "clip.mp4", ".mp4", "HASH123", "xxh3", "good"),
+        )
+        mid = c.execute("SELECT id FROM media WHERE file_hash=?", ("HASH123",)).fetchone()["id"]
+    db.add_tag(mid, "keeper")
+
+    row = db.find_moved_row("HASH123")
+    assert row is not None and row["id"] == mid  # old path gone → move-detected
+
+    # re-point to the new location; only the path changes
+    new_abs = tmp_path / "new" / "clip.mp4"
+    new_abs.parent.mkdir(parents=True)
+    new_abs.write_bytes(b"x")
+    db.repoint_media_path(mid, str(new_abs))
+
+    with db.get_conn() as c:
+        r = c.execute("SELECT path, rating FROM media WHERE id=?", (mid,)).fetchone()
+        tags = [t["name"] for t in c.execute("SELECT name FROM tags WHERE media_id=?", (mid,))]
+        n = c.execute("SELECT COUNT(*) AS n FROM media").fetchone()["n"]
+    assert r["path"] == "new/clip.mp4"   # stored relative to PROJECT_ROOT
+    assert r["rating"] == "good"          # ratings preserved
+    assert tags == ["keeper"]             # tags preserved
+    assert n == 1                         # re-pointed, NOT duplicated
+
+
+def test_find_moved_row_ignores_live_duplicate_and_misses(tmp_db, tmp_path, monkeypatch):
+    db = importlib.import_module("db")
+    config = importlib.import_module("config")
+    monkeypatch.setattr(config, "PROJECT_ROOT", tmp_path)
+
+    # a row whose file STILL exists on disk = a genuine second copy, not a move
+    existing = tmp_path / "here" / "clip.mp4"
+    existing.parent.mkdir(parents=True)
+    existing.write_bytes(b"x")
+    with db.get_conn() as c:
+        c.execute("INSERT INTO media (path, filename, ext, file_hash) VALUES (?,?,?,?)",
+                  ("here/clip.mp4", "clip.mp4", ".mp4", "DUP"))
+
+    assert db.find_moved_row("DUP") is None    # live path → NOT re-pointed
+    assert db.find_moved_row("") is None        # empty hash
+    assert db.find_moved_row("no-such-hash") is None


### PR DESCRIPTION
## Round-5 Wave 1 · R5-11 · closes #8 (the largest DI PR)

Dedup was **path-only** and `file_hash` was never populated (its column default was a bogus `'xxh3-128'`), so a folder reorg re-ingested the whole library as duplicates — hours of re-Whisper/vision, the old rows keeping their ratings/tags but pointing at **dead paths**, and stats double-counting.

## Fix — content-addressed clips

- `process_file` populates `media.file_hash` (xxh3) + `hash_algo='xxh3'`; the hash is computed **once** and reused (no double-read), and a refresh backfills legacy NULL-hash rows.
- Before ingesting an **unknown path**, if its content hash matches a row whose stored path is **gone**, the file was moved/renamed → `db.repoint_media_path` re-points the existing row (preserving ratings/tags/transcript/frames) instead of re-ingesting.
- Fixes the bogus `'xxh3-128'` column default → `'xxh3'`.

## Semantics — move-detection (your decision)

**Move-detection, not blanket content-dedup.** A hash match whose path **still exists** is a genuine second copy and is ingested as a new row — the original is never silently abandoned (`db.find_moved_row` only returns dead-path rows). Poisoned/escaping legacy paths are skipped, never re-pointed onto.

## Tests (`tests/test_move_detection.py`, +2)

A moved file re-points its row (ratings + tags preserved, **no duplicate row**); a live-path hash match is **not** re-pointed; empty/miss hashes return None.

Full suite **726 passed, 5 skipped**. 3.9-safe.

Part of the round-5 review (docs PR #134). **Completes Wave 1 (data safety).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)