### PR TITLE
perf(query): index media columns, chunk id IN(), bound federation fallback (round-5 #20/#21/#24)

### DIFF
--- a/db.py
+++ b/db.py
@@ -360,6 +360,16 @@ def init_db():
             "CREATE INDEX IF NOT EXISTS idx_jobs_status_priority "
             "ON jobs(status, priority, created_at)"
         )
+        # fable-audit round-5 #20: the gallery/list/search paths sorted + filtered on
+        # these media columns with ZERO indexes — every page was a full-table scan +
+        # temp B-tree sort, and tag name-lookups scanned the whole tags table. These
+        # make the common query patterns index-backed on a 100k+ row library.
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_media_processed_at ON media(processed_at)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_media_lang ON media(lang)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_media_rating ON media(rating)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_media_filename ON media(filename)")
+        # covering index for the tag subquery (WHERE name=? → media_id)
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_tags_name_media ON tags(name, media_id)")
         # Phase 9.7 G2: per-language transcript archive. media.transcript/lang/
         # segments_json/words_json stay the ACTIVE transcript (what search indexes
         # + exports use); this table keeps every transcribed language so a

--- a/federation.py
+++ b/federation.py
@@ -196,10 +196,15 @@ def _query_chroma(project: ProjectMeta, query_embeddings, limit: int) -> List[Di
 
 def _sql_like_search(conn: sqlite3.Connection, project: ProjectMeta, query: str, limit: int) -> List[Dict[str, Any]]:
     like = "%%%s%%" % query
+    # fable-audit round-5 #24: bound the fallback. Pre-fix it fetched the FULL
+    # transcript of EVERY match with no LIMIT — an embedder outage + a common CJK
+    # token on a big library pulled hundreds of MB per project and pinned workers.
+    # LIMIT caps the rows; substr keeps only the excerpt this function actually uses.
     rows = conn.execute(
-        "SELECT id, path, filename, duration_s, rating, lang, ext, transcript "
-        "FROM media WHERE filename LIKE ? OR transcript LIKE ? ORDER BY id",
-        (like, like),
+        "SELECT id, path, filename, duration_s, rating, lang, ext, "
+        "substr(transcript, 1, 300) AS transcript "
+        "FROM media WHERE filename LIKE ? OR transcript LIKE ? ORDER BY id LIMIT ?",
+        (like, like, limit),
     ).fetchall()
     seen = set()
     results = []

--- a/server.py
+++ b/server.py
@@ -1130,13 +1130,21 @@ def _get_light_records_by_ids(media_ids) -> list:
     ids = [int(m) for m in media_ids]
     if not ids:
         return []
-    placeholders = ",".join("?" * len(ids))
+    # fable-audit round-5 #21: chunk the IN() so a broad structured/semantic query
+    # (thousands of matching ids) doesn't blow past SQLite's max variable count
+    # (999 on old builds) → "too many SQL variables" HTTP 500.
+    by_id = {}
+    _CHUNK = 500
     with db.get_conn() as conn:
-        rows = conn.execute(
-            f"SELECT {db.LIGHT_COLS} FROM media WHERE id IN ({placeholders})",
-            ids,
-        ).fetchall()
-    by_id = {r["id"]: dict(r) for r in rows}
+        for start in range(0, len(ids), _CHUNK):
+            chunk = ids[start:start + _CHUNK]
+            placeholders = ",".join("?" * len(chunk))
+            rows = conn.execute(
+                f"SELECT {db.LIGHT_COLS} FROM media WHERE id IN ({placeholders})",
+                chunk,
+            ).fetchall()
+            for r in rows:
+                by_id[r["id"]] = dict(r)
     return [by_id[i] for i in ids if i in by_id]
 
 

--- a/tests/test_query_scale.py
+++ b/tests/test_query_scale.py
@@ -1,0 +1,38 @@
+"""Query-scale hardening (fable-audit round-5 #20/#21).
+
+#21: a broad structured/semantic query can match thousands of ids; the id→record
+fetch must chunk its IN() so it never exceeds SQLite's max variable count.
+#20: the common gallery/search columns must be indexed.
+"""
+import importlib
+
+
+def test_light_records_chunks_large_id_list(server_module):
+    """#21: >500 ids are fetched across chunks, preserving input order with no drops
+    or duplicates (pre-fix a single unbounded IN() risked 'too many SQL variables')."""
+    db = importlib.import_module("db")
+    import server
+
+    N = 1200  # spans multiple 500-id chunks
+    with db.get_conn() as c:
+        c.executemany(
+            "INSERT INTO media (path, filename, ext) VALUES (?,?,?)",
+            [("scale/p{0}.mp4".format(i), "f{0}.mp4".format(i), ".mp4") for i in range(N)],
+        )
+        ids = [r["id"] for r in c.execute("SELECT id FROM media ORDER BY id").fetchall()]
+    assert len(ids) == N
+
+    ordered = list(reversed(ids))  # arbitrary order → must be preserved
+    recs = server._get_light_records_by_ids(ordered)
+    assert [r["id"] for r in recs] == ordered
+
+
+def test_query_indexes_created(tmp_db):
+    """#20: init_db creates the media/tags query indexes."""
+    db = importlib.import_module("db")
+    with db.get_conn() as c:
+        names = {r["name"] for r in c.execute(
+            "SELECT name FROM sqlite_master WHERE type='index'").fetchall()}
+    for name in ("idx_media_processed_at", "idx_media_lang", "idx_media_rating",
+                 "idx_media_filename", "idx_tags_name_media"):
+        assert name in names, "missing index {0}".format(name)


### PR DESCRIPTION
## Round-5 Wave 2 · R5-13 · closes #20, #21, #24

Three scale defects that bite a real (100k+ row, TB) library:

- **#20 — zero indexes.** `init_db` had no index on any media/tags query column, so every gallery page was a full-table scan + temp B-tree sort and tag lookups scanned the whole tags table. Adds indexes on `media(processed_at/lang/rating/filename)` + a covering `idx_tags_name_media(name, media_id)`.
- **#21 — unbounded IN() → HTTP 500.** `/api/search/query` materialized ALL matching ids and `_get_light_records_by_ids` built one `IN()` over them — a broad query (thousands of matches) exceeded SQLite's max variable count (999 on old builds) → *"too many SQL variables"*. The fetch now **chunks the IN() at 500 ids**, preserving input order.
- **#24 — unbounded federation fallback.** The SQL fallback (embedder outage) SELECTed the **full transcript of every match with no LIMIT** — a common CJK token on a big library pulled hundreds of MB per project and pinned workers. Now `LIMIT ?` + `substr(transcript, 1, 300)`.

## Tests (+2, federation suite still green)

1200-id fetch preserves order across chunks with no drops/dupes; the query indexes exist after `init_db`.

Full suite **726 passed, 5 skipped**. 3.9-safe.

Part of the round-5 review (docs PR #134). First Wave-2 (performance) PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)