### PR TITLE
perf(payload): trim media-detail, single-pass stats, ids-only embed reconcile (round-5 #26/#27/#31)

### DIFF
--- a/db.py
+++ b/db.py
@@ -723,29 +723,27 @@ def set_canonical_tags(media_id: int, tags: list) -> None:
 def get_stats() -> Dict:
     """Aggregate stats for sidebar and dashboard."""
     with get_conn() as conn:
-        total = conn.execute("SELECT COUNT(*) FROM media").fetchone()[0]
-        with_transcript = conn.execute(
-            "SELECT COUNT(*) FROM media WHERE transcript IS NOT NULL"
-        ).fetchone()[0]
-        with_thumb = conn.execute(
-            "SELECT COUNT(*) FROM media WHERE thumbnail_path IS NOT NULL"
-        ).fetchone()[0]
-        total_duration = conn.execute(
-            "SELECT COALESCE(SUM(duration_s), 0) FROM media"
-        ).fetchone()[0]
-        total_size = conn.execute(
-            "SELECT COALESCE(SUM(size_mb), 0) FROM media"
-        ).fetchone()[0]
+        # fable-audit round-5 #27: fold five separate full-table scans into ONE
+        # single-pass aggregate. COUNT(col) counts non-NULL values, i.e. it equals
+        # COUNT(*) WHERE col IS NOT NULL — so with_transcript / with_thumb come free.
+        agg = conn.execute(
+            "SELECT COUNT(*) AS total, "
+            "COUNT(transcript) AS with_transcript, "
+            "COUNT(thumbnail_path) AS with_thumb, "
+            "COALESCE(SUM(duration_s), 0) AS total_duration, "
+            "COALESCE(SUM(size_mb), 0) AS total_size "
+            "FROM media"
+        ).fetchone()
         langs = conn.execute(
             "SELECT lang, COUNT(*) as cnt FROM media "
             "WHERE lang IS NOT NULL GROUP BY lang ORDER BY cnt DESC"
         ).fetchall()
         return {
-            "total": total,
-            "with_transcript": with_transcript,
-            "with_thumb": with_thumb,
-            "total_duration_s": total_duration,
-            "total_size_mb": total_size,
+            "total": agg["total"],
+            "with_transcript": agg["with_transcript"],
+            "with_thumb": agg["with_thumb"],
+            "total_duration_s": agg["total_duration"],
+            "total_size_mb": agg["total_size"],
             "langs": {r["lang"]: r["cnt"] for r in langs},
         }
 

--- a/embed.py
+++ b/embed.py
@@ -50,9 +50,17 @@ def get_records_by_ids(ids: List[int]) -> List[Dict]:
 
 
 def get_indexed_media_ids(col) -> set[str]:
-    """Return set of media_ids already in ChromaDB."""
-    result = col.get(include=["metadatas"])
-    return {m["media_id"] for m in result["metadatas"]}
+    """media_ids already in ChromaDB, derived from chunk-id PREFIXES.
+
+    fable-audit round-5 #31: pulling include=["metadatas"] fetched every chunk's
+    full metadata (hundreds of MB for 150-250k chunks) on EVERY reconcile — including
+    no-op watch runs — just to build an id set. Chunk ids are '{media_id}_t{i}' /
+    '{media_id}_f0' (vectordb.build/upsert) and media ids are integers (no '_'), so
+    the prefix before the first '_' is the media_id. include=[] returns only the ids.
+    Returned as strings, matching the reconcile diff's str(id) comparisons."""
+    result = col.get(include=[])
+    ids = result.get("ids") or []
+    return {cid.split("_", 1)[0] for cid in ids}
 
 
 def run_embed(rebuild: bool = False, force_ids=None, prune: bool = True) -> dict:

--- a/server.py
+++ b/server.py
@@ -1467,6 +1467,13 @@ def get_media_detail(
             rec["canonical_tags"] = json.loads(rec["canonical_tags"])
         except Exception:
             rec["canonical_tags"] = None
+    # fable-audit round-5 #26 (codex-verified): words_json (word-level timing JSON,
+    # multi-MB) has NO frontend consumer here — the inspector's transcript seek uses
+    # segments_json (kept), and word-level data is served separately via
+    # /api/media/{id}/remotion-props. Drop only words_json from this per-click
+    # response so it isn't shipped over NAS/Tailscale on every arrow-key. The shared
+    # db.get_record_by_id is untouched (export/retranscribe/remotion still need it).
+    rec.pop("words_json", None)
     return rec
 
 

--- a/tests/test_payload_diet.py
+++ b/tests/test_payload_diet.py
@@ -1,0 +1,56 @@
+"""Payload-diet perf fixes (fable-audit round-5 #26/#27/#31)."""
+import importlib
+
+
+def test_media_detail_drops_words_json_keeps_segments(fastapi_client):
+    """#26 (codex-verified): the per-click media-detail response drops words_json
+    (multi-MB, no frontend consumer — word data is served via /remotion-props) but
+    KEEPS segments_json, which the inspector's transcript seek uses."""
+    db = importlib.import_module("db")
+    with db.get_conn() as c:
+        c.execute(
+            "INSERT INTO media (path, filename, ext, transcript, segments_json, words_json) "
+            "VALUES (?,?,?,?,?,?)",
+            ("m.mp4", "m.mp4", ".mp4", "hi",
+             '[{"start":0,"end":1,"text":"hi"}]', '[{"word":"hi","start":0}]'),
+        )
+    r = fastapi_client.get("/api/media/1")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "words_json" not in body       # dropped from the per-click response
+    assert "segments_json" in body         # kept — inspector seek depends on it
+
+
+def test_get_stats_single_pass_aggregate(server_module):
+    """#27: get_stats folds five full-table scans into one; the output is unchanged."""
+    db = importlib.import_module("db")
+    with db.get_conn() as c:
+        c.executemany(
+            "INSERT INTO media (path, filename, ext, transcript, thumbnail_path, "
+            "duration_s, size_mb, lang) VALUES (?,?,?,?,?,?,?,?)",
+            [
+                ("a.mp4", "a", ".mp4", "t", "th.jpg", 10.0, 5.0, "zh"),
+                ("b.mp4", "b", ".mp4", None, None, 20.0, 3.0, "en"),
+                ("c.mp4", "c", ".mp4", "t2", "th2.jpg", 5.0, 1.0, "zh"),
+            ],
+        )
+    s = db.get_stats()
+    assert s["total"] == 3
+    assert s["with_transcript"] == 2       # a, c (COUNT(transcript) = non-NULL)
+    assert s["with_thumb"] == 2            # a, c
+    assert s["total_duration_s"] == 35.0
+    assert s["total_size_mb"] == 9.0
+    assert s["langs"] == {"zh": 2, "en": 1}
+
+
+def test_get_indexed_media_ids_from_chunk_prefixes():
+    """#31: reconcile derives media_ids from chunk-id prefixes (ids-only fetch) instead
+    of pulling every chunk's metadata."""
+    embed = importlib.import_module("embed")
+
+    class FakeCol:
+        def get(self, include=None, limit=None):
+            assert include == []           # ids-only — no heavy metadata pull
+            return {"ids": ["12_t0", "12_t1", "12_f0", "7_t0"]}
+
+    assert embed.get_indexed_media_ids(FakeCol()) == {"12", "7"}


### PR DESCRIPTION
## Round-5 Wave 2 · R5-14 · closes #26, #27, #31

Three payload/scan wins on the hot dashboard + inspector + ingest paths:

- **#26 — media-detail shipped multi-MB word JSON per click (Codex-verified).** `GET /api/media/{id}` returned the full `words_json` on every inspector click / arrow-key over NAS/Tailscale. A Codex investigation confirmed `words_json` has **no frontend consumer** here (word-level data is served separately via `/remotion-props`) while `segments_json` **is** used by the inspector's transcript seek (`MainLive.svelte:451-458`, `Inspector.svelte:331-335`). So drop **only** `words_json`, at the endpoint response level — the shared `db.get_record_by_id` is untouched (export / retranscribe / remotion still need both fields).
- **#27 — five scans per /api/stats.** `get_stats` ran five separate full-table scans. Folded into **one** single-pass aggregate (`COUNT(col)` counts non-NULL → `with_transcript`/`with_thumb` come free); output shape unchanged.
- **#31 — reconcile pulled all metadata.** Embed reconcile used `include=["metadatas"]` — every chunk's full metadata (hundreds of MB for 150-250k chunks) on every run, including no-op watch runs — just to build an id set. Now `include=[]` (ids only) + derive `media_id` from the `{media_id}_t{i}` / `{media_id}_f0` chunk-id prefix, returned as strings to match the reconcile diff's `str(id)` comparisons.

**#25 (collections cache) deferred:** the proposed `(MAX id, COUNT, MAX processed_at)` key goes stale on a rating/tag edit that changes membership — needs an invalidation design, tracked separately.

## Collaboration

The #26 safe-scope determination (drop `words_json` only, not `segments_json`) came from an independent **Codex** investigation of the frontend coupling — it caught that stripping both would break inspector seek.

## Tests (+3)

media-detail drops `words_json` / keeps `segments_json`; `get_stats` aggregates correctly; reconcile derives ids from chunk prefixes.

Full suite **727 passed, 5 skipped**. 3.9-safe.

Part of the round-5 review (docs PR #134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)