### PR TITLE
perf(bins): batch bin-detail status probe by project (round-5 #23)

### DIFF
--- a/bins.py
+++ b/bins.py
@@ -335,6 +335,70 @@ def bin_item_status(project_name: str, media_id: Any) -> str:
             conn.close()
 
 
+def bin_item_statuses(items) -> Dict[Any, str]:
+    """Batch of bin_item_status keyed by (project_name, str(media_id)).
+
+    fable-audit round-5 #23: calling bin_item_status per item did a registry read +
+    health probe + fresh SQLite connection PER ITEM — a 200-item NAS bin cost ~200×
+    (discover + health + open) on every bin open and every add/remove. This groups
+    items by project and pays that cost ONCE per project, fetching all of a project's
+    rows with a single WHERE id IN (...). `items` is any iterable exposing
+    project_name + media_id (bin items or (name, id) tuples)."""
+    from projects import discover_projects
+    from health import project_health, HealthStatus
+    from federation import _connect_project_db, _resolve_paths
+
+    by_project: Dict[str, list] = {}
+    for it in items:
+        pn = it.project_name if hasattr(it, "project_name") else it[0]
+        mid = it.media_id if hasattr(it, "media_id") else it[1]
+        by_project.setdefault(pn, []).append(str(mid))
+
+    result: Dict[Any, str] = {}
+    projects_by_name = {p.name: p for p in discover_projects()}  # ONE registry read
+
+    for pn, mids in by_project.items():
+        project = projects_by_name.get(pn)
+        if project is None:
+            for mid in mids:
+                result[(pn, mid)] = STATUS_PROJECT_UNREGISTERED
+            continue
+        health = project_health(project)  # ONE health probe per project
+        if health != HealthStatus.OK:
+            hv = health.value if isinstance(health, HealthStatus) else str(health)
+            for mid in mids:
+                result[(pn, mid)] = hv
+            continue
+        conn = None
+        try:
+            conn = _connect_project_db(project)  # ONE connection per project
+            placeholders = ",".join("?" * len(mids))
+            rows = {
+                str(r["id"]): r
+                for r in conn.execute(
+                    "SELECT id, path FROM media WHERE id IN ({0})".format(placeholders),
+                    mids,
+                ).fetchall()
+            }
+            for mid in mids:
+                row = rows.get(mid)
+                if row is None:
+                    result[(pn, mid)] = STATUS_ROW_MISSING
+                    continue
+                _relative, absolute = _resolve_paths(project, row["path"] or "")
+                if not absolute or not os.path.exists(absolute):
+                    result[(pn, mid)] = STATUS_FILE_MISSING
+                else:
+                    result[(pn, mid)] = STATUS_OK
+        except Exception:
+            for mid in mids:
+                result.setdefault((pn, mid), STATUS_ERROR)
+        finally:
+            if conn is not None:
+                conn.close()
+    return result
+
+
 def resolve_source(project_name: str, media_id: Any) -> Optional[Dict[str, Any]]:
     """Server-side ONLY: (project_name, media_id) → {absolute_path, filename,
     status}. The absolute path is for the copy orchestrator (server.py); never

--- a/server.py
+++ b/server.py
@@ -719,9 +719,12 @@ def _bin_detail_payload(b) -> dict:
     """Bin + per-item reachability status. The status probe re-resolves the source
     server-side; only the enum + basename filename + project_name reach the client
     (Phase 16.2 — no absolute path ever leaves the backend)."""
+    # fable-audit round-5 #23: one batched status probe (grouped by project) instead
+    # of a per-item registry read + health probe + sqlite open.
+    statuses = bins_store.bin_item_statuses(b.items)
     items = []
     for item in b.items:
-        status = bins_store.bin_item_status(item.project_name, item.media_id)
+        status = statuses.get((item.project_name, str(item.media_id)), bins_store.STATUS_ERROR)
         items.append({
             "project_name": item.project_name,
             "media_id": item.media_id,

--- a/tests/test_bins.py
+++ b/tests/test_bins.py
@@ -139,6 +139,38 @@ def test_status_row_missing(tmp_path, monkeypatch):
     assert bins.bin_item_status("libB", "999") == bins.STATUS_ROW_MISSING
 
 
+def test_bin_item_statuses_batches_one_registry_read_and_matches(tmp_path, monkeypatch):
+    """fable-audit round-5 #23: the batched status probe groups by project — ONE
+    registry read for the whole bin (not per item) — and returns the same status
+    each per-item bin_item_status would."""
+    bins = _fresh_bins(tmp_path, monkeypatch)
+    rootA = _make_project(tmp_path, "libA", make_file=True)
+    rootB = _make_project(tmp_path, "libB", make_file=True)
+    _register(tmp_path, monkeypatch, "libA", rootA)
+    _register(tmp_path, monkeypatch, "libB", rootB)
+
+    import projects
+    calls = {"n": 0}
+    real_discover = projects.discover_projects
+
+    def counting_discover(*a, **k):
+        calls["n"] += 1
+        return real_discover(*a, **k)
+    monkeypatch.setattr(projects, "discover_projects", counting_discover)
+
+    items = [("libA", "1"), ("libB", "1"), ("libB", "999"), ("ghost", "1")]
+    res = bins.bin_item_statuses(items)
+    assert res[("libA", "1")] == bins.STATUS_OK
+    assert res[("libB", "1")] == bins.STATUS_OK
+    assert res[("libB", "999")] == bins.STATUS_ROW_MISSING
+    assert res[("ghost", "1")] == bins.STATUS_PROJECT_UNREGISTERED
+    assert calls["n"] == 1  # ONE registry read for the whole batch, not per item
+
+    # parity with the per-item probe (this loop itself re-reads the registry)
+    for pn, mid in items:
+        assert res[(pn, mid)] == bins.bin_item_status(pn, mid)
+
+
 def test_status_file_missing(tmp_path, monkeypatch):
     bins = _fresh_bins(tmp_path, monkeypatch)
     # row exists but the referenced file is never created on disk


### PR DESCRIPTION
## Round-5 Wave 2 · R5-16 · closes #23

`_bin_detail_payload` called `bin_item_status` **per item**, and each call did a registry read (`discover_projects`) + a project health probe + a **fresh per-project SQLite connection**. A 200-item cross-project bin therefore cost ~200× (discover + health + open) on **every bin open AND every add/remove** — N+1 across processes over a NAS mount.

## Fix

New `bins.bin_item_statuses(items)` groups items by project and pays that cost **once per project**: one registry read for the whole batch, one health probe + one connection per project, and a single `WHERE id IN (...)` fetch. `_bin_detail_payload` uses it. Per-item status semantics are unchanged.

## Test

A mixed batch (reachable / row-missing / unregistered-project) returns the **same** statuses the per-item probe would, with exactly **one** registry read for the whole bin (asserted via a call counter).

Full suite **725 passed, 5 skipped**. 3.9-safe.

Part of the round-5 review (docs PR #134). Completes Wave 2's independent perf PRs (with R5-13/R5-14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)