### PR TITLE
perf(ingest): drop heavy transcript JSON from Phase-1→2 retained record (round-5 #28)

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -1693,6 +1693,15 @@ def main():
                                 )
                 # Queue for Phase 2 vision
                 if frames and need_vision:
+                    # fable-audit round-5 #28: the FULL record (transcript +
+                    # segments_json + words_json) is already persisted by the Phase-1
+                    # upsert above, and Phase 2 reads the record only for _auto_tags
+                    # (codex-verified) — so drop the heavy transcript JSON before
+                    # retaining it, or an interview-heavy batch pins 100-300MB of dead
+                    # strings in RAM through the entire vision + proxy passes while
+                    # Ollama runs. duration_s etc. stay for the bench line below.
+                    for _heavy in ("transcript", "segments_json", "words_json"):
+                        record.pop(_heavy, None)
                     phase1_results[str(f)] = (record, frames)
 
                 dur = record.get("duration_s", 0)


### PR DESCRIPTION
## Round-5 Wave 2 · R5-15 · closes #28 (#29 deferred)

ingest Phase 1 stored `phase1_results[path] = (record, frames)` where `record` still carried the full `transcript` + `segments_json` + `words_json`, held in RAM through the entire Phase 2 (vision) + Phase 3 (proxy) passes. An interview-heavy batch pinned **100–300MB of dead strings** while Ollama ran → swap pressure on the 16GB box.

## Fix

The full record is already persisted by the Phase-1 upsert immediately above, and Phase 2 reads the retained record **only** for `_auto_tags` (**Codex-verified**: Phase 2 mutates frames + `media.frame_tags`/`editability_score`, never re-reads the transcript; Phase 3 re-queries SQLite directly). So drop `transcript`/`segments_json`/`words_json` from the retained record before queueing it. `duration_s` etc. stay for the bench line.

## #29 deferred

The in-process retranscribe pinning whisper weights (#29) is a bigger change: Codex confirmed the **MLX path (what runs on Mac) has no visible model handle** to `unload()`, so the real fix is shelling the retranscribe out to a subprocess (frees on exit) with a **new JSON CLI mode** on `transcribe.py` (its current CLI prints only text, losing lang/segments/words). Tracked as a follow-up.

## Testing

Covered by the existing ingest pipeline tests — the trim doesn't change DB persistence (the record is already upserted), only what's retained in memory after it. Not unit-testable in isolation without the full whisper/ffmpeg pipeline. Full suite **725 passed, 5 skipped**. 3.9-safe.

Part of the round-5 review (docs PR #134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)