### PR TITLE
fix(frontend): stale-response guards on bin + search loaders (round-5 #35/#36)

### DIFF
--- a/frontend/src/routes/Bins.svelte
+++ b/frontend/src/routes/Bins.svelte
@@ -59,11 +59,19 @@
 
   async function select(id) {
     activeId = id
+    detail = null
     loading = true
     try {
-      detail = await api.getBin(id)
-    } catch (e) { pushToast('讀取精選集失敗: ' + e.message, 'error'); detail = null }
-    loading = false
+      const d = await api.getBin(id)
+      // round-5 #35: ignore a stale response — if the user clicked another bin
+      // while this one's (slow NAS) detail was in flight, activeId has moved on and
+      // assigning would show bin A's items under bin B (and mutations would hit the
+      // wrong bin). Mirrors MainLive.fetchDetail's guard.
+      if (activeId === id) detail = d
+    } catch (e) {
+      if (activeId === id) { pushToast('讀取精選集失敗: ' + e.message, 'error'); detail = null }
+    }
+    if (activeId === id) loading = false
   }
 
   async function create() {

--- a/frontend/src/routes/Bins.svelte
+++ b/frontend/src/routes/Bins.svelte
@@ -87,8 +87,14 @@
   }
 
   async function removeItem(it) {
+    // round-5 #35 (codex): act on the bin currently SHOWN (detail.id), and ignore
+    // the response if the user switched bins mid-removal — else the old bin's
+    // updated detail renders under the newer selection.
+    const id = detail && detail.id
+    if (!id) return
     try {
-      detail = await api.removeBinItem(activeId, it.project_name, it.media_id)
+      const d = await api.removeBinItem(id, it.project_name, it.media_id)
+      if (activeId === id) detail = d
       loadBins() // refresh counts
     } catch (e) { pushToast('移除失敗: ' + e.message, 'error') }
   }
@@ -134,9 +140,13 @@
       if (!existingProj) { pushToast('請選目的專案', 'error'); return }
       body.dest = existingProj
     }
+    // round-5 #35 (codex): copy the bin whose detail is OPEN (detail.id), not
+    // whichever bin happens to be active at click time.
+    const binId = detail && detail.id
+    if (!binId) { pushToast('請先選一個精選集', 'error'); return }
     copyRunning = true; copyLog = []; copySummary = null
     try {
-      const res = await api.copyBin(activeId, body)
+      const res = await api.copyBin(binId, body)
       const reader = res.body.getReader()
       const dec = new TextDecoder()
       let buf = ''
@@ -155,7 +165,7 @@
         const s = copySummary
         pushToast(`複製完成 → ${s.dest}：${s.copied} 支${s.skipped.length ? '，略過 ' + s.skipped.length : ''}`)
       }
-      loadBins(); if (activeId) select(activeId)
+      loadBins(); select(binId)
     } catch (e) { pushToast('複製失敗: ' + e.message, 'error') }
     copyRunning = false
   }
@@ -164,12 +174,15 @@
   let renameVal = ''
   function startRename() { renameVal = detail.name; renaming = true }
   async function saveRename() {
+    // round-5 #35 (codex): rename the bin being edited (detail.id), not whichever
+    // bin is active if the user switched selection while the rename box was open.
+    const binId = detail && detail.id
     const name = renameVal.trim()
-    if (!name || name === detail.name) { renaming = false; return }
+    if (!binId || !name || name === detail.name) { renaming = false; return }
     try {
-      await api.renameBin(activeId, name)
+      await api.renameBin(binId, name)
       renaming = false
-      await loadBins(); await select(activeId)
+      await loadBins(); await select(binId)
       pushToast('已改名')
     } catch (e) { pushToast('改名失敗: ' + e.message, 'error') }
   }

--- a/frontend/src/routes/SearchLive.svelte
+++ b/frontend/src/routes/SearchLive.svelte
@@ -133,10 +133,18 @@
   }
 
   // Current-project search (/api/media?q=) → one group of openable rows.
-  async function runCurrent(q) {
+  // round-5 #36: monotonic search sequence. Toggling Current ↔ federated (or
+  // re-searching) while a request is in flight must not let the STALE response
+  // paint over the newer one — a slow /api/search/all resolving after a fast
+  // Current-only search used to clobber `groups` with contradictory, unclickable
+  // rows. Each run captures its seq and bails on assignment if superseded.
+  let _searchSeq = 0
+
+  async function runCurrent(q, mySeq) {
     const params = { q, limit: 40 }
     if (mediaType !== 'all') params.media_type = mediaType
     const r = await api.getMedia(params)
+    if (mySeq !== _searchSeq) return  // superseded by a newer search
     total = r.total ?? (r.items || []).length
     const items = (r.items || []).map((it) => ({
       id: it.id,
@@ -155,8 +163,9 @@
   }
 
   // Federated search (/api/search/all) → one group per project, read-only rows.
-  async function runFederated(q) {
+  async function runFederated(q, mySeq) {
     const r = await api.search(q, { limit: 40 })
+    if (mySeq !== _searchSeq) return  // superseded by a newer search
     total = r.total_results ?? (r.items || []).length
     projectsQueried = r.projects_queried ?? 0
     projectsFailed = r.projects_failed ?? 0
@@ -184,16 +193,19 @@
 
   async function runSearch() {
     const q = query.trim()
-    if (!q) { state = 'idle'; groups = []; total = 0; fedErrors = []; return }
+    if (!q) { _searchSeq++; state = 'idle'; groups = []; total = 0; fedErrors = []; return }
+    const mySeq = ++_searchSeq  // round-5 #36: claim this run's sequence
     state = 'loading'
     syncHash()
     const t0 = performance.now()
     try {
-      if (crossProject) await runFederated(q)
-      else await runCurrent(q)
+      if (crossProject) await runFederated(q, mySeq)
+      else await runCurrent(q, mySeq)
+      if (mySeq !== _searchSeq) return  // a newer search superseded us — don't flip state
       elapsedMs = Math.round(performance.now() - t0)
       state = 'ok'
     } catch (e) {
+      if (mySeq !== _searchSeq) return
       state = 'error'
       err = e.message + (e.body ? ' · ' + JSON.stringify(e.body) : '')
     }


### PR DESCRIPTION
## Round-5 Wave 3 · R5-18 · closes #35, #36 (#41 deferred)

Two async loaders painted a **stale** response over a newer selection:

- **#35 Bins.select** assigned `detail = await api.getBin(id)` with no check that the user hadn't clicked another bin while the (slow NAS) request was in flight — bin A's items would render under bin B, and remove/rename would then hit the **wrong bin**. Now guarded by `if (activeId === id)` after the await (mirrors `MainLive.fetchDetail`'s existing guard) + clears `detail` on switch.
- **#36 SearchLive** — toggling Current ↔ federated (or re-searching) let a slow `/api/search/all` response resolve **after** a fast Current-only search and clobber `groups` with contradictory, unclickable rows. A monotonic `_searchSeq` is claimed per run; `runCurrent`/`runFederated` bail on assignment if superseded, and `runSearch` won't flip state for a stale run.

**#41** (MainLive `load()`/`runSearch()`/`loadIds()` 3-way race) deferred to a focused follow-up — larger surface.

## Testing

Frontend has no CI unit tests — verified via `npm run build` (green). The seq-guard logic is under independent **Codex** review (this repo's frontend can't be unit-tested in CI).

Part of the round-5 review (docs PR #134). First Wave-3 (frontend) PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)