### PR TITLE
fix(frontend): surface API errors — ApiError detail + silent mutation catches (round-5 #49/#43)

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -20,7 +20,14 @@ export function setToken(t) {
 
 class ApiError extends Error {
   constructor(status, path, body) {
-    super(`arkiv API ${status} on ${path}`)
+    // round-5 #49: fold the backend's FastAPI `detail` into the message so every
+    // toast that shows e.message surfaces WHY it failed (e.g. "找不到媒體檔案") instead
+    // of an opaque "arkiv API 500 on /path". body is usually {detail: "..."}.
+    const detail = body && typeof body === 'object' ? body.detail : body
+    const suffix = detail
+      ? `：${typeof detail === 'string' ? detail : JSON.stringify(detail)}`
+      : ''
+    super(`arkiv API ${status} on ${path}${suffix}`)
     this.status = status
     this.path = path
     this.body = body

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -418,7 +418,7 @@
     try {
       await api.activateTranscript(selected.id, lang)
       await Promise.all([fetchDetail(selected.id), fetchTranscripts(selected.id)])
-    } catch (e) { err = `切換主要語言失敗: ${e.message}` }
+    } catch (e) { pushToast(`切換主要語言失敗: ${e.message}`, 'error') }  // round-5 #43
   }
 
   // Real audio waveform peaks (0..1) from the backend ffmpeg endpoint — fetched
@@ -500,7 +500,7 @@
       const r = await api.addTag(id, n)
       if (detail && detail.id === id) detail = { ...detail, tags: r.tags }
     } catch (e) {
-      err = `加標籤失敗: ${e.message}`
+      pushToast(`加標籤失敗: ${e.message}`, 'error')  // round-5 #43
     }
   }
   async function removeTag(name) {
@@ -516,7 +516,7 @@
       if (detail && detail.id === id) detail = { ...detail, tags: r.tags }
     } catch (e) {
       if (detail && detail.id === id && prev) detail = { ...detail, tags: prev }
-      err = `刪標籤失敗: ${e.message}`
+      pushToast(`刪標籤失敗: ${e.message}`, 'error')  // round-5 #43 — was a silent revert
     }
   }
 
@@ -570,7 +570,7 @@
     } catch (e) {
       // revert on failure
       items = items.map((m) => (m.id === id ? { ...m, rating: prev } : m))
-      err = `rating 寫入失敗: ${e.message}`
+      pushToast(`rating 寫入失敗: ${e.message}`, 'error')  // round-5 #43 — was a silent revert
     }
   }
 </script>


### PR DESCRIPTION
## Round-5 Wave 3 · R5-19 · closes #49, #43 (#42/#44/#47/#40 deferred)

- **#49 — opaque error toasts.** `ApiError`'s message was `arkiv API 500 on /path` — the actionable FastAPI `detail` was stored on the error but never shown. Fold `body.detail` into the message so every toast that renders `e.message` (~20 call sites) surfaces **why** it failed, in one change.
- **#43 — silent mutation failures.** `rate()` / `addTag()` / `removeTag()` / `onActivateLang()` in MainLive caught errors by assigning a **never-rendered `err`** var, so a failed rating/tag/language write silently reverted with zero feedback (the B11 anti-pattern `toast.js` exists to kill). All four now `pushToast('…', 'error')`.

**Deferred** to a focused follow-up (span SettingsLive/ChatLive, need more care): #42 retranscribe-status poll backoff, #44 project-delete confirm, #47 '清全部' confirm, #40 tokened Smart-Collection thumbnails.

## Testing

`npm run build` green. Frontend has no CI unit tests.

Part of the round-5 review (docs PR #134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)