### PR TITLE
fix(vision): thread fallback model through _call_vision — kill dead VISION_MODEL global (round-5 #50)

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -815,15 +815,14 @@ def _describe_frames_with_fallback(frame_paths):
             print(f" [Phase 1: {len(failed_indices)} failed, fallback '{fallback_model or 'none'}' 未安裝 → 跳過]", end="", flush=True)
         else:
             print(f" [Phase 1: {len(failed_indices)} failed, trying fallback {fallback_model}]", end="", flush=True)
-            original_model = vis.VISION_MODEL
-            try:
-                vis.VISION_MODEL = fallback_model
-                retry_results = vis.describe_frames([frame_paths[i] for i in failed_indices])
-                for idx, retry_r in zip(failed_indices, retry_results):
-                    if retry_r.get("description") and not retry_r.get("error"):
-                        frame_results[idx] = retry_r
-            finally:
-                vis.VISION_MODEL = original_model
+            # Pass the fallback model explicitly so _call_vision actually runs it
+            # (round-5 #50: the old vis.VISION_MODEL swap was dead — _call_vision
+            # re-read the model from settings, so the fallback re-ran the primary).
+            retry_results = vis.describe_frames(
+                [frame_paths[i] for i in failed_indices], model=fallback_model)
+            for idx, retry_r in zip(failed_indices, retry_results):
+                if retry_r.get("description") and not retry_r.get("error"):
+                    frame_results[idx] = retry_r
     still_failed = [i for i, vr in enumerate(frame_results) if vr.get("error") or not vr.get("description")]
     return frame_results, still_failed
 

--- a/server.py
+++ b/server.py
@@ -56,13 +56,6 @@ from state import (  # noqa: F401  (re-exported for backward compat)
 # inside route handlers (and a test writes the raw flag), so they need a
 # mutable-container refactor rather than a plain import to move to state.py.
 
-# audit M9 (partial): vision.VISION_MODEL is module-global, so two concurrent
-# retry-vision calls could interleave their save/swap/restore and permanently
-# pin the fallback model as "primary" (silent quality degradation). Serializing
-# the swap window removes the race; the full fix (pass the model as a
-# describe_frames parameter) needs a vision.py signature change.
-_vision_fallback_lock = _threading.Lock()
-
 # audit M8: single-flight for the embed rebuild — double-clicking the rebuild
 # button used to launch N concurrent drop+rebuild subprocesses over the same
 # Chroma collection.
@@ -2730,20 +2723,15 @@ def retry_vision(
     # installed, instead of 404-ing once per failed frame.
     if failed and config.VISION_FALLBACK_MODEL and vis.model_available(config.VISION_FALLBACK_MODEL):
         fallback_model = config.VISION_FALLBACK_MODEL
-        # audit M9: hold the lock across save/swap/restore so a concurrent
-        # retry-vision can't snapshot the fallback as "original" and restore it
-        # as the permanent primary model.
-        with _vision_fallback_lock:
-            original_model = vis.VISION_MODEL
-            try:
-                vis.VISION_MODEL = fallback_model
-                retry_paths = [frame_paths[i] for i in failed]
-                retry_results = vis.describe_frames(retry_paths)
-                for idx, retry_r in zip(failed, retry_results):
-                    if retry_r.get("description") and not retry_r.get("error"):
-                        results[idx] = retry_r
-            finally:
-                vis.VISION_MODEL = original_model
+        # round-5 #50: pass the fallback model straight through to _call_vision.
+        # The old vis.VISION_MODEL global-swap was dead (_call_vision re-read the
+        # model from settings) — and being a module global it also raced across
+        # concurrent retry-vision calls. Threading the arg fixes both.
+        retry_paths = [frame_paths[i] for i in failed]
+        retry_results = vis.describe_frames(retry_paths, model=fallback_model)
+        for idx, retry_r in zip(failed, retry_results):
+            if retry_r.get("description") and not retry_r.get("error"):
+                results[idx] = retry_r
 
     # Write results to DB
     patched = 0

--- a/tests/test_audit_20260612.py
+++ b/tests/test_audit_20260612.py
@@ -103,7 +103,7 @@ def test_c1_retry_vision_no_deadlock_persists_tags(
     import vision as vis
     monkeypatch.setattr(
         vis, "describe_frames",
-        lambda paths: [{"description": "一隻貓", "tags": ["貓", "室內"], "focus_score": 80}],
+        lambda paths, model=None: [{"description": "一隻貓", "tags": ["貓", "室內"], "focus_score": 80}],
     )
     monkeypatch.setattr(server_module, "_resolve_media_path", lambda p: p)
 

--- a/tests/test_phase8.py
+++ b/tests/test_phase8.py
@@ -391,7 +391,7 @@ def test_describe_frames_representative_strategy(monkeypatch):
     vis = importlib.import_module("vision")
     calls = []
 
-    def mock_full(path, max_retries=2):
+    def mock_full(path, max_retries=2, model=None):
         calls.append(("full", path))
         r = vis._empty_result()
         r["description"] = "full desc"
@@ -402,7 +402,7 @@ def test_describe_frames_representative_strategy(monkeypatch):
         r["edit_reason"] = "建立場景"
         return r
 
-    def mock_light(path, max_retries=2):
+    def mock_light(path, max_retries=2, model=None):
         calls.append(("light", path))
         r = vis._empty_result()
         r["description"] = "light desc"

--- a/tests/test_r5_21_vision_fallback.py
+++ b/tests/test_r5_21_vision_fallback.py
@@ -1,0 +1,75 @@
+"""Round-5 #50 / R5-21 — the vision fallback model must actually run.
+
+Before the fix, `vision._call_vision` re-read the model from settings on every
+call, and the failure-fallback path tried to redirect it by swapping a module
+global `vision.VISION_MODEL`. That swap was DEAD: `_call_vision` never read the
+global, so the "fallback" silently re-ran the *same* failing primary model. The
+log said "trying fallback minicpm-v" while minicpm-v was never invoked.
+
+The fix threads an explicit `model` argument from `describe_frames` down to
+`_call_vision`. These tests mock `_call_vision` at that boundary and assert the
+fallback model name actually reaches it — which is impossible under the old code
+(where `_call_vision` had no `model` parameter at all).
+"""
+import importlib
+import json
+
+import pytest
+
+import config
+
+
+@pytest.fixture
+def vis():
+    return importlib.import_module("vision")
+
+
+@pytest.fixture
+def ing():
+    return importlib.import_module("ingest")
+
+
+def test_describe_frames_threads_model_to_call_vision(vis, monkeypatch):
+    """An explicit model passed to describe_frames must reach _call_vision verbatim."""
+    seen = []
+
+    def fake_call_vision(img_path, prompt, max_retries=2, model=None):
+        seen.append(model)
+        return json.dumps({"description": "ok", "tags": ["t"]})
+
+    monkeypatch.setattr(vis, "_call_vision", fake_call_vision)
+    vis.describe_frames(["/only.jpg"], model="minicpm-v:latest")
+
+    assert seen == ["minicpm-v:latest"]
+
+
+def test_fallback_model_name_reaches_call_vision(vis, ing, monkeypatch):
+    """End-to-end via the ingest fallback orchestrator: the primary attempt runs
+    with the default (None) model and fails; the fallback attempt must invoke
+    _call_vision with the *configured fallback* model name — the exact thing the
+    dead VISION_MODEL swap failed to do."""
+    seen_models = []
+
+    def fake_call_vision(img_path, prompt, max_retries=2, model=None):
+        seen_models.append(model)
+        # Only the fallback model produces a usable result; the primary (model=None)
+        # fails, forcing the fallback path.
+        if model and "minicpm" in model:
+            return json.dumps({"description": "後備模型描述", "tags": ["a"]})
+        raise RuntimeError("primary vision model failed")
+
+    monkeypatch.setattr(vis, "_call_vision", fake_call_vision)
+    # Fallback path gates on availability; treat the fallback as installed so the
+    # rescue runs without a live Ollama.
+    monkeypatch.setattr(vis, "model_available", lambda name: True)
+
+    results, still_failed = ing._describe_frames_with_fallback(["/frame_0.jpg"])
+
+    fallback = config.VISION_FALLBACK_MODEL
+    assert "minicpm" in fallback, "sanity: fallback must differ from the primary"
+    # Primary attempt: default model (None). Fallback attempt: the configured name.
+    assert seen_models[0] is None
+    assert fallback in seen_models[1:], seen_models
+    # And the fallback actually rescued the frame.
+    assert still_failed == []
+    assert results[0]["description"] == "後備模型描述"

--- a/tests/test_vision_tolerance.py
+++ b/tests/test_vision_tolerance.py
@@ -55,13 +55,14 @@ def test_consecutive_guard_overrides_skip_failed(ing):
 
 # ── _describe_frames_with_fallback ──────────────────────────────────────────
 def _install_fake_vision(ing, monkeypatch):
-    """describe_frames mock keyed on path tokens. Reads vis.VISION_MODEL so the
-    fallback pass can rescue a TFAIL (transient) frame but not a PFAIL one."""
-    def fake(paths):
+    """describe_frames mock keyed on path tokens. Reads the threaded `model` arg so
+    the fallback pass can rescue a TFAIL (transient) frame but not a PFAIL one —
+    proving the fallback model name actually reaches describe_frames (round-5 #50)."""
+    def fake(paths, model=None):
         out = []
         for p in paths:
             ps = str(p)
-            is_fallback = "minicpm" in (ing.vis.VISION_MODEL or "")
+            is_fallback = "minicpm" in (model or "")
             if "PFAIL" in ps:
                 out.append({"description": ""})                       # both models fail
             elif "TFAIL" in ps and not is_fallback:

--- a/vision.py
+++ b/vision.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import base64
 import json
 import re
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import requests
 
@@ -10,7 +10,6 @@ import config
 from llm import vision
 
 OLLAMA_URL = f"{config.OLLAMA_URL}/api/generate"
-VISION_MODEL = config.VISION_MODEL
 
 _model_avail_cache: Dict[str, bool] = {}
 
@@ -136,18 +135,22 @@ def _empty_result() -> Dict:
     return result
 
 
-def describe_frames(frame_paths: List[str]) -> List[Dict]:
+def describe_frames(frame_paths: List[str], model: Optional[str] = None) -> List[Dict]:
     """
     Representative frame strategy:
     - Middle frame: full 12-field analysis
     - Other frames: light 11-field + inherit edit_reason only
     - Skip unusable frames (black/white/blurry)
+
+    `model` is threaded down to `_call_vision`; when None the effective/default
+    model is resolved from settings (behavior-preserving). Callers pass an explicit
+    model name to force the fallback path onto that model (round-5 #50).
     """
     if not frame_paths:
         return []
 
     rep_idx = len(frame_paths) // 2
-    rep_result = _describe_one(frame_paths[rep_idx])
+    rep_result = _describe_one(frame_paths[rep_idx], model=model)
     rep_result["file"] = frame_paths[rep_idx]
 
     inheritable = ("edit_reason",)
@@ -167,7 +170,7 @@ def describe_frames(frame_paths: List[str]) -> List[Dict]:
             results.append(skip_result)
             continue
 
-        light = _describe_one_light(path)
+        light = _describe_one_light(path, model=model)
         light["file"] = path
         for k in inheritable:
             light[k] = rep_result.get(k)
@@ -191,14 +194,17 @@ def _normalize_result(parsed: Dict) -> Dict:
     return result
 
 
-def _call_vision(img_path, prompt, max_retries=2):
-    """Send image to Ollama vision, return raw response text."""
+def _call_vision(img_path, prompt, max_retries=2, model=None):
+    """Send image to Ollama vision, return raw response text.
+
+    `model`, when given, is used verbatim (this is how the failure-fallback path
+    forces the fallback model to actually run — round-5 #50). When None, Phase 9.7
+    G5③ honors the operator's library default (settings table), falling back to
+    config.VISION_MODEL / num_ctx when unset (behavior-preserving)."""
     with open(img_path, "rb") as f:
         b64 = base64.b64encode(f.read()).decode()
-    # Phase 9.7 G5③: honor the operator's library default (settings table),
-    # falling back to config.VISION_MODEL / num_ctx when unset (behavior-preserving).
     import settings as _settings
-    eff_model = _settings.vision_model()
+    eff_model = model if model is not None else _settings.vision_model()
     eff_num_ctx = _settings.vision_num_ctx()
     for attempt in range(max_retries):
         try:
@@ -214,9 +220,9 @@ def _call_vision(img_path, prompt, max_retries=2):
     return ""
 
 
-def _describe_one(img_path, max_retries=2):
+def _describe_one(img_path, max_retries=2, model=None):
     try:
-        raw = _call_vision(img_path, PROMPT, max_retries)
+        raw = _call_vision(img_path, PROMPT, max_retries, model=model)
     except Exception as e:
         print(f" [VISION FAIL: {e}]", end="", flush=True)
         result = _empty_result()
@@ -240,10 +246,10 @@ def _describe_one(img_path, max_retries=2):
     return result
 
 
-def _describe_one_light(img_path, max_retries=2):
+def _describe_one_light(img_path, max_retries=2, model=None):
     """Lightweight vision: description + tags + 7 quality/content fields."""
     try:
-        raw = _call_vision(img_path, LIGHT_PROMPT, max_retries)
+        raw = _call_vision(img_path, LIGHT_PROMPT, max_retries, model=model)
     except Exception as e:
         print(f" [VISION-LIGHT FAIL: {e}]", end="", flush=True)
         return _empty_result()


### PR DESCRIPTION
## What
The vision failure-fallback path was dead. `vision._call_vision` always re-resolved the model from `settings.vision_model()`, while the fallback orchestrators (ingest `_describe_frames_with_fallback`, server `retry-vision`) tried to redirect it by swapping the module global `vision.VISION_MODEL` — which `_call_vision` never read. So the "fallback" silently re-ran the **same failing primary model**; the log said "trying fallback minicpm-v" while minicpm-v was never invoked. Server's `_vision_fallback_lock` guarded a no-op swap window.

## Fix (R5-21)
- `describe_frames(frame_paths, model=None)` threads `model` down through `_describe_one` / `_describe_one_light` to `_call_vision`. `model is None` → resolve default from settings (behavior-preserving); a non-None value is used verbatim.
- Deleted the dead `vision.VISION_MODEL` global and server's `_vision_fallback_lock` (both no-ops). Fallback callers now pass `model=config.VISION_FALLBACK_MODEL` straight through, also removing the cross-request race the lock papered over.
- `config.VISION_MODEL` (config-layer default) untouched.

## Test
New `tests/test_r5_21_vision_fallback.py` mocks `_call_vision` and asserts the configured fallback model name actually reaches it on retry (primary attempt = default/None, fallback attempt = the fallback name) — impossible under the old code where `_call_vision` had no `model` parameter. Mocks in `test_phase8` / `test_audit_20260612` / `test_vision_tolerance` updated to the new signatures.

Full suite: **726 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)