### PR TITLE
fix(media): single-source extension sets in mediatypes.py — fixes .insv/.360 SQL drift (round-5 #57)

### DIFF
--- a/db.py
+++ b/db.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 import config as _config
+import mediatypes
 from config import DB_PATH
 
 from contextlib import contextmanager
@@ -968,9 +969,11 @@ def _build_filter_clause(
         clauses.append("rating = ?")
         params.append(rating)
     if media_type == "video":
-        clauses.append("ext IN ('.mp4', '.mov', '.mkv', '.avi', '.webm', '.m4v', '.mts')")
+        # R5-24: sourced from the shared set so .insv/.360 are included and this
+        # filter can never drift from the rest of the codebase again.
+        clauses.append("ext IN " + mediatypes.sql_in_literal(mediatypes.VIDEO_EXT))
     elif media_type == "audio":
-        clauses.append("ext IN ('.mp3', '.wav', '.flac', '.aac', '.m4a', '.ogg')")
+        clauses.append("ext IN " + mediatypes.sql_in_literal(mediatypes.AUDIO_EXT))
     return " AND ".join(clauses), params
 
 

--- a/frames.py
+++ b/frames.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 import config
+import mediatypes
 
 THUMBNAILS_DIR = config.THUMBNAILS_DIR
 
@@ -17,7 +18,7 @@ THUMBNAILS_DIR = config.THUMBNAILS_DIR
 # the raw fisheye buries the wearer + on-screen text (event name, bib #) in the
 # distorted edge and the VLM reads nothing; the equirect stitch surfaces them. 360
 # frames extract larger (1024px vs the normal 320px) so reprojected detail survives.
-_FISHEYE_360_EXT = {".insv", ".360"}
+_FISHEYE_360_EXT = mediatypes.VIDEO_360_EXT  # R5-24: shared source of truth
 _V360_360_FILTER = "v360=dfisheye:equirect:ih_fov=193:iv_fov=193"
 _360_SCALE = "scale=1024:-1"
 _NORMAL_SCALE = "scale=320:-1"

--- a/ingest.py
+++ b/ingest.py
@@ -22,23 +22,16 @@ import codec
 import config
 import db
 import frames as frm
+import mediatypes
 import tag_quality
 import transcribe as tr
 import vision as vis
 
-SUPPORTED = {".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts",
-             ".insv", ".360",  # 360 rigs (Insta360 / GoPro Max) — see VIDEO_EXT note
-             ".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg"}
-# B3: .mkv/.avi/.webm are in SUPPORTED (so they ingest into the DB) but were
-# absent here, so is_video was False for them → they silently skipped
-# thumbnail/frames/vision. ffmpeg/ffprobe handle these containers, so treat
-# them as video too. Keep VIDEO_EXT ⊆ SUPPORTED.
-# 360 formats: .insv (Insta360) / .360 (GoPro Max) are HEVC-in-MOV/MP4 — ffmpeg
-# probes + extracts frames fine (.insv verified 2026-06-12: dual 2880×2880 HEVC
-# fisheye + AAC, thumbnail decodes). Frames land as raw fisheye, which is exactly
-# what we want indexed (VLM still describes them). Competitor StoryCube shows the
-# same files as UNKNOWN — see case-study storycube-asus-gopro-20260612.
-VIDEO_EXT = {".mp4", ".mov", ".m4v", ".mts", ".mkv", ".avi", ".webm", ".insv", ".360"}
+# R5-24: extension sets live in mediatypes.py (single source of truth). VIDEO_EXT
+# ⊆ SUPPORTED still holds. .mkv/.avi/.webm count as video (B3); .insv/.360 are the
+# 360 rigs — see mediatypes for the full rationale.
+SUPPORTED = mediatypes.MEDIA_EXT
+VIDEO_EXT = mediatypes.VIDEO_EXT
 # Codecs needing browser-playable proxy — single source of truth in codec.py.
 PROXY_CODECS = codec.PROXY_CODECS
 logger = logging.getLogger(__name__)

--- a/mediatypes.py
+++ b/mediatypes.py
@@ -1,0 +1,49 @@
+"""Single source of truth for the media file-extension sets.
+
+Round-5 #57: the video / audio / all-media extension sets were hand-copied in
+~7 modules (ingest.py, server.py, watch.py, db.py, query_builder.py, frames.py,
+...). db.py's SQL video filter had already DRIFTED — its `ext IN (...)` literal
+was missing `.insv` / `.360`, so 360 clips vanished from the non-search video
+filter. Every module now imports these constants instead of re-declaring a
+literal, and db.py builds its SQL predicate from `VIDEO_EXT` / `AUDIO_EXT`, so
+the filter can never drift again.
+
+Kept import-safe under Python 3.8+ (pure stdlib, plain literals, no `X | Y`
+type unions, no walrus) because watch.py / db.py run on the NAS.
+
+Every extension is lowercase with a leading dot; callers must lowercase the
+suffix before a membership test (`Path(...).suffix.lower()`), exactly as before.
+"""
+from typing import FrozenSet
+
+# 360 dual-fisheye rigs — Insta360 `.insv` / GoPro Max `.360`. HEVC-in-MOV/MP4
+# that ffmpeg / ffprobe probe and extract frames from like any other video.
+# Broken out as a named subset because frames.py stitches these to equirectangular
+# BEFORE frame extraction (Phase 8.3b); the video pipeline otherwise treats them
+# as ordinary video (verified 2026-06-12: dual 2880x2880 HEVC fisheye + AAC).
+VIDEO_360_EXT = frozenset({".insv", ".360"})
+
+# Video containers the ingest pipeline probes / thumbnails / extracts frames from.
+# `.mkv` / `.avi` / `.webm` are ffmpeg-handled containers and count as video (B3).
+VIDEO_EXT = frozenset({
+    ".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts",
+}) | VIDEO_360_EXT
+
+# Audio the pipeline transcribes.
+AUDIO_EXT = frozenset({".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg"})
+
+# Everything the ingest pipeline accepts (video + audio partition MEDIA_EXT).
+MEDIA_EXT = VIDEO_EXT | AUDIO_EXT
+
+
+def sql_in_literal(exts: FrozenSet[str]) -> str:
+    """Return a SQL tuple literal — e.g. ``('.mp4', '.mov', ...)`` — for a fixed
+    extension set, for use as ``ext IN <literal>``.
+
+    Only ever called on this module's own constant frozensets (never on user
+    input), so literal interpolation carries no injection risk and lets the
+    predicate stay parameterless like the hand-written SQL it replaces. Sorted
+    for a deterministic string; SQL ``IN`` is order-independent.
+    """
+    quoted = ", ".join("'{0}'".format(ext) for ext in sorted(exts))
+    return "({0})".format(quoted)

--- a/query_builder.py
+++ b/query_builder.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Tuple
 
+import mediatypes
+
 
 class QueryError(ValueError):
     """Raised on an unknown field, disallowed op, or malformed value."""
@@ -53,9 +55,10 @@ _FIELDS: Dict[str, Tuple[Optional[str], set, str]] = {
     "semantic": (None, {"contains"}, "semantic"),
 }
 
-# ext buckets — kept in sync with server._VIDEO_EXTS / _AUDIO_EXTS.
-_VIDEO_EXTS = (".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts", ".insv", ".360")
-_AUDIO_EXTS = (".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg")
+# ext buckets — R5-24: shared source of truth in mediatypes.py (was hand-copied
+# in sync with server._VIDEO_EXTS / _AUDIO_EXTS).
+_VIDEO_EXTS = mediatypes.VIDEO_EXT
+_AUDIO_EXTS = mediatypes.AUDIO_EXT
 
 
 def _one_condition(cond: Dict[str, Any]) -> Tuple[Optional[str], List[Any], Optional[str]]:

--- a/server.py
+++ b/server.py
@@ -30,6 +30,7 @@ import config
 import corrections
 import db
 import federation
+import mediatypes
 import projects as project_registry
 import settings as settings_store
 import smart_collections
@@ -1114,9 +1115,10 @@ def media_pool(
 
 
 # audit H14: ext buckets mirror db._build_filter_clause's media_type sets so the
-# search branch applies the SAME filter the SQL (non-search) path does.
-_VIDEO_EXTS = frozenset({".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts", ".insv", ".360"})
-_AUDIO_EXTS = frozenset({".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg"})
+# search branch applies the SAME filter the SQL (non-search) path does. R5-24:
+# both now come from the shared mediatypes source, so they can't drift apart.
+_VIDEO_EXTS = mediatypes.VIDEO_EXT
+_AUDIO_EXTS = mediatypes.AUDIO_EXT
 
 
 def _get_tags_bulk(media_ids) -> dict:
@@ -2224,9 +2226,9 @@ def _ingest_cmd_opts(body: "IngestRequest") -> list:
 class ScanRequest(BaseModel):
     path: str
 
-MEDIA_EXTS = {".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts", ".insv", ".360", ".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg"}
-VIDEO_EXTS = {".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts", ".insv", ".360"}
-AUDIO_EXTS = {".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg"}
+MEDIA_EXTS = mediatypes.MEDIA_EXT
+VIDEO_EXTS = mediatypes.VIDEO_EXT
+AUDIO_EXTS = mediatypes.AUDIO_EXT
 assert VIDEO_EXTS | AUDIO_EXTS == MEDIA_EXTS  # the two must partition MEDIA_EXTS
 # camera raw / stills the ingest pipeline does not process — surfaced in the scan
 # manifest as "skipped" so the redesign's setup dialog (op-01) can show what will

--- a/tests/test_r5_24_mediatypes.py
+++ b/tests/test_r5_24_mediatypes.py
@@ -1,0 +1,65 @@
+"""R5-24: mediatypes.py is the single source of truth for the media extension
+sets. These tests fail if any module re-introduces a hand-copied literal (the
+identity checks break) or if db.py's SQL video filter drifts away from .insv/.360
+again (the SQL check breaks).
+"""
+import mediatypes
+
+
+def test_video_set_includes_360():
+    # The whole point of the fix: 360 rigs are video.
+    assert ".insv" in mediatypes.VIDEO_EXT
+    assert ".360" in mediatypes.VIDEO_EXT
+    assert mediatypes.VIDEO_360_EXT == {".insv", ".360"}
+    assert mediatypes.VIDEO_360_EXT <= mediatypes.VIDEO_EXT
+
+
+def test_media_partitions_into_video_and_audio():
+    assert mediatypes.VIDEO_EXT | mediatypes.AUDIO_EXT == mediatypes.MEDIA_EXT
+    assert mediatypes.VIDEO_EXT.isdisjoint(mediatypes.AUDIO_EXT)
+
+
+def test_every_module_references_the_shared_set():
+    """Each module binds its extension name to the SAME shared object — no copies."""
+    import ingest
+    import server
+    import watch
+    import query_builder
+    import frames
+
+    assert ingest.VIDEO_EXT is mediatypes.VIDEO_EXT
+    assert ingest.SUPPORTED is mediatypes.MEDIA_EXT
+
+    assert server.VIDEO_EXTS is mediatypes.VIDEO_EXT
+    assert server.AUDIO_EXTS is mediatypes.AUDIO_EXT
+    assert server.MEDIA_EXTS is mediatypes.MEDIA_EXT
+    assert server._VIDEO_EXTS is mediatypes.VIDEO_EXT
+    assert server._AUDIO_EXTS is mediatypes.AUDIO_EXT
+
+    assert watch.MEDIA_EXTS is mediatypes.MEDIA_EXT
+
+    assert query_builder._VIDEO_EXTS is mediatypes.VIDEO_EXT
+    assert query_builder._AUDIO_EXTS is mediatypes.AUDIO_EXT
+
+    assert frames._FISHEYE_360_EXT is mediatypes.VIDEO_360_EXT
+
+
+def test_db_video_filter_now_includes_360():
+    """db.py's SQL video filter is built from the shared set — the drift bug fix."""
+    import db
+
+    clause, _params = db._build_filter_clause(media_type="video")
+    assert ".insv" in clause
+    assert ".360" in clause
+    # every video ext appears in the generated predicate
+    for ext in mediatypes.VIDEO_EXT:
+        assert "'{0}'".format(ext) in clause
+
+    audio_clause, _ = db._build_filter_clause(media_type="audio")
+    assert ".insv" not in audio_clause
+    assert ".mp3" in audio_clause
+
+
+def test_sql_in_literal_shape():
+    lit = mediatypes.sql_in_literal(frozenset({".mp4", ".mov"}))
+    assert lit == "('.mov', '.mp4')"  # sorted, quoted, parenthesized

--- a/watch.py
+++ b/watch.py
@@ -34,11 +34,10 @@ import time
 from pathlib import Path
 from typing import Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
-MEDIA_EXTS = {
-    ".mp4", ".mov", ".mkv", ".avi", ".webm", ".m4v", ".mts",  # video
-    ".insv", ".360",  # 360 rigs (Insta360 / GoPro Max)
-    ".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg",  # audio
-}
+import mediatypes
+
+# R5-24: single source of truth in mediatypes.py (video + 360 rigs + audio).
+MEDIA_EXTS = mediatypes.MEDIA_EXT
 
 Signature = Tuple[int, float]  # (size_bytes, mtime)
 


### PR DESCRIPTION
## What

The media file-extension sets (video / audio / all-media) were hand-copied across ~7 modules (`ingest.py`, `server.py`, `watch.py`, `db.py`, `query_builder.py`, `frames.py`). This introduces **`mediatypes.py`** at repo root as the single source of truth (`VIDEO_EXT`, `AUDIO_EXT`, `MEDIA_EXT`, and the named `VIDEO_360_EXT` subset), and rewires every module to import from it.

## Why

The copies had already **drifted**: `db.py`'s `_build_filter_clause` SQL video filter read `ext IN ('.mp4', '.mov', '.mkv', '.avi', '.webm', '.m4v', '.mts')` — **missing `.insv` / `.360`**. So 360 clips (Insta360 / GoPro Max) silently vanished from the non-search video filter (`?media_type=video`), even though ingest, the search branch, `query_builder`, and the scan manifest all counted them as video. Live, shipped bug (round-5 #57).

The shared sets are the **union/superset** of what every module previously declared — no extension any module recognized is dropped. `db.py`'s SQL predicate is now **built from the shared set** via `mediatypes.sql_in_literal()`, so `.insv`/`.360` are included and it can never drift again.

The only behavior change is the intended fix: **360 clips now appear in `db.py`'s video filter**. Everything else is equivalent (SQL `IN` is order-independent; extensions stay lowercase). `mediatypes.py` is import-safe under Python 3.8+ (pure stdlib, no `X|Y` unions/walrus) for the NAS-touching modules. `offload._CARD_MEDIA_EXTS` (card-detection superset incl. cinema-raw + stills) and `camera_report`'s label dict are deliberately distinct and left untouched.

## Test

`tests/test_r5_24_mediatypes.py` asserts every module binds its extension name to the **same** shared object (identity), that `.insv`/`.360` are in the video set, and that `db.py`'s generated SQL video filter now includes them.

`.venv/bin/python -m pytest -q` → **729 passed, 5 skipped** (724 baseline + 5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)