### PR TITLE
fix(offload): resumable per-source state + single-flight + abortable run (round-5 #19/#45)

### DIFF
--- a/frontend/src/routes/Offload.svelte
+++ b/frontend/src/routes/Offload.svelte
@@ -16,6 +16,7 @@
      Safety: offload.py copies + verifies, NEVER deletes the source. -->
 <script>
   import { push } from 'svelte-spa-router'
+  import { onDestroy } from 'svelte'
   import * as api from '../lib/api.js'
   import ArkivLogo from '../lib/ArkivLogo.svelte'
   import Mono from '../lib/Mono.svelte'
@@ -39,9 +40,18 @@
   let recent = [] // [{name, status}] — last handful of files, failed flagged
   let summary = null // {dst: {verified_files, failed_files, mhl_path, status}}
   let doneCode = null
+  // R5-17 (#45): a running offload used to be uncancellable — Cancel just navigated
+  // away and left the fetch (and the server-side copy) running orphaned. Hold the
+  // AbortController so Stop / navigate-away can drop the connection; the server
+  // already terminates the copy subprocess on disconnect (offload_run GeneratorExit).
+  let abortCtl = null
+  let stopped = false
 
   $: liveDsts = dsts.map((d) => d.trim()).filter(Boolean)
-  $: canRun = phase === 'preview' && liveDsts.length > 0
+  // Run is armed after a Preview; also re-armed after a Stop so the user can
+  // Resume directly — the backend keeps a per-source state file and picks up from
+  // the last verified file (R5-17 #19), no re-Preview needed.
+  $: canRun = (phase === 'preview' || (phase === 'done' && stopped)) && liveDsts.length > 0
   $: pct = pTotal ? Math.min(100, Math.round((pDone / pTotal) * 100)) : 0
   $: anyFailed = summary ? Object.values(summary).some((s) => s.failed_files > 0) || doneCode !== 0 : false
   const base = (p) => String(p).split(/[\\/]/).pop()
@@ -65,13 +75,14 @@
 
   async function doRun() {
     if (!canRun) return
-    err = ''; phase = 'running'
+    err = ''; phase = 'running'; stopped = false
     curDst = ''; pTotal = 0; pDone = 0; pFailed = 0; recent = []; summary = null; doneCode = null
+    abortCtl = new AbortController()
     try {
       const res = await api.offloadRun({
         src: src.trim(), dst: liveDsts,
         organize: organize.trim() || null, include_heic: includeHeic,
-      })
+      }, { signal: abortCtl.signal })
       const reader = res.body.getReader()
       const dec = new TextDecoder()
       let buf = ''
@@ -99,10 +110,31 @@
       }
       if (phase !== 'done') { phase = 'done'; doneCode = doneCode ?? 1 }
     } catch (e) {
-      err = e.body?.detail || e.message
-      phase = 'done'; doneCode = doneCode ?? 1
+      if (stopped || e.name === 'AbortError') {
+        // User stopped it (or navigated away): the copy is resumable, so this is
+        // not a failure — verified files are kept and re-Run continues from here.
+        phase = 'done'; doneCode = doneCode ?? 130; err = ''
+      } else {
+        err = e.body?.detail || e.message
+        phase = 'done'; doneCode = doneCode ?? 1
+      }
+    } finally {
+      abortCtl = null
     }
   }
+
+  // R5-17 (#45): stop a running offload. Aborting the fetch drops the HTTP
+  // connection, which trips the server's terminate-on-disconnect; the per-source
+  // state file is preserved so a later Run resumes from the last verified file.
+  function stopRun() {
+    if (phase !== 'running' || !abortCtl) return
+    if (!confirm('轉存進行中，確定停止？已複製並校驗的檔案會保留，可稍後從中斷處續傳。')) return
+    stopped = true
+    abortCtl.abort()
+  }
+
+  // Navigating away mid-copy must also stop the server-side copy, not orphan it.
+  onDestroy(() => { if (abortCtl) abortCtl.abort() })
 
   // 2-phase handoff — ingest the first destination we just offloaded.
   function ingestNext() {
@@ -186,7 +218,7 @@
           </div>
         {:else}
           <!-- running / done -->
-          <Eyebrow>{phase === 'running' ? 'Copying · verify + MHL' : (anyFailed ? 'Offload — failed' : 'Offload — complete')}</Eyebrow>
+          <Eyebrow>{phase === 'running' ? 'Copying · verify + MHL' : (stopped ? 'Offload — stopped' : (anyFailed ? 'Offload — failed' : 'Offload — complete'))}</Eyebrow>
           {#if curDst}<Mono dim style="font-size:10px;">→ {curDst}</Mono>{/if}
           <div class="bar"><div class="barfill" class:fail={anyFailed} style="width:{phase === 'done' ? 100 : pct}%;"></div></div>
           <Mono dim style="font-size:10.5px;">{pDone}{pTotal ? `/${pTotal}` : ''} files{pFailed ? ` · ${pFailed} failed` : ''}</Mono>
@@ -220,13 +252,18 @@
 
     <div class="footer">
       {#if err}<Mono style="font-size:11px;" class="errtext">{err}</Mono>
+      {:else if phase === 'done' && stopped}<Mono style="font-size:11px;">■ 已停止 · 已校驗檔案保留，可續傳</Mono>
       {:else if phase === 'done'}<Mono style="font-size:11px;" class={anyFailed ? 'errtext' : ''}>{anyFailed ? `✗ 轉存有失敗 (exit ${doneCode})` : `✓ 轉存完成 (exit ${doneCode})`}</Mono>{/if}
       <div class="grow"></div>
       {#if phase === 'done' && !anyFailed}
         <button class="ak-btn" on:click={ingestNext}>接著 ingest →</button>
       {/if}
-      <button class="ak-btn" on:click={() => push('/')}>{phase === 'done' ? 'Done' : 'Cancel'}</button>
-      <button class="ak-btn ak-btn--primary" on:click={doRun} disabled={!canRun}>{phase === 'running' ? 'copying…' : 'Run offload →'}</button>
+      {#if phase === 'running'}
+        <button class="ak-btn stopbtn" on:click={stopRun}>停止</button>
+      {:else}
+        <button class="ak-btn" on:click={() => push('/')}>{phase === 'done' ? 'Done' : 'Cancel'}</button>
+      {/if}
+      <button class="ak-btn ak-btn--primary" on:click={doRun} disabled={!canRun}>{phase === 'running' ? 'copying…' : (stopped && phase === 'done' ? 'Resume →' : 'Run offload →')}</button>
     </div>
   </div>
 </div>
@@ -279,4 +316,5 @@
 
   .footer { display: flex; align-items: center; gap: 12px; padding: 16px 28px; border-top: 1px solid var(--rule); }
   .footer :global(.errtext) { color: var(--danger); }
+  .stopbtn { border-color: var(--cyan); color: var(--cyan); }
 </style>

--- a/offload.py
+++ b/offload.py
@@ -307,9 +307,15 @@ def _load_state(path):
 
 
 def _save_state(path, state):
+    # R5-17 (#19): write atomically (tmp on the same dir + os.replace) so a crash
+    # or SIGTERM mid-write can't leave a half-written JSON that _load_state then
+    # fails to parse — the resume path depends on this file always being valid.
     path = Path(path)
     _ensure_parent(path)
-    path.write_text(json.dumps(state, indent=2, ensure_ascii=False, sort_keys=True), encoding="utf-8")
+    data = json.dumps(state, indent=2, ensure_ascii=False, sort_keys=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(data, encoding="utf-8")
+    os.replace(str(tmp), str(path))
 
 
 def _build_file_records(source_files, dsts):

--- a/server.py
+++ b/server.py
@@ -74,6 +74,26 @@ _retranscribe_lock = _threading.Lock()
 _retranscribe_active = False
 _retranscribe_progress = {"total": 0, "done": 0, "failed": 0, "current": None, "running": False, "backup": None}
 
+# R5-17 (#19): single-flight the offload endpoint PER SOURCE. Two runs over the
+# same card (a double-clicked Run, or a retry over a still-live run) would race
+# on that source's resumable state file, tearing the JSON mid-write and
+# double-copying every byte. Keyed on the resolved source path so offloading two
+# *different* cards concurrently is still allowed.
+_offload_lock = _threading.Lock()
+_offload_active: Set[str] = set()
+
+def _acquire_offload_slot(key: str) -> bool:
+    with _offload_lock:
+        if key in _offload_active:
+            return False
+        _offload_active.add(key)
+        return True
+
+def _release_offload_slot(key: str) -> None:
+    with _offload_lock:
+        _offload_active.discard(key)
+
+
 # ── Init ─────────────────────────────────────────────────────────────────────
 db.init_db()
 
@@ -2467,16 +2487,33 @@ def offload_run(
     # project's .arkiv dir so the state is scoped + resumable per project.
     state_cwd = config.THUMBNAILS_DIR.parent
     state_cwd.mkdir(parents=True, exist_ok=True)
+    # R5-17 (#19): give each source card its OWN resumable state file and ALWAYS
+    # --resume it. Previously no --resume was passed, so offload.py fell back to a
+    # single cwd/offload-state.json: a retry re-copied from zero, and a second
+    # concurrent card clobbered the first's state. A stable per-source path means a
+    # 400GB offload that dies at 92% picks up from the last verified file.
+    import hashlib as _hashlib
+    state_path = state_cwd / "offload-state-{0}.json".format(
+        _hashlib.sha1(str(src).encode("utf-8")).hexdigest()[:16])
+    cmd += ["--resume", str(state_path)]
+
+    # Single-flight per source (see _acquire_offload_slot): reject a second run over
+    # the same card so the two can't tear the shared state file. Acquired here (sync)
+    # so the collision surfaces as a real 409; released in the generator's finally.
+    slot_key = str(src)
+    if not _acquire_offload_slot(slot_key):
+        raise HTTPException(409, "此來源的轉存正在進行中，請稍候")
 
     def _stream():
         # Stream the offload's --progress json events line-by-line (ndjson) so the UI
         # shows live per-file progress instead of blocking on one giant request.
-        proc = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
-            bufsize=1, cwd=str(state_cwd))
-        saw_done = False
         import json as _json
+        proc = None
+        saw_done = False
         try:
+            proc = subprocess.Popen(
+                cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+                bufsize=1, cwd=str(state_cwd))
             for line in proc.stdout:
                 try:  # JSON parse (not substring) so a filename can't false-positive
                     if _json.loads(line).get("type") == "done":
@@ -2492,18 +2529,22 @@ def offload_run(
                 yield _json.dumps({"type": "done", "code": proc.returncode if proc.returncode is not None else 1,
                                    "summary": {}}, ensure_ascii=False) + "\n"
         except GeneratorExit:
-            # client disconnected — stop the (resumable) offload and bound the wait
-            # so a stalled child can't pin the worker forever (Codex).
-            proc.terminate()
-            try:
-                proc.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.wait()  # reap to avoid a zombie if terminate timed out
+            # client disconnected (Stop button / navigate-away) — stop the
+            # (resumable) offload and bound the wait so a stalled child can't pin
+            # the worker forever (Codex). The per-source state file is left intact
+            # so the next Run resumes.
+            if proc is not None:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()  # reap to avoid a zombie if terminate timed out
             raise
         finally:
-            if proc.stdout and not proc.stdout.closed:
+            if proc is not None and proc.stdout and not proc.stdout.closed:
                 proc.stdout.close()
+            _release_offload_slot(slot_key)
     return StreamingResponse(_stream(), media_type="application/x-ndjson")
 
 

--- a/tests/test_r5_17_offload_lifecycle.py
+++ b/tests/test_r5_17_offload_lifecycle.py
@@ -1,0 +1,109 @@
+"""R5-17 (round-5 #45/#19): offload lifecycle hardening — backend half.
+
+  * /api/offload gives each source card its OWN resumable state file and always
+    --resume's it (no copy-from-zero on retry; no clobber between concurrent cards),
+  * a per-source single-flight rejects a second concurrent run over the same card
+    with 409 (the two would otherwise tear the shared state JSON),
+  * offload._save_state writes atomically (tmp + os.replace) so a crash mid-write
+    can't corrupt the resume state.
+
+The AbortController / Stop-button half (#45 UI) is frontend-only — verified via
+`vite build` (the CI frontend-build gate), the repo has no JS unit harness.
+"""
+import hashlib
+import importlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _state_dir(monkeypatch, tmp_path):
+    config = importlib.import_module("config")
+    d = tmp_path / "arkiv-state" / "thumbnails"
+    d.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(config, "THUMBNAILS_DIR", d)
+    return d.parent  # the endpoint uses THUMBNAILS_DIR.parent as state_cwd
+
+
+def _expected_state_path(state_cwd, src):
+    h = hashlib.sha1(str(Path(src).expanduser().resolve()).encode("utf-8")).hexdigest()[:16]
+    return state_cwd / "offload-state-{0}.json".format(h)
+
+
+def test_endpoint_writes_per_source_resumable_state(fastapi_client, tmp_path, monkeypatch):
+    state_cwd = _state_dir(monkeypatch, tmp_path)
+    card = tmp_path / "cardA"; card.mkdir()
+    (card / "A.MP4").write_bytes(b"aaa")
+    dst = tmp_path / "dstA"; dst.mkdir()
+    r = fastapi_client.post("/api/offload", json={"src": str(card), "dst": [str(dst)]})
+    assert r.status_code == 200
+    _ = r.text  # drain the stream so the subprocess completes
+    sp = _expected_state_path(state_cwd, card)
+    assert sp.exists(), "endpoint must write a per-source state file it can resume"
+    state = json.loads(sp.read_text(encoding="utf-8"))
+    assert "files" in state and Path(state["source"]).name == "cardA"
+    assert not sp.with_name(sp.name + ".tmp").exists(), "no half-written temp left behind"
+
+
+def test_distinct_sources_get_distinct_state_files(fastapi_client, tmp_path, monkeypatch):
+    state_cwd = _state_dir(monkeypatch, tmp_path)
+    paths = []
+    for name in ("card1", "card2"):
+        card = tmp_path / name; card.mkdir()
+        (card / "X.MP4").write_bytes(b"x")
+        dst = tmp_path / (name + "-dst"); dst.mkdir()
+        r = fastapi_client.post("/api/offload", json={"src": str(card), "dst": [str(dst)]})
+        assert r.status_code == 200
+        _ = r.text
+        paths.append(_expected_state_path(state_cwd, card))
+    assert paths[0] != paths[1]
+    assert paths[0].exists() and paths[1].exists(), "two cards must not share one state file"
+
+
+def test_concurrent_same_source_is_409(fastapi_client, server_module, tmp_path, monkeypatch):
+    _state_dir(monkeypatch, tmp_path)
+    card = tmp_path / "busycard"; card.mkdir()
+    (card / "A.MP4").write_bytes(b"a")
+    dst = tmp_path / "busydst"; dst.mkdir()
+    key = str(card.resolve())
+    assert server_module._acquire_offload_slot(key)  # simulate a run already in flight
+    try:
+        r = fastapi_client.post("/api/offload", json={"src": str(card), "dst": [str(dst)]})
+        assert r.status_code == 409
+    finally:
+        server_module._release_offload_slot(key)
+    # slot freed → a fresh run over the same card is accepted again
+    r2 = fastapi_client.post("/api/offload", json={"src": str(card), "dst": [str(dst)]})
+    assert r2.status_code == 200
+    _ = r2.text
+
+
+def test_offload_slot_guard_semantics(server_module):
+    k = "/tmp/some/card"
+    assert server_module._acquire_offload_slot(k) is True
+    assert server_module._acquire_offload_slot(k) is False       # same key blocked
+    assert server_module._acquire_offload_slot(k + "2") is True  # a different card is fine
+    server_module._release_offload_slot(k)
+    server_module._release_offload_slot(k + "2")
+    assert server_module._acquire_offload_slot(k) is True        # released → reusable
+    server_module._release_offload_slot(k)
+
+
+def test_save_state_is_atomic(tmp_path, monkeypatch):
+    offload = importlib.import_module("offload")
+    sp = tmp_path / "offload-state.json"
+    offload._save_state(sp, {"v": 1})
+    assert json.loads(sp.read_text(encoding="utf-8")) == {"v": 1}
+    assert not sp.with_name(sp.name + ".tmp").exists(), "no temp leftover after a clean save"
+
+    # A crash DURING os.replace must leave the previous good state intact — the
+    # write goes to a temp file and never truncates the real one in place.
+    def boom(src, dst):
+        raise RuntimeError("simulated crash mid-replace")
+    monkeypatch.setattr(offload.os, "replace", boom)
+    with pytest.raises(RuntimeError):
+        offload._save_state(sp, {"v": 2})
+    monkeypatch.undo()
+    assert json.loads(sp.read_text(encoding="utf-8")) == {"v": 1}, "old state must survive a failed write"


### PR DESCRIPTION
**Round-5 Wave 3 · findings #19 (data, med) + #45 (frontend, high)** — offload lifecycle.

### #19 — never resumes; shared state clobbered/torn
`/api/offload` passed no `--resume`, so `offload.py` used a single `cwd/offload-state.json`: a 400GB run that died at 92% re-copied from **zero** on retry, and a second concurrent card clobbered the first's state. `_save_state` also wrote non-atomically (a crash mid-write left corrupt JSON that `_load_state` then failed to parse).

- Endpoint derives a **stable per-source state path** (sha1 of the resolved source) under `.arkiv` and **always `--resume`s** it → retries resume from the last verified file; different cards no longer share a file.
- **Per-source single-flight** (`_acquire/_release_offload_slot`, `threading.Lock`, mirrors the H3 ingest-slot idiom): a double-clicked Run over the same card returns **409** instead of tearing state. Acquired sync in the endpoint (real 409), released in the streaming generator `finally`.
- `offload._save_state` → tmp + `os.replace` (atomic); a failed replace leaves the prior good state intact.

### #45 — running offload uncancellable
Cancel just navigated away and orphaned the fetch + the server-side copy. The server already terminates the copy on disconnect (`offload_run` `GeneratorExit`) — the UI just never dropped the connection.

- `doRun()` threads an `AbortController` signal into `api.offloadRun`; a confirm-guarded **停止** button aborts it, and `onDestroy` aborts on navigate-away → connection drops → server terminates the copy. A stopped run is **resumable** (not a failure); the primary button becomes **Resume →**.

### Verification
- `tests/test_r5_17_offload_lifecycle.py`: per-source path, distinct-source isolation, 409, slot semantics, atomic save (incl. failed-`replace` survival) — 5 tests.
- Full suite **729 passed, 5 skipped**. Frontend `vite build` green (no JS unit harness in-repo, consistent with R5-18/#151 · R5-19/#152 · R5-20/#153).

🤖 Generated with [Claude Code](https://claude.com/claude-code)