### PR TITLE
refactor(server): DB-path SSOT accessor + move init/log-filter into lifespan (round-5 #53/#54)

### DIFF
--- a/db.py
+++ b/db.py
@@ -8,14 +8,39 @@ from typing import Dict, List, Optional, Tuple
 
 import config as _config
 import mediatypes
-from config import DB_PATH
 
 from contextlib import contextmanager
 
 
+# R5-23 (#54): the DB path is a SINGLE source of truth reached ONLY through
+# get_db_path()/set_db_path(). Previously db.py did `from config import DB_PATH`
+# (a frozen value copy) while `--db` rebound db.DB_PATH and health/server read
+# config.DB_PATH — so a `--db` run preflighted the DEFAULT db while writing the
+# backup db (a silent mixed-database run). Now `--db` calls set_db_path() and
+# every reader calls get_db_path(); a lint test forbids value imports of DB_PATH.
+# The override defaults to None → we follow config.DB_PATH dynamically, so a test
+# that monkeypatches config.DB_PATH is honored without a second knob.
+_db_path_override: Optional[Path] = None
+
+
+def get_db_path() -> Path:
+    """The one true DB path. An explicit set_db_path()/--db override wins;
+    otherwise follow config.DB_PATH so an env/config change is picked up live."""
+    return _db_path_override if _db_path_override is not None else _config.DB_PATH
+
+
+def set_db_path(path) -> Path:
+    """Point every db.get_conn() (and every reader routed through get_db_path())
+    at `path`. Pass None to fall back to config.DB_PATH."""
+    global _db_path_override, _init_done_for
+    _db_path_override = Path(path) if path is not None else None
+    _init_done_for = None  # force re-init against the new location on next open
+    return get_db_path()
+
+
 # audit L14: once-only init — the parent-dir check + double chmod used to run
 # on EVERY connection, multiplying syscalls on N+1-heavy call paths. Keyed on
-# the DB path (not a plain bool) so tests / `--db` that rebind db.DB_PATH at
+# the DB path (not a plain bool) so tests / `--db` that switch the path at
 # runtime still re-init for the new location.
 _init_done_for: Optional[str] = None
 
@@ -23,13 +48,14 @@ _init_done_for: Optional[str] = None
 @contextmanager
 def get_conn():
     global _init_done_for
-    first_open = _init_done_for != str(DB_PATH)
+    db_path = get_db_path()
+    first_open = _init_done_for != str(db_path)
     if first_open:
         # Ensure the DB's parent dir exists. On a fresh clone the .arkiv/ data dir
-        # doesn't exist yet, and server.py calls init_db() at import → sqlite would
+        # doesn't exist yet, and init_db() at startup would otherwise make sqlite
         # raise "unable to open database file". Covers every DB-opening path
         # (server / ingest / embed / tests), not just server startup.
-        parent = Path(DB_PATH).expanduser().parent
+        parent = Path(db_path).expanduser().parent
         if parent and not parent.exists():
             parent.mkdir(parents=True, exist_ok=True)
             # Only tighten a dir WE just created — never an existing (possibly shared)
@@ -38,7 +64,7 @@ def get_conn():
                 os.chmod(parent, 0o700)
             except OSError:
                 pass
-    conn = sqlite3.connect(DB_PATH, timeout=30)
+    conn = sqlite3.connect(db_path, timeout=30)
     # audit M6: SQLite ships with foreign_keys OFF per-connection, so every
     # ON DELETE CASCADE in the schema was dead — revoking a token or deleting
     # media left orphan child rows. init_db() clears pre-existing orphans via
@@ -48,10 +74,10 @@ def get_conn():
         # Our own token-hash DB file — keep it owner-only on shared hosts.
         # Best-effort (no-op / may fail on Windows).
         try:
-            os.chmod(DB_PATH, 0o600)
+            os.chmod(db_path, 0o600)
         except OSError:
             pass
-        _init_done_for = str(DB_PATH)
+        _init_done_for = str(db_path)
     conn.row_factory = sqlite3.Row
     try:
         yield conn

--- a/export.py
+++ b/export.py
@@ -288,7 +288,7 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     args = parser.parse_args(argv)
     if args.db:
-        db.DB_PATH = Path(args.db)
+        db.set_db_path(Path(args.db))  # R5-23 (#54): via SSOT accessor, not a raw rebind
 
     if args.cmd == "corpus":
         _emit(build_corpus(args.lang), args.out)

--- a/health.py
+++ b/health.py
@@ -112,6 +112,8 @@ def preflight_paths():
     main() still returned exit 0.
     """
     import config
+    import db  # R5-23 (#54): read the DB path through the SSOT accessor, not a
+              # frozen config value, so a --db override preflights the SAME db it writes
     import sqlite3
 
     errors = []
@@ -137,7 +139,7 @@ def preflight_paths():
 
     # 8.0e: per-path writable + symlink-target check
     paths_to_check = [
-        ("DB_PATH parent", config.DB_PATH.parent),
+        ("DB_PATH parent", db.get_db_path().parent),
         ("THUMBNAILS_DIR", config.THUMBNAILS_DIR),
         ("PROXIES_DIR", config.PROXIES_DIR),
         ("CHROMA_PATH", config.CHROMA_PATH),
@@ -161,9 +163,9 @@ def preflight_paths():
             errors.append(f"{name} 不可寫: {p} ({e.__class__.__name__}: {e})")
 
     # Sample DB resolve: stale PROJECT_ROOT after media move shows up here
-    if config.DB_PATH.exists():
+    if db.get_db_path().exists():
         try:
-            conn = sqlite3.connect(str(config.DB_PATH))
+            conn = sqlite3.connect(str(db.get_db_path()))
             row = conn.execute("SELECT path FROM media LIMIT 1").fetchone()
             conn.close()
             if row and row[0]:
@@ -365,15 +367,16 @@ def main():
     print("\n-- Database --")
     try:
         import config
+        import db  # R5-23 (#54): DB path via the SSOT accessor (see preflight_paths)
         check("config.py", True)
 
-        db_exists = config.DB_PATH.exists()
+        db_path = db.get_db_path()
+        db_exists = db_path.exists()
         check("media.db", db_exists,
-              f"({config.DB_PATH})" if db_exists else "(will be created on first run)",
+              f"({db_path})" if db_exists else "(will be created on first run)",
               required=False)
 
         if db_exists:
-            import db
             stats = db.get_stats()
             total = stats["total"]
             transcribed = stats["with_transcript"]

--- a/ingest.py
+++ b/ingest.py
@@ -1438,7 +1438,7 @@ def main():
         parser.error("--dir (or --files) is required unless using --migrate-storage / --migrate-relative / --regenerate-proxies / --vision-only")
 
     if args.db:
-        db.DB_PATH = Path(args.db)
+        db.set_db_path(Path(args.db))  # R5-23 (#54): via SSOT accessor, not a raw rebind
 
     # --migrate-storage runs BEFORE db.init_db() because it creates the
     # storage layout (BASE_DIR/.arkiv/) that init_db needs. Other maintenance
@@ -1927,7 +1927,7 @@ def main():
 
     _moved_suffix = f"  moved={moved}" if moved else ""
     print(f"\nDone. OK={ok}  skip={skipped}  fail={failed}{_moved_suffix}")
-    print(f"DB: {db.DB_PATH}")
+    print(f"DB: {db.get_db_path()}")
 
     # Auto-build the vector index so semantic search + chat work immediately.
     # ingest writes SQLite records; embeddings live in ChromaDB and were a

--- a/server.py
+++ b/server.py
@@ -89,13 +89,19 @@ def _release_offload_slot(key: str) -> None:
 
 
 # ── Init ─────────────────────────────────────────────────────────────────────
-db.init_db()
+# R5-23 (#53): DB init + log-filter install are SIDE EFFECTS and must NOT fire at
+# import time — a transitional `import server` (e.g. during the APIRouter split, a
+# tooling import, or a test collection) used to create .arkiv/ and run migrations
+# against the env-configured PRODUCTION db before any preflight ran. They now run
+# in _lifespan, so they fire on real app startup only. TestClient enters the
+# lifespan via its context manager, so the fixtures keep working.
 
 # Redact `?token=` from uvicorn access logs. /api/stream accepts the token as a
 # query param (a <video src> can't send a header), and uvicorn's default access
 # log records the full request line incl. query string → the raw token would be
 # written to stdout / any redirected logfile. This filter scrubs it everywhere
-# the access logger formats a request path.
+# the access logger formats a request path. (Class defined at import; INSTALLED in
+# _lifespan so a bare import doesn't mutate global logging state.)
 import logging as _logging
 import re as _re
 _TOKEN_QS = _re.compile(r"(token=)[^&\s\"']+")
@@ -110,13 +116,21 @@ class _RedactTokenFilter(_logging.Filter):
         except Exception:
             pass
         return True
-_logging.getLogger("uvicorn.access").addFilter(_RedactTokenFilter())
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI):
+    db.init_db()  # R5-23 (#53): create/migrate the db on startup, not at import
+    _install_token_redaction_filter()
     _bootstrap_admin_token()  # late-bound; defined below near the admin routes
     yield
     # no shutdown work today; add teardown after the yield when needed
+
+
+def _install_token_redaction_filter() -> None:
+    # Idempotent: never stack a second filter if the app is (re)started in-process.
+    logger = _logging.getLogger("uvicorn.access")
+    if not any(isinstance(f, _RedactTokenFilter) for f in logger.filters):
+        logger.addFilter(_RedactTokenFilter())
 
 app = FastAPI(title="Media Asset Manager API", lifespan=_lifespan)
 _ALLOWED_ORIGINS = [
@@ -1711,7 +1725,8 @@ def get_stats(
     # effort: a stat() failure (e.g. path vanished) must not 500 the dashboard.
     try:
         import shutil
-        du = shutil.disk_usage(config.DB_PATH.parent if config.DB_PATH else ROOT)
+        _db_path = db.get_db_path()  # R5-23 (#54): SSOT accessor, not config value
+        du = shutil.disk_usage(_db_path.parent if _db_path else ROOT)
         stats["disk"] = {
             "used_gb": round(du.used / 1e9, 1),
             "total_gb": round(du.total / 1e9, 1),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,8 +122,10 @@ def tmp_db(tmp_path, monkeypatch):
     config = importlib.import_module("config")
     db = importlib.import_module("db")
     db_path = tmp_path / "test.db"
+    # R5-23 (#54): db.get_db_path() follows config.DB_PATH when no --db override is
+    # set, so monkeypatching config.DB_PATH alone points the whole stack at the tmp
+    # db (the old separate `db.DB_PATH` value copy is gone).
     monkeypatch.setattr(config, "DB_PATH", db_path)
-    monkeypatch.setattr(db, "DB_PATH", db_path)
     db.init_db()
     return db_path
 

--- a/tests/test_camera_report.py
+++ b/tests/test_camera_report.py
@@ -24,8 +24,7 @@ def test_camera_report_writes_three_section_csv_and_summary_matches_sql(monkeypa
     try:
         db_path = temp_root_path / "test.db"
         monkeypatch.setattr(config, "PROJECT_ROOT", temp_root_path)
-        monkeypatch.setattr(config, "DB_PATH", db_path)
-        monkeypatch.setattr(db, "DB_PATH", db_path)
+        monkeypatch.setattr(config, "DB_PATH", db_path)  # R5-23: SSOT accessor follows config.DB_PATH
         db.init_db()
 
         camera_report = importlib.import_module("camera_report")
@@ -209,8 +208,7 @@ def test_camera_report_main_returns_1_when_no_data(monkeypatch):
     try:
         db_path = temp_root_path / "test.db"
         monkeypatch.setattr(config, "PROJECT_ROOT", temp_root_path)
-        monkeypatch.setattr(config, "DB_PATH", db_path)
-        monkeypatch.setattr(db, "DB_PATH", db_path)
+        monkeypatch.setattr(config, "DB_PATH", db_path)  # R5-23: SSOT accessor follows config.DB_PATH
         db.init_db()
 
         camera_report = importlib.import_module("camera_report")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -237,5 +237,5 @@ def test_db_file_is_owner_only(tmp_db):
     db = importlib.import_module("db")
     with db.get_conn() as conn:
         conn.execute("SELECT 1")
-    mode = stat.S_IMODE(os.stat(db.DB_PATH).st_mode)
+    mode = stat.S_IMODE(os.stat(db.get_db_path()).st_mode)
     assert mode & 0o077 == 0, f"DB world/group-accessible: {oct(mode)}"

--- a/tests/test_r5_23_lifespan_dbpath.py
+++ b/tests/test_r5_23_lifespan_dbpath.py
@@ -1,0 +1,117 @@
+"""R5-23 (round-5 #53/#54): import-time side effects → _lifespan, and a single
+source of truth for the DB path.
+
+#53 — db.init_db() + the uvicorn-access token-redaction filter used to fire at
+import time, so a transitional `import server` created .arkiv/ and ran migrations
+against the production DB and mutated global logging state. They now run in
+_lifespan (real startup only); TestClient enters the lifespan so fixtures work.
+
+#54 — `--db` rebound db.DB_PATH (a frozen value copy) while health/server read
+config.DB_PATH, so a --db run preflighted the DEFAULT DB while writing the backup
+DB. Now db.get_db_path()/set_db_path() are the one knob; health/server route
+through the accessor; value imports of DB_PATH are forbidden.
+"""
+import pathlib
+import re
+
+import pytest
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+# ── #54: single source of truth ─────────────────────────────────────────────
+def test_get_db_path_follows_config_when_no_override(monkeypatch, tmp_path):
+    import config
+    import db
+    p = tmp_path / "follows.db"
+    monkeypatch.setattr(config, "DB_PATH", p)
+    db.set_db_path(None)  # no override → follow config
+    try:
+        assert db.get_db_path() == p
+    finally:
+        db.set_db_path(None)
+
+
+def test_set_db_path_overrides_and_get_conn_uses_it(tmp_path):
+    import db
+    override = tmp_path / "override.db"
+    db.set_db_path(override)
+    try:
+        assert db.get_db_path() == override
+        with db.get_conn() as conn:
+            conn.execute("SELECT 1")
+        assert override.exists(), "get_conn must open the override path, not the default"
+    finally:
+        db.set_db_path(None)
+
+
+def test_override_decouples_from_config_default(tmp_path, monkeypatch):
+    # The #54 bug: --db moved the WRITE target but health/server kept reading the
+    # config default → mixed-database run. get_db_path() is now the ONLY knob, so
+    # an override is what every routed reader (health.py, server.py) sees.
+    import config
+    import db
+    default = tmp_path / "default.db"
+    backup = tmp_path / "backup.db"
+    monkeypatch.setattr(config, "DB_PATH", default)
+    db.set_db_path(backup)
+    try:
+        assert db.get_db_path() == backup           # readers follow the accessor…
+        assert config.DB_PATH == default            # …not the untouched config default
+    finally:
+        db.set_db_path(None)
+
+
+def test_no_value_imports_of_db_path():
+    pat = re.compile(r"^\s*from\s+(config|db)\s+import\s+.*\bDB_PATH\b", re.M)
+    bad = [py.name for py in _ROOT.glob("*.py")
+           if py.name != "config.py" and pat.search(py.read_text(encoding="utf-8"))]
+    assert not bad, "value imports of DB_PATH freeze a copy — use db.get_db_path(): {0}".format(bad)
+
+
+def test_health_and_server_read_db_path_via_accessor():
+    # Regression guard for the dual-source bug: neither module may read
+    # config.DB_PATH directly for the DB location (comments excluded).
+    offenders = []
+    for name in ("health.py", "server.py"):
+        code = "\n".join(l for l in (_ROOT / name).read_text(encoding="utf-8").splitlines()
+                         if not l.lstrip().startswith("#"))
+        if "config.DB_PATH" in code:
+            offenders.append(name)
+    assert not offenders, "{0} still read config.DB_PATH directly; route through db.get_db_path()".format(offenders)
+
+
+# ── #53: side effects moved to _lifespan ────────────────────────────────────
+def test_redaction_filter_install_is_idempotent(server_module):
+    import logging
+    logger = logging.getLogger("uvicorn.access")
+    RF = server_module._RedactTokenFilter
+    for f in [x for x in logger.filters if isinstance(x, RF)]:
+        logger.removeFilter(f)
+    server_module._install_token_redaction_filter()
+    server_module._install_token_redaction_filter()  # second call must not stack
+    assert sum(isinstance(x, RF) for x in logger.filters) == 1
+
+
+def test_lifespan_installs_filter_and_inits_db(server_module):
+    # Entering the TestClient runs _lifespan → installs the redaction filter and
+    # inits the DB. Proves the side effects fire on startup (not merely at import).
+    import logging
+    from starlette.testclient import TestClient
+    logger = logging.getLogger("uvicorn.access")
+    RF = server_module._RedactTokenFilter
+    for f in [x for x in logger.filters if isinstance(x, RF)]:
+        logger.removeFilter(f)
+    assert not any(isinstance(x, RF) for x in logger.filters)
+    with TestClient(server_module.app):
+        assert any(isinstance(x, RF) for x in logger.filters), "lifespan must install the redaction filter"
+
+
+def test_importing_server_does_not_install_filter_at_module_top():
+    # The install call must live in _lifespan / _install_token_redaction_filter,
+    # not as a bare module-level statement that fires on import.
+    src = (_ROOT / "server.py").read_text(encoding="utf-8")
+    # a bare top-level `getLogger("uvicorn.access").addFilter(` (no indentation)
+    # would mean import-time mutation of global logging state.
+    assert not re.search(r"^_logging\.getLogger\([\"']uvicorn\.access[\"']\)\.addFilter\(",
+                         src, re.M), "token-redaction filter must be installed in _lifespan, not at import"


### PR DESCRIPTION
**Round-5 Wave 4 · findings #53 + #54** — architecture prerequisites for the PR8–11 router split (#51).

### #53 — import-time side effects
`db.init_db()` and the uvicorn-access token-redaction filter fired at **import** time: a transitional `import server` (the coming router split, a tooling import, test collection) created `.arkiv/`, ran migrations against the env-configured **production** DB, and mutated global logging state — all before any preflight.

- Both now run in `_lifespan` (real startup only). Filter install is **idempotent**. `TestClient` enters the lifespan via its context manager, so fixtures keep working.

### #54 — DB_PATH dual source of truth
`db.py` froze `from config import DB_PATH`, `--db` rebound `db.DB_PATH`, and `health.py`/`server.py` read `config.DB_PATH`. A `--db` run therefore **preflighted/reported the DEFAULT db while WRITING the backup db** — a silent mixed-database run.

- `db.get_db_path()` / `db.set_db_path()` are the single knob (explicit override wins, else follow `config.DB_PATH` dynamically).
- `get_conn()` reads `get_db_path()`; `export`/`ingest` `--db` call `set_db_path()`; `health.py` + `server.py` route through the accessor.
- Frozen value import removed; a **lint test** forbids `from config import DB_PATH` / `from db import DB_PATH` and direct `config.DB_PATH` reads in health/server.
- `conftest`/`test_camera_report` drop the now-dead `db.DB_PATH` monkeypatch (the `config.DB_PATH` one drives the accessor).

### Verification
`tests/test_r5_23_lifespan_dbpath.py` (8 tests: SSOT follow/override/decouple, lint guards, idempotent + lifespan-only filter install). Full suite **732 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)