### PR TITLE
refactor(state): embed/retranscribe → state.SingleFlight + guard proxy build (round-5 #52/#59)

### DIFF
--- a/server.py
+++ b/server.py
@@ -51,22 +51,16 @@ from state import (  # noqa: F401  (re-exported for backward compat)
     _acquire_ingest_slot,
     _release_ingest_slot,
     ingest_ws,
+    embed_rebuild as _embed_guard,
+    retranscribe as _retranscribe_guard,
+    proxy_build as _proxy_guard,
 )
 
-# The remaining guards stay here for now — their flags are rebound via `global`
-# inside route handlers (and a test writes the raw flag), so they need a
-# mutable-container refactor rather than a plain import to move to state.py.
-
-# audit M8: single-flight for the embed rebuild — double-clicking the rebuild
-# button used to launch N concurrent drop+rebuild subprocesses over the same
-# Chroma collection.
-_embed_rebuild_lock = _threading.Lock()
-_embed_rebuild_active = False
-
-# Phase 9.6d: project-wide batch retranscribe (single-flight + progress poll).
-_retranscribe_lock = _threading.Lock()
-_retranscribe_active = False
-_retranscribe_progress = {"total": 0, "done": 0, "failed": 0, "current": None, "running": False, "backup": None}
+# R5-22 (#52): the embed-rebuild / retranscribe single-flight guards + the
+# retranscribe progress dict now live in state.py as SingleFlight OBJECTS
+# (_embed_guard / _retranscribe_guard), so an APIRouter-split module imports a
+# live instance instead of a frozen bool copy. The retranscribe progress dict is
+# _retranscribe_guard.progress (mutated in place).
 
 # R5-17 (#19): single-flight the offload endpoint PER SOURCE. Two runs over the
 # same card (a double-clicked Run, or a retry over a still-live run) would race
@@ -2951,7 +2945,7 @@ def clear_cache(
     _assert_same_site(request)
     import shutil
     # #15: never rmtree the index out from under an active rebuild.
-    if target in ("chromadb", "all") and _embed_rebuild_active:
+    if target in ("chromadb", "all") and _embed_guard.active:
         raise HTTPException(409, "語意索引重建進行中，請待完成後再清除")
     cleared = []
     if target in ("thumbnails", "all"):
@@ -4137,7 +4131,12 @@ def proxy_build(request: Request, background_tasks: BackgroundTasks, _tok: dict 
     ]
     if not to_build:
         return {"message": "全部 proxy 已存在", "queued": 0}
-    background_tasks.add_task(_build_proxies, to_build)
+    # R5-22 (#59): single-flight the whole-library build so a double-click can't
+    # launch parallel full-library ffmpeg loops (mid-build playback would stream
+    # truncated proxies). The guarded wrapper releases the slot in its finally.
+    if not _proxy_guard.acquire():
+        raise HTTPException(409, "proxy 生成已在進行中，請稍候")
+    background_tasks.add_task(_build_proxies_all, to_build)
     return {"message": f"開始生成 {len(to_build)} 個 proxy（背景執行）", "queued": len(to_build)}
 
 
@@ -4163,6 +4162,16 @@ def proxy_build_one(media_id: int, request: Request, background_tasks: Backgroun
     }
 
 
+def _build_proxies_all(items: list):
+    """Whole-library proxy build background task — holds the R5-22 (#59)
+    single-flight for its whole lifetime and frees it in finally. The per-id build
+    stays unguarded (targeted, cheap) and calls _build_proxies directly."""
+    try:
+        _build_proxies(items)
+    finally:
+        _proxy_guard.release()
+
+
 def _build_proxies(items: list):
     """Background task: generate H.264 proxy for each file."""
     import ingest
@@ -4181,15 +4190,12 @@ def embed_rebuild(request: Request, background_tasks: BackgroundTasks, _tok: dic
     """Drop + rebuild the ChromaDB semantic index from all media.
     Wired to 進階設定 → 搜尋引擎 → 「重建向量索引」button."""
     _assert_same_site(request)  # audit M14
-    global _embed_rebuild_active
     with db.get_conn() as conn:
         total = conn.execute("SELECT count(*) FROM media").fetchone()[0]
     if not total:
         return {"message": "尚無素材可建立索引", "queued": 0}
-    with _embed_rebuild_lock:  # audit M8: refuse concurrent rebuilds
-        if _embed_rebuild_active:
-            raise HTTPException(409, "向量索引重建已在進行中，請稍候")
-        _embed_rebuild_active = True
+    if not _embed_guard.acquire():  # audit M8: refuse concurrent rebuilds
+        raise HTTPException(409, "向量索引重建已在進行中，請稍候")
     background_tasks.add_task(_rebuild_embeddings)
     return {"message": f"開始重建向量索引（{total} 筆素材，背景執行）", "queued": total}
 
@@ -4198,7 +4204,6 @@ def _rebuild_embeddings():
     """Background task: full embedding rebuild via subprocess. Runs embed.py in a
     child process to isolate its sys.exit() guard and use sys.executable per the
     platform Python-concurrency rule (not in-process — sys.exit would kill server)."""
-    global _embed_rebuild_active
     import subprocess
     import sys
     try:
@@ -4206,8 +4211,7 @@ def _rebuild_embeddings():
     except Exception as e:
         print(f"[embed] rebuild failed: {e}")
     finally:
-        with _embed_rebuild_lock:  # audit M8: always free the single-flight slot
-            _embed_rebuild_active = False
+        _embed_guard.release()  # audit M8: always free the single-flight slot
 
 
 # ── Phase 9.6b: per-project correction dictionary ────────────────────────────
@@ -4259,12 +4263,9 @@ def recorrect(
     result = corrections.apply()
     embed_started = False
     if rebuild and result.get("media_updated"):
-        global _embed_rebuild_active
-        with _embed_rebuild_lock:  # audit M8: refuse concurrent rebuilds
-            if not _embed_rebuild_active:
-                _embed_rebuild_active = True
-                background_tasks.add_task(_rebuild_embeddings)
-                embed_started = True
+        if _embed_guard.acquire():  # audit M8: only start if no rebuild is running
+            background_tasks.add_task(_rebuild_embeddings)
+            embed_started = True
     return {"dry_run": False, **result, "embed_rebuild_started": embed_started}
 
 
@@ -4321,26 +4322,24 @@ def retranscribe_all(
     to the shared correction-backups first (RP-4 — restorable via the same
     revert)."""
     _assert_same_site(request)
-    global _retranscribe_active
     with db.get_conn() as conn:
         rows = conn.execute("SELECT id, path FROM media WHERE has_audio=1").fetchall()
     targets = [(r["id"], r["path"]) for r in rows]
     if not targets:
         return {"queued": 0, "message": "沒有含音訊的素材可重轉錄"}
-    with _retranscribe_lock:  # refuse concurrent batch runs (mirrors embed M8)
-        if _retranscribe_active:
-            raise HTTPException(409, "批次重轉錄已在進行中，請稍候")
-        # fable-audit 2026-07-12 (#11): this batch runs whisper IN-PROCESS over the
-        # whole library — it must also hold the shared H3 ingest slot, or a
-        # concurrent /api/ingest loads a second whisper → double-whisper OOM. The
-        # background worker releases it in its finally.
-        if not _acquire_ingest_slot():
-            raise HTTPException(409, "已有匯入任務進行中，請稍候")
-        _retranscribe_active = True
-        _retranscribe_progress.update({
-            "total": len(targets), "done": 0, "failed": 0,
-            "current": None, "running": True, "backup": None,
-        })
+    if not _retranscribe_guard.acquire():  # refuse concurrent batch runs (mirrors embed M8)
+        raise HTTPException(409, "批次重轉錄已在進行中，請稍候")
+    # fable-audit 2026-07-12 (#11): this batch runs whisper IN-PROCESS over the
+    # whole library — it must also hold the shared H3 ingest slot, or a concurrent
+    # /api/ingest loads a second whisper → double-whisper OOM. The background
+    # worker releases both in its finally; if the slot is busy we must free our own
+    # guard before bailing so a later retry isn't wrongly rejected.
+    if not _acquire_ingest_slot():
+        _retranscribe_guard.release()
+        raise HTTPException(409, "已有匯入任務進行中，請稍候")
+    _retranscribe_guard.reset_progress(
+        total=len(targets), done=0, failed=0, current=None, running=True, backup=None,
+    )
     background_tasks.add_task(_run_retranscribe_all, targets, body.language, body.backup)
     return {"queued": len(targets)}
 
@@ -4348,8 +4347,13 @@ def retranscribe_all(
 def _run_retranscribe_all(targets, language, backup):
     """Background worker: re-transcribe each target, preserving the single-clip
     guard (never blank a good transcript on an empty/failed decode — audit H1)."""
-    global _retranscribe_active
     import transcribe as tr
+    # The worker owns its progress lifecycle: seed a clean counter set at the start
+    # (the route also seeds it for the poll window before this task is scheduled).
+    _retranscribe_guard.reset_progress(
+        total=len(targets), done=0, failed=0, current=None, running=True, backup=None,
+    )
+    progress = _retranscribe_guard.progress  # in-place dict shared with the poller
     try:
         if backup:
             rows = []
@@ -4365,27 +4369,27 @@ def _run_retranscribe_all(targets, language, backup):
                     if r:
                         rows.append(dict(r))
             if rows:
-                _retranscribe_progress["backup"] = corrections._write_backup(
+                progress["backup"] = corrections._write_backup(
                     rows, [{"op": "retranscribe-all", "language": language}]
                 )
         for mid, path in targets:
-            _retranscribe_progress["current"] = mid
+            progress["current"] = mid
             media_path = _resolve_media_path(path or "")
             if not Path(media_path).exists():
-                _retranscribe_progress["failed"] += 1
-                _retranscribe_progress["done"] += 1
+                progress["failed"] += 1
+                progress["done"] += 1
                 continue
             try:
                 text, lang, segments, words = tr.transcribe(media_path, language=language)
             except Exception:
-                _retranscribe_progress["failed"] += 1
-                _retranscribe_progress["done"] += 1
+                progress["failed"] += 1
+                progress["done"] += 1
                 continue
             rec = db.get_record_by_id(mid) or {}
             # refuse to overwrite a good transcript with nothing (H1)
             if not (text or "").strip() and (rec.get("transcript") or "").strip():
-                _retranscribe_progress["failed"] += 1
-                _retranscribe_progress["done"] += 1
+                progress["failed"] += 1
+                progress["done"] += 1
                 continue
             _al = lang or language
             _sj = json.dumps(segments, ensure_ascii=False) if segments else None
@@ -4409,19 +4413,18 @@ def _run_retranscribe_all(targets, language, backup):
                     ),
                 )
                 db.upsert_transcript(mid, _al, text, _sj, _wj, _conn=conn)  # G2 archive
-            _retranscribe_progress["done"] += 1
+            progress["done"] += 1
     finally:
-        _retranscribe_progress["running"] = False
-        _retranscribe_progress["current"] = None
-        with _retranscribe_lock:
-            _retranscribe_active = False
+        progress["running"] = False
+        progress["current"] = None
+        _retranscribe_guard.release()
         _release_ingest_slot()  # fable-audit 2026-07-12 (#11): free the shared H3 slot
 
 
 @app.get("/api/retranscribe-all/status")
 def retranscribe_all_status(_tok: dict = Depends(require_scopes("projects_read"))):
     """Poll batch-retranscribe progress {total, done, failed, current, running, backup}."""
-    return dict(_retranscribe_progress)
+    return dict(_retranscribe_guard.progress)
 
 
 # ── Serve Frontend ───────────────────────────────────────────────────────────

--- a/state.py
+++ b/state.py
@@ -18,6 +18,68 @@ from typing import Set
 
 from fastapi import WebSocket
 
+
+# ── Named single-flight guards ────────────────────────────────────────────────
+# R5-22 (#52): embed-rebuild / retranscribe used bare module-global bools
+# (`_embed_rebuild_active` etc.) rebound via `global` inside route handlers. Once
+# the APIRouter split moves those routes into their own modules, `from server
+# import _embed_rebuild_active` would import a FROZEN COPY of the bool — the
+# importing router's guard reads False forever and the single-flight is silently
+# dead (embed has no ingest-slot backstop). Wrapping the flag in an OBJECT means a
+# router imports ONE live instance; acquire()/release() mutate it in place, and
+# the progress dict is mutated in place too, so a poller holding the same dict
+# sees updates. This is the mutable-container refactor state.py's header deferred.
+class SingleFlight:
+    """A named, thread-safe single-flight slot with an in-place progress dict."""
+
+    def __init__(self, name):
+        self.name = name
+        self._lock = _threading.Lock()
+        self._active = False
+        self.progress = {}
+
+    def acquire(self):
+        """Reserve the slot. True if reserved, False if already held."""
+        with self._lock:
+            if self._active:
+                return False
+            self._active = True
+            return True
+
+    def release(self):
+        with self._lock:
+            self._active = False
+
+    @property
+    def active(self):
+        with self._lock:
+            return self._active
+
+    def reset_progress(self, **fields):
+        """Replace the progress dict CONTENTS in place (never rebind), so a
+        reference already handed to a poller keeps pointing at live data."""
+        self.progress.clear()
+        self.progress.update(fields)
+
+
+# audit M8: single-flight for the embed rebuild — double-clicking 「重建向量索引」
+# used to launch N concurrent drop+rebuild subprocesses over the same Chroma
+# collection. Shared by /api/embed/rebuild and the recorrect rebuild chain.
+embed_rebuild = SingleFlight("embed_rebuild")
+
+# Phase 9.6d: project-wide batch retranscribe (single-flight + progress poll).
+# Seed the poll shape so GET /api/retranscribe-all/status returns the full dict
+# even before the first run (parity with the old module-global default).
+retranscribe = SingleFlight("retranscribe")
+retranscribe.reset_progress(
+    total=0, done=0, failed=0, current=None, running=False, backup=None,
+)
+
+# R5-22 (#59): /api/proxy/build had NO single-flight (unlike its embed/retranscribe
+# siblings) — a double-click launched parallel full-library ffmpeg loops and
+# mid-build playback streamed truncated proxies.
+proxy_build = SingleFlight("proxy_build")
+
 # ── Ingest single-flight guard ────────────────────────────────────────────────
 # One guard for ALL ingest entry points (REST /api/ingest, reingest, WS, bin-copy,
 # retranscribe-all) so two full pipelines can't run at once → DB-lock contention +

--- a/tests/test_hardening_round4.py
+++ b/tests/test_hardening_round4.py
@@ -197,8 +197,11 @@ def test_cache_clear_chromadb_invalidates_client_cache(fastapi_client, tmp_path,
     assert called["n"] == 1             # cached System dropped so a rebuild is seen
 
 
-def test_cache_clear_refuses_chromadb_during_embed_rebuild(fastapi_client, monkeypatch):
+def test_cache_clear_refuses_chromadb_during_embed_rebuild(fastapi_client):
     import server
-    monkeypatch.setattr(server, "_embed_rebuild_active", True)  # a rebuild is mid-flight
-    r = fastapi_client.post("/api/cache/clear", params={"target": "chromadb"})
-    assert r.status_code == 409
+    assert server._embed_guard.acquire()  # R5-22: a rebuild is mid-flight (state.SingleFlight)
+    try:
+        r = fastapi_client.post("/api/cache/clear", params={"target": "chromadb"})
+        assert r.status_code == 409
+    finally:
+        server._embed_guard.release()

--- a/tests/test_r5_22_singleflight.py
+++ b/tests/test_r5_22_singleflight.py
@@ -1,0 +1,102 @@
+"""R5-22 (round-5 #52/#59): state.SingleFlight for embed/retranscribe/proxy.
+
+#52 — embed-rebuild / retranscribe used bare module-global bools rebound via
+`global` in route handlers. Once the APIRouter split moves those routes to their
+own modules, `from server import _embed_rebuild_active` would import a FROZEN COPY
+of the bool → the importing router's guard reads False forever. Wrapping the flag
+in a state.SingleFlight OBJECT means every module holds one live instance.
+
+#59 — /api/proxy/build had no single-flight (unlike its siblings); a double-click
+launched parallel full-library ffmpeg loops. Now guarded by state.proxy_build,
+released by the _build_proxies_all wrapper.
+"""
+import importlib
+
+import pytest
+
+
+def _insert_media(path="clip.mov", filename="clip.mov"):
+    db = importlib.import_module("db")
+    with db.get_conn() as conn:
+        conn.execute("INSERT INTO media (path, filename) VALUES (?, ?)", (path, filename))
+
+
+# ── #52: SingleFlight primitive + cross-module liveness ─────────────────────
+def test_singleflight_semantics():
+    import state
+    sf = state.SingleFlight("t")
+    assert sf.acquire() is True
+    assert sf.acquire() is False    # already held → refused
+    assert sf.active is True
+    sf.release()
+    assert sf.active is False
+    assert sf.acquire() is True     # released → reusable
+    sf.release()
+
+
+def test_progress_dict_mutated_in_place_not_rebound():
+    import state
+    sf = state.SingleFlight("p")
+    ref = sf.progress               # a poller captures the dict reference
+    sf.reset_progress(total=3, done=0)
+    assert ref is sf.progress and ref["total"] == 3   # same object, updated in place
+    sf.progress["done"] = 2
+    assert ref["done"] == 2
+
+
+def test_guard_is_one_live_instance_across_modules(server_module):
+    # The crux of #52: server imports the guard OBJECT from state, so a mutation
+    # via server's alias is visible on state.embed_rebuild — a frozen bool copy
+    # would read False forever in the importing module.
+    import state
+    assert server_module._embed_guard is state.embed_rebuild
+    assert server_module._retranscribe_guard is state.retranscribe
+    assert server_module._proxy_guard is state.proxy_build
+    try:
+        assert server_module._embed_guard.acquire()
+        assert state.embed_rebuild.active is True
+    finally:
+        server_module._embed_guard.release()
+
+
+# ── #52: endpoints refuse concurrent runs via the shared guard ──────────────
+def test_embed_rebuild_409_when_guard_held(fastapi_client, server_module):
+    _insert_media("a.mp4", "a.mp4")  # non-empty library → past the early return
+    assert server_module._embed_guard.acquire()
+    try:
+        r = fastapi_client.post("/api/embed/rebuild")
+        assert r.status_code == 409
+    finally:
+        server_module._embed_guard.release()
+
+
+# ── #59: proxy build single-flight + wrapper release ────────────────────────
+def test_proxy_build_409_when_guard_held(fastapi_client, server_module, tmp_path, monkeypatch):
+    config = importlib.import_module("config")
+    monkeypatch.setattr(config, "PROJECT_ROOT", tmp_path)
+    _insert_media("clip.mov", "clip.mov")  # proxy doesn't exist → to_build non-empty
+    assert server_module._proxy_guard.acquire()
+    try:
+        r = fastapi_client.post("/api/proxy/build")
+        assert r.status_code == 409
+    finally:
+        server_module._proxy_guard.release()
+
+
+def test_proxy_build_wrapper_releases_slot(server_module, monkeypatch):
+    calls = []
+    monkeypatch.setattr(server_module, "_build_proxies", lambda items: calls.append(items))
+    assert server_module._proxy_guard.acquire()  # route would have acquired it
+    server_module._build_proxies_all([{"id": 1, "path": "x"}])
+    assert server_module._proxy_guard.active is False, "wrapper must free the slot"
+    assert calls == [[{"id": 1, "path": "x"}]]
+
+
+def test_proxy_build_wrapper_releases_on_exception(server_module, monkeypatch):
+    def boom(items):
+        raise RuntimeError("ffmpeg blew up")
+    monkeypatch.setattr(server_module, "_build_proxies", boom)
+    assert server_module._proxy_guard.acquire()
+    with pytest.raises(RuntimeError):
+        server_module._build_proxies_all([])
+    assert server_module._proxy_guard.active is False, "slot freed even on failure"

--- a/tests/test_retranscribe_all.py
+++ b/tests/test_retranscribe_all.py
@@ -46,9 +46,9 @@ def test_batch_updates_all_and_backup_reverts(srv, tmp_path, monkeypatch):
 
     srv._run_retranscribe_all([(id1, p1), (id2, p2)], None, True)
 
-    assert srv._retranscribe_progress["done"] == 2
-    assert srv._retranscribe_progress["failed"] == 0
-    assert srv._retranscribe_progress["backup"]
+    assert srv._retranscribe_guard.progress["done"] == 2
+    assert srv._retranscribe_guard.progress["failed"] == 0
+    assert srv._retranscribe_guard.progress["backup"]
     with db.get_conn() as conn:
         got = [r["transcript"] for r in conn.execute("SELECT transcript FROM media ORDER BY id")]
     assert got == ["新的逐字稿", "新的逐字稿"]
@@ -69,8 +69,8 @@ def test_batch_guard_never_blanks_good_transcript(srv, tmp_path, monkeypatch):
 
     srv._run_retranscribe_all([(id1, p1)], None, False)
 
-    assert srv._retranscribe_progress["failed"] == 1
-    assert srv._retranscribe_progress["done"] == 1
+    assert srv._retranscribe_guard.progress["failed"] == 1
+    assert srv._retranscribe_guard.progress["done"] == 1
     with db.get_conn() as conn:
         kept = conn.execute("SELECT transcript FROM media WHERE id=?", (id1,)).fetchone()["transcript"]
     assert kept == "務必保留這段"  # untouched
@@ -87,7 +87,7 @@ def test_batch_missing_file_counts_failed(srv, tmp_path, monkeypatch):
         gid = cur.lastrowid
     monkeypatch.setattr(transcribe, "transcribe", lambda path, language=None: ("x", "zh", [], []))
     srv._run_retranscribe_all([(gid, "/no/such/file.wav")], None, False)
-    assert srv._retranscribe_progress["failed"] == 1
+    assert srv._retranscribe_guard.progress["failed"] == 1
     with db.get_conn() as conn:
         assert conn.execute("SELECT transcript FROM media WHERE id=?", (gid,)).fetchone()["transcript"] == "原文"
 
@@ -117,12 +117,12 @@ def test_api_refuses_concurrent_run(fastapi_client, server_module, tmp_path, mon
     config = importlib.import_module("config")
     monkeypatch.setattr(config, "PROJECT_ROOT", tmp_path)
     _seed_audio(tmp_path, "丙")
-    server_module._retranscribe_active = True  # pretend a batch is mid-flight
+    assert server_module._retranscribe_guard.acquire()  # pretend a batch is mid-flight
     try:
         r = fastapi_client.post("/api/retranscribe-all", json={})
         assert r.status_code == 409
     finally:
-        server_module._retranscribe_active = False
+        server_module._retranscribe_guard.release()
 
 
 def test_batch_backup_and_revert_restore_lang(srv, tmp_path, monkeypatch):


### PR DESCRIPTION
**Round-5 Wave 4 · findings #52 + #59.** Stacked on **PR7 (#133, `feat/hardening-state-extraction`)** — its `state.py` header explicitly deferred these guards as "a follow-up"; this is that follow-up. **Base this PR on #133, not main.**

### #52 — rebindable module-global guards freeze on by-name import
`embed-rebuild` / `retranscribe` used bare module-global bools (`_embed_rebuild_active`, `_retranscribe_active`) rebound via `global` in route handlers. Once the APIRouter split (#51) moves those routes into their own modules, `from server import _embed_rebuild_active` imports a **frozen copy** of the bool — the importing router's guard reads `False` forever and the single-flight is silently dead (embed has no ingest-slot backstop).

- New `state.SingleFlight` object (lock + active flag + in-place progress dict). `embed_rebuild` / `retranscribe` / `proxy_build` instances live in `state.py`, so every module holds **one live instance**.
- `server.py` imports them and drops the local lock+flag+dict trio. Retranscribe progress is `_retranscribe_guard.progress` (mutated in place; seeded so `/api/retranscribe-all/status` keeps its full shape before the first run).

### #59 — proxy build had no single-flight
A double-click on `/api/proxy/build` launched **parallel full-library ffmpeg loops**; mid-build playback streamed truncated proxies.

- Guarded by `state.proxy_build`; the new `_build_proxies_all` wrapper holds the slot for the whole background build and frees it in `finally`. Per-id `/api/proxy/build/{id}` stays unguarded (targeted + cheap).

### Verification
`tests/test_r5_22_singleflight.py` (7): SingleFlight semantics, in-place progress, one-live-instance-across-modules, embed + proxy 409, wrapper releases on success **and** on exception. `test_retranscribe_all` migrated to the guard. Full suite **734 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)