### PR TITLE
fix(auth): token ids never start with '-' — kill flaky test_cli_revoke (task13)

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -92,9 +92,16 @@ def _candidate_hashes(raw):
 
 
 def new_token_id():
-    if nanoid_generate is not None:
-        return nanoid_generate()
-    return secrets.token_urlsafe(16)
+    # Both nanoid and base64url use the alphabet [A-Za-z0-9_-]. A LEADING '-'
+    # makes `arkiv_token.py revoke <id>` argparse-ambiguous — the id is read as an
+    # option flag, so the positional goes unfilled ("error: the following
+    # arguments are required: token_id"). That surfaced as an intermittent
+    # (~1/64) CI failure of test_cli_revoke_removes_token. Re-roll until the first
+    # char isn't '-' so every issued id is CLI-safe; entropy impact is negligible.
+    while True:
+        tid = nanoid_generate() if nanoid_generate is not None else secrets.token_urlsafe(16)
+        if tid and not tid.startswith("-"):
+            return tid
 
 
 def new_raw_token():

--- a/tests/test_token_id_cli_safe.py
+++ b/tests/test_token_id_cli_safe.py
@@ -1,0 +1,17 @@
+"""Regression: token ids must be CLI-safe (never start with '-').
+
+`new_token_id()` draws from the base64url / nanoid alphabet [A-Za-z0-9_-]. An id
+that STARTS with '-' makes `arkiv_token.py revoke <id>` argparse-parse the id as
+an option flag, leaving the positional unfilled ("error: the following arguments
+are required: token_id"). That was the intermittent ~1/64 CI failure of
+test_cli_revoke_removes_token — deterministic per-id, not truly random.
+"""
+import auth
+
+
+def test_new_token_id_never_starts_with_dash():
+    ids = [auth.new_token_id() for _ in range(5000)]
+    # Without the re-roll, ~1/64 of 5000 ids (~78) would start with '-'.
+    bad = [t for t in ids if t.startswith("-")]
+    assert not bad, "leading-dash token ids break `revoke <id>`: {0}".format(bad[:5])
+    assert all(ids), "token ids must be non-empty"


### PR DESCRIPTION
**Prereq for the round-5 merge train.** `test_cli_revoke_removes_token` intermittently failed `test (3.9)`/`test (3.12)` (it's why #139 sits BLOCKED). Root cause: `new_token_id()` uses the base64url / nanoid alphabet `[A-Za-z0-9_-]`; when an id **starts with `-`**, `arkiv_token.py revoke <id>` makes argparse read it as an option flag → `error: the following arguments are required: token_id`. Deterministic per-id (~1/64), not truly random — and a real CLI bug for any such token.

**Fix:** re-roll `new_token_id()` until the first char isn't `-` (both nanoid and `secrets.token_urlsafe` paths). Regression test asserts 5000 ids are CLI-safe.

Merging this **first** so every rebased round-5 branch inherits a reliable CI gate.

Verified: previously-flaky test 20/20 green locally; full suite 725 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)