### PR TITLE
refactor(server): extract pathres.py (router-split foundation, round-5 #51 / R5-25 PR8)

### DIFF
--- a/pathres.py
+++ b/pathres.py
@@ -1,0 +1,92 @@
+"""Path-resolution service for the API layer.
+
+R5-25 / round-5 #51: the APIRouter split is blocked by ~50 cross-group helpers —
+a naive cut has each router doing `from server import _resolve_media_path`, and
+since `server` imports the routers, that's a partially-initialized-module
+ImportError. The fix is to extract the shared helpers into leaf service modules
+that the routers (and server) import, breaking the cycle. This is the first such
+module: the non-leaking display-path + media-path resolution used by ~every
+media/bins/export/stream route.
+
+Depends only on `db` (to_relative / resolve_path) and stdlib — no server state —
+so it sits safely at the bottom of the import graph. server.py re-exports these
+names for backward compatibility (existing call sites + tests that reference
+`server._resolve_media_path` keep working).
+"""
+import os
+
+import db
+
+
+def _basename_safe(value: str) -> str:
+    """Separator-agnostic basename. `os.path.basename` on a POSIX host treats `\\`
+    as an ordinary character, so a Windows project path (`C:\\Users\\me\\proj`)
+    handed over by a cross-platform federation peer would survive `basename` +
+    `rstrip("/")` and leak intact. Normalise both separators first."""
+    if not value:
+        return value
+    normalized = str(value).replace("\\", "/").rstrip("/")
+    return normalized.rsplit("/", 1)[-1] or normalized
+
+
+def _looks_absolute(p: str) -> bool:
+    """True for POSIX (`/x`), Windows drive (`C:\\x`), or UNC (`\\\\host`) absolute
+    paths. `os.path.isabs` on a POSIX host misses the Windows forms, which would
+    let a cross-platform peer's absolute path slip past the leak guard."""
+    if not p:
+        return False
+    return (
+        p.startswith("/")
+        or p.startswith("\\\\")
+        # Windows drive form `X:` followed by EITHER separator (`C:\` or `C:/` —
+        # Windows APIs emit and accept both). Security-first call on an inherent
+        # ambiguity: `C:/...` could also be a POSIX *relative* path under a dir
+        # literally named "C:", but a leak guard must not let a Windows-absolute
+        # path through, and a Unix media dir literally named "C:" is pathological.
+        # So we basename it (the rare round-trip loss is the accepted trade-off vs
+        # re-opening the path leak). (Codex round-1 wanted C:/ preserved; round-2
+        # showed that re-leaks C:/ Windows absolutes — no-leak wins.)
+        or (len(p) >= 3 and p[0].isalpha() and p[1] == ":" and p[2] in ("\\", "/"))
+    )
+
+
+def _display_path(path: str) -> str:
+    """Phase 16.2: the non-leaking path form for API responses.
+
+    Returning the absolute fs path leaked the operator's directory tree
+    (/Volumes/home/影片專案/…) to any read-scope / loopback client. We return the
+    PROJECT_ROOT-relative form; a legacy row whose stored path is absolute AND
+    outside PROJECT_ROOT (so to_relative can't relativize it) is reduced to its
+    basename rather than leaking the full path. Relative paths round-trip through
+    /api/open-file (db.is_processed matches relative; the server re-absolutizes);
+    once a library is migrated (ingest.py --migrate-relative) every row is
+    relative and open-file works for all of them.
+    """
+    if not path:
+        return path
+    rel = db.to_relative(path)
+    if _looks_absolute(rel):  # absolute (POSIX/Windows/UNC) & outside root — don't leak
+        return _basename_safe(rel)
+    return rel
+
+
+def _resolve_record(rec: dict) -> dict:
+    if rec.get("path"):
+        rec["path"] = _display_path(rec["path"])
+    if rec.get("thumbnail_path"):
+        rec["thumbnail_path"] = _display_path(rec["thumbnail_path"])
+    return rec
+
+
+def _resolve_frame(frame: dict) -> dict:
+    if frame.get("thumbnail_path"):
+        frame["thumbnail_path"] = _display_path(frame["thumbnail_path"])
+    return frame
+
+
+def _resolve_media_path(path: str) -> str:
+    if not path:
+        return path
+    if os.name == "nt" and path.startswith("/"):
+        return path
+    return db.resolve_path(path)

--- a/server.py
+++ b/server.py
@@ -178,78 +178,19 @@ def serve_thumbnail(
     return FileResponse(str(resolved))
 
 
-def _basename_safe(value: str) -> str:
-    """Separator-agnostic basename. `os.path.basename` on a POSIX host treats `\\`
-    as an ordinary character, so a Windows project path (`C:\\Users\\me\\proj`)
-    handed over by a cross-platform federation peer would survive `basename` +
-    `rstrip("/")` and leak intact. Normalise both separators first."""
-    if not value:
-        return value
-    normalized = str(value).replace("\\", "/").rstrip("/")
-    return normalized.rsplit("/", 1)[-1] or normalized
-
-
-def _looks_absolute(p: str) -> bool:
-    """True for POSIX (`/x`), Windows drive (`C:\\x`), or UNC (`\\\\host`) absolute
-    paths. `os.path.isabs` on a POSIX host misses the Windows forms, which would
-    let a cross-platform peer's absolute path slip past the leak guard."""
-    if not p:
-        return False
-    return (
-        p.startswith("/")
-        or p.startswith("\\\\")
-        # Windows drive form `X:` followed by EITHER separator (`C:\` or `C:/` —
-        # Windows APIs emit and accept both). Security-first call on an inherent
-        # ambiguity: `C:/...` could also be a POSIX *relative* path under a dir
-        # literally named "C:", but a leak guard must not let a Windows-absolute
-        # path through, and a Unix media dir literally named "C:" is pathological.
-        # So we basename it (the rare round-trip loss is the accepted trade-off vs
-        # re-opening the path leak). (Codex round-1 wanted C:/ preserved; round-2
-        # showed that re-leaks C:/ Windows absolutes — no-leak wins.)
-        or (len(p) >= 3 and p[0].isalpha() and p[1] == ":" and p[2] in ("\\", "/"))
-    )
-
-
-def _display_path(path: str) -> str:
-    """Phase 16.2: the non-leaking path form for API responses.
-
-    Returning the absolute fs path leaked the operator's directory tree
-    (/Volumes/home/影片專案/…) to any read-scope / loopback client. We return the
-    PROJECT_ROOT-relative form; a legacy row whose stored path is absolute AND
-    outside PROJECT_ROOT (so to_relative can't relativize it) is reduced to its
-    basename rather than leaking the full path. Relative paths round-trip through
-    /api/open-file (db.is_processed matches relative; the server re-absolutizes);
-    once a library is migrated (ingest.py --migrate-relative) every row is
-    relative and open-file works for all of them.
-    """
-    if not path:
-        return path
-    rel = db.to_relative(path)
-    if _looks_absolute(rel):  # absolute (POSIX/Windows/UNC) & outside root — don't leak
-        return _basename_safe(rel)
-    return rel
-
-
-def _resolve_record(rec: dict) -> dict:
-    if rec.get("path"):
-        rec["path"] = _display_path(rec["path"])
-    if rec.get("thumbnail_path"):
-        rec["thumbnail_path"] = _display_path(rec["thumbnail_path"])
-    return rec
-
-
-def _resolve_frame(frame: dict) -> dict:
-    if frame.get("thumbnail_path"):
-        frame["thumbnail_path"] = _display_path(frame["thumbnail_path"])
-    return frame
-
-
-def _resolve_media_path(path: str) -> str:
-    if not path:
-        return path
-    if os.name == "nt" and path.startswith("/"):
-        return path
-    return db.resolve_path(path)
+# R5-25 / #51: path-resolution helpers live in pathres.py (a leaf service module,
+# no server state) so the coming APIRouter split can import them without the
+# router→server→router import cycle. Re-exported here for backward compat —
+# existing call sites and tests that reference `server._resolve_media_path` etc.
+# keep working unchanged.
+from pathres import (  # noqa: F401 (re-exported for backward compat)
+    _basename_safe,
+    _looks_absolute,
+    _display_path,
+    _resolve_record,
+    _resolve_frame,
+    _resolve_media_path,
+)
 
 
 # ── Models ───────────────────────────────────────────────────────────────────

--- a/tests/test_r5_25_pathres_module.py
+++ b/tests/test_r5_25_pathres_module.py
@@ -1,0 +1,112 @@
+"""R5-25 (round-5 #51): path-resolution helpers extracted to pathres.py.
+
+The APIRouter split is blocked by ~50 cross-group helpers that every router
+would otherwise pull via `from server import ...` — a router→server→router
+import cycle (partially-initialized module → ImportError). The fix is to extract
+the shared, server-state-free helpers into leaf service modules the routers and
+server both import. pathres.py is the first: the non-leaking display-path +
+media-path resolution used by ~every media/bins/export/stream route.
+
+These tests pin two things a future refactor must not silently regress:
+  1. pathres is a genuine leaf — it imports no server state (no `import server`),
+     so it can sit below the routers in the import graph.
+  2. server.py re-exports the names by identity, so existing call sites and
+     tests referencing `server._resolve_media_path` etc. keep working unchanged.
+Plus the leak-guard behaviour itself, so the move didn't alter semantics.
+"""
+import pathlib
+import re
+
+import pytest
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+_NAMES = (
+    "_basename_safe",
+    "_looks_absolute",
+    "_display_path",
+    "_resolve_record",
+    "_resolve_frame",
+    "_resolve_media_path",
+)
+
+
+# ── module boundary ──────────────────────────────────────────────────────────
+def test_pathres_is_a_leaf_module():
+    # pathres must not import server (directly or via `import server`), else it
+    # can't sit below the routers in the import graph — the whole point of #51.
+    src = (_ROOT / "pathres.py").read_text(encoding="utf-8")
+    assert not re.search(r"^\s*import\s+server\b", src, re.M)
+    assert not re.search(r"^\s*from\s+server\b", src, re.M)
+
+
+def test_server_reexports_pathres_by_identity():
+    import server
+    import pathres
+    for name in _NAMES:
+        assert getattr(server, name) is getattr(pathres, name), (
+            "server.{0} must BE pathres.{0} (a re-export), so call sites and "
+            "tests referencing server.{0} keep working".format(name)
+        )
+
+
+def test_pathres_functions_are_importable_standalone():
+    import pathres
+    for name in _NAMES:
+        assert callable(getattr(pathres, name))
+
+
+# ── leak-guard behaviour preserved by the move ───────────────────────────────
+def test_basename_safe_normalises_both_separators():
+    import pathres
+    assert pathres._basename_safe("C:\\Users\\me\\proj\\clip.mov") == "clip.mov"
+    assert pathres._basename_safe("/Volumes/home/proj/clip.mov") == "clip.mov"
+    assert pathres._basename_safe("clip.mov") == "clip.mov"
+    assert pathres._basename_safe("proj/") == "proj"       # trailing slash stripped
+    assert pathres._basename_safe("") == ""
+
+
+@pytest.mark.parametrize("p", [
+    "/Volumes/home/x",   # POSIX absolute
+    "\\\\host\\share",   # UNC
+    "C:\\Users\\me",     # Windows drive + backslash
+    "C:/Users/me",       # Windows drive + forward slash
+])
+def test_looks_absolute_true(p):
+    import pathres
+    assert pathres._looks_absolute(p) is True
+
+
+@pytest.mark.parametrize("p", ["", "proj/clip.mov", "clip.mov", "a:relative"])
+def test_looks_absolute_false(p):
+    import pathres
+    assert pathres._looks_absolute(p) is False
+
+
+def test_display_path_reduces_out_of_root_absolute_to_basename(monkeypatch):
+    # to_relative can't relativize a path outside PROJECT_ROOT → still absolute →
+    # reduced to basename rather than leaking the operator's directory tree.
+    import pathres
+    monkeypatch.setattr(pathres.db, "to_relative", lambda p: p)  # identity → stays absolute
+    assert pathres._display_path("/Volumes/home/secret/footage/clip.mov") == "clip.mov"
+
+
+def test_display_path_returns_relative_untouched(monkeypatch):
+    import pathres
+    monkeypatch.setattr(pathres.db, "to_relative", lambda p: "proj/clip.mov")
+    assert pathres._display_path("/anything") == "proj/clip.mov"
+
+
+def test_display_path_passthrough_empty():
+    import pathres
+    assert pathres._display_path("") == ""
+    assert pathres._display_path(None) is None
+
+
+def test_resolve_record_and_frame_use_display_path(monkeypatch):
+    import pathres
+    monkeypatch.setattr(pathres, "_display_path", lambda p: "SAFE:" + p)
+    rec = pathres._resolve_record({"path": "/abs/a", "thumbnail_path": "/abs/t"})
+    assert rec == {"path": "SAFE:/abs/a", "thumbnail_path": "SAFE:/abs/t"}
+    frame = pathres._resolve_frame({"thumbnail_path": "/abs/f"})
+    assert frame == {"thumbnail_path": "SAFE:/abs/f"}


### PR DESCRIPTION
## What

First PR of **R5-25 (#51)**: the APIRouter split. This one extracts the path-resolution helper cluster into a new leaf module **`pathres.py`** and re-exports the names from `server.py` for backward compatibility.

## Why

The router split is blocked by ~50 cross-group helpers. A naive router cut has each router do `from server import _resolve_media_path`, and since `server` imports the routers, that's a **partially-initialized-module `ImportError`** (router → server → router cycle). The fix is to peel the shared, server-state-free helpers into leaf service modules that both the routers and `server` import — breaking the cycle from the bottom up.

`pathres.py` is the first such module: the non-leaking display-path + media-path resolution used by ~every media/bins/export/stream route:

- `_basename_safe`, `_looks_absolute`, `_display_path`, `_resolve_record`, `_resolve_frame`, `_resolve_media_path`

It depends only on `db` + stdlib — no server state — so it sits at the very bottom of the import graph.

## Backward compat

`server.py` re-exports all six names (matching the PR7 `state.py` pattern):

```python
from pathres import (  # noqa: F401 (re-exported for backward compat)
    _basename_safe, _looks_absolute, _display_path,
    _resolve_record, _resolve_frame, _resolve_media_path,
)
```

So every existing call site and every test referencing `server._resolve_media_path` etc. keeps working unchanged. Net `server.py` **−72 lines**.

## Tests

New `tests/test_r5_25_pathres_module.py` (16 tests) pins:
1. **Leaf boundary** — `pathres` imports no server state (no `import server`), so it can sit below the routers.
2. **Re-export identity** — `server._resolve_media_path is pathres._resolve_media_path`, so the move is transparent to callers/tests.
3. **Leak-guard behaviour preserved** — separator-agnostic basename, POSIX/Windows/UNC absolute detection, out-of-root absolute → basename (no directory-tree leak), relative round-trip.

**803 passed, 5 skipped** locally (787 baseline + 16 new). No behaviour change — pure module boundary extraction.

## Sequence

R5-25 continues leaf-first: next PRs peel `webguard` / `ingest_opts` / `export_builders`, then the 11 routers (admin → settings → … → ingest/WS last).

🤖 Generated with [Claude Code](https://claude.com/claude-code)