### PR TITLE
refactor(server): extract webguard.py (router-split, round-5 #51 / R5-25 PR9)

### DIFF
--- a/server.py
+++ b/server.py
@@ -127,13 +127,24 @@ def _install_token_redaction_filter() -> None:
         logger.addFilter(_RedactTokenFilter())
 
 app = FastAPI(title="Media Asset Manager API", lifespan=_lifespan)
-_ALLOWED_ORIGINS = [
-    "http://localhost:8501",
-    "http://127.0.0.1:8501",
-    "http://localhost:5173",     # Vite dev server (frontend dev + ws proxy)
-    "http://127.0.0.1:5173",
-    "https://tauri.localhost",   # Tauri webview
-]
+# R5-25 / #51: web-security boundary guards live in webguard.py (a leaf service
+# module, no server state) so the coming APIRouter split can import them without
+# the router→server→router import cycle. `_ALLOWED_ORIGINS` is owned there (both
+# the CORS middleware below AND webguard._assert_same_site need it). Re-exported
+# here for backward compat — call sites / tests referencing
+# `server._assert_export_dest_safe` etc. keep working unchanged.
+from webguard import (  # noqa: F401,E402 (re-exported for backward compat)
+    _ALLOWED_ORIGINS,
+    _ALLOWED_EXPORT_EXTS,
+    _allowed_export_roots,
+    _assert_export_dest_safe,
+    _OFFLOAD_DENY_SUBSTR,
+    _OFFLOAD_DENY_ROOTS,
+    _assert_offload_dst_safe,
+    _allowed_ingest_roots,
+    _assert_ingest_path_safe,
+    _assert_same_site,
+)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_ALLOWED_ORIGINS,
@@ -1788,91 +1799,11 @@ def size_by_ext(
 # ── Metadata Export (Phase 7.6) ──────────────────────────────────────────────
 
 _CSV_FORMULA_PREFIXES = ("=", "+", "-", "@", "\t", "\r")
-def _allowed_export_roots() -> list:
-    """Approved roots for export-to endpoints. User can override with
-    ARKIV_EXPORT_ROOTS env (os.pathsep-separated list of abs paths — ':' on
-    POSIX, ';' on Windows). fable-audit 2026-07-12 (#3): splitting on a literal
-    ':' shredded Windows drive-letter paths (D:\\Exports → ['D', '\\Exports'])
-    at the export-allowlist boundary — mirror the _allowed_ingest_roots fix."""
-    custom = os.environ.get("ARKIV_EXPORT_ROOTS", "").strip()
-    if custom:
-        return [Path(p).expanduser().resolve() for p in custom.split(os.pathsep) if p.strip()]
-    home = Path.home()
-    return [
-        (home / "Desktop").resolve(),
-        (home / "Documents").resolve(),
-        (home / "Downloads").resolve(),
-        (home / "Movies").resolve(),
-        # Cross-platform tmp + project root for tests / scripted exports
-        Path("/tmp").resolve(),
-        Path(os.environ.get("TMPDIR", "/tmp")).resolve(),
-        (Path.cwd() / "temp").resolve(),
-        (config.PROJECT_ROOT / "temp").resolve(),
-    ]
 
 
-_ALLOWED_EXPORT_EXTS = {
-    ".csv", ".srt", ".vtt", ".edl", ".fcpxml", ".xml", ".txt", ".json",
-}
-
-
-def _assert_export_dest_safe(dest: Path) -> None:
-    """Reject writes outside approved user export roots.
-
-    Codex Round-2 audit Critical fix: 舊版 denylist 只擋 6 個系統 dir，能寫
-    `~/.ssh/authorized_keys` / `/Library/LaunchAgents/*.plist` / `/var/log`
-    等敏感位置。Tailscale 共享 + 無 auth 場景下任何 collaborator 直接 RCE。
-
-    新策略：allowlist — dest 的 canonical path 必須落在 ALLOWED 之一底下；
-    副檔名也限定在常見匯出格式（.csv/.srt/.vtt/.edl/.fcpxml/.xml/.txt/.json），
-    防止寫 .plist / .pem / .ssh-config 之類執行/憑證檔。
-    """
-    canonical = dest.resolve()
-    if canonical.suffix.lower() not in _ALLOWED_EXPORT_EXTS:
-        raise HTTPException(403, f"不允許的匯出副檔名：{canonical.suffix}")
-    roots = _allowed_export_roots()
-    for root in roots:
-        try:
-            canonical.relative_to(root)
-            return  # under approved root
-        except ValueError:
-            continue
-    # fable-audit 2026-07-12: don't echo the resolved absolute roots in the 403
-    # body — that leaks the operator's home layout to any caller probing the
-    # boundary. Return stable labels instead.
-    raise HTTPException(
-        403,
-        "匯出路徑必須在批准的目錄下（Desktop / Documents / Downloads / Movies / temp，"
-        "或 ARKIV_EXPORT_ROOTS 指定的目錄）",
-    )
-
-
-# Offload destinations are arbitrary by design (camera card → backup drives, e.g.
-# /Volumes/*), so — unlike export — we do NOT apply the approved-roots allowlist.
-# But refuse writes INTO OS-sensitive locations where a copied file could gain
-# execution/persistence (LaunchAgents/LaunchDaemons, ~/.ssh, cron, systemd, /etc,
-# system dirs). A card offload has no legitimate reason to target these; the
-# export path already 403s for the same class of write.
-# fable-audit 2026-07-12 (#1 /api/offload arbitrary-file-write).
-_OFFLOAD_DENY_SUBSTR = (
-    "/library/launchagents", "/library/launchdaemons",
-    "/.ssh", "/.config/systemd/", "/var/spool/cron", "/private/etc/",
-)
-_OFFLOAD_DENY_ROOTS = (
-    "/system", "/bin", "/sbin", "/usr/bin", "/usr/sbin", "/etc", "/private/etc",
-)
-
-
-def _assert_offload_dst_safe(dst: str) -> None:
-    """Reject offload destinations that land inside OS-sensitive/executable dirs."""
-    canonical = str(Path(dst).expanduser().resolve()).replace("\\", "/").lower().rstrip("/")
-    probe = canonical + "/"
-    for bad in _OFFLOAD_DENY_SUBSTR:
-        if bad in probe:
-            raise HTTPException(403, "拒絕寫入系統敏感目錄（LaunchAgents / .ssh / cron / systemd 等）")
-    for root in _OFFLOAD_DENY_ROOTS:
-        if canonical == root or probe.startswith(root + "/"):
-            raise HTTPException(403, "拒絕寫入系統目錄")
+# _allowed_export_roots / _ALLOWED_EXPORT_EXTS / _assert_export_dest_safe and the
+# offload denylist (_OFFLOAD_DENY_* / _assert_offload_dst_safe) moved to
+# webguard.py (R5-25 / #51) and are re-exported at the top of this module.
 
 
 def _csv_safe(value: str) -> str:
@@ -2200,60 +2131,8 @@ def _build_scan_manifest(files: list, unsupp: dict) -> dict:
         "total_size_mb": round(sum(f["size_mb"] for f in files), 1),
     }
 
-def _allowed_ingest_roots() -> list:
-    """Approved roots for ingest scan / ingest endpoints.
-
-    Default: PROJECT_ROOT (where arkiv 's own DB lives) + standard user media
-    locations. Override with ARKIV_INGEST_ROOTS env (colon-separated).
-
-    Codex Round-2 audit (J1): without bounds, /api/ingest/scan walked any path
-    a Tailscale collaborator could supply, returning size + abs path of every
-    media file — full filesystem inventory leak.
-    """
-    custom = os.environ.get("ARKIV_INGEST_ROOTS", "").strip()
-    if custom:
-        # os.pathsep, not ':' — Windows uses ';' AND ':' appears in drive letters
-        # (C:\...), so splitting on ':' shredded every Windows path.
-        return [Path(p).expanduser().resolve() for p in custom.split(os.pathsep) if p.strip()]
-    home = Path.home()
-    roots = [
-        config.PROJECT_ROOT.resolve() if config.PROJECT_ROOT else None,
-        (home / "Desktop").resolve(),
-        (home / "Documents").resolve(),
-        (home / "Movies").resolve(),
-        (home / "Pictures").resolve(),
-    ]
-    # /Volumes/* (Mac SMB mounts of NAS shares) — allow each top-level mount
-    volumes = Path("/Volumes")
-    if volumes.exists():
-        try:
-            for vol in volumes.iterdir():
-                if vol.is_dir():
-                    resolved = vol.resolve()
-                    # Skip a volume that resolves to the filesystem root (e.g.
-                    # /Volumes/Macintosh HD → '/'): allowing '/' makes the J1
-                    # bound a no-op — every path is then "under an approved root".
-                    if str(resolved) != resolved.anchor:
-                        roots.append(resolved)
-        except OSError:
-            pass
-    # Final guard: never allow a bare filesystem/drive root through (defeats J1).
-    return [r for r in roots if r is not None and str(r) != r.anchor]
-
-
-def _assert_ingest_path_safe(target: Path) -> None:
-    roots = _allowed_ingest_roots()
-    canonical = target.resolve()
-    for root in roots:
-        try:
-            canonical.relative_to(root)
-            return
-        except ValueError:
-            continue
-    raise HTTPException(
-        403,
-        f"ingest 路徑必須在批准的目錄底下：{[str(r) for r in roots]} (override via ARKIV_INGEST_ROOTS env)",
-    )
+# _allowed_ingest_roots / _assert_ingest_path_safe moved to webguard.py
+# (R5-25 / #51) and are re-exported at the top of this module.
 
 
 @app.get("/api/ingest/engines")
@@ -4024,24 +3903,8 @@ def stream_media(media_id: int, _tok: dict = Depends(require_scopes("videos_read
 # ── Proxy Management ─────────────────────────────────────────────────────────
 
 # PROXY_CODECS lives in codec.py — single source of truth.
-
-def _assert_same_site(request: Request) -> None:
-    """audit M14: the no-body POSTs below are CORS 'simple requests' — a
-    malicious page can fire them cross-site WITHOUT a preflight, and
-    loopback-trust then authorizes them (whole-library rebuild / proxy-build
-    DoS). Browsers attach Sec-Fetch-Site and/or Origin on cross-site POSTs;
-    non-browser clients (curl, scripts) send neither and pass through."""
-    sfs = request.headers.get("sec-fetch-site")
-    if sfs and sfs not in ("same-origin", "same-site", "none"):
-        raise HTTPException(403, "cross-site request rejected")
-    origin = request.headers.get("origin")
-    if not origin:
-        return  # non-browser client
-    if origin in _ALLOWED_ORIGINS:
-        return
-    if origin != "null" and origin.split("://", 1)[-1] == request.headers.get("host", ""):
-        return  # same-origin for whatever host/port this deployment uses
-    raise HTTPException(403, "cross-site request rejected")
+# _assert_same_site moved to webguard.py (R5-25 / #51) and is re-exported at the
+# top of this module.
 
 @app.get("/api/proxy/status")
 def proxy_status(_tok: dict = Depends(require_scopes("videos_read"))):

--- a/tests/test_r5_25_webguard_module.py
+++ b/tests/test_r5_25_webguard_module.py
@@ -1,0 +1,151 @@
+"""R5-25 (round-5 #51): web-security boundary guards extracted to webguard.py.
+
+Second leaf module of the APIRouter split. Holds the write-boundary + same-site
+guards that ~every mutating route calls: the export-destination allowlist, the
+offload-destination denylist, the ingest-path allowlist, and the same-site
+(CSRF) guard — plus the `_ALLOWED_ORIGINS` allowlist those consult.
+
+`_ALLOWED_ORIGINS` is the subtle part: it is used at server import time by the
+CORSMiddleware AND by webguard._assert_same_site. It must be ONE object owned by
+the leaf module — if server.py kept its own copy while webguard imported another,
+the middleware and the same-site guard could silently diverge, and worse, the
+router split would re-introduce the router→server→router import cycle. These
+tests pin single-ownership + identity re-export + the leak/CSRF behaviour so the
+move is provably semantics-preserving.
+
+Behavioural coverage of the guards through the live app (403 bodies, offload
+denylist, same-site rejection) already lives in test_hardening_round4.py; here we
+pin the module boundary and a few direct-call invariants.
+"""
+import pathlib
+import re
+
+import pytest
+from fastapi import HTTPException
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+_NAMES = (
+    "_ALLOWED_ORIGINS",
+    "_ALLOWED_EXPORT_EXTS",
+    "_allowed_export_roots",
+    "_assert_export_dest_safe",
+    "_OFFLOAD_DENY_SUBSTR",
+    "_OFFLOAD_DENY_ROOTS",
+    "_assert_offload_dst_safe",
+    "_allowed_ingest_roots",
+    "_assert_ingest_path_safe",
+    "_assert_same_site",
+)
+
+
+# ── module boundary ──────────────────────────────────────────────────────────
+def test_webguard_is_a_leaf_module():
+    src = (_ROOT / "webguard.py").read_text(encoding="utf-8")
+    assert not re.search(r"^\s*import\s+server\b", src, re.M)
+    assert not re.search(r"^\s*from\s+server\b", src, re.M)
+
+
+def test_server_reexports_webguard_by_identity():
+    import server
+    import webguard
+    for name in _NAMES:
+        assert getattr(server, name) is getattr(webguard, name), (
+            "server.{0} must BE webguard.{0} (a re-export)".format(name)
+        )
+
+
+def test_allowed_origins_single_ownership():
+    # The whole point of moving _ALLOWED_ORIGINS to the leaf: exactly one object,
+    # shared by the CORS middleware and the same-site guard. A regression that
+    # re-defines it in server.py (or hardcodes a different list into the
+    # middleware) would break this and let the two boundaries drift apart.
+    import server
+    import webguard
+    assert server._ALLOWED_ORIGINS is webguard._ALLOWED_ORIGINS
+
+
+def test_cors_middleware_uses_the_webguard_allowlist():
+    import server
+    import webguard
+    cors = None
+    for mw in server.app.user_middleware:
+        kw = getattr(mw, "kwargs", {}) or {}
+        if "allow_origins" in kw:
+            cors = kw["allow_origins"]
+            break
+    assert cors is not None, "CORSMiddleware allow_origins not found"
+    assert cors is webguard._ALLOWED_ORIGINS, (
+        "CORS middleware must be configured with the shared webguard allowlist, "
+        "not a private copy"
+    )
+
+
+def test_server_defines_no_private_allowed_origins():
+    # Guard against a future edit re-introducing a module-level `_ALLOWED_ORIGINS = [`
+    # literal in server.py, which would shadow the re-export and re-create the
+    # dual-source drift this refactor removed.
+    src = (_ROOT / "server.py").read_text(encoding="utf-8")
+    assert not re.search(r"^_ALLOWED_ORIGINS\s*=\s*\[", src, re.M), (
+        "server.py must import _ALLOWED_ORIGINS from webguard, not define its own"
+    )
+
+
+# ── guard behaviour preserved by the move (direct calls) ─────────────────────
+def test_export_dest_rejects_bad_extension_and_outside_root(tmp_path, monkeypatch):
+    import webguard
+    monkeypatch.setenv("ARKIV_EXPORT_ROOTS", str(tmp_path))
+    # bad extension → 403 before the root check
+    with pytest.raises(HTTPException) as e1:
+        webguard._assert_export_dest_safe(tmp_path / "evil.plist")
+    assert e1.value.status_code == 403
+    # good extension but outside the approved root → 403
+    with pytest.raises(HTTPException) as e2:
+        webguard._assert_export_dest_safe(pathlib.Path("/etc/x.csv"))
+    assert e2.value.status_code == 403
+    # good extension inside the approved root → allowed
+    webguard._assert_export_dest_safe(tmp_path / "ok.csv")
+
+
+@pytest.mark.parametrize("bad", ["/etc", "~/.ssh", "/System/Library"])
+def test_offload_dst_denies_system_dirs(bad):
+    import webguard
+    with pytest.raises(HTTPException) as e:
+        webguard._assert_offload_dst_safe(bad)
+    assert e.value.status_code == 403
+
+
+def test_offload_dst_allows_backup_target(tmp_path):
+    import webguard
+    webguard._assert_offload_dst_safe(str(tmp_path))  # must not raise
+
+
+def test_ingest_roots_default_never_include_filesystem_root(monkeypatch):
+    import webguard
+    # J1: the auto-discovered default roots (incl. the /Volumes/* sweep that could
+    # otherwise surface a mount resolving to '/') must never contain a bare
+    # drive/fs root — else the bound is a no-op. (The operator-supplied
+    # ARKIV_INGEST_ROOTS override is trusted and intentionally not filtered.)
+    monkeypatch.delenv("ARKIV_INGEST_ROOTS", raising=False)
+    roots = webguard._allowed_ingest_roots()
+    assert roots, "default roots should be non-empty"
+    assert all(str(r) != r.anchor for r in roots)
+
+
+def test_same_site_rejects_cross_site_and_passes_non_browser():
+    import webguard
+
+    class _Req:
+        def __init__(self, headers):
+            self.headers = headers
+
+    # cross-site Sec-Fetch-Site → reject
+    with pytest.raises(HTTPException):
+        webguard._assert_same_site(_Req({"sec-fetch-site": "cross-site"}))
+    # foreign Origin → reject
+    with pytest.raises(HTTPException):
+        webguard._assert_same_site(_Req({"origin": "https://evil.example", "host": "localhost:8501"}))
+    # no Origin / Sec-Fetch-Site (curl) → pass
+    webguard._assert_same_site(_Req({}))
+    # known allowed origin → pass
+    webguard._assert_same_site(_Req({"origin": webguard._ALLOWED_ORIGINS[0]}))

--- a/webguard.py
+++ b/webguard.py
@@ -1,0 +1,204 @@
+"""Web-security boundary guards for the API layer.
+
+R5-25 / round-5 #51: the APIRouter split is blocked by ~50 cross-group helpers —
+a naive cut has each router do `from server import _assert_same_site`, and since
+`server` imports the routers, that's a partially-initialized-module ImportError.
+The fix is to extract the shared, server-state-free helpers into leaf service
+modules that the routers (and server) import. This is the write-boundary /
+same-site cluster: the export-destination allowlist, the offload-destination
+denylist, the ingest-path allowlist, and the same-site (CSRF) guard.
+
+Depends only on config + fastapi + stdlib — no server state — so it sits at the
+bottom of the import graph. server.py re-exports these names for backward compat
+(existing call sites + tests referencing `server._assert_export_dest_safe` etc.
+keep working unchanged).
+"""
+import os
+from pathlib import Path
+
+from fastapi import HTTPException, Request
+
+import config
+
+# CORS / same-site allowlist. Owned HERE, not in server.py, because both
+# `_assert_same_site` (below) AND server's CORSMiddleware need it — leaving it in
+# server.py while webguard imported it back would re-create the very
+# router→server→router import cycle this split exists to remove. server.py
+# re-imports it for the middleware.
+_ALLOWED_ORIGINS = [
+    "http://localhost:8501",
+    "http://127.0.0.1:8501",
+    "http://localhost:5173",     # Vite dev server (frontend dev + ws proxy)
+    "http://127.0.0.1:5173",
+    "https://tauri.localhost",   # Tauri webview
+]
+
+
+# ── export destination allowlist (write boundary) ────────────────────────────
+
+def _allowed_export_roots() -> list:
+    """Approved roots for export-to endpoints. User can override with
+    ARKIV_EXPORT_ROOTS env (os.pathsep-separated list of abs paths — ':' on
+    POSIX, ';' on Windows). fable-audit 2026-07-12 (#3): splitting on a literal
+    ':' shredded Windows drive-letter paths (D:\\Exports → ['D', '\\Exports'])
+    at the export-allowlist boundary — mirror the _allowed_ingest_roots fix."""
+    custom = os.environ.get("ARKIV_EXPORT_ROOTS", "").strip()
+    if custom:
+        return [Path(p).expanduser().resolve() for p in custom.split(os.pathsep) if p.strip()]
+    home = Path.home()
+    return [
+        (home / "Desktop").resolve(),
+        (home / "Documents").resolve(),
+        (home / "Downloads").resolve(),
+        (home / "Movies").resolve(),
+        # Cross-platform tmp + project root for tests / scripted exports
+        Path("/tmp").resolve(),
+        Path(os.environ.get("TMPDIR", "/tmp")).resolve(),
+        (Path.cwd() / "temp").resolve(),
+        (config.PROJECT_ROOT / "temp").resolve(),
+    ]
+
+
+_ALLOWED_EXPORT_EXTS = {
+    ".csv", ".srt", ".vtt", ".edl", ".fcpxml", ".xml", ".txt", ".json",
+}
+
+
+def _assert_export_dest_safe(dest: Path) -> None:
+    """Reject writes outside approved user export roots.
+
+    Codex Round-2 audit Critical fix: 舊版 denylist 只擋 6 個系統 dir，能寫
+    `~/.ssh/authorized_keys` / `/Library/LaunchAgents/*.plist` / `/var/log`
+    等敏感位置。Tailscale 共享 + 無 auth 場景下任何 collaborator 直接 RCE。
+
+    新策略：allowlist — dest 的 canonical path 必須落在 ALLOWED 之一底下；
+    副檔名也限定在常見匯出格式（.csv/.srt/.vtt/.edl/.fcpxml/.xml/.txt/.json），
+    防止寫 .plist / .pem / .ssh-config 之類執行/憑證檔。
+    """
+    canonical = dest.resolve()
+    if canonical.suffix.lower() not in _ALLOWED_EXPORT_EXTS:
+        raise HTTPException(403, f"不允許的匯出副檔名：{canonical.suffix}")
+    roots = _allowed_export_roots()
+    for root in roots:
+        try:
+            canonical.relative_to(root)
+            return  # under approved root
+        except ValueError:
+            continue
+    # fable-audit 2026-07-12: don't echo the resolved absolute roots in the 403
+    # body — that leaks the operator's home layout to any caller probing the
+    # boundary. Return stable labels instead.
+    raise HTTPException(
+        403,
+        "匯出路徑必須在批准的目錄下（Desktop / Documents / Downloads / Movies / temp，"
+        "或 ARKIV_EXPORT_ROOTS 指定的目錄）",
+    )
+
+
+# ── offload destination denylist ─────────────────────────────────────────────
+
+# Offload destinations are arbitrary by design (camera card → backup drives, e.g.
+# /Volumes/*), so — unlike export — we do NOT apply the approved-roots allowlist.
+# But refuse writes INTO OS-sensitive locations where a copied file could gain
+# execution/persistence (LaunchAgents/LaunchDaemons, ~/.ssh, cron, systemd, /etc,
+# system dirs). A card offload has no legitimate reason to target these; the
+# export path already 403s for the same class of write.
+# fable-audit 2026-07-12 (#1 /api/offload arbitrary-file-write).
+_OFFLOAD_DENY_SUBSTR = (
+    "/library/launchagents", "/library/launchdaemons",
+    "/.ssh", "/.config/systemd/", "/var/spool/cron", "/private/etc/",
+)
+_OFFLOAD_DENY_ROOTS = (
+    "/system", "/bin", "/sbin", "/usr/bin", "/usr/sbin", "/etc", "/private/etc",
+)
+
+
+def _assert_offload_dst_safe(dst: str) -> None:
+    """Reject offload destinations that land inside OS-sensitive/executable dirs."""
+    canonical = str(Path(dst).expanduser().resolve()).replace("\\", "/").lower().rstrip("/")
+    probe = canonical + "/"
+    for bad in _OFFLOAD_DENY_SUBSTR:
+        if bad in probe:
+            raise HTTPException(403, "拒絕寫入系統敏感目錄（LaunchAgents / .ssh / cron / systemd 等）")
+    for root in _OFFLOAD_DENY_ROOTS:
+        if canonical == root or probe.startswith(root + "/"):
+            raise HTTPException(403, "拒絕寫入系統目錄")
+
+
+# ── ingest path allowlist (filesystem-inventory-leak boundary) ───────────────
+
+def _allowed_ingest_roots() -> list:
+    """Approved roots for ingest scan / ingest endpoints.
+
+    Default: PROJECT_ROOT (where arkiv 's own DB lives) + standard user media
+    locations. Override with ARKIV_INGEST_ROOTS env (colon-separated).
+
+    Codex Round-2 audit (J1): without bounds, /api/ingest/scan walked any path
+    a Tailscale collaborator could supply, returning size + abs path of every
+    media file — full filesystem inventory leak.
+    """
+    custom = os.environ.get("ARKIV_INGEST_ROOTS", "").strip()
+    if custom:
+        # os.pathsep, not ':' — Windows uses ';' AND ':' appears in drive letters
+        # (C:\...), so splitting on ':' shredded every Windows path.
+        return [Path(p).expanduser().resolve() for p in custom.split(os.pathsep) if p.strip()]
+    home = Path.home()
+    roots = [
+        config.PROJECT_ROOT.resolve() if config.PROJECT_ROOT else None,
+        (home / "Desktop").resolve(),
+        (home / "Documents").resolve(),
+        (home / "Movies").resolve(),
+        (home / "Pictures").resolve(),
+    ]
+    # /Volumes/* (Mac SMB mounts of NAS shares) — allow each top-level mount
+    volumes = Path("/Volumes")
+    if volumes.exists():
+        try:
+            for vol in volumes.iterdir():
+                if vol.is_dir():
+                    resolved = vol.resolve()
+                    # Skip a volume that resolves to the filesystem root (e.g.
+                    # /Volumes/Macintosh HD → '/'): allowing '/' makes the J1
+                    # bound a no-op — every path is then "under an approved root".
+                    if str(resolved) != resolved.anchor:
+                        roots.append(resolved)
+        except OSError:
+            pass
+    # Final guard: never allow a bare filesystem/drive root through (defeats J1).
+    return [r for r in roots if r is not None and str(r) != r.anchor]
+
+
+def _assert_ingest_path_safe(target: Path) -> None:
+    roots = _allowed_ingest_roots()
+    canonical = target.resolve()
+    for root in roots:
+        try:
+            canonical.relative_to(root)
+            return
+        except ValueError:
+            continue
+    raise HTTPException(
+        403,
+        f"ingest 路徑必須在批准的目錄底下：{[str(r) for r in roots]} (override via ARKIV_INGEST_ROOTS env)",
+    )
+
+
+# ── same-site (CSRF) guard ───────────────────────────────────────────────────
+
+def _assert_same_site(request: Request) -> None:
+    """audit M14: the no-body POSTs below are CORS 'simple requests' — a
+    malicious page can fire them cross-site WITHOUT a preflight, and
+    loopback-trust then authorizes them (whole-library rebuild / proxy-build
+    DoS). Browsers attach Sec-Fetch-Site and/or Origin on cross-site POSTs;
+    non-browser clients (curl, scripts) send neither and pass through."""
+    sfs = request.headers.get("sec-fetch-site")
+    if sfs and sfs not in ("same-origin", "same-site", "none"):
+        raise HTTPException(403, "cross-site request rejected")
+    origin = request.headers.get("origin")
+    if not origin:
+        return  # non-browser client
+    if origin in _ALLOWED_ORIGINS:
+        return
+    if origin != "null" and origin.split("://", 1)[-1] == request.headers.get("host", ""):
+        return  # same-origin for whatever host/port this deployment uses
+    raise HTTPException(403, "cross-site request rejected")


### PR DESCRIPTION
## What

Second PR of **R5-25 (#51)**, the APIRouter split. Extracts the web-security boundary guards into a new leaf module **`webguard.py`**. **Stacked on PR8 (#160, pathres.py)** — base is `feat/r5-25-router-split-services`; will retarget to `main` once #160 merges.

## Why

Same import-cycle problem as PR8: the router split is blocked by cross-group helpers that every router would pull via `from server import ...`, and since `server` imports the routers that's a partially-initialized-module `ImportError`. `webguard` is the write-boundary + same-site cluster that ~every mutating route calls:

| helper | boundary |
|---|---|
| `_allowed_export_roots` / `_ALLOWED_EXPORT_EXTS` / `_assert_export_dest_safe` | export destination allowlist |
| `_OFFLOAD_DENY_*` / `_assert_offload_dst_safe` | offload destination denylist |
| `_allowed_ingest_roots` / `_assert_ingest_path_safe` | ingest-path allowlist (filesystem-inventory-leak bound) |
| `_assert_same_site` | same-site / CSRF guard |

Depends only on `config` + `fastapi` + stdlib — no server state — so it sits at the bottom of the import graph.

## The `_ALLOWED_ORIGINS` subtlety

`_ALLOWED_ORIGINS` moves into `webguard` too, and this is the ordering-sensitive part called out when scoping R5-25. It's read **at server import time** by *both* the `CORSMiddleware` and `_assert_same_site`. It must be **one object owned by the leaf**:

- Keeping it in `server.py` while `webguard` imported it back would re-create the exact `router→server→router` cycle this split exists to remove.
- A private copy in each module would let the CORS middleware and the same-site guard silently **drift apart**.

So `server.py` now imports it (before the `CORSMiddleware` config just below) and re-exports it. The new test pins single-ownership: the CORS middleware reads the shared list, and `server.py` defines no private `_ALLOWED_ORIGINS = [` literal.

## Backward compat

`server.py` re-exports all 10 names (`from webguard import ... # noqa: F401`), so every existing call site and every test referencing `server._assert_export_dest_safe` etc. keeps working unchanged. Net `server.py` **−162 lines**.

## Tests

New `tests/test_r5_25_webguard_module.py` (12 tests): leaf boundary (no `import server`), identity re-export of all 10 names, `_ALLOWED_ORIGINS` single-ownership + CORS-middleware-uses-shared-list + no-private-copy, and direct-call guard behaviour (export ext/root reject, offload system-dir deny, ingest J1 no-bare-root, same-site cross-site reject / non-browser pass). Behavioural coverage through the live app already lives in `test_hardening_round4.py`.

**815 passed, 5 skipped** locally (803 baseline + 12 new). Pure module-boundary extraction, no behaviour change.

## Sequence

R5-25 continues: next PRs peel `export_builders` / `ingest_opts`, then the 11 routers leaf-first (admin → … → ingest/WS last).

🤖 Generated with [Claude Code](https://claude.com/claude-code)