### PR TITLE
refactor(server): extract reqopts.py — request-option helpers (router-split, round-5 #51 / R5-25 PR11)

### DIFF
--- a/reqopts.py
+++ b/reqopts.py
@@ -1,0 +1,74 @@
+"""Request-input parsers / option builders for the API layer.
+
+R5-25 / round-5 #51: the APIRouter split is blocked by ~50 cross-group helpers —
+a naive cut has each router do `from server import _ingest_cmd_opts`, and since
+`server` imports the routers, that's a partially-initialized-module ImportError.
+The fix is to extract the shared, server-state-free helpers into leaf service
+modules that the routers (and server) import. This is the request-option
+cluster: helpers that turn a raw request input (a `?ids=` query, an IngestRequest
+body) into validated internal options, raising HTTPException on bad input.
+
+Depends only on config + fastapi + stdlib — no server state — so it sits at the
+bottom of the import graph. server.py re-exports these names for backward compat
+(existing call sites + tests referencing `server._ingest_cmd_opts` etc. keep
+working unchanged).
+
+`_ingest_cmd_opts` takes an IngestRequest but only reads attributes (duck-typed
+via a string annotation), so the pydantic model stays in server.py — no import
+of server needed, no cycle.
+"""
+from fastapi import HTTPException
+
+import config
+
+
+def _parse_ids_query(ids_query):
+    """Decode ?ids=1,2,3 query string → [int]. Returns None when no filter requested."""
+    if not ids_query:
+        return None
+    parsed = []
+    for raw in ids_query.split(","):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            parsed.append(int(raw))
+        except ValueError:
+            raise HTTPException(400, f"無效的 media id: {raw!r}")
+    return parsed  # may be [] if all entries were blank → caller treats as filter-with-no-rows
+
+
+# brick 4 — whisper language codes the setup picker offers (whisper supports many
+# more; this is the curated UI set). Omit / None = auto-detect or the preset hint.
+_INGEST_LANGUAGES = [
+    {"code": "zh", "label": "中文"},
+    {"code": "en", "label": "English"},
+    {"code": "ja", "label": "日本語"},
+    {"code": "ko", "label": "한국어"},
+]
+_INGEST_LANGUAGE_CODES = {lang["code"] for lang in _INGEST_LANGUAGES}
+
+
+def _ingest_cmd_opts(body: "IngestRequest") -> list:
+    """Translate IngestRequest options into ingest.py CLI flags. Shared by the
+    REST (/api/ingest) and WebSocket (/api/ingest/ws) triggers so the two never
+    drift. --dir / --limit stay with the callers; this is only the extra knobs."""
+    opts: list = []
+    if body.skip_vision:
+        opts.append("--skip-vision")
+    if body.refresh:
+        opts.append("--refresh")
+    if body.recursive:
+        opts.append("--recursive")
+    if body.max_failures and body.max_failures > 0:
+        opts += ["--max-failures", str(int(body.max_failures))]
+    if body.skip_failed:
+        opts.append("--skip-failed")
+    if body.no_embed:
+        opts.append("--no-embed")
+    # brick 4 — only emit when explicitly set (and valid) so defaults stay untouched.
+    if body.whisper_guard is not None and body.whisper_guard in config.WHISPER_GUARD_LAYERS:
+        opts += ["--whisper-guard", str(int(body.whisper_guard))]
+    if body.language and body.language in _INGEST_LANGUAGE_CODES:
+        opts += ["--language", body.language]
+    return opts

--- a/server.py
+++ b/server.py
@@ -220,6 +220,15 @@ from export_builders import (  # noqa: F401 (re-exported for backward compat)
     _edl_fps_warning,
     _fcpxml_rational,
 )
+# R5-25 / #51: request-input parsers / option builders (the ?ids= query parser +
+# the IngestRequest→CLI-flags translator + the whisper language allowlist) live
+# in reqopts.py (a leaf — config + fastapi only). Re-exported here for compat.
+from reqopts import (  # noqa: F401 (re-exported for backward compat)
+    _parse_ids_query,
+    _INGEST_LANGUAGES,
+    _INGEST_LANGUAGE_CODES,
+    _ingest_cmd_opts,
+)
 
 
 # ── Models ───────────────────────────────────────────────────────────────────
@@ -1822,20 +1831,8 @@ def size_by_ext(
 # this module.
 
 
-def _parse_ids_query(ids_query):
-    """Decode ?ids=1,2,3 query string → [int]. Returns None when no filter requested."""
-    if not ids_query:
-        return None
-    parsed = []
-    for raw in ids_query.split(","):
-        raw = raw.strip()
-        if not raw:
-            continue
-        try:
-            parsed.append(int(raw))
-        except ValueError:
-            raise HTTPException(400, f"無效的 media id: {raw!r}")
-    return parsed  # may be [] if all entries were blank → caller treats as filter-with-no-rows
+# _parse_ids_query moved to reqopts.py (R5-25 / #51), re-exported at the top of
+# this module.
 
 
 @app.get("/api/export/metadata-csv")
@@ -1928,40 +1925,8 @@ class IngestRequest(BaseModel):
     language: Optional[str] = None
 
 
-# brick 4 — whisper language codes the setup picker offers (whisper supports many
-# more; this is the curated UI set). Omit / None = auto-detect or the preset hint.
-_INGEST_LANGUAGES = [
-    {"code": "zh", "label": "中文"},
-    {"code": "en", "label": "English"},
-    {"code": "ja", "label": "日本語"},
-    {"code": "ko", "label": "한국어"},
-]
-_INGEST_LANGUAGE_CODES = {lang["code"] for lang in _INGEST_LANGUAGES}
-
-
-def _ingest_cmd_opts(body: "IngestRequest") -> list:
-    """Translate IngestRequest options into ingest.py CLI flags. Shared by the
-    REST (/api/ingest) and WebSocket (/api/ingest/ws) triggers so the two never
-    drift. --dir / --limit stay with the callers; this is only the extra knobs."""
-    opts: list = []
-    if body.skip_vision:
-        opts.append("--skip-vision")
-    if body.refresh:
-        opts.append("--refresh")
-    if body.recursive:
-        opts.append("--recursive")
-    if body.max_failures and body.max_failures > 0:
-        opts += ["--max-failures", str(int(body.max_failures))]
-    if body.skip_failed:
-        opts.append("--skip-failed")
-    if body.no_embed:
-        opts.append("--no-embed")
-    # brick 4 — only emit when explicitly set (and valid) so defaults stay untouched.
-    if body.whisper_guard is not None and body.whisper_guard in config.WHISPER_GUARD_LAYERS:
-        opts += ["--whisper-guard", str(int(body.whisper_guard))]
-    if body.language and body.language in _INGEST_LANGUAGE_CODES:
-        opts += ["--language", body.language]
-    return opts
+# _INGEST_LANGUAGES / _INGEST_LANGUAGE_CODES / _ingest_cmd_opts moved to
+# reqopts.py (R5-25 / #51), re-exported at the top of this module.
 
 
 class ScanRequest(BaseModel):

--- a/tests/test_r5_25_reqopts_module.py
+++ b/tests/test_r5_25_reqopts_module.py
@@ -1,0 +1,118 @@
+"""R5-25 (round-5 #51): request-input parsers / option builders → reqopts.py.
+
+Fourth (final) leaf-service module of the APIRouter split. Holds the helpers that
+turn a raw request input into validated internal options: the `?ids=` query
+parser (export routes) and the IngestRequest→ingest.py-CLI-flags translator plus
+its whisper-language allowlist (ingest routes). Both raise HTTPException on bad
+input; both are server-state-free.
+
+`_ingest_cmd_opts` reads an IngestRequest by attribute (duck-typed via a string
+annotation), so the pydantic model stays in server.py — reqopts imports no
+server. These tests pin the leaf boundary, identity re-export, and the
+parse/validation behaviour so the move is provably semantics-preserving. (Route +
+IngestRequest-integration coverage already lives in test_ingest_options.py.)
+"""
+import pathlib
+import re
+
+import pytest
+from fastapi import HTTPException
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+_NAMES = (
+    "_parse_ids_query",
+    "_INGEST_LANGUAGES",
+    "_INGEST_LANGUAGE_CODES",
+    "_ingest_cmd_opts",
+)
+
+
+# ── module boundary ──────────────────────────────────────────────────────────
+def test_reqopts_is_a_leaf_module():
+    src = (_ROOT / "reqopts.py").read_text(encoding="utf-8")
+    assert not re.search(r"^\s*import\s+server\b", src, re.M)
+    assert not re.search(r"^\s*from\s+server\b", src, re.M)
+
+
+def test_server_reexports_reqopts_by_identity():
+    import server
+    import reqopts
+    for name in _NAMES:
+        assert getattr(server, name) is getattr(reqopts, name), (
+            "server.{0} must BE reqopts.{0} (a re-export)".format(name)
+        )
+
+
+def test_ingest_request_model_stays_in_server():
+    # The pydantic model is a server/API-schema concern; reqopts only duck-types on
+    # it, so it must NOT have moved (would drag pydantic wiring into the leaf).
+    import server
+    assert hasattr(server, "IngestRequest")
+
+
+# ── _parse_ids_query behaviour ───────────────────────────────────────────────
+def test_parse_ids_query_decodes_and_validates():
+    import reqopts
+    assert reqopts._parse_ids_query("1,2,3") == [1, 2, 3]
+    assert reqopts._parse_ids_query(None) is None       # no filter requested
+    assert reqopts._parse_ids_query("") is None
+    assert reqopts._parse_ids_query(" 1 , ,2 ") == [1, 2]  # blanks skipped, trimmed
+    assert reqopts._parse_ids_query(",,") == []          # all-blank → empty filter
+    with pytest.raises(HTTPException) as e:
+        reqopts._parse_ids_query("1,abc")
+    assert e.value.status_code == 400
+
+
+# ── _ingest_cmd_opts behaviour (duck-typed body) ─────────────────────────────
+class _Body:
+    """Minimal stand-in with IngestRequest's attribute surface."""
+    def __init__(self, **kw):
+        defaults = dict(
+            skip_vision=False, refresh=False, recursive=False, max_failures=0,
+            skip_failed=False, no_embed=False, whisper_guard=None, language=None,
+        )
+        defaults.update(kw)
+        self.__dict__.update(defaults)
+
+
+def test_ingest_cmd_opts_defaults_empty():
+    import reqopts
+    assert reqopts._ingest_cmd_opts(_Body()) == []
+
+
+def test_ingest_cmd_opts_emits_flags():
+    import reqopts
+    opts = reqopts._ingest_cmd_opts(_Body(
+        skip_vision=True, refresh=True, recursive=True, max_failures=3,
+        skip_failed=True, no_embed=True,
+    ))
+    assert "--skip-vision" in opts and "--refresh" in opts and "--recursive" in opts
+    assert opts[opts.index("--max-failures") + 1] == "3"
+    assert "--skip-failed" in opts and "--no-embed" in opts
+
+
+def test_ingest_cmd_opts_max_failures_zero_omitted():
+    import reqopts
+    assert "--max-failures" not in reqopts._ingest_cmd_opts(_Body(max_failures=0))
+
+
+def test_ingest_cmd_opts_language_allowlist():
+    import reqopts
+    # a valid curated code emits; an unknown code is silently dropped (not injected)
+    assert reqopts._ingest_cmd_opts(_Body(language="zh")) == ["--language", "zh"]
+    assert "--language" not in reqopts._ingest_cmd_opts(_Body(language="xx"))
+    assert reqopts._INGEST_LANGUAGE_CODES == {"zh", "en", "ja", "ko"}
+
+
+def test_ingest_cmd_opts_whisper_guard_validated_against_config():
+    import reqopts
+    import config
+    valid = next(iter(config.WHISPER_GUARD_LAYERS))
+    assert reqopts._ingest_cmd_opts(_Body(whisper_guard=valid)) == [
+        "--whisper-guard", str(int(valid))
+    ]
+    # a guard value not in config is dropped, not passed through
+    bogus = 9999
+    assert bogus not in config.WHISPER_GUARD_LAYERS
+    assert "--whisper-guard" not in reqopts._ingest_cmd_opts(_Body(whisper_guard=bogus))


### PR DESCRIPTION
## What

Fourth and **final service-module PR** of **R5-25 (#51)**, the APIRouter split. Extracts the request-input parsers / option builders into a new leaf module **`reqopts.py`**. **Stacked on PR10 (#162, export_builders.py)** — base is `feat/r5-25-export-builders`; retargets to `main` as the stack merges down.

After this PR, the leaf-extraction phase is complete: `pathres` (PR8) + `webguard` (PR9) + `export_builders` (PR10) + `reqopts` (PR11) hold every cross-group helper the routers share, so the **11 routers can now be peeled leaf-first** without any `from server import <helper>` → `router→server→router` cycle.

## What moved

| helper | used by |
|---|---|
| `_parse_ids_query` | export routes (`?ids=1,2,3` → `[int]`) |
| `_ingest_cmd_opts` | ingest routes (REST + WS) — IngestRequest → ingest.py CLI flags |
| `_INGEST_LANGUAGES` / `_INGEST_LANGUAGE_CODES` | the curated whisper-language allowlist `_ingest_cmd_opts` validates against |

Depends only on `config` + `fastapi` — no server state.

## Naming

Called **`reqopts`**, not `ingest_opts` (the name floated when scoping R5-25), because `_parse_ids_query` is an **export-route** query parser, not ingest-specific. The honest shared concept is *"validate a request input into internal options, raising `HTTPException` on bad input."*

## Why IngestRequest stays in server.py

`_ingest_cmd_opts` reads an `IngestRequest` **by attribute** (duck-typed via a string annotation `body: \"IngestRequest\"`), so the pydantic model stays put — `reqopts` imports no `server`, and no pydantic/schema wiring leaks into the leaf. `test_ingest_options.py` calls `server._ingest_cmd_opts(server.IngestRequest(...))` and keeps working via the re-export.

## Backward compat

`server.py` re-exports all 4 names (`from reqopts import ... # noqa: F401`). Net `server.py` **−48 lines**.

## Tests

New `tests/test_r5_25_reqopts_module.py` (9 tests): leaf boundary, identity re-export, `IngestRequest` staying in server, and parse/validation behaviour — ids decode + trim/skip-blanks + 400-on-garbage, ingest flag emission, `max_failures=0` omission, language allowlist (unknown code dropped, not injected), and `whisper_guard` validated against `config.WHISPER_GUARD_LAYERS` (bogus value dropped). Route/IngestRequest-integration coverage already lives in `test_ingest_options.py`.

**834 passed, 5 skipped** locally (825 baseline + 9 new). Pure module-boundary extraction, no behaviour change.

## Sequence

Service-module extraction phase **complete** (PR8–PR11). Next: peel the 11 routers leaf-first (admin → settings → … → ingest/WS last), each its own draft PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)