### PR TITLE
refactor(server): peel admin token routes → routers/admin.py (router-split, round-5 #51 / R5-25 PR12)

### DIFF
--- a/routers/__init__.py
+++ b/routers/__init__.py
@@ -1,0 +1,11 @@
+"""APIRouter modules for the arkiv server (R5-25 / round-5 #51).
+
+The #51 finding: server.py had grown into a ~4.5k-line monolith mixing route
+handlers, business logic, and helpers. The router split peels the route groups
+into focused APIRouter modules that server.py mounts via app.include_router().
+
+The prerequisite leaf service modules (pathres / webguard / export_builders /
+reqopts, plus the pre-existing auth / admin / db / state / settings modules) hold
+the cross-group helpers, so a router module imports what it needs directly — no
+`from server import ...`, no router→server→router import cycle.
+"""

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -1,0 +1,70 @@
+"""Admin token-management routes (R5-25 / round-5 #51 router split).
+
+The first router peeled from server.py. These four handlers are thin HTTP
+wrappers over the already-extracted `admin` business-logic module; the only
+route-local piece is the CreateTokenRequest body model, which moves here with
+them. Depends on auth (require_scopes) + admin + fastapi/pydantic — no server
+import, so server.py mounts this via app.include_router() with no cycle.
+"""
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+import admin
+from auth import require_scopes
+
+router = APIRouter()
+
+
+class CreateTokenRequest(BaseModel):
+    name: str
+    scopes: List[str]
+    description: Optional[str] = None
+    expires_in_days: Optional[int] = None
+    allowed_ips: Optional[List[str]] = None
+
+
+@router.post("/api/admin/tokens")
+def admin_create_token(
+    req: CreateTokenRequest,
+    _tok: dict = Depends(require_scopes("admin")),
+):
+    try:
+        return admin.create_token(
+            name=req.name,
+            scopes=req.scopes,
+            description=req.description,
+            expires_in_days=req.expires_in_days,
+            allowed_ips=req.allowed_ips,
+        )
+    except ValueError as exc:
+        raise HTTPException(400, str(exc))
+
+
+@router.get("/api/admin/tokens")
+def admin_list_tokens(
+    _tok: dict = Depends(require_scopes("admin")),
+):
+    return {"tokens": admin.list_tokens()}
+
+
+@router.get("/api/admin/tokens/{token_id}")
+def admin_get_token(
+    token_id: str,
+    _tok: dict = Depends(require_scopes("admin")),
+):
+    token = admin.get_token(token_id)
+    if not token:
+        raise HTTPException(404, "Token not found")
+    return token
+
+
+@router.delete("/api/admin/tokens/{token_id}")
+def admin_revoke_token(
+    token_id: str,
+    _tok: dict = Depends(require_scopes("admin")),
+):
+    if not admin.revoke_token(token_id):
+        raise HTTPException(404, "Token not found")
+    return {"ok": True, "deleted": token_id}

--- a/server.py
+++ b/server.py
@@ -152,6 +152,12 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# R5-25 / #51 router split: route groups peeled from this module into focused
+# APIRouter modules under routers/, mounted here. Each is self-contained (imports
+# auth/admin/db/state/… + the leaf service modules directly — no server import).
+from routers.admin import router as admin_router  # noqa: E402
+app.include_router(admin_router)
+
 ROOT = Path(__file__).parent
 # Built Svelte SPA (frontend/dist). Gitignored — produced by `npm run build`.
 FRONTEND_DIST = ROOT / "frontend" / "dist"
@@ -322,12 +328,8 @@ class BinCopyRequest(BaseModel):
     no_embed: bool = False
 
 
-class CreateTokenRequest(BaseModel):
-    name: str
-    scopes: List[str]
-    description: Optional[str] = None
-    expires_in_days: Optional[int] = None
-    allowed_ips: Optional[List[str]] = None
+# CreateTokenRequest + the /api/admin/tokens handlers moved to routers/admin.py
+# (R5-25 / #51 router split), mounted via app.include_router below.
 
 
 class ChatRequest(BaseModel):
@@ -3232,54 +3234,6 @@ def export_timeline(
         media_type="application/xml; charset=utf-8",
         headers={"Content-Disposition": 'attachment; filename="arkiv-timeline.fcpxml"'},
     )
-
-
-# ── Admin Tokens ─────────────────────────────────────────────────────────────
-
-
-@app.post("/api/admin/tokens")
-def admin_create_token(
-    req: CreateTokenRequest,
-    _tok: dict = Depends(require_scopes("admin")),
-):
-    try:
-        return admin.create_token(
-            name=req.name,
-            scopes=req.scopes,
-            description=req.description,
-            expires_in_days=req.expires_in_days,
-            allowed_ips=req.allowed_ips,
-        )
-    except ValueError as exc:
-        raise HTTPException(400, str(exc))
-
-
-@app.get("/api/admin/tokens")
-def admin_list_tokens(
-    _tok: dict = Depends(require_scopes("admin")),
-):
-    return {"tokens": admin.list_tokens()}
-
-
-@app.get("/api/admin/tokens/{token_id}")
-def admin_get_token(
-    token_id: str,
-    _tok: dict = Depends(require_scopes("admin")),
-):
-    token = admin.get_token(token_id)
-    if not token:
-        raise HTTPException(404, "Token not found")
-    return token
-
-
-@app.delete("/api/admin/tokens/{token_id}")
-def admin_revoke_token(
-    token_id: str,
-    _tok: dict = Depends(require_scopes("admin")),
-):
-    if not admin.revoke_token(token_id):
-        raise HTTPException(404, "Token not found")
-    return {"ok": True, "deleted": token_id}
 
 
 # ── WebSocket: Ingest Progress ───────────────────────────────────────────

--- a/tests/test_r5_25_router_admin.py
+++ b/tests/test_r5_25_router_admin.py
@@ -1,0 +1,57 @@
+"""R5-25 (round-5 #51): first APIRouter peeled from server.py → routers/admin.py.
+
+The admin token routes are thin wrappers over the already-extracted `admin`
+business-logic module, so they were the cleanest first peel. These tests pin the
+split itself: the router module owns the routes + its body model, server.py no
+longer defines the handlers, and the routes are still mounted + auth-guarded on
+the app. Full authenticated CRUD behaviour is covered by test_auth.py.
+"""
+import pathlib
+import re
+
+from starlette.testclient import TestClient
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def test_admin_router_is_a_leaf_module():
+    src = (_ROOT / "routers" / "admin.py").read_text(encoding="utf-8")
+    assert not re.search(r"^\s*import\s+server\b", src, re.M)
+    assert not re.search(r"^\s*from\s+server\b", src, re.M)
+
+
+def test_router_owns_the_four_token_routes():
+    import routers.admin as ra
+    # one (path, method) pair per handler, ignoring the auto-added HEAD on GET
+    pairs = {
+        (r.path, m)
+        for r in ra.router.routes
+        for m in r.methods
+        if m != "HEAD"
+    }
+    assert pairs == {
+        ("/api/admin/tokens", "POST"),
+        ("/api/admin/tokens", "GET"),
+        ("/api/admin/tokens/{token_id}", "GET"),
+        ("/api/admin/tokens/{token_id}", "DELETE"),
+    }
+    # the body model moved WITH the router
+    assert hasattr(ra, "CreateTokenRequest")
+
+
+def test_server_no_longer_defines_the_handlers():
+    src = (_ROOT / "server.py").read_text(encoding="utf-8")
+    # no @app-decorated admin handler and no CreateTokenRequest class left behind
+    assert "class CreateTokenRequest" not in src
+    assert not re.search(r"@app\.(post|get|delete)\(\"/api/admin/tokens", src)
+    # and it IS mounted
+    assert "include_router(admin_router)" in src
+
+
+def test_admin_routes_mounted_and_auth_guarded(server_module):
+    # 401 (auth dependency fires) proves the route is MOUNTED; a missing route
+    # would 404. Contrast with a genuinely nonexistent path.
+    with TestClient(server_module.app) as c:
+        assert c.post("/api/admin/tokens", json={"name": "x", "scopes": ["admin"]}).status_code == 401
+        assert c.delete("/api/admin/tokens/abc").status_code == 401
+        assert c.post("/api/zzz_nonexistent_route", json={}).status_code == 404


### PR DESCRIPTION
## What

**First router peeled** from the server.py monolith — the start of R5-25's router-split phase, now that the leaf service modules (`pathres`/`webguard`/`export_builders`/`reqopts`, merged #160–163) hold the shared helpers and the import cycle is broken. Off clean `main`.

Introduces the `routers/` package and moves the `/api/admin/tokens` group into **`routers/admin.py`**, mounted via `app.include_router()`.

## Why this group first

The admin token routes are the cleanest possible first peel: four **thin handlers** over the already-extracted `admin` business-logic module, with a single route-local body model (`CreateTokenRequest`) that moves with them. `routers/admin.py` imports `auth` (`require_scopes`) + `admin` + fastapi/pydantic — **no `from server import`**, so server.py mounts it with no `router→server→router` cycle. It proves the pattern with minimal risk before the larger groups (media/bins/ingest).

## Changes

- New `routers/__init__.py` (package docstring explaining the split) + `routers/admin.py` (router + the 4 handlers + `CreateTokenRequest`).
- server.py: removed the 4 `@app` handlers + the model; added `from routers.admin import router as admin_router` + `app.include_router(admin_router)` after the CORS middleware.

## Tests

New `tests/test_r5_25_router_admin.py` (4 tests): the router is a leaf (no `import server`), owns exactly the 4 token routes + the body model, server.py no longer defines the handlers/model but **does** mount the router, and the routes stay mounted + auth-guarded — verified by the 401-not-404 discrimination (a mounted route with a failing auth dependency returns 401; a missing route 404s). Full authenticated CRUD behaviour remains covered by `test_auth.py`.

**838 passed, 5 skipped** locally (834 baseline + 4 new). No behaviour change — the routes keep their exact paths/methods/auth.

## Sequence

Router peel continues **merge-as-green** (each router removes handlers + adds an `include_router` line, so independent off-main branches would collide — they must merge before the next peels off updated main). Remaining groups: media (18) · bins (7) · projects (5) · ingest (4) · export (4) · settings (3) · proxy (3) · chat (3) · recorrect (3) · misc/analytics · WS last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)