### PR TITLE
refactor(server): peel settings routes → routers/settings.py (R5-25 PR13)

### DIFF
--- a/routers/settings.py
+++ b/routers/settings.py
@@ -1,0 +1,85 @@
+"""Settings routes (R5-25 / round-5 #51 router split).
+
+The /api/settings group: read the effective (default ← global ← project) settings,
+persist a batch of overrides at a scope, and reset one key. Thin wrappers over the
+already-extracted `settings` store; the scope-validation helper and the update
+body model are settings-local and move here with the handlers. Imports auth +
+settings + config + projects (registry) — no server import, no cycle.
+"""
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+import config
+import projects as project_registry
+import settings as settings_store
+from auth import require_scopes
+
+router = APIRouter()
+
+
+def _resolve_settings_scope(scope: str) -> str:
+    """Validate the scope param. 'global' is the library-wide default; any other
+    value must be a known project root (registry or the current PROJECT_ROOT) —
+    we never let an arbitrary string become a scope row, so the table can't be
+    used as free-form key/value storage."""
+    if not scope or scope == settings_store.GLOBAL_SCOPE:
+        return settings_store.GLOBAL_SCOPE
+    known = {str(config.PROJECT_ROOT)}
+    try:
+        known.update(p.path for p in project_registry.list_registry_projects())
+    except project_registry.RegistryError:
+        pass
+    if scope not in known:
+        raise HTTPException(status_code=400, detail="unknown settings scope: {0}".format(scope))
+    return scope
+
+
+@router.get("/api/settings")
+def get_settings(
+    scope: str = "global",
+    _tok: dict = Depends(require_scopes("projects_read")),
+):
+    """Effective settings (default ← global ← project) + metadata per key."""
+    resolved = _resolve_settings_scope(scope)
+    project = None if resolved == settings_store.GLOBAL_SCOPE else resolved
+    return {"scope": resolved, "settings": settings_store.describe(project=project)}
+
+
+class SettingsUpdate(BaseModel):
+    scope: str = "global"
+    values: dict
+
+
+@router.put("/api/settings")
+def put_settings(
+    body: SettingsUpdate,
+    _tok: dict = Depends(require_scopes("admin")),
+):
+    """Persist a batch of overrides at the given scope. Validate-all-then-write:
+    a single bad key/value rejects the whole batch (422), nothing is stored."""
+    resolved = _resolve_settings_scope(body.scope)
+    try:
+        written = settings_store.put(body.values, scope=resolved)
+    except settings_store.SettingError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+    project = None if resolved == settings_store.GLOBAL_SCOPE else resolved
+    return {
+        "scope": resolved,
+        "written": written,
+        "settings": settings_store.describe(project=project),
+    }
+
+
+@router.delete("/api/settings/{key}")
+def reset_setting(
+    key: str,
+    scope: str = "global",
+    _tok: dict = Depends(require_scopes("admin")),
+):
+    """Drop one override so the key falls back to the next layer down."""
+    resolved = _resolve_settings_scope(scope)
+    try:
+        settings_store.reset(key, scope=resolved)
+    except settings_store.SettingError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return {"scope": resolved, "reset": key}

--- a/server.py
+++ b/server.py
@@ -156,7 +156,9 @@ app.add_middleware(
 # APIRouter modules under routers/, mounted here. Each is self-contained (imports
 # auth/admin/db/state/… + the leaf service modules directly — no server import).
 from routers.admin import router as admin_router  # noqa: E402
+from routers.settings import router as settings_router  # noqa: E402
 app.include_router(admin_router)
+app.include_router(settings_router)
 
 ROOT = Path(__file__).parent
 # Built Svelte SPA (frontend/dist). Gitignored — produced by `npm run build`.
@@ -972,72 +974,9 @@ def copy_bin(bin_id: str, body: BinCopyRequest, _tok: dict = Depends(require_sco
 
 # --- Phase 9.7 G5②: persisted settings (curated key/value overrides) ---
 
-def _resolve_settings_scope(scope: str) -> str:
-    """Validate the scope param. 'global' is the library-wide default; any other
-    value must be a known project root (registry or the current PROJECT_ROOT) —
-    we never let an arbitrary string become a scope row, so the table can't be
-    used as free-form key/value storage."""
-    if not scope or scope == settings_store.GLOBAL_SCOPE:
-        return settings_store.GLOBAL_SCOPE
-    known = {str(config.PROJECT_ROOT)}
-    try:
-        known.update(p.path for p in project_registry.list_registry_projects())
-    except project_registry.RegistryError:
-        pass
-    if scope not in known:
-        raise HTTPException(status_code=400, detail="unknown settings scope: {0}".format(scope))
-    return scope
-
-
-@app.get("/api/settings")
-def get_settings(
-    scope: str = "global",
-    _tok: dict = Depends(require_scopes("projects_read")),
-):
-    """Effective settings (default ← global ← project) + metadata per key."""
-    resolved = _resolve_settings_scope(scope)
-    project = None if resolved == settings_store.GLOBAL_SCOPE else resolved
-    return {"scope": resolved, "settings": settings_store.describe(project=project)}
-
-
-class SettingsUpdate(BaseModel):
-    scope: str = "global"
-    values: dict
-
-
-@app.put("/api/settings")
-def put_settings(
-    body: SettingsUpdate,
-    _tok: dict = Depends(require_scopes("admin")),
-):
-    """Persist a batch of overrides at the given scope. Validate-all-then-write:
-    a single bad key/value rejects the whole batch (422), nothing is stored."""
-    resolved = _resolve_settings_scope(body.scope)
-    try:
-        written = settings_store.put(body.values, scope=resolved)
-    except settings_store.SettingError as exc:
-        raise HTTPException(status_code=422, detail=str(exc))
-    project = None if resolved == settings_store.GLOBAL_SCOPE else resolved
-    return {
-        "scope": resolved,
-        "written": written,
-        "settings": settings_store.describe(project=project),
-    }
-
-
-@app.delete("/api/settings/{key}")
-def reset_setting(
-    key: str,
-    scope: str = "global",
-    _tok: dict = Depends(require_scopes("admin")),
-):
-    """Drop one override so the key falls back to the next layer down."""
-    resolved = _resolve_settings_scope(scope)
-    try:
-        settings_store.reset(key, scope=resolved)
-    except settings_store.SettingError as exc:
-        raise HTTPException(status_code=404, detail=str(exc))
-    return {"scope": resolved, "reset": key}
+# The /api/settings group (_resolve_settings_scope + SettingsUpdate + the 3
+# handlers) moved to routers/settings.py (R5-25 / #51), mounted via
+# app.include_router below.
 
 
 @app.get("/api/media/position/{media_id}")

--- a/tests/test_r5_25_router_settings.py
+++ b/tests/test_r5_25_router_settings.py
@@ -1,0 +1,52 @@
+"""R5-25 (round-5 #51): settings routes peeled to routers/settings.py.
+
+Second router peeled. Pins the split: the router is a leaf, owns the 3 settings
+routes + its scope helper + body model, server.py no longer defines them, and the
+routes stay mounted + auth-guarded. Behavioural coverage lives in
+test_settings_g5.py.
+"""
+import pathlib
+import re
+
+from starlette.testclient import TestClient
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def test_settings_router_is_a_leaf_module():
+    src = (_ROOT / "routers" / "settings.py").read_text(encoding="utf-8")
+    assert not re.search(r"^\s*import\s+server\b", src, re.M)
+    assert not re.search(r"^\s*from\s+server\b", src, re.M)
+
+
+def test_router_owns_settings_routes_and_helpers():
+    import routers.settings as rs
+    pairs = {
+        (r.path, m)
+        for r in rs.router.routes
+        for m in r.methods
+        if m != "HEAD"
+    }
+    assert pairs == {
+        ("/api/settings", "GET"),
+        ("/api/settings", "PUT"),
+        ("/api/settings/{key}", "DELETE"),
+    }
+    assert hasattr(rs, "SettingsUpdate")            # body model moved with it
+    assert hasattr(rs, "_resolve_settings_scope")   # scope helper moved with it
+
+
+def test_server_no_longer_defines_settings_handlers():
+    src = (_ROOT / "server.py").read_text(encoding="utf-8")
+    assert "class SettingsUpdate" not in src
+    assert "def _resolve_settings_scope" not in src
+    assert not re.search(r"@app\.(get|put|delete)\(\"/api/settings", src)
+    assert "include_router(settings_router)" in src
+
+
+def test_settings_routes_mounted_and_auth_guarded(server_module):
+    with TestClient(server_module.app) as c:
+        assert c.get("/api/settings").status_code == 401
+        assert c.put("/api/settings", json={"scope": "global", "values": {}}).status_code == 401
+        assert c.delete("/api/settings/x").status_code == 401
+        assert c.get("/api/settings_nonexistent").status_code == 404

--- a/tests/test_state_extraction.py
+++ b/tests/test_state_extraction.py
@@ -14,8 +14,14 @@ def test_no_duplicate_route_registrations(server_module):
     seen = set()
     dupes = []
     for r in server_module.app.routes:
+        path = getattr(r, "path", None)
+        # app.include_router() appends a pathless `_IncludedRouter` sentinel to
+        # app.routes per include (R5-25 router split) — not a real route, so one
+        # per mounted router is expected. Only real (path, methods) routes count.
+        if path is None:
+            continue
         methods = tuple(sorted(getattr(r, "methods", None) or ()))
-        key = (getattr(r, "path", None), methods)
+        key = (path, methods)
         if key in seen:
             dupes.append(key)
         seen.add(key)


### PR DESCRIPTION
## What

Second router peeled (merge-as-green off `main` after PR12/admin #164). The `/api/settings` group moves into **`routers/settings.py`**.

- 3 handlers: GET effective settings, PUT a batch of scoped overrides, DELETE one key.
- Moves with them (both settings-local): `_resolve_settings_scope` (scope validator) + `SettingsUpdate` (body model).
- Imports `auth` + `settings` + `config` + `projects` — no `from server import`, no cycle.

## Also: fixes a guard test the split surfaced

`test_state_extraction.test_no_duplicate_route_registrations` flagged `(None, ())`. Cause: FastAPI appends a **pathless `_IncludedRouter` sentinel** to `app.routes` for *each* `app.include_router()` call. With one router (admin) there was one sentinel; the second include (settings) made two → the naive `(path, methods)` duplicate check tripped. Fix: skip pathless sentinels — only real routes count. (This is why it passed on PR12 and only broke now.)

## Tests

New `tests/test_r5_25_router_settings.py` (4): leaf boundary, route+helper+model ownership, server no longer defines them but mounts the router, routes mounted + auth-guarded (401 not 404). Behavioural coverage stays in `test_settings_g5.py`. **838 passed, 5 skipped.**

## Sequence

Next clean peels: projects → chat → cache. Then recorrect/proxy/misc need two shared helpers (`_rebuild_embeddings`, `_proxy_ready`) extracted to shared modules first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)