### PR TITLE
refactor(server): peel projects routes → routers/projects.py (R5-25 PR14)

### DIFF
--- a/routers/projects.py
+++ b/routers/projects.py
@@ -1,0 +1,128 @@
+"""Projects registry routes (R5-25 / round-5 #51 router split).
+
+The /api/projects group: list / add / remove / sync registry projects + a health
+probe. Thin wrappers over the already-extracted `projects` registry module. The
+create body model (ProjectCreate, with its name validator) and the path-visibility
+sanitisers (fable-audit #22: absolute roots only leak to admin-scoped callers)
+are projects-local and move here. Imports auth + projects + pathres — no server
+import, no cycle.
+"""
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, field_validator
+
+import projects as project_registry
+from auth import require_scopes
+from pathres import _basename_safe
+
+router = APIRouter()
+
+
+class ProjectCreate(BaseModel):
+    name: str
+    path: str
+    tags: Optional[List[str]] = None
+
+    # audit M21: empty / control-char / separator-bearing names were accepted —
+    # a name containing '/' can be created but never DELETEd (the path param
+    # can't match it), and unbounded names bloat the registry.
+    @field_validator("name")
+    @classmethod
+    def _clean_project_name(cls, v: str) -> str:
+        cleaned = " ".join(
+            "".join(c for c in (v or "") if c == " " or (ord(c) >= 0x20 and c != "\x7f")).split()
+        )
+        if not cleaned:
+            raise ValueError("project name must not be empty")
+        if len(cleaned) > 100:
+            raise ValueError("project name too long (max 100)")
+        if "/" in cleaned or "\\" in cleaned:
+            raise ValueError("project name must not contain path separators")
+        return cleaned
+
+
+def _project_paths_visible(tok: dict) -> bool:
+    """fable-audit 2026-07-12 (#22): absolute project roots leave the backend only
+    for admin-scoped callers. Loopback-trust already grants all scopes (incl.
+    'admin'), so the LOCAL operator's registry / mount UI is unaffected (case a);
+    a remote admin token also sees full paths (case c); a remote projects_read-only
+    token gets basenames — so a browse-only LAN/Tailscale client can't map the
+    operator's home layout, drive structure, or other clients' folder names."""
+    return "admin" in (tok.get("scopes") or ())
+
+
+def _sanitize_project_paths(projects: list, tok: dict) -> list:
+    if _project_paths_visible(tok):
+        return projects
+    for p in projects:
+        if p.get("path"):
+            p["path"] = _basename_safe(p["path"])
+    return projects
+
+
+@router.get("/api/projects")
+def list_projects(
+    _tok: dict = Depends(require_scopes("projects_read")),
+):
+    # A corrupt ~/.arkiv-projects.json must not 500 with a raw stack trace on
+    # every read — return a clean error the UI can show.
+    try:
+        projects = [project.to_dict() for project in project_registry.list_registry_projects()]
+    except project_registry.RegistryError as exc:
+        raise HTTPException(status_code=500, detail="project registry unreadable: {0}".format(exc))
+    _sanitize_project_paths(projects, _tok)
+    return {"projects": projects, "total": len(projects)}
+
+
+@router.post("/api/projects")
+def add_project(
+    body: ProjectCreate,
+    _tok: dict = Depends(require_scopes("projects_write")),
+):
+    # audit M21: registry add_project silently REPLACES an existing entry of the
+    # same name — surface the collision as 409 instead of overwriting.
+    try:
+        existing = {p.name for p in project_registry.list_registry_projects()}
+    except project_registry.RegistryError as exc:
+        raise HTTPException(status_code=500, detail="project registry unreadable: {0}".format(exc))
+    if body.name in existing:
+        raise HTTPException(status_code=409, detail="project name already exists: {0}".format(body.name))
+    try:
+        project = project_registry.add_project(body.name, body.path, body.tags or [])
+    except project_registry.RegistryError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return project.to_dict()
+
+
+@router.delete("/api/projects/{name}")
+def remove_project(
+    name: str,
+    _tok: dict = Depends(require_scopes("projects_write")),
+):
+    try:
+        project = project_registry.remove_project(name)
+    except project_registry.RegistryError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return project.to_dict()
+
+
+@router.post("/api/projects/sync")
+def sync_projects(
+    _tok: dict = Depends(require_scopes("projects_write")),
+):
+    try:
+        projects = [project.to_dict() for project in project_registry.sync_projects()]
+    except project_registry.RegistryError as exc:
+        raise HTTPException(status_code=500, detail="project registry unreadable: {0}".format(exc))
+    return {"projects": projects, "total": len(projects)}
+
+
+@router.get("/api/projects/health")
+def projects_health(
+    _tok: dict = Depends(require_scopes("projects_read")),
+):
+    projects = project_registry.health_projects()
+    _sanitize_project_paths(projects, _tok)  # fable-audit #22 — see list_projects
+    ok_count = sum(1 for item in projects if item["status"] == "ok")
+    return {"projects": projects, "total": len(projects), "ok": ok_count}

--- a/server.py
+++ b/server.py
@@ -157,8 +157,10 @@ app.add_middleware(
 # auth/admin/db/state/… + the leaf service modules directly — no server import).
 from routers.admin import router as admin_router  # noqa: E402
 from routers.settings import router as settings_router  # noqa: E402
+from routers.projects import router as projects_router  # noqa: E402
 app.include_router(admin_router)
 app.include_router(settings_router)
+app.include_router(projects_router)
 
 ROOT = Path(__file__).parent
 # Built Svelte SPA (frontend/dist). Gitignored — produced by `npm run build`.
@@ -268,27 +270,8 @@ class TagCreate(BaseModel):
         return cleaned
  
  
-class ProjectCreate(BaseModel):
-    name: str
-    path: str
-    tags: Optional[List[str]] = None
-
-    # audit M21: empty / control-char / separator-bearing names were accepted —
-    # a name containing '/' can be created but never DELETEd (the path param
-    # can't match it), and unbounded names bloat the registry.
-    @field_validator("name")
-    @classmethod
-    def _clean_project_name(cls, v: str) -> str:
-        cleaned = " ".join(
-            "".join(c for c in (v or "") if c == " " or (ord(c) >= 0x20 and c != "\x7f")).split()
-        )
-        if not cleaned:
-            raise ValueError("project name must not be empty")
-        if len(cleaned) > 100:
-            raise ValueError("project name too long (max 100)")
-        if "/" in cleaned or "\\" in cleaned:
-            raise ValueError("project name must not contain path separators")
-        return cleaned
+# ProjectCreate + the /api/projects handlers + path sanitisers moved to
+# routers/projects.py (R5-25 / #51), mounted via app.include_router below.
 
 
 class BinCreate(BaseModel):
@@ -585,90 +568,8 @@ def search_all(
     return JSONResponse(content=payload, status_code=status_code)
 
 
-def _project_paths_visible(tok: dict) -> bool:
-    """fable-audit 2026-07-12 (#22): absolute project roots leave the backend only
-    for admin-scoped callers. Loopback-trust already grants all scopes (incl.
-    'admin'), so the LOCAL operator's registry / mount UI is unaffected (case a);
-    a remote admin token also sees full paths (case c); a remote projects_read-only
-    token gets basenames — so a browse-only LAN/Tailscale client can't map the
-    operator's home layout, drive structure, or other clients' folder names."""
-    return "admin" in (tok.get("scopes") or ())
-
-
-def _sanitize_project_paths(projects: list, tok: dict) -> list:
-    if _project_paths_visible(tok):
-        return projects
-    for p in projects:
-        if p.get("path"):
-            p["path"] = _basename_safe(p["path"])
-    return projects
-
-
-@app.get("/api/projects")
-def list_projects(
-    _tok: dict = Depends(require_scopes("projects_read")),
-):
-    # A corrupt ~/.arkiv-projects.json must not 500 with a raw stack trace on
-    # every read — return a clean error the UI can show.
-    try:
-        projects = [project.to_dict() for project in project_registry.list_registry_projects()]
-    except project_registry.RegistryError as exc:
-        raise HTTPException(status_code=500, detail="project registry unreadable: {0}".format(exc))
-    _sanitize_project_paths(projects, _tok)
-    return {"projects": projects, "total": len(projects)}
-
-
-@app.post("/api/projects")
-def add_project(
-    body: ProjectCreate,
-    _tok: dict = Depends(require_scopes("projects_write")),
-):
-    # audit M21: registry add_project silently REPLACES an existing entry of the
-    # same name — surface the collision as 409 instead of overwriting.
-    try:
-        existing = {p.name for p in project_registry.list_registry_projects()}
-    except project_registry.RegistryError as exc:
-        raise HTTPException(status_code=500, detail="project registry unreadable: {0}".format(exc))
-    if body.name in existing:
-        raise HTTPException(status_code=409, detail="project name already exists: {0}".format(body.name))
-    try:
-        project = project_registry.add_project(body.name, body.path, body.tags or [])
-    except project_registry.RegistryError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
-    return project.to_dict()
-
-
-@app.delete("/api/projects/{name}")
-def remove_project(
-    name: str,
-    _tok: dict = Depends(require_scopes("projects_write")),
-):
-    try:
-        project = project_registry.remove_project(name)
-    except project_registry.RegistryError as exc:
-        raise HTTPException(status_code=404, detail=str(exc))
-    return project.to_dict()
-
-
-@app.post("/api/projects/sync")
-def sync_projects(
-    _tok: dict = Depends(require_scopes("projects_write")),
-):
-    try:
-        projects = [project.to_dict() for project in project_registry.sync_projects()]
-    except project_registry.RegistryError as exc:
-        raise HTTPException(status_code=500, detail="project registry unreadable: {0}".format(exc))
-    return {"projects": projects, "total": len(projects)}
-
-
-@app.get("/api/projects/health")
-def projects_health(
-    _tok: dict = Depends(require_scopes("projects_read")),
-):
-    projects = project_registry.health_projects()
-    _sanitize_project_paths(projects, _tok)  # fable-audit #22 — see list_projects
-    ok_count = sum(1 for item in projects if item["status"] == "ok")
-    return {"projects": projects, "total": len(projects), "ok": ok_count}
+# _project_paths_visible / _sanitize_project_paths + the 5 /api/projects handlers
+# moved to routers/projects.py (R5-25 / #51), mounted via app.include_router below.
 
 
 # --- Cross-library 精選集 (bins): persistent named selections spanning projects ---

--- a/tests/test_r5_25_router_projects.py
+++ b/tests/test_r5_25_router_projects.py
@@ -1,0 +1,66 @@
+"""R5-25 (round-5 #51): projects registry routes peeled to routers/projects.py.
+
+Third router peeled. Pins the split: leaf module, owns the 5 project routes + the
+path sanitisers + the ProjectCreate model (incl. its name validator), server.py
+no longer defines them, routes mounted + auth-guarded. Behaviour covered by
+test_hardening_projpath.py / project registry tests.
+"""
+import pathlib
+import re
+
+from starlette.testclient import TestClient
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def test_projects_router_is_a_leaf_module():
+    src = (_ROOT / "routers" / "projects.py").read_text(encoding="utf-8")
+    assert not re.search(r"^\s*import\s+server\b", src, re.M)
+    assert not re.search(r"^\s*from\s+server\b", src, re.M)
+
+
+def test_router_owns_projects_routes_and_helpers():
+    import routers.projects as rp
+    pairs = {
+        (r.path, m)
+        for r in rp.router.routes
+        for m in r.methods
+        if m != "HEAD"
+    }
+    assert pairs == {
+        ("/api/projects", "GET"),
+        ("/api/projects", "POST"),
+        ("/api/projects/{name}", "DELETE"),
+        ("/api/projects/sync", "POST"),
+        ("/api/projects/health", "GET"),
+    }
+    assert hasattr(rp, "ProjectCreate")
+    assert hasattr(rp, "_project_paths_visible")
+    assert hasattr(rp, "_sanitize_project_paths")
+
+
+def test_project_name_validator_still_enforced():
+    # the #22/M21 name validator must travel WITH the model
+    import routers.projects as rp
+    import pytest
+    with pytest.raises(Exception):
+        rp.ProjectCreate(name="a/b", path="/x")   # separator rejected
+    with pytest.raises(Exception):
+        rp.ProjectCreate(name="   ", path="/x")    # empty-after-clean rejected
+    assert rp.ProjectCreate(name="  ok name ", path="/x").name == "ok name"  # trimmed
+
+
+def test_server_no_longer_defines_projects_handlers():
+    src = (_ROOT / "server.py").read_text(encoding="utf-8")
+    assert "class ProjectCreate" not in src
+    assert "def _sanitize_project_paths" not in src
+    assert not re.search(r"@app\.(get|post|delete)\(\"/api/projects", src)
+    assert "include_router(projects_router)" in src
+
+
+def test_projects_routes_mounted_and_auth_guarded(server_module):
+    with TestClient(server_module.app) as c:
+        assert c.get("/api/projects").status_code == 401
+        assert c.post("/api/projects", json={"name": "x", "path": "/y"}).status_code == 401
+        assert c.get("/api/projects/health").status_code == 401
+        assert c.get("/api/projects_nonexistent").status_code == 404

--- a/tests/test_state_extraction.py
+++ b/tests/test_state_extraction.py
@@ -10,14 +10,32 @@
 import importlib
 
 
+def _iter_all_routes(app):
+    """Yield every real route, descending into included routers.
+
+    R5-25 router split: FastAPI ≥0.138 does NOT flatten app.include_router()
+    routes into app.routes — it inserts a lazy `_IncludedRouter` matcher whose
+    real routes live in `.original_router.routes`. A flat scan of app.routes
+    therefore misses every peeled router's endpoints (they still match at request
+    time — this is purely an enumeration concern). Descend into each included
+    router so route-surface guards see the whole app.
+    """
+    try:
+        from fastapi.routing import _IncludedRouter
+    except ImportError:  # older FastAPI flattens; no marker type
+        _IncludedRouter = ()
+    for r in app.routes:
+        if _IncludedRouter and isinstance(r, _IncludedRouter):
+            yield from r.original_router.routes
+        else:
+            yield r
+
+
 def test_no_duplicate_route_registrations(server_module):
     seen = set()
     dupes = []
-    for r in server_module.app.routes:
+    for r in _iter_all_routes(server_module.app):
         path = getattr(r, "path", None)
-        # app.include_router() appends a pathless `_IncludedRouter` sentinel to
-        # app.routes per include (R5-25 router split) — not a real route, so one
-        # per mounted router is expected. Only real (path, methods) routes count.
         if path is None:
             continue
         methods = tuple(sorted(getattr(r, "methods", None) or ()))
@@ -28,12 +46,13 @@ def test_no_duplicate_route_registrations(server_module):
     assert not dupes, f"duplicate route registrations: {dupes}"
     # sanity: the app actually has a substantial route surface (guards an empty/half
     # -wired app slipping past a future split)
-    api_routes = [r for r in server_module.app.routes if getattr(r, "path", "").startswith("/api/")]
+    api_routes = [r for r in _iter_all_routes(server_module.app)
+                  if getattr(r, "path", "").startswith("/api/")]
     assert len(api_routes) >= 50
 
 
 def test_critical_routes_present(server_module):
-    paths = {getattr(r, "path", "") for r in server_module.app.routes}
+    paths = {getattr(r, "path", "") for r in _iter_all_routes(server_module.app)}
     for p in ("/api/projects", "/api/bins/{bin_id}/copy", "/api/offload",
               "/api/cache/clear", "/api/retranscribe-all", "/api/search/all"):
         assert p in paths, f"missing route {p}"


### PR DESCRIPTION
## What

Third router peeled (merge-as-green off `main` after PR13/settings). The `/api/projects` group moves into **`routers/projects.py`**.

- 5 handlers: list / add (409 on dup) / remove / sync / health.
- Moves with them (all projects-local): `ProjectCreate` (body model + its #22/M21 name validator — rejects empty/oversized/separator-bearing names) and the path-visibility sanitisers `_project_paths_visible` / `_sanitize_project_paths` (fable-audit #22: absolute roots only leak to admin-scoped callers).
- Imports `auth` + `projects` + `pathres` (`_basename_safe`) — no `from server import`.

## Also: fixes the route-parity guards for FastAPI ≥0.138

This is important. FastAPI **0.138** stopped flattening `include_router()` routes into `app.routes` — it inserts a lazy **`_IncludedRouter`** whose real routes live in `.original_router.routes`. A flat scan of `app.routes` misses every peeled router's endpoints (they still match at request time — purely an enumeration gap). So `test_state_extraction`'s `test_no_duplicate_route_registrations` and `test_critical_routes_present` now descend into included routers via a shared `_iter_all_routes()` helper. Without this the route-parity safety net silently stops seeing peeled routes — `test_critical_routes_present` fails the moment `/api/projects` becomes a router (i.e. this PR).

## Tests

New `tests/test_r5_25_router_projects.py` (5): leaf boundary, route+helper+model ownership, **the name validator still fires** (separator/empty rejected, whitespace trimmed), server no longer defines them but mounts the router, routes mounted + auth-guarded. **842 passed, 5 skipped.**

## Sequence

Next clean peel: chat → cache. Then recorrect/proxy/misc need `_rebuild_embeddings` + `_proxy_ready` extracted to shared modules first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)