### PR TITLE
refactor(server): peel chat routes → routers/chat.py (R5-25 PR15)

### DIFF
--- a/routers/chat.py
+++ b/routers/chat.py
@@ -1,0 +1,172 @@
+"""Chat routes (R5-25 / round-5 #51 router split).
+
+The /api/chat group: dispatch a prompt (creating or appending to a conversation),
+read a conversation's history, and list conversations. Thin wrappers over the
+already-extracted `chat` module; the request/response models and the ownership
+SQL-filter helper (`_chat_owner_filter` — remote tokens only see their own
+conversations) are chat-local and move here. Imports auth + chat + db — no server
+import, no cycle.
+"""
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, field_validator
+
+import chat
+import db
+from auth import require_scopes
+
+router = APIRouter()
+
+
+class ChatRequest(BaseModel):
+    prompt: str
+    conversation_id: Optional[str] = None
+    project_scope: Optional[List[str]] = None
+
+    @field_validator("prompt")
+    @classmethod
+    def _check_prompt(cls, v: str) -> str:
+        # reject empty/whitespace. Oversize prompts are NOT rejected — existing
+        # behavior trims them for the LLM (chat._trim_prompt) and that's tested;
+        # the storage-cap for the persisted copy lives in the handler instead.
+        if not v or not v.strip():
+            raise ValueError("prompt must not be empty")
+        return v
+
+    @field_validator("project_scope")
+    @classmethod
+    def _cap_scope(cls, v):
+        if v is not None and len(v) > 200:
+            raise ValueError("project_scope too large (max 200)")
+        return v
+
+
+class ChatResponse(BaseModel):
+    conversation_id: str
+    assistant_text: str
+    scene_ids: List[object]
+    intent: Optional[str] = None
+    tokens_used: int
+    latency_ms: int
+
+
+def _chat_owner_filter(tok: dict):
+    """SQL fragment + params restricting chat_conversations to those a token may
+    read. Loopback / admin (the local owner) see all → no filter. Any other token
+    sees only its own conversations plus legacy ones with no recorded owner.
+    Returns ('', ()) for the unrestricted case."""
+    tok_id = (tok or {}).get("id")
+    scopes = (tok or {}).get("scopes") or ()
+    if tok_id == "loopback" or "admin" in scopes:
+        return "", ()
+    return " AND (user_token_id = ? OR user_token_id IS NULL)", (tok_id,)
+
+
+@router.post("/api/chat", response_model=ChatResponse)
+def chat_endpoint(
+    request: Request,
+    req: ChatRequest,
+    _tok: dict = Depends(require_scopes("chat_write")),
+) -> ChatResponse:
+    del request
+    if req.conversation_id is None:
+        conv_id = chat.create_conversation(
+            user_token_id=_tok.get("id"),
+            first_prompt=req.prompt,
+            project_scope=req.project_scope,
+        )
+    else:
+        conv_id = req.conversation_id
+        # Ownership on the WRITE path too: a non-owner who learns a conversation
+        # id must not be able to append a prompt/response to someone else's
+        # history (read-side filtering alone left this open). 404 (not 403/400)
+        # so a non-owner can't even confirm the id exists.
+        owner_sql, owner_params = _chat_owner_filter(_tok)
+        with db.get_conn() as conn:
+            owned = conn.execute(
+                "SELECT 1 FROM chat_conversations WHERE id = ?" + owner_sql,
+                (conv_id, *owner_params),
+            ).fetchone()
+        if not owned:
+            raise HTTPException(status_code=404, detail="conversation not found")
+
+    # Persist a length-capped copy: the LLM only ever sees a trimmed prompt
+    # (chat._trim_prompt), so storing the raw multi-MB original would bloat the
+    # conversation DB unboundedly for no benefit.
+    chat.persist_message(conv_id, role="user", content=req.prompt[:8000])
+    result = chat.dispatch(req.prompt, conv_id, project_scope=req.project_scope)
+    chat.persist_message(
+        conv_id,
+        role="assistant",
+        content=result["assistant_text"],
+        intent=result.get("intent", "compilation"),
+        scene_ids=result["scene_ids"],
+        tokens_used=result["tokens_used"],
+        stage=result.get("stage", "done"),
+        latency_ms=result.get("latency_ms"),
+    )
+    return ChatResponse(
+        conversation_id=conv_id,
+        assistant_text=result["assistant_text"],
+        scene_ids=result["scene_ids"],
+        intent=result.get("intent", "compilation"),
+        tokens_used=result["tokens_used"],
+        latency_ms=result.get("latency_ms", 0),
+    )
+
+
+@router.get("/api/chat/history/{conv_id}")
+def get_chat_history(
+    request: Request,
+    conv_id: str,
+    limit: int = 50,
+    _tok: dict = Depends(require_scopes("chat_read")),
+) -> dict:
+    del request
+    limit = max(1, min(500, limit))
+    # Conversation ownership: a remote token may only read its OWN conversations
+    # (or legacy ones with no owner). The ownership column was recorded on create
+    # but never enforced on read, so any chat_read token could read every other
+    # token's history. Loopback / admin (the local owner) see everything.
+    owner_sql, owner_params = _chat_owner_filter(_tok)
+    with db.get_conn() as conn:
+        conv = conn.execute(
+            "SELECT id, title, project_scope_json, created_at, updated_at "
+            "FROM chat_conversations WHERE id = ?" + owner_sql,
+            (conv_id, *owner_params),
+        ).fetchone()
+        if not conv:
+            # 404 (not 403) so a non-owner can't even confirm the id exists
+            raise HTTPException(status_code=404, detail="conversation not found")
+
+        rows = conn.execute(
+            "SELECT id, role, content, intent, scene_ids_json, tokens_used, stage, "
+            "latency_ms, created_at FROM chat_messages "
+            "WHERE conversation_id = ? ORDER BY created_at ASC LIMIT ?",
+            (conv_id, limit),
+        ).fetchall()
+
+    return {
+        "conversation": dict(conv),
+        "messages": [dict(row) for row in rows],
+    }
+
+
+@router.get("/api/chat/conversations")
+def list_chat_conversations(
+    request: Request,
+    limit: int = 50,
+    _tok: dict = Depends(require_scopes("chat_read")),
+) -> dict:
+    del request
+    limit = max(1, min(500, limit))
+    owner_sql, owner_params = _chat_owner_filter(_tok)
+    where = (" WHERE 1=1" + owner_sql) if owner_sql else ""
+    with db.get_conn() as conn:
+        rows = conn.execute(
+            "SELECT id, title, project_scope_json, created_at, updated_at "
+            "FROM chat_conversations" + where + " ORDER BY updated_at DESC LIMIT ?",
+            (*owner_params, limit),
+        ).fetchall()
+    return {"conversations": [dict(row) for row in rows]}

--- a/server.py
+++ b/server.py
@@ -158,9 +158,11 @@ app.add_middleware(
 from routers.admin import router as admin_router  # noqa: E402
 from routers.settings import router as settings_router  # noqa: E402
 from routers.projects import router as projects_router  # noqa: E402
+from routers.chat import router as chat_router  # noqa: E402
 app.include_router(admin_router)
 app.include_router(settings_router)
 app.include_router(projects_router)
+app.include_router(chat_router)
 
 ROOT = Path(__file__).parent
 # Built Svelte SPA (frontend/dist). Gitignored — produced by `npm run build`.
@@ -317,36 +319,8 @@ class BinCopyRequest(BaseModel):
 # (R5-25 / #51 router split), mounted via app.include_router below.
 
 
-class ChatRequest(BaseModel):
-    prompt: str
-    conversation_id: Optional[str] = None
-    project_scope: Optional[List[str]] = None
-
-    @field_validator("prompt")
-    @classmethod
-    def _check_prompt(cls, v: str) -> str:
-        # reject empty/whitespace. Oversize prompts are NOT rejected — existing
-        # behavior trims them for the LLM (chat._trim_prompt) and that's tested;
-        # the storage-cap for the persisted copy lives in the handler instead.
-        if not v or not v.strip():
-            raise ValueError("prompt must not be empty")
-        return v
-
-    @field_validator("project_scope")
-    @classmethod
-    def _cap_scope(cls, v):
-        if v is not None and len(v) > 200:
-            raise ValueError("project_scope too large (max 200)")
-        return v
-
-
-class ChatResponse(BaseModel):
-    conversation_id: str
-    assistant_text: str
-    scene_ids: List[object]
-    intent: Optional[str] = None
-    tokens_used: int
-    latency_ms: int
+# ChatRequest / ChatResponse + the /api/chat handlers + _chat_owner_filter moved
+# to routers/chat.py (R5-25 / #51), mounted via app.include_router below.
 
 
 def _split_csv(value: Optional[str]) -> Optional[List[str]]:
@@ -384,127 +358,6 @@ def _bootstrap_admin_token():
 
 
 # ── API Routes ───────────────────────────────────────────────────────────────
-
-def _chat_owner_filter(tok: dict):
-    """SQL fragment + params restricting chat_conversations to those a token may
-    read. Loopback / admin (the local owner) see all → no filter. Any other token
-    sees only its own conversations plus legacy ones with no recorded owner.
-    Returns ('', ()) for the unrestricted case."""
-    tok_id = (tok or {}).get("id")
-    scopes = (tok or {}).get("scopes") or ()
-    if tok_id == "loopback" or "admin" in scopes:
-        return "", ()
-    return " AND (user_token_id = ? OR user_token_id IS NULL)", (tok_id,)
-
-
-@app.post("/api/chat", response_model=ChatResponse)
-def chat_endpoint(
-    request: Request,
-    req: ChatRequest,
-    _tok: dict = Depends(require_scopes("chat_write")),
-) -> ChatResponse:
-    del request
-    if req.conversation_id is None:
-        conv_id = chat.create_conversation(
-            user_token_id=_tok.get("id"),
-            first_prompt=req.prompt,
-            project_scope=req.project_scope,
-        )
-    else:
-        conv_id = req.conversation_id
-        # Ownership on the WRITE path too: a non-owner who learns a conversation
-        # id must not be able to append a prompt/response to someone else's
-        # history (read-side filtering alone left this open). 404 (not 403/400)
-        # so a non-owner can't even confirm the id exists.
-        owner_sql, owner_params = _chat_owner_filter(_tok)
-        with db.get_conn() as conn:
-            owned = conn.execute(
-                "SELECT 1 FROM chat_conversations WHERE id = ?" + owner_sql,
-                (conv_id, *owner_params),
-            ).fetchone()
-        if not owned:
-            raise HTTPException(status_code=404, detail="conversation not found")
-
-    # Persist a length-capped copy: the LLM only ever sees a trimmed prompt
-    # (chat._trim_prompt), so storing the raw multi-MB original would bloat the
-    # conversation DB unboundedly for no benefit.
-    chat.persist_message(conv_id, role="user", content=req.prompt[:8000])
-    result = chat.dispatch(req.prompt, conv_id, project_scope=req.project_scope)
-    chat.persist_message(
-        conv_id,
-        role="assistant",
-        content=result["assistant_text"],
-        intent=result.get("intent", "compilation"),
-        scene_ids=result["scene_ids"],
-        tokens_used=result["tokens_used"],
-        stage=result.get("stage", "done"),
-        latency_ms=result.get("latency_ms"),
-    )
-    return ChatResponse(
-        conversation_id=conv_id,
-        assistant_text=result["assistant_text"],
-        scene_ids=result["scene_ids"],
-        intent=result.get("intent", "compilation"),
-        tokens_used=result["tokens_used"],
-        latency_ms=result.get("latency_ms", 0),
-    )
-
-
-@app.get("/api/chat/history/{conv_id}")
-def get_chat_history(
-    request: Request,
-    conv_id: str,
-    limit: int = 50,
-    _tok: dict = Depends(require_scopes("chat_read")),
-) -> dict:
-    del request
-    limit = max(1, min(500, limit))
-    # Conversation ownership: a remote token may only read its OWN conversations
-    # (or legacy ones with no owner). The ownership column was recorded on create
-    # but never enforced on read, so any chat_read token could read every other
-    # token's history. Loopback / admin (the local owner) see everything.
-    owner_sql, owner_params = _chat_owner_filter(_tok)
-    with db.get_conn() as conn:
-        conv = conn.execute(
-            "SELECT id, title, project_scope_json, created_at, updated_at "
-            "FROM chat_conversations WHERE id = ?" + owner_sql,
-            (conv_id, *owner_params),
-        ).fetchone()
-        if not conv:
-            # 404 (not 403) so a non-owner can't even confirm the id exists
-            raise HTTPException(status_code=404, detail="conversation not found")
-
-        rows = conn.execute(
-            "SELECT id, role, content, intent, scene_ids_json, tokens_used, stage, "
-            "latency_ms, created_at FROM chat_messages "
-            "WHERE conversation_id = ? ORDER BY created_at ASC LIMIT ?",
-            (conv_id, limit),
-        ).fetchall()
-
-    return {
-        "conversation": dict(conv),
-        "messages": [dict(row) for row in rows],
-    }
-
-
-@app.get("/api/chat/conversations")
-def list_chat_conversations(
-    request: Request,
-    limit: int = 50,
-    _tok: dict = Depends(require_scopes("chat_read")),
-) -> dict:
-    del request
-    limit = max(1, min(500, limit))
-    owner_sql, owner_params = _chat_owner_filter(_tok)
-    where = (" WHERE 1=1" + owner_sql) if owner_sql else ""
-    with db.get_conn() as conn:
-        rows = conn.execute(
-            "SELECT id, title, project_scope_json, created_at, updated_at "
-            "FROM chat_conversations" + where + " ORDER BY updated_at DESC LIMIT ?",
-            (*owner_params, limit),
-        ).fetchall()
-    return {"conversations": [dict(row) for row in rows]}
-
 
 @app.get("/api/search/all")
 def search_all(

--- a/tests/test_r5_25_router_chat.py
+++ b/tests/test_r5_25_router_chat.py
@@ -1,0 +1,67 @@
+"""R5-25 (round-5 #51): chat routes peeled to routers/chat.py.
+
+Fourth router peeled. Pins the split: leaf module, owns the 3 chat routes +
+the ownership filter + the request/response models (incl. the prompt validator),
+server.py no longer defines them, routes mounted + auth-guarded. Behaviour +
+ownership enforcement covered by the chat tests in test_server.py.
+"""
+import pathlib
+import re
+
+import pytest
+from starlette.testclient import TestClient
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def test_chat_router_is_a_leaf_module():
+    src = (_ROOT / "routers" / "chat.py").read_text(encoding="utf-8")
+    assert not re.search(r"^\s*import\s+server\b", src, re.M)
+    assert not re.search(r"^\s*from\s+server\b", src, re.M)
+
+
+def test_router_owns_chat_routes_and_helpers():
+    import routers.chat as rc
+    pairs = {
+        (r.path, m)
+        for r in rc.router.routes
+        for m in r.methods
+        if m != "HEAD"
+    }
+    assert pairs == {
+        ("/api/chat", "POST"),
+        ("/api/chat/history/{conv_id}", "GET"),
+        ("/api/chat/conversations", "GET"),
+    }
+    for name in ("ChatRequest", "ChatResponse", "_chat_owner_filter"):
+        assert hasattr(rc, name)
+
+
+def test_chat_prompt_validator_and_owner_filter():
+    import routers.chat as rc
+    with pytest.raises(Exception):
+        rc.ChatRequest(prompt="   ")            # empty-after-strip rejected
+    assert rc.ChatRequest(prompt="hi").prompt == "hi"
+    # loopback / admin → no ownership restriction; a plain token → restricted
+    assert rc._chat_owner_filter({"id": "loopback"}) == ("", ())
+    assert rc._chat_owner_filter({"scopes": ["admin"]}) == ("", ())
+    sql, params = rc._chat_owner_filter({"id": "tok9", "scopes": ["chat_read"]})
+    assert "user_token_id" in sql and params == ("tok9",)
+
+
+def test_server_no_longer_defines_chat_handlers():
+    src = (_ROOT / "server.py").read_text(encoding="utf-8")
+    assert "class ChatRequest" not in src
+    assert "def _chat_owner_filter" not in src
+    assert not re.search(r"@app\.(get|post)\(\"/api/chat", src)
+    assert "include_router(chat_router)" in src
+    # _split_csv (used by search) must NOT have been dragged along
+    assert "def _split_csv" in src
+
+
+def test_chat_routes_mounted_and_auth_guarded(server_module):
+    with TestClient(server_module.app) as c:
+        assert c.post("/api/chat", json={"prompt": "hi"}).status_code == 401
+        assert c.get("/api/chat/history/x").status_code == 401
+        assert c.get("/api/chat/conversations").status_code == 401
+        assert c.get("/api/chat_nonexistent").status_code == 404

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1326,10 +1326,11 @@ def test_chat_persists_capped_prompt(server_module):
     """A multi-MB prompt must not be stored verbatim in the conversation DB."""
     import importlib
     chat = importlib.import_module("chat")
-    server = importlib.import_module("server")
+    # ChatRequest moved to routers/chat.py in the R5-25 router split.
+    chat_router = importlib.import_module("routers.chat")
     capped = ("x" * 50000)[:8000]
     assert len(capped) == 8000  # the slice the handler persists
-    assert len(server.ChatRequest(prompt="x" * 50000).prompt) == 50000  # model keeps it for trim
+    assert len(chat_router.ChatRequest(prompt="x" * 50000).prompt) == 50000  # model keeps it for trim
 
 
 def test_access_log_redacts_token_query_param():


### PR DESCRIPTION
## What

Fourth router peeled (merge-as-green off `main` after PR14/projects). The `/api/chat` group moves into **`routers/chat.py`**.

- 3 handlers: POST dispatch (create-or-append conversation), GET history, GET conversations list.
- Moves with them (all chat-local): `ChatRequest` (+ empty-prompt validator, project_scope cap) / `ChatResponse` models and `_chat_owner_filter` (conversation-ownership SQL filter — remote tokens see only their own conversations; loopback/admin see all).
- Imports `auth` + `chat` + `db` — no `from server import`.
- `_split_csv` (search helper) and `_bootstrap_admin_token`, interleaved in the same region, deliberately stay in server.py.

## Test touch-up

`test_server.test_chat_persists_capped_prompt` referenced `server.ChatRequest` directly (to assert the model keeps the full prompt for trimming). Repointed to `routers.chat.ChatRequest` — the model's new home — rather than re-exporting router models back into server (which would undermine the split). All other chat coverage is via HTTP and unaffected.

## Tests

New `tests/test_r5_25_router_chat.py` (5): leaf boundary, route+helper+model ownership, **the prompt validator + owner filter still behave** (empty rejected; loopback/admin unrestricted; plain token restricted to its own rows), server no longer defines them but mounts the router (and did NOT drag `_split_csv` along), routes mounted + auth-guarded. **847 passed, 5 skipped.**

## Sequence

Remaining clean peel: cache. Then recorrect/proxy/misc need `_rebuild_embeddings` + `_proxy_ready` extracted to shared modules first; then the big groups (media/bins/ingest/export) + WS last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)