### PR TITLE
refactor(server): peel dashboard analytics routes into routers/analytics.py (R5-25 PR19)

### DIFF
--- a/routers/analytics.py
+++ b/routers/analytics.py
@@ -1,0 +1,159 @@
+"""Dashboard analytics routes (R5-25 / round-5 #51 router split).
+
+The read-only aggregate endpoints behind the dashboard: library stats (+ real
+disk usage + top tags + registered project name), the full tag cloud, Smart
+Collections, and the duration-by-lang / size-by-ext breakdowns. Group-local
+helpers `_current_project_registry_name` (get_stats) and `_thumb_url`
+(list_collections) move here with them. `BASE_DIR` (config) replaces
+server.ROOT for the disk-usage fallback. Imports auth + db + config +
+tag_quality/tag_aliases/smart_collections/projects — no server import, no cycle.
+"""
+from fastapi import APIRouter, Depends
+
+import config
+import db
+import projects as project_registry
+import smart_collections
+import tag_aliases
+import tag_quality
+from auth import require_scopes
+from config import BASE_DIR
+
+router = APIRouter()
+
+
+def _current_project_registry_name():
+    try:
+        root_key = str(config.PROJECT_ROOT.expanduser().resolve(strict=False)).casefold()
+        for p in project_registry.discover_projects():
+            if p.key() == root_key:
+                return p.name
+    except Exception:
+        pass
+    return None
+
+
+def _thumb_url(thumbnail_path):
+    """Absolute fs thumbnail_path → served /thumbnails/<basename> URL (or None)."""
+    if not thumbnail_path:
+        return None
+    base = str(thumbnail_path).replace("\\", "/").rsplit("/", 1)[-1]
+    return "/thumbnails/{0}".format(base)
+
+
+@router.get("/api/stats")
+def get_stats(
+    _tok: dict = Depends(require_scopes("videos_read")),
+):
+    """Aggregate stats for dashboard."""
+    stats = db.get_stats()
+    stats["rating"] = db.get_rating_stats()
+    # Real disk usage of the volume holding the arkiv data — feeds the sidebar's
+    # Storage footer (was a hardcoded "4.8 TB · 12 TB · 40%" placeholder). Best
+    # effort: a stat() failure (e.g. path vanished) must not 500 the dashboard.
+    try:
+        import shutil
+        _db_path = db.get_db_path()  # R5-23 (#54): SSOT accessor, not config value
+        du = shutil.disk_usage(_db_path.parent if _db_path else BASE_DIR)
+        stats["disk"] = {
+            "used_gb": round(du.used / 1e9, 1),
+            "total_gb": round(du.total / 1e9, 1),
+            "pct": round(du.used / du.total * 100) if du.total else 0,
+        }
+    except Exception:
+        stats["disk"] = None
+    # Screen quality-defect tags here too (Codex review P2) — index.html and any
+    # stats-driven cloud read top_tags. Over-fetch then filter so we still get 10
+    # real tags even if some of the top entries were noise.
+    stats["top_tags"] = tag_quality.filter_tag_records(db.get_top_tags(40))[:10]
+    # Real project name (basename of PROJECT_ROOT) so the UI shows the loaded
+    # library instead of a hardcoded demo name. Multi-library installs (one .arkiv
+    # per project) each report their own name.
+    stats["project"] = config.PROJECT_ROOT.name if config.PROJECT_ROOT else None
+    # The REGISTRY name for the currently-loaded project (may differ from the dir
+    # basename — a library registered as "恬馨庫" can live in a dir named "tianxin").
+    # A cross-library 精選集 item is keyed by registry name, so the grid's
+    # "加入精選集" needs this — null when the current project isn't registered
+    # (then a grid-added item couldn't be resolved back → the UI disables the add).
+    stats["project_registered_name"] = _current_project_registry_name()
+    return stats
+
+
+@router.get("/api/tags")
+def get_all_tags(
+    _tok: dict = Depends(require_scopes("videos_read")),
+):
+    """All unique tag names with counts. Quality-defect tags (模糊/低解析度…)
+    are screened out, variant-char spellings (人群/人羣) merged (tag_quality), then
+    near-synonyms folded to their preferred label via the reviewed alias map
+    (tag_aliases) — a no-op until `ingest --propose-aliases`/`--apply-aliases`."""
+    return tag_aliases.fold_records(tag_quality.merge_tag_records(db.get_all_tag_names()))
+
+
+@router.get("/api/collections")
+def list_collections(
+    _tok: dict = Depends(require_scopes("collections_read")),
+):
+    """Smart Collections — classify every media item against the Tier-1
+    definitions (smart_collections.DEFAULT_COLLECTIONS) and group the results.
+
+    Rule-driven (not ML clustering): see smart_collections.py. Returns one entry
+    per collection that has >=1 member, each with its member media (id/filename/
+    thumb/duration/score), sorted by score desc. Membership is non-exclusive.
+    """
+    defs = smart_collections.DEFAULT_COLLECTIONS
+    buckets = {c.key: {"key": c.key, "title": c.title, "category": c.category, "items": []} for c in defs}
+
+    # audit L13: classify reads only these columns (frame_tags + media-level
+    # aggregates + gps + duration/audio) — get_all_records() was SELECT *,
+    # hauling words_json/segments_json/transcript for the entire library.
+    with db.get_conn() as conn:
+        rows = conn.execute(
+            "SELECT id, filename, thumbnail_path, duration_s, has_audio, "
+            "frame_tags, content_type, atmosphere, energy, gps_lat, gps_lon, "
+            "rating, processed_at "
+            "FROM media ORDER BY id"
+        ).fetchall()
+    for rec in (dict(r) for r in rows):
+        for hit in smart_collections.classify(rec, defs):
+            buckets[hit["key"]]["items"].append({
+                "id": rec["id"],
+                "filename": rec.get("filename"),
+                "thumb": _thumb_url(rec.get("thumbnail_path")),
+                "duration_s": rec.get("duration_s"),
+                "score": hit["score"],
+            })
+
+    out = []
+    for b in buckets.values():
+        if not b["items"]:
+            continue
+        b["items"].sort(key=lambda r: r["score"], reverse=True)
+        b["count"] = len(b["items"])
+        out.append(b)
+    out.sort(key=lambda c: c["count"], reverse=True)
+    return {"collections": out, "total": len(out)}
+
+
+@router.get("/api/duration-by-lang")
+def duration_by_lang(
+    _tok: dict = Depends(require_scopes("videos_read")),
+):
+    with db.get_conn() as conn:
+        rows = conn.execute(
+            "SELECT lang, SUM(duration_s) as total_s, COUNT(*) as count "
+            "FROM media WHERE lang IS NOT NULL GROUP BY lang ORDER BY total_s DESC"
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+
+@router.get("/api/size-by-ext")
+def size_by_ext(
+    _tok: dict = Depends(require_scopes("videos_read")),
+):
+    with db.get_conn() as conn:
+        rows = conn.execute(
+            "SELECT ext, SUM(size_mb) as total_mb, COUNT(*) as count "
+            "FROM media GROUP BY ext ORDER BY total_mb DESC"
+        ).fetchall()
+        return [dict(r) for r in rows]

--- a/server.py
+++ b/server.py
@@ -33,8 +33,6 @@ import federation
 import mediatypes
 import projects as project_registry
 import settings as settings_store
-import smart_collections
-import tag_aliases
 import tag_quality
 
 
@@ -147,6 +145,7 @@ from routers.chat import router as chat_router  # noqa: E402
 from routers.cache import router as cache_router  # noqa: E402
 from routers.bins import router as bins_router  # noqa: E402
 from routers.offload import router as offload_router  # noqa: E402
+from routers.analytics import router as analytics_router  # noqa: E402
 app.include_router(admin_router)
 app.include_router(settings_router)
 app.include_router(projects_router)
@@ -154,6 +153,7 @@ app.include_router(chat_router)
 app.include_router(cache_router)
 app.include_router(bins_router)
 app.include_router(offload_router)
+app.include_router(analytics_router)
 
 ROOT = Path(__file__).parent
 # Built Svelte SPA (frontend/dist). Gitignored — produced by `npm run build`.
@@ -1044,141 +1044,9 @@ def remove_tag(
     return {"ok": True, "tags": db.get_tags(media_id)}
 
 
-@app.get("/api/stats")
-def get_stats(
-    _tok: dict = Depends(require_scopes("videos_read")),
-):
-    """Aggregate stats for dashboard."""
-    stats = db.get_stats()
-    stats["rating"] = db.get_rating_stats()
-    # Real disk usage of the volume holding the arkiv data — feeds the sidebar's
-    # Storage footer (was a hardcoded "4.8 TB · 12 TB · 40%" placeholder). Best
-    # effort: a stat() failure (e.g. path vanished) must not 500 the dashboard.
-    try:
-        import shutil
-        _db_path = db.get_db_path()  # R5-23 (#54): SSOT accessor, not config value
-        du = shutil.disk_usage(_db_path.parent if _db_path else ROOT)
-        stats["disk"] = {
-            "used_gb": round(du.used / 1e9, 1),
-            "total_gb": round(du.total / 1e9, 1),
-            "pct": round(du.used / du.total * 100) if du.total else 0,
-        }
-    except Exception:
-        stats["disk"] = None
-    # Screen quality-defect tags here too (Codex review P2) — index.html and any
-    # stats-driven cloud read top_tags. Over-fetch then filter so we still get 10
-    # real tags even if some of the top entries were noise.
-    stats["top_tags"] = tag_quality.filter_tag_records(db.get_top_tags(40))[:10]
-    # Real project name (basename of PROJECT_ROOT) so the UI shows the loaded
-    # library instead of a hardcoded demo name. Multi-library installs (one .arkiv
-    # per project) each report their own name.
-    stats["project"] = config.PROJECT_ROOT.name if config.PROJECT_ROOT else None
-    # The REGISTRY name for the currently-loaded project (may differ from the dir
-    # basename — a library registered as "恬馨庫" can live in a dir named "tianxin").
-    # A cross-library 精選集 item is keyed by registry name, so the grid's
-    # "加入精選集" needs this — null when the current project isn't registered
-    # (then a grid-added item couldn't be resolved back → the UI disables the add).
-    stats["project_registered_name"] = _current_project_registry_name()
-    return stats
-
-
-def _current_project_registry_name():
-    try:
-        root_key = str(config.PROJECT_ROOT.expanduser().resolve(strict=False)).casefold()
-        for p in project_registry.discover_projects():
-            if p.key() == root_key:
-                return p.name
-    except Exception:
-        pass
-    return None
-
-
-@app.get("/api/tags")
-def get_all_tags(
-    _tok: dict = Depends(require_scopes("videos_read")),
-):
-    """All unique tag names with counts. Quality-defect tags (模糊/低解析度…)
-    are screened out, variant-char spellings (人群/人羣) merged (tag_quality), then
-    near-synonyms folded to their preferred label via the reviewed alias map
-    (tag_aliases) — a no-op until `ingest --propose-aliases`/`--apply-aliases`."""
-    return tag_aliases.fold_records(tag_quality.merge_tag_records(db.get_all_tag_names()))
-
-
-def _thumb_url(thumbnail_path):
-    """Absolute fs thumbnail_path → served /thumbnails/<basename> URL (or None)."""
-    if not thumbnail_path:
-        return None
-    base = str(thumbnail_path).replace("\\", "/").rsplit("/", 1)[-1]
-    return "/thumbnails/{0}".format(base)
-
-
-@app.get("/api/collections")
-def list_collections(
-    _tok: dict = Depends(require_scopes("collections_read")),
-):
-    """Smart Collections — classify every media item against the Tier-1
-    definitions (smart_collections.DEFAULT_COLLECTIONS) and group the results.
-
-    Rule-driven (not ML clustering): see smart_collections.py. Returns one entry
-    per collection that has >=1 member, each with its member media (id/filename/
-    thumb/duration/score), sorted by score desc. Membership is non-exclusive.
-    """
-    defs = smart_collections.DEFAULT_COLLECTIONS
-    buckets = {c.key: {"key": c.key, "title": c.title, "category": c.category, "items": []} for c in defs}
-
-    # audit L13: classify reads only these columns (frame_tags + media-level
-    # aggregates + gps + duration/audio) — get_all_records() was SELECT *,
-    # hauling words_json/segments_json/transcript for the entire library.
-    with db.get_conn() as conn:
-        rows = conn.execute(
-            "SELECT id, filename, thumbnail_path, duration_s, has_audio, "
-            "frame_tags, content_type, atmosphere, energy, gps_lat, gps_lon, "
-            "rating, processed_at "
-            "FROM media ORDER BY id"
-        ).fetchall()
-    for rec in (dict(r) for r in rows):
-        for hit in smart_collections.classify(rec, defs):
-            buckets[hit["key"]]["items"].append({
-                "id": rec["id"],
-                "filename": rec.get("filename"),
-                "thumb": _thumb_url(rec.get("thumbnail_path")),
-                "duration_s": rec.get("duration_s"),
-                "score": hit["score"],
-            })
-
-    out = []
-    for b in buckets.values():
-        if not b["items"]:
-            continue
-        b["items"].sort(key=lambda r: r["score"], reverse=True)
-        b["count"] = len(b["items"])
-        out.append(b)
-    out.sort(key=lambda c: c["count"], reverse=True)
-    return {"collections": out, "total": len(out)}
-
-
-@app.get("/api/duration-by-lang")
-def duration_by_lang(
-    _tok: dict = Depends(require_scopes("videos_read")),
-):
-    with db.get_conn() as conn:
-        rows = conn.execute(
-            "SELECT lang, SUM(duration_s) as total_s, COUNT(*) as count "
-            "FROM media WHERE lang IS NOT NULL GROUP BY lang ORDER BY total_s DESC"
-        ).fetchall()
-        return [dict(r) for r in rows]
-
-
-@app.get("/api/size-by-ext")
-def size_by_ext(
-    _tok: dict = Depends(require_scopes("videos_read")),
-):
-    with db.get_conn() as conn:
-        rows = conn.execute(
-            "SELECT ext, SUM(size_mb) as total_mb, COUNT(*) as count "
-            "FROM media GROUP BY ext ORDER BY total_mb DESC"
-        ).fetchall()
-        return [dict(r) for r in rows]
+# The dashboard analytics routes (/api/stats, /api/tags, /api/collections,
+# /api/duration-by-lang, /api/size-by-ext) — with _current_project_registry_name
+# and _thumb_url — now live in routers/analytics.py (R5-25 / #51).
 
 
 # ── Metadata Export (Phase 7.6) ──────────────────────────────────────────────

--- a/tests/test_r5_25_router_analytics.py
+++ b/tests/test_r5_25_router_analytics.py
@@ -1,0 +1,66 @@
+"""R5-25 (round-5 #51): analytics routes peeled to routers/analytics.py.
+
+Eighth router peeled. Pins the split: the leaf module owns the 5 dashboard
+aggregate routes + its two group-local helpers (_current_project_registry_name,
+_thumb_url), server.py no longer defines them, routes mounted + auth-guarded
+(401-not-404). The /api/stats registry-name behaviour is covered end-to-end by
+test_bins.py::test_stats_reports_current_project_registry_name.
+"""
+import pathlib
+import re
+
+from starlette.testclient import TestClient
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def test_analytics_router_is_a_leaf_module():
+    src = (_ROOT / "routers" / "analytics.py").read_text(encoding="utf-8")
+    assert not re.search(r"^\s*import\s+server\b", src, re.M)
+    assert not re.search(r"^\s*from\s+server\b", src, re.M)
+
+
+def test_router_owns_analytics_routes_and_helpers():
+    import routers.analytics as ra
+    pairs = {
+        (r.path, m)
+        for r in ra.router.routes
+        for m in r.methods
+        if m != "HEAD"
+    }
+    assert pairs == {
+        ("/api/stats", "GET"),
+        ("/api/tags", "GET"),
+        ("/api/collections", "GET"),
+        ("/api/duration-by-lang", "GET"),
+        ("/api/size-by-ext", "GET"),
+    }
+    for name in ("_current_project_registry_name", "_thumb_url",
+                 "get_stats", "get_all_tags", "list_collections"):
+        assert hasattr(ra, name)
+
+
+def test_thumb_url_helper_semantics():
+    import routers.analytics as ra
+    assert ra._thumb_url(None) is None
+    assert ra._thumb_url("") is None
+    assert ra._thumb_url("/data/.arkiv/thumbnails/abc.jpg") == "/thumbnails/abc.jpg"
+    # Windows-style separators collapse to the served basename too.
+    assert ra._thumb_url("C:\\arkiv\\thumbnails\\x.png") == "/thumbnails/x.png"
+
+
+def test_server_no_longer_defines_analytics_handlers():
+    src = (_ROOT / "server.py").read_text(encoding="utf-8")
+    assert not re.search(r"@app\.get\(\"/api/(stats|tags|collections|duration-by-lang|size-by-ext)\"", src)
+    assert "def _current_project_registry_name" not in src
+    assert "def _thumb_url" not in src
+    assert "include_router(analytics_router)" in src
+
+
+def test_analytics_routes_mounted_and_auth_guarded(server_module):
+    with TestClient(server_module.app) as c:
+        # each aggregate route is mounted (401 from the auth dep, not a 404 miss)
+        for path in ("/api/stats", "/api/tags", "/api/collections",
+                     "/api/duration-by-lang", "/api/size-by-ext"):
+            assert c.get(path).status_code == 401, path
+        assert c.get("/api/statszz").status_code == 404


### PR DESCRIPTION
## R5-25 router split — PR19 (analytics)

Eighth router peeled out of the `server.py` monolith (`#51`, round-5 fable hardening audit).

Moves the 5 read-only dashboard aggregate endpoints into a leaf `routers/analytics.py`:
- `GET /api/stats` (+ real disk usage, top tags, registered project name)
- `GET /api/tags`
- `GET /api/collections`
- `GET /api/duration-by-lang`
- `GET /api/size-by-ext`

Their two group-local helpers `_current_project_registry_name` and `_thumb_url` move with them. `config.BASE_DIR` replaces `server.ROOT` for the `get_stats` disk-usage fallback. Drops the now-unused `smart_collections` / `tag_aliases` imports from `server.py`.

**Behaviour-preserving**: paths/methods/scopes unchanged → SPA + CLI unaffected. `server.py` 3099 → 2967.

### Tests
- New `tests/test_r5_25_router_analytics.py`: leaf-ness, exact route ownership (HEAD filtered), `_thumb_url` semantics, server-no-longer-defines, mounted + auth-guarded (401-not-404).
- Existing `/api/stats` registry-name coverage (`test_bins.py`) is route-level → unaffected.
- Full suite green locally: **874 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)