### PR TITLE
refactor(server): peel batch-retranscribe routes into routers/retranscribe.py (R5-25 PR20)

### DIFF
--- a/routers/retranscribe.py
+++ b/routers/retranscribe.py
@@ -1,0 +1,177 @@
+"""Project-wide batch retranscribe routes (R5-25 / round-5 #51 router split).
+
+Phase 9.6d (2a upgrade path): re-run Whisper across the whole library when a term
+was mis-heard too badly for find→replace to recover. Long-running → single-flight
+background task (`/api/retranscribe-all` + its `/status` poller) plus the worker
+`_run_retranscribe_all`. The two-lock ordering is preserved VERBATIM: acquire the
+retranscribe guard first, then the shared H3 ingest slot (a batch runs whisper
+in-process, so it must hold the ingest slot too or a concurrent /api/ingest would
+load a second whisper → OOM); the worker releases both in its finally. Both live
+in state.py so this module imports the ONE shared instance, never a copy. Imports
+auth + db + corrections + webguard + pathres + state — no server import, no cycle.
+"""
+import json
+import re as _re
+from pathlib import Path
+from typing import Optional
+
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Request,
+)
+from pydantic import BaseModel, field_validator
+
+import corrections
+import db
+from auth import require_scopes
+from pathres import _resolve_media_path
+from state import (
+    retranscribe as _retranscribe_guard,
+    _acquire_ingest_slot,
+    _release_ingest_slot,
+)
+from webguard import _assert_same_site
+
+router = APIRouter()
+
+
+class RetranscribeAllRequest(BaseModel):
+    language: Optional[str] = None
+    backup: bool = True
+
+    # fable-audit 2026-07-12 (#10): the single-clip RetranscribeRequest got the
+    # M23 ISO-639 validator but this whole-library sibling didn't — an unvalidated
+    # language flowed into whisper for the ENTIRE project, raising deep in a
+    # background batch (swallowed, hours of churn, lock held). Reject up front.
+    @field_validator("language")
+    @classmethod
+    def _check_language(cls, v):
+        if v is None:
+            return v
+        v = v.strip().lower()
+        if not _re.fullmatch(r"[a-z]{2,3}", v):
+            raise ValueError("language must be null or a 2-3 letter ISO-639 code (e.g. 'zh', 'en')")
+        return v
+
+
+@router.post("/api/retranscribe-all")
+def retranscribe_all(
+    body: RetranscribeAllRequest,
+    request: Request,
+    background_tasks: BackgroundTasks,
+    _tok: dict = Depends(require_scopes("ingest_write")),
+):
+    """Re-run Whisper across the whole project (the 2a upgrade path: only needed
+    when a term was mis-heard so badly that find→replace can't recover it). Each
+    clip's transcribe hot-reads the project vocabulary + correction-dictionary
+    pre-terms, so the new hotwords take effect. Long-running → single-flight
+    background task; poll GET /api/retranscribe-all/status. Snapshots transcripts
+    to the shared correction-backups first (RP-4 — restorable via the same
+    revert)."""
+    _assert_same_site(request)
+    with db.get_conn() as conn:
+        rows = conn.execute("SELECT id, path FROM media WHERE has_audio=1").fetchall()
+    targets = [(r["id"], r["path"]) for r in rows]
+    if not targets:
+        return {"queued": 0, "message": "沒有含音訊的素材可重轉錄"}
+    if not _retranscribe_guard.acquire():  # refuse concurrent batch runs (mirrors embed M8)
+        raise HTTPException(409, "批次重轉錄已在進行中，請稍候")
+    # fable-audit 2026-07-12 (#11): this batch runs whisper IN-PROCESS over the
+    # whole library — it must also hold the shared H3 ingest slot, or a concurrent
+    # /api/ingest loads a second whisper → double-whisper OOM. The background
+    # worker releases both in its finally; if the slot is busy we must free our own
+    # guard before bailing so a later retry isn't wrongly rejected.
+    if not _acquire_ingest_slot():
+        _retranscribe_guard.release()
+        raise HTTPException(409, "已有匯入任務進行中，請稍候")
+    _retranscribe_guard.reset_progress(
+        total=len(targets), done=0, failed=0, current=None, running=True, backup=None,
+    )
+    background_tasks.add_task(_run_retranscribe_all, targets, body.language, body.backup)
+    return {"queued": len(targets)}
+
+
+def _run_retranscribe_all(targets, language, backup):
+    """Background worker: re-transcribe each target, preserving the single-clip
+    guard (never blank a good transcript on an empty/failed decode — audit H1)."""
+    import transcribe as tr
+    # The worker owns its progress lifecycle: seed a clean counter set at the start
+    # (the route also seeds it for the poll window before this task is scheduled).
+    _retranscribe_guard.reset_progress(
+        total=len(targets), done=0, failed=0, current=None, running=True, backup=None,
+    )
+    progress = _retranscribe_guard.progress  # in-place dict shared with the poller
+    try:
+        if backup:
+            rows = []
+            with db.get_conn() as conn:
+                for mid, _ in targets:
+                    r = conn.execute(
+                        # fable-audit round-5 #14: include lang so revert restores the
+                        # language too — else a zh→en batch, reverted, leaves zh text
+                        # tagged lang='en', which later archives cross-contaminate.
+                        "SELECT id, transcript, segments_json, words_json, lang FROM media WHERE id=?",
+                        (mid,),
+                    ).fetchone()
+                    if r:
+                        rows.append(dict(r))
+            if rows:
+                progress["backup"] = corrections._write_backup(
+                    rows, [{"op": "retranscribe-all", "language": language}]
+                )
+        for mid, path in targets:
+            progress["current"] = mid
+            media_path = _resolve_media_path(path or "")
+            if not Path(media_path).exists():
+                progress["failed"] += 1
+                progress["done"] += 1
+                continue
+            try:
+                text, lang, segments, words = tr.transcribe(media_path, language=language)
+            except Exception:
+                progress["failed"] += 1
+                progress["done"] += 1
+                continue
+            rec = db.get_record_by_id(mid) or {}
+            # refuse to overwrite a good transcript with nothing (H1)
+            if not (text or "").strip() and (rec.get("transcript") or "").strip():
+                progress["failed"] += 1
+                progress["done"] += 1
+                continue
+            _al = lang or language
+            _sj = json.dumps(segments, ensure_ascii=False) if segments else None
+            _wj = json.dumps(words, ensure_ascii=False) if words else None
+            with db.get_conn() as conn:
+                # fable-audit round-5 C2: archive the OUTGOING transcript first, like
+                # the single-clip retranscribe does — else a batch zh→en overwrites
+                # media's zh with en and, if the per-run backup is off/lost, the prior
+                # active text is gone from the archive too.
+                if (rec.get("transcript") or "").strip() and rec.get("lang"):
+                    db.upsert_transcript(mid, rec["lang"], rec.get("transcript"),
+                                         rec.get("segments_json"), rec.get("words_json"), _conn=conn)
+                conn.execute(
+                    "UPDATE media SET transcript=?, lang=?, segments_json=?, words_json=? WHERE id=?",
+                    (
+                        text,
+                        _al,
+                        _sj,
+                        _wj,
+                        mid,
+                    ),
+                )
+                db.upsert_transcript(mid, _al, text, _sj, _wj, _conn=conn)  # G2 archive
+            progress["done"] += 1
+    finally:
+        progress["running"] = False
+        progress["current"] = None
+        _retranscribe_guard.release()
+        _release_ingest_slot()  # fable-audit 2026-07-12 (#11): free the shared H3 slot
+
+
+@router.get("/api/retranscribe-all/status")
+def retranscribe_all_status(_tok: dict = Depends(require_scopes("projects_read"))):
+    """Poll batch-retranscribe progress {total, done, failed, current, running, backup}."""
+    return dict(_retranscribe_guard.progress)

--- a/server.py
+++ b/server.py
@@ -146,6 +146,7 @@ from routers.cache import router as cache_router  # noqa: E402
 from routers.bins import router as bins_router  # noqa: E402
 from routers.offload import router as offload_router  # noqa: E402
 from routers.analytics import router as analytics_router  # noqa: E402
+from routers.retranscribe import router as retranscribe_router  # noqa: E402
 app.include_router(admin_router)
 app.include_router(settings_router)
 app.include_router(projects_router)
@@ -154,6 +155,7 @@ app.include_router(cache_router)
 app.include_router(bins_router)
 app.include_router(offload_router)
 app.include_router(analytics_router)
+app.include_router(retranscribe_router)
 
 ROOT = Path(__file__).parent
 # Built Svelte SPA (frontend/dist). Gitignored — produced by `npm run build`.
@@ -2723,144 +2725,10 @@ def recorrect_revert(
 
 
 # ── Phase 9.6d: project-wide batch retranscribe (2a) ─────────────────────────
-
-class RetranscribeAllRequest(BaseModel):
-    language: Optional[str] = None
-    backup: bool = True
-
-    # fable-audit 2026-07-12 (#10): the single-clip RetranscribeRequest got the
-    # M23 ISO-639 validator but this whole-library sibling didn't — an unvalidated
-    # language flowed into whisper for the ENTIRE project, raising deep in a
-    # background batch (swallowed, hours of churn, lock held). Reject up front.
-    @field_validator("language")
-    @classmethod
-    def _check_language(cls, v):
-        if v is None:
-            return v
-        v = v.strip().lower()
-        if not _re.fullmatch(r"[a-z]{2,3}", v):
-            raise ValueError("language must be null or a 2-3 letter ISO-639 code (e.g. 'zh', 'en')")
-        return v
-
-
-@app.post("/api/retranscribe-all")
-def retranscribe_all(
-    body: RetranscribeAllRequest,
-    request: Request,
-    background_tasks: BackgroundTasks,
-    _tok: dict = Depends(require_scopes("ingest_write")),
-):
-    """Re-run Whisper across the whole project (the 2a upgrade path: only needed
-    when a term was mis-heard so badly that find→replace can't recover it). Each
-    clip's transcribe hot-reads the project vocabulary + correction-dictionary
-    pre-terms, so the new hotwords take effect. Long-running → single-flight
-    background task; poll GET /api/retranscribe-all/status. Snapshots transcripts
-    to the shared correction-backups first (RP-4 — restorable via the same
-    revert)."""
-    _assert_same_site(request)
-    with db.get_conn() as conn:
-        rows = conn.execute("SELECT id, path FROM media WHERE has_audio=1").fetchall()
-    targets = [(r["id"], r["path"]) for r in rows]
-    if not targets:
-        return {"queued": 0, "message": "沒有含音訊的素材可重轉錄"}
-    if not _retranscribe_guard.acquire():  # refuse concurrent batch runs (mirrors embed M8)
-        raise HTTPException(409, "批次重轉錄已在進行中，請稍候")
-    # fable-audit 2026-07-12 (#11): this batch runs whisper IN-PROCESS over the
-    # whole library — it must also hold the shared H3 ingest slot, or a concurrent
-    # /api/ingest loads a second whisper → double-whisper OOM. The background
-    # worker releases both in its finally; if the slot is busy we must free our own
-    # guard before bailing so a later retry isn't wrongly rejected.
-    if not _acquire_ingest_slot():
-        _retranscribe_guard.release()
-        raise HTTPException(409, "已有匯入任務進行中，請稍候")
-    _retranscribe_guard.reset_progress(
-        total=len(targets), done=0, failed=0, current=None, running=True, backup=None,
-    )
-    background_tasks.add_task(_run_retranscribe_all, targets, body.language, body.backup)
-    return {"queued": len(targets)}
-
-
-def _run_retranscribe_all(targets, language, backup):
-    """Background worker: re-transcribe each target, preserving the single-clip
-    guard (never blank a good transcript on an empty/failed decode — audit H1)."""
-    import transcribe as tr
-    # The worker owns its progress lifecycle: seed a clean counter set at the start
-    # (the route also seeds it for the poll window before this task is scheduled).
-    _retranscribe_guard.reset_progress(
-        total=len(targets), done=0, failed=0, current=None, running=True, backup=None,
-    )
-    progress = _retranscribe_guard.progress  # in-place dict shared with the poller
-    try:
-        if backup:
-            rows = []
-            with db.get_conn() as conn:
-                for mid, _ in targets:
-                    r = conn.execute(
-                        # fable-audit round-5 #14: include lang so revert restores the
-                        # language too — else a zh→en batch, reverted, leaves zh text
-                        # tagged lang='en', which later archives cross-contaminate.
-                        "SELECT id, transcript, segments_json, words_json, lang FROM media WHERE id=?",
-                        (mid,),
-                    ).fetchone()
-                    if r:
-                        rows.append(dict(r))
-            if rows:
-                progress["backup"] = corrections._write_backup(
-                    rows, [{"op": "retranscribe-all", "language": language}]
-                )
-        for mid, path in targets:
-            progress["current"] = mid
-            media_path = _resolve_media_path(path or "")
-            if not Path(media_path).exists():
-                progress["failed"] += 1
-                progress["done"] += 1
-                continue
-            try:
-                text, lang, segments, words = tr.transcribe(media_path, language=language)
-            except Exception:
-                progress["failed"] += 1
-                progress["done"] += 1
-                continue
-            rec = db.get_record_by_id(mid) or {}
-            # refuse to overwrite a good transcript with nothing (H1)
-            if not (text or "").strip() and (rec.get("transcript") or "").strip():
-                progress["failed"] += 1
-                progress["done"] += 1
-                continue
-            _al = lang or language
-            _sj = json.dumps(segments, ensure_ascii=False) if segments else None
-            _wj = json.dumps(words, ensure_ascii=False) if words else None
-            with db.get_conn() as conn:
-                # fable-audit round-5 C2: archive the OUTGOING transcript first, like
-                # the single-clip retranscribe does — else a batch zh→en overwrites
-                # media's zh with en and, if the per-run backup is off/lost, the prior
-                # active text is gone from the archive too.
-                if (rec.get("transcript") or "").strip() and rec.get("lang"):
-                    db.upsert_transcript(mid, rec["lang"], rec.get("transcript"),
-                                         rec.get("segments_json"), rec.get("words_json"), _conn=conn)
-                conn.execute(
-                    "UPDATE media SET transcript=?, lang=?, segments_json=?, words_json=? WHERE id=?",
-                    (
-                        text,
-                        _al,
-                        _sj,
-                        _wj,
-                        mid,
-                    ),
-                )
-                db.upsert_transcript(mid, _al, text, _sj, _wj, _conn=conn)  # G2 archive
-            progress["done"] += 1
-    finally:
-        progress["running"] = False
-        progress["current"] = None
-        _retranscribe_guard.release()
-        _release_ingest_slot()  # fable-audit 2026-07-12 (#11): free the shared H3 slot
-
-
-@app.get("/api/retranscribe-all/status")
-def retranscribe_all_status(_tok: dict = Depends(require_scopes("projects_read"))):
-    """Poll batch-retranscribe progress {total, done, failed, current, running, backup}."""
-    return dict(_retranscribe_guard.progress)
+#
+# The /api/retranscribe-all POST + /status poller + _run_retranscribe_all worker
+# (RetranscribeAllRequest with its ISO-639 validator, the two-lock ordering) moved
+# to routers/retranscribe.py (R5-25 / #51), mounted via app.include_router below.
 
 
 # ── Serve Frontend ───────────────────────────────────────────────────────────

--- a/tests/test_r5_25_router_retranscribe.py
+++ b/tests/test_r5_25_router_retranscribe.py
@@ -1,0 +1,75 @@
+"""R5-25 (round-5 #51): batch-retranscribe routes peeled to routers/retranscribe.py.
+
+Ninth router peeled. Pins the split: the leaf module owns the /api/retranscribe-all
+POST + /status poller + the _run_retranscribe_all worker + RetranscribeAllRequest,
+server.py no longer defines them, routes mounted + auth-guarded (401-not-404). The
+batch loop / two-lock ordering / backup-revert behaviour is covered end-to-end by
+test_retranscribe_all.py; the ISO-639 validator by test_hardening_round4.py.
+"""
+import pathlib
+import re
+
+from starlette.testclient import TestClient
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def test_retranscribe_router_is_a_leaf_module():
+    src = (_ROOT / "routers" / "retranscribe.py").read_text(encoding="utf-8")
+    assert not re.search(r"^\s*import\s+server\b", src, re.M)
+    assert not re.search(r"^\s*from\s+server\b", src, re.M)
+
+
+def test_router_owns_retranscribe_routes():
+    import routers.retranscribe as rr
+    pairs = {
+        (r.path, m)
+        for r in rr.router.routes
+        for m in r.methods
+        if m != "HEAD"
+    }
+    assert pairs == {
+        ("/api/retranscribe-all", "POST"),
+        ("/api/retranscribe-all/status", "GET"),
+    }
+    for name in ("RetranscribeAllRequest", "_run_retranscribe_all",
+                 "retranscribe_all", "retranscribe_all_status"):
+        assert hasattr(rr, name)
+
+
+def test_router_shares_the_state_singleflight_guard():
+    # The guard MUST be the one shared instance in state.py — never a per-module
+    # copy — so a batch run and a concurrent /api/ingest serialise on the same slot.
+    import routers.retranscribe as rr
+    import state
+    assert rr._retranscribe_guard is state.retranscribe
+    assert rr._acquire_ingest_slot is state._acquire_ingest_slot
+
+
+def test_retranscribe_all_language_validator_moved():
+    import routers.retranscribe as rr
+    import pydantic
+    # null + valid ISO-639 accepted; non-ASCII / too-long rejected at the model.
+    assert rr.RetranscribeAllRequest(language=None).language is None
+    assert rr.RetranscribeAllRequest(language="ZH").language == "zh"
+    for bad in ("中文", "english", "e"):
+        try:
+            rr.RetranscribeAllRequest(language=bad)
+            assert False, "expected validation error for {0!r}".format(bad)
+        except pydantic.ValidationError:
+            pass
+
+
+def test_server_no_longer_defines_retranscribe_handlers():
+    src = (_ROOT / "server.py").read_text(encoding="utf-8")
+    assert "class RetranscribeAllRequest" not in src
+    assert "def _run_retranscribe_all" not in src
+    assert not re.search(r"@app\.(get|post)\(\"/api/retranscribe-all", src)
+    assert "include_router(retranscribe_router)" in src
+
+
+def test_retranscribe_routes_mounted_and_auth_guarded(server_module):
+    with TestClient(server_module.app) as c:
+        assert c.post("/api/retranscribe-all", json={}).status_code == 401
+        assert c.get("/api/retranscribe-all/status").status_code == 401
+        assert c.post("/api/retranscribe-allzz", json={}).status_code == 404

--- a/tests/test_retranscribe_all.py
+++ b/tests/test_retranscribe_all.py
@@ -27,10 +27,14 @@ _seed_audio.n = 0
 
 @pytest.fixture
 def srv(server_module, tmp_path, monkeypatch):
-    """server module with active project rooted at tmp_path (for backups)."""
+    """batch-retranscribe router module (the worker + the shared single-flight
+    guard), active project rooted at tmp_path (for backups). Depends on
+    server_module so the app/db is initialised; _run_retranscribe_all + the
+    _retranscribe_guard moved to routers.retranscribe in the R5-25 router split
+    (the guard is the SAME state.retranscribe object server_module re-exports)."""
     config = importlib.import_module("config")
     monkeypatch.setattr(config, "PROJECT_ROOT", tmp_path)
-    return server_module
+    return importlib.import_module("routers.retranscribe")
 
 
 def test_batch_updates_all_and_backup_reverts(srv, tmp_path, monkeypatch):


### PR DESCRIPTION
## R5-25 router split — PR20 (batch retranscribe)

Ninth router peeled out of the `server.py` monolith (`#51`, round-5 fable hardening audit).

Moves the project-wide batch retranscribe group (Phase 9.6d) into a leaf `routers/retranscribe.py`:
- `POST /api/retranscribe-all` (single-flight background batch)
- `GET /api/retranscribe-all/status` (progress poller)
- the `_run_retranscribe_all` background worker
- `RetranscribeAllRequest` (with its M23 ISO-639 language validator)

**Two-lock ordering preserved verbatim**: acquire the retranscribe single-flight guard, then the shared H3 ingest slot (the batch runs whisper in-process, so it must hold the ingest slot too or a concurrent `/api/ingest` double-loads whisper → OOM); the worker releases both in its `finally`. Guard + slot are imported from `state.py` — the ONE shared instance, never recreated.

**Behaviour-preserving**: paths/methods/scopes unchanged → SPA + CLI unaffected. `server.py` 2967 → 2825.

### Tests
- `test_retranscribe_all.py`'s `srv` fixture repointed to `routers.retranscribe` (the worker + the same `state.retranscribe` guard object).
- New `tests/test_r5_25_router_retranscribe.py`: leaf-ness, route ownership, shared-guard identity (`rr._retranscribe_guard is state.retranscribe`), the moved validator, server-no-longer-defines, mounted + auth-guarded (401-not-404).
- Route-level coverage (`test_hardening_round4.py` validator, `test_state_extraction.py` critical-routes) unaffected.
- Full suite green locally: **880 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)