### PR TITLE
refactor(server): peel proxy routes into routers/proxy.py + _proxy_ready→pathres (R5-25 PR21)

### DIFF
--- a/pathres.py
+++ b/pathres.py
@@ -14,6 +14,7 @@ names for backward compatibility (existing call sites + tests that reference
 `server._resolve_media_path` keep working).
 """
 import os
+from pathlib import Path
 
 import db
 
@@ -90,3 +91,14 @@ def _resolve_media_path(path: str) -> str:
     if os.name == "nt" and path.startswith("/"):
         return path
     return db.resolve_path(path)
+
+
+def _proxy_ready(p: Path) -> bool:
+    """A proxy counts as present only if it exists AND is non-empty. A zero/truncated
+    file left by a killed encode must not be served as valid nor block a rebuild
+    (fable-audit round-5 C1 — the consumer side of the atomic-write fix in
+    ingest.generate_proxy). Shared by /api/stream (server) + the proxy routes."""
+    try:
+        return p.exists() and p.stat().st_size > 0
+    except OSError:
+        return False

--- a/routers/proxy.py
+++ b/routers/proxy.py
@@ -1,0 +1,104 @@
+"""Proxy-management routes (R5-25 / round-5 #51 router split).
+
+H.264 proxy generation for browser-incompatible codecs (HEVC/ProRes): the
+whole-library status/build, the per-id build, and the two background workers
+(_build_proxies + the guarded _build_proxies_all). The whole-library build is
+single-flighted by the shared R5-22 (#59) guard — imported from state.py (the ONE
+instance) so a double-clicked "build all" can't launch parallel ffmpeg loops that
+would stream truncated proxies mid-build. `_proxy_ready` (the consumer side of the
+C1 atomic-write fix) moved to pathres.py so /api/stream + these routes share it.
+Imports auth + db + config + webguard + pathres + state — no server import, no cycle.
+"""
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+
+import config
+import db
+from auth import require_scopes
+from pathres import _proxy_ready, _resolve_media_path
+from state import proxy_build as _proxy_guard
+from webguard import _assert_same_site
+
+router = APIRouter()
+
+
+@router.get("/api/proxy/status")
+def proxy_status(_tok: dict = Depends(require_scopes("videos_read"))):
+    """Check proxy status for all media files."""
+    proxy_dir = config.PROXIES_DIR
+    proxy_dir.mkdir(parents=True, exist_ok=True)
+    with db.get_conn() as conn:
+        rows = conn.execute("SELECT id, path FROM media").fetchall()
+    proxied = sum(
+        1 for r in rows
+        if _proxy_ready(config.proxy_path_for(r["id"], _resolve_media_path(r["path"])))
+    )
+    size_mb = round(sum(p.stat().st_size for p in proxy_dir.glob("*.mp4")) / 1048576, 1)
+    return {"total": len(rows), "proxied": proxied, "size_mb": size_mb}
+
+
+@router.post("/api/proxy/build")
+def proxy_build(request: Request, background_tasks: BackgroundTasks, _tok: dict = Depends(require_scopes("ingest_write"))):
+    """Queue proxy generation for all HEVC/ProRes files without proxy."""
+    _assert_same_site(request)  # audit M14
+    proxy_dir = config.PROXIES_DIR
+    proxy_dir.mkdir(parents=True, exist_ok=True)
+    with db.get_conn() as conn:
+        rows = conn.execute("SELECT id, path FROM media").fetchall()
+    to_build = [
+        dict(r) for r in rows
+        if not _proxy_ready(config.proxy_path_for(r["id"], _resolve_media_path(r["path"])))
+    ]
+    if not to_build:
+        return {"message": "全部 proxy 已存在", "queued": 0}
+    # R5-22 (#59): single-flight the whole-library build so a double-click can't
+    # launch parallel full-library ffmpeg loops (mid-build playback would stream
+    # truncated proxies). The guarded wrapper releases the slot in its finally.
+    if not _proxy_guard.acquire():
+        raise HTTPException(409, "proxy 生成已在進行中，請稍候")
+    background_tasks.add_task(_build_proxies_all, to_build)
+    return {"message": f"開始生成 {len(to_build)} 個 proxy（背景執行）", "queued": len(to_build)}
+
+
+@router.post("/api/proxy/build/{media_id}")
+def proxy_build_one(media_id: int, request: Request, background_tasks: BackgroundTasks, _tok: dict = Depends(require_scopes("ingest_write"))):
+    """Per-id proxy build — surface 自 7.7g 409 「生成 proxy」按鈕，使用者點到
+    哪個 HEVC 就只建那個，避免 build all 整庫拖時間。"""
+    _assert_same_site(request)  # audit M14
+    proxy_dir = config.PROXIES_DIR
+    proxy_dir.mkdir(parents=True, exist_ok=True)
+    rec = db.get_record_by_id(media_id)
+    if not rec:
+        raise HTTPException(404, "找不到媒體")
+    src = _resolve_media_path(rec["path"])
+    if _proxy_ready(config.proxy_path_for(media_id, src)):
+        return {"message": "proxy 已存在", "queued": 0, "media_id": media_id}
+    background_tasks.add_task(_build_proxies, [{"id": media_id, "path": rec["path"]}])
+    return {
+        "message": f"開始生成 proxy（背景執行）",
+        "queued": 1,
+        "media_id": media_id,
+        "filename": rec.get("filename"),
+    }
+
+
+def _build_proxies_all(items: list):
+    """Whole-library proxy build background task — holds the R5-22 (#59)
+    single-flight for its whole lifetime and frees it in finally. The per-id build
+    stays unguarded (targeted, cheap) and calls _build_proxies directly."""
+    try:
+        _build_proxies(items)
+    finally:
+        _proxy_guard.release()
+
+
+def _build_proxies(items: list):
+    """Background task: generate H.264 proxy for each file."""
+    import ingest
+    for item in items:
+        src = _resolve_media_path(item["path"])
+        try:
+            result = ingest.generate_proxy(item["id"], src)
+            if not result:
+                print(f"[proxy] Failed {item['id']}")
+        except Exception as e:
+            print(f"[proxy] Failed {item['id']}: {e}")

--- a/server.py
+++ b/server.py
@@ -147,6 +147,7 @@ from routers.bins import router as bins_router  # noqa: E402
 from routers.offload import router as offload_router  # noqa: E402
 from routers.analytics import router as analytics_router  # noqa: E402
 from routers.retranscribe import router as retranscribe_router  # noqa: E402
+from routers.proxy import router as proxy_router  # noqa: E402
 app.include_router(admin_router)
 app.include_router(settings_router)
 app.include_router(projects_router)
@@ -156,6 +157,7 @@ app.include_router(bins_router)
 app.include_router(offload_router)
 app.include_router(analytics_router)
 app.include_router(retranscribe_router)
+app.include_router(proxy_router)
 
 ROOT = Path(__file__).parent
 # Built Svelte SPA (frontend/dist). Gitignored — produced by `npm run build`.
@@ -206,6 +208,7 @@ from pathres import (  # noqa: F401 (re-exported for backward compat)
     _resolve_record,
     _resolve_frame,
     _resolve_media_path,
+    _proxy_ready,
 )
 # R5-25 / #51: export-format builders (CSV/EDL/FCPXML/SRT/VTT serialisers + the
 # timecode/framerate math they share) live in export_builders.py (a leaf service
@@ -2456,16 +2459,9 @@ async def ingest_media_ws(
 
 import mimetypes
 
-
-def _proxy_ready(p: Path) -> bool:
-    """A proxy counts as present only if it exists AND is non-empty. A zero/truncated
-    file left by a killed encode must not be served as valid nor block a rebuild
-    (fable-audit round-5 C1 — the consumer side of the atomic-write fix in
-    ingest.generate_proxy)."""
-    try:
-        return p.exists() and p.stat().st_size > 0
-    except OSError:
-        return False
+# _proxy_ready moved to pathres.py (R5-25 / #51) — shared by /api/stream (below)
+# and the proxy routes (routers/proxy.py) — and re-exported at the top of this
+# module.
 
 
 @app.get("/api/stream/{media_id}")
@@ -2537,90 +2533,10 @@ def stream_media(media_id: int, _tok: dict = Depends(require_scopes("videos_read
 # ── Proxy Management ─────────────────────────────────────────────────────────
 
 # PROXY_CODECS lives in codec.py — single source of truth.
-# _assert_same_site moved to webguard.py (R5-25 / #51) and is re-exported at the
-# top of this module.
-
-@app.get("/api/proxy/status")
-def proxy_status(_tok: dict = Depends(require_scopes("videos_read"))):
-    """Check proxy status for all media files."""
-    proxy_dir = config.PROXIES_DIR
-    proxy_dir.mkdir(parents=True, exist_ok=True)
-    with db.get_conn() as conn:
-        rows = conn.execute("SELECT id, path FROM media").fetchall()
-    proxied = sum(
-        1 for r in rows
-        if _proxy_ready(config.proxy_path_for(r["id"], _resolve_media_path(r["path"])))
-    )
-    size_mb = round(sum(p.stat().st_size for p in proxy_dir.glob("*.mp4")) / 1048576, 1)
-    return {"total": len(rows), "proxied": proxied, "size_mb": size_mb}
-
-
-@app.post("/api/proxy/build")
-def proxy_build(request: Request, background_tasks: BackgroundTasks, _tok: dict = Depends(require_scopes("ingest_write"))):
-    """Queue proxy generation for all HEVC/ProRes files without proxy."""
-    _assert_same_site(request)  # audit M14
-    proxy_dir = config.PROXIES_DIR
-    proxy_dir.mkdir(parents=True, exist_ok=True)
-    with db.get_conn() as conn:
-        rows = conn.execute("SELECT id, path FROM media").fetchall()
-    to_build = [
-        dict(r) for r in rows
-        if not _proxy_ready(config.proxy_path_for(r["id"], _resolve_media_path(r["path"])))
-    ]
-    if not to_build:
-        return {"message": "全部 proxy 已存在", "queued": 0}
-    # R5-22 (#59): single-flight the whole-library build so a double-click can't
-    # launch parallel full-library ffmpeg loops (mid-build playback would stream
-    # truncated proxies). The guarded wrapper releases the slot in its finally.
-    if not _proxy_guard.acquire():
-        raise HTTPException(409, "proxy 生成已在進行中，請稍候")
-    background_tasks.add_task(_build_proxies_all, to_build)
-    return {"message": f"開始生成 {len(to_build)} 個 proxy（背景執行）", "queued": len(to_build)}
-
-
-@app.post("/api/proxy/build/{media_id}")
-def proxy_build_one(media_id: int, request: Request, background_tasks: BackgroundTasks, _tok: dict = Depends(require_scopes("ingest_write"))):
-    """Per-id proxy build — surface 自 7.7g 409 「生成 proxy」按鈕，使用者點到
-    哪個 HEVC 就只建那個，避免 build all 整庫拖時間。"""
-    _assert_same_site(request)  # audit M14
-    proxy_dir = config.PROXIES_DIR
-    proxy_dir.mkdir(parents=True, exist_ok=True)
-    rec = db.get_record_by_id(media_id)
-    if not rec:
-        raise HTTPException(404, "找不到媒體")
-    src = _resolve_media_path(rec["path"])
-    if _proxy_ready(config.proxy_path_for(media_id, src)):
-        return {"message": "proxy 已存在", "queued": 0, "media_id": media_id}
-    background_tasks.add_task(_build_proxies, [{"id": media_id, "path": rec["path"]}])
-    return {
-        "message": f"開始生成 proxy（背景執行）",
-        "queued": 1,
-        "media_id": media_id,
-        "filename": rec.get("filename"),
-    }
-
-
-def _build_proxies_all(items: list):
-    """Whole-library proxy build background task — holds the R5-22 (#59)
-    single-flight for its whole lifetime and frees it in finally. The per-id build
-    stays unguarded (targeted, cheap) and calls _build_proxies directly."""
-    try:
-        _build_proxies(items)
-    finally:
-        _proxy_guard.release()
-
-
-def _build_proxies(items: list):
-    """Background task: generate H.264 proxy for each file."""
-    import ingest
-    for item in items:
-        src = _resolve_media_path(item["path"])
-        try:
-            result = ingest.generate_proxy(item["id"], src)
-            if not result:
-                print(f"[proxy] Failed {item['id']}")
-        except Exception as e:
-            print(f"[proxy] Failed {item['id']}: {e}")
+# The proxy routes (/api/proxy/status, /api/proxy/build, /api/proxy/build/{id})
+# plus the _build_proxies / _build_proxies_all background workers moved to
+# routers/proxy.py (R5-25 / #51), mounted via app.include_router below. The R5-22
+# (#59) single-flight guard is shared from state.py.
 
 
 @app.post("/api/embed/rebuild")

--- a/tests/test_r5_22_singleflight.py
+++ b/tests/test_r5_22_singleflight.py
@@ -84,19 +84,23 @@ def test_proxy_build_409_when_guard_held(fastapi_client, server_module, tmp_path
 
 
 def test_proxy_build_wrapper_releases_slot(server_module, monkeypatch):
+    # _build_proxies / _build_proxies_all moved to routers/proxy.py in the R5-25
+    # split; _proxy_guard there is the SAME state.proxy_build instance.
+    import routers.proxy as rp
     calls = []
-    monkeypatch.setattr(server_module, "_build_proxies", lambda items: calls.append(items))
-    assert server_module._proxy_guard.acquire()  # route would have acquired it
-    server_module._build_proxies_all([{"id": 1, "path": "x"}])
-    assert server_module._proxy_guard.active is False, "wrapper must free the slot"
+    monkeypatch.setattr(rp, "_build_proxies", lambda items: calls.append(items))
+    assert rp._proxy_guard.acquire()  # route would have acquired it
+    rp._build_proxies_all([{"id": 1, "path": "x"}])
+    assert rp._proxy_guard.active is False, "wrapper must free the slot"
     assert calls == [[{"id": 1, "path": "x"}]]
 
 
 def test_proxy_build_wrapper_releases_on_exception(server_module, monkeypatch):
+    import routers.proxy as rp
     def boom(items):
         raise RuntimeError("ffmpeg blew up")
-    monkeypatch.setattr(server_module, "_build_proxies", boom)
-    assert server_module._proxy_guard.acquire()
+    monkeypatch.setattr(rp, "_build_proxies", boom)
+    assert rp._proxy_guard.acquire()
     with pytest.raises(RuntimeError):
-        server_module._build_proxies_all([])
-    assert server_module._proxy_guard.active is False, "slot freed even on failure"
+        rp._build_proxies_all([])
+    assert rp._proxy_guard.active is False, "slot freed even on failure"

--- a/tests/test_r5_25_pathres_module.py
+++ b/tests/test_r5_25_pathres_module.py
@@ -28,6 +28,7 @@ _NAMES = (
     "_resolve_record",
     "_resolve_frame",
     "_resolve_media_path",
+    "_proxy_ready",  # moved here in the proxy peel (R5-25 PR21); shared by /api/stream + proxy routes
 )
 
 

--- a/tests/test_r5_25_router_proxy.py
+++ b/tests/test_r5_25_router_proxy.py
@@ -1,0 +1,72 @@
+"""R5-25 (round-5 #51): proxy-management routes peeled to routers/proxy.py.
+
+Tenth router peeled. Pins the split: the leaf module owns the 3 proxy routes +
+the _build_proxies / _build_proxies_all workers, server.py no longer defines them,
+routes mounted + auth-guarded (401-not-404). The R5-22 (#59) single-flight guard
+stays the ONE shared state.proxy_build instance (covered by test_r5_22_singleflight);
+_proxy_ready moved to pathres.py (still used by /api/stream), pinned there by
+test_r5_25_pathres_module.
+"""
+import pathlib
+import re
+
+from starlette.testclient import TestClient
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def test_proxy_router_is_a_leaf_module():
+    src = (_ROOT / "routers" / "proxy.py").read_text(encoding="utf-8")
+    assert not re.search(r"^\s*import\s+server\b", src, re.M)
+    assert not re.search(r"^\s*from\s+server\b", src, re.M)
+
+
+def test_router_owns_proxy_routes_and_workers():
+    import routers.proxy as rp
+    pairs = {
+        (r.path, m)
+        for r in rp.router.routes
+        for m in r.methods
+        if m != "HEAD"
+    }
+    assert pairs == {
+        ("/api/proxy/status", "GET"),
+        ("/api/proxy/build", "POST"),
+        ("/api/proxy/build/{media_id}", "POST"),
+    }
+    for name in ("proxy_status", "proxy_build", "proxy_build_one",
+                 "_build_proxies", "_build_proxies_all"):
+        assert hasattr(rp, name)
+
+
+def test_router_shares_the_state_proxy_guard():
+    # the whole-library build must serialise on the ONE shared guard, never a copy
+    import routers.proxy as rp
+    import state
+    assert rp._proxy_guard is state.proxy_build
+
+
+def test_proxy_ready_moved_to_pathres_not_defined_here():
+    src = (_ROOT / "routers" / "proxy.py").read_text(encoding="utf-8")
+    assert "def _proxy_ready" not in src   # it lives in pathres now, imported
+    import routers.proxy as rp
+    import pathres
+    assert rp._proxy_ready is pathres._proxy_ready
+
+
+def test_server_no_longer_defines_proxy_handlers():
+    src = (_ROOT / "server.py").read_text(encoding="utf-8")
+    assert "def proxy_status" not in src
+    assert "def _build_proxies" not in src
+    assert not re.search(r"@app\.(get|post)\(\"/api/proxy", src)
+    assert "include_router(proxy_router)" in src
+    # /api/stream stays in server.py and still uses the (re-exported) _proxy_ready
+    assert "def stream_media" in src
+
+
+def test_proxy_routes_mounted_and_auth_guarded(server_module):
+    with TestClient(server_module.app) as c:
+        assert c.get("/api/proxy/status").status_code == 401
+        assert c.post("/api/proxy/build").status_code == 401
+        assert c.post("/api/proxy/build/1").status_code == 401
+        assert c.get("/api/proxy/statuszz").status_code == 404

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -758,7 +758,8 @@ def test_proxy_build_one_queues_single_media_when_proxy_missing(
 
     queued = []
     import server
-    monkeypatch.setattr(server, "_build_proxies", lambda items: queued.extend(items))
+    import routers.proxy as _rp  # proxy routes moved here in the R5-25 split
+    monkeypatch.setattr(_rp, "_build_proxies", lambda items: queued.extend(items))
 
     resp = fastapi_client.post("/api/proxy/build/1")
     assert resp.status_code == 200
@@ -791,7 +792,8 @@ def test_proxy_build_one_skips_when_proxy_already_exists(
 
     import server
     queued = []
-    monkeypatch.setattr(server, "_build_proxies", lambda items: queued.extend(items))
+    import routers.proxy as _rp  # proxy routes moved here in the R5-25 split
+    monkeypatch.setattr(_rp, "_build_proxies", lambda items: queued.extend(items))
 
     resp = fastapi_client.post("/api/proxy/build/1")
     assert resp.status_code == 200
@@ -821,7 +823,8 @@ def test_proxy_build_one_rebuilds_when_existing_proxy_is_empty(
 
     import server
     queued = []
-    monkeypatch.setattr(server, "_build_proxies", lambda items: queued.extend(items))
+    import routers.proxy as _rp  # proxy routes moved here in the R5-25 split
+    monkeypatch.setattr(_rp, "_build_proxies", lambda items: queued.extend(items))
 
     resp = fastapi_client.post("/api/proxy/build/1")
     assert resp.status_code == 200


### PR DESCRIPTION
## R5-25 router split — PR21 (proxy management)

Tenth router peeled out of the `server.py` monolith (`#51`, round-5 fable hardening audit).

Moves the proxy group into a leaf `routers/proxy.py`:
- `GET /api/proxy/status`
- `POST /api/proxy/build` (whole-library, single-flighted)
- `POST /api/proxy/build/{media_id}` (per-id)
- `_build_proxies` / `_build_proxies_all` background workers

The R5-22 (#59) whole-library **single-flight guard** is imported from `state.py` (the ONE `proxy_build` instance) — a double-clicked "build all" still can't launch parallel ffmpeg loops that stream truncated proxies mid-build.

**`_proxy_ready` → `pathres.py`**: the C1 consumer-side non-empty check is shared by `/api/stream` (stays in `server.py`, misc group later) and the proxy routes, so it moves to the leaf `pathres` module and `server.py` re-exports it (stream_media + any `server.`-referencing call site keep working).

**Behaviour-preserving**: paths/methods/scopes unchanged → SPA + CLI unaffected. `server.py` 2835 → 2751.

### Tests
- `test_r5_22_singleflight.py` + `test_server.py` proxy tests repointed to `routers.proxy` (same shared `state.proxy_build` guard).
- `test_r5_25_pathres_module.py` `_NAMES` gains `_proxy_ready` (pins the re-export identity).
- New `tests/test_r5_25_router_proxy.py`: leaf-ness, route ownership, shared-guard identity, `_proxy_ready is pathres._proxy_ready`, server-no-longer-defines (+ stream_media stays), mounted + auth-guarded (401-not-404).
- Full suite green locally: **886 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)