### PR TITLE
refactor(server): peel recorrect routes into routers/recorrect.py + _rebuild_embeddings→state (R5-25 PR22)

### DIFF
--- a/routers/recorrect.py
+++ b/routers/recorrect.py
@@ -1,0 +1,91 @@
+"""Correction-dictionary + recorrect routes (R5-25 / round-5 #51 router split).
+
+Phase 9.6b: the per-project correction dictionary (GET/PUT /api/corrections) and
+the batch recorrect flow — /api/recorrect (dry-run preview by default, RP-4),
+/api/recorrect/backups, /api/recorrect/revert. Applying with rebuild=1 chains the
+shared embedding rebuild so search reflects the corrected text; that worker
+(_rebuild_embeddings) and its single-flight guard (embed_rebuild) live in state.py
+and are imported here — the ONE instance shared with /api/embed/rebuild, never a
+copy. Imports auth + corrections + webguard + state — no server import, no cycle.
+"""
+from typing import List, Optional
+
+from fastapi import APIRouter, BackgroundTasks, Depends, Query, Request
+from pydantic import BaseModel
+
+import corrections
+from auth import require_scopes
+from state import _rebuild_embeddings, embed_rebuild as _embed_guard
+from webguard import _assert_same_site
+
+router = APIRouter()
+
+
+class CorrectionsBody(BaseModel):
+    # raw dicts; corrections._clean_rule validates (sidesteps `from` keyword).
+    rules: List[dict] = []
+
+
+class RevertBody(BaseModel):
+    backup: Optional[str] = None
+
+
+@router.get("/api/corrections")
+def get_corrections(_tok: dict = Depends(require_scopes("projects_read"))):
+    """The active project's correction dictionary (.arkiv/corrections.json)."""
+    return {"rules": corrections.load_rules()}
+
+
+@router.put("/api/corrections")
+def put_corrections(
+    body: CorrectionsBody,
+    request: Request,
+    _tok: dict = Depends(require_scopes("projects_write")),
+):
+    """Replace the dictionary. Returns the cleaned rules actually persisted."""
+    _assert_same_site(request)
+    saved = corrections.save_rules(body.rules)
+    return {"ok": True, "rules": saved, "count": len(saved)}
+
+
+@router.post("/api/recorrect")
+def recorrect(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    dry_run: int = Query(1, description="1 = preview only (default, writes nothing)"),
+    rebuild: int = Query(0, description="1 = rebuild embeddings after applying"),
+    _tok: dict = Depends(require_scopes("ingest_write")),
+):
+    """Batch-apply the dictionary's post-rules to stored transcripts.
+
+    Defaults to dry-run (RP-4): a bare POST previews hits and writes nothing.
+    dry_run=0 applies (transcript + segments_json synced, backup written first);
+    rebuild=1 then chains the existing single-flight embedding rebuild so search
+    reflects the corrected text."""
+    if dry_run:
+        return {"dry_run": True, **corrections.scan()}
+    _assert_same_site(request)  # mutating — same-origin only (audit M14 pattern)
+    result = corrections.apply()
+    embed_started = False
+    if rebuild and result.get("media_updated"):
+        if _embed_guard.acquire():  # audit M8: only start if no rebuild is running
+            background_tasks.add_task(_rebuild_embeddings)
+            embed_started = True
+    return {"dry_run": False, **result, "embed_rebuild_started": embed_started}
+
+
+@router.get("/api/recorrect/backups")
+def recorrect_backups(_tok: dict = Depends(require_scopes("projects_read"))):
+    """Reversible recorrect backups, newest first (for the revert picker)."""
+    return {"backups": corrections.list_backups()}
+
+
+@router.post("/api/recorrect/revert")
+def recorrect_revert(
+    body: RevertBody,
+    request: Request,
+    _tok: dict = Depends(require_scopes("ingest_write")),
+):
+    """Restore transcripts from a recorrect backup (latest if unspecified)."""
+    _assert_same_site(request)
+    return corrections.revert(body.backup)

--- a/server.py
+++ b/server.py
@@ -52,6 +52,7 @@ from state import (  # noqa: F401  (re-exported for backward compat)
     embed_rebuild as _embed_guard,
     retranscribe as _retranscribe_guard,
     proxy_build as _proxy_guard,
+    _rebuild_embeddings,
 )
 
 # R5-22 (#52): the embed-rebuild / retranscribe single-flight guards + the
@@ -148,6 +149,7 @@ from routers.offload import router as offload_router  # noqa: E402
 from routers.analytics import router as analytics_router  # noqa: E402
 from routers.retranscribe import router as retranscribe_router  # noqa: E402
 from routers.proxy import router as proxy_router  # noqa: E402
+from routers.recorrect import router as recorrect_router  # noqa: E402
 app.include_router(admin_router)
 app.include_router(settings_router)
 app.include_router(projects_router)
@@ -158,6 +160,7 @@ app.include_router(offload_router)
 app.include_router(analytics_router)
 app.include_router(retranscribe_router)
 app.include_router(proxy_router)
+app.include_router(recorrect_router)
 
 ROOT = Path(__file__).parent
 # Built Svelte SPA (frontend/dist). Gitignored — produced by `npm run build`.
@@ -2554,90 +2557,18 @@ def embed_rebuild(request: Request, background_tasks: BackgroundTasks, _tok: dic
     return {"message": f"開始重建向量索引（{total} 筆素材，背景執行）", "queued": total}
 
 
-def _rebuild_embeddings():
-    """Background task: full embedding rebuild via subprocess. Runs embed.py in a
-    child process to isolate its sys.exit() guard and use sys.executable per the
-    platform Python-concurrency rule (not in-process — sys.exit would kill server)."""
-    import subprocess
-    import sys
-    try:
-        subprocess.run([sys.executable, str(ROOT / "embed.py"), "--rebuild"], check=False)
-    except Exception as e:
-        print(f"[embed] rebuild failed: {e}")
-    finally:
-        _embed_guard.release()  # audit M8: always free the single-flight slot
+# _rebuild_embeddings moved to state.py (R5-25 / #51, ROOT→config.BASE_DIR) so
+# /api/embed/rebuild (above) and the /api/recorrect rebuild chain
+# (routers/recorrect.py) share ONE worker + the ONE embed_rebuild guard. Re-exported
+# at the top of this module for the embed_rebuild route + backward compat.
 
 
 # ── Phase 9.6b: per-project correction dictionary ────────────────────────────
-
-class CorrectionsBody(BaseModel):
-    # raw dicts; corrections._clean_rule validates (sidesteps `from` keyword).
-    rules: List[dict] = []
-
-
-class RevertBody(BaseModel):
-    backup: Optional[str] = None
-
-
-@app.get("/api/corrections")
-def get_corrections(_tok: dict = Depends(require_scopes("projects_read"))):
-    """The active project's correction dictionary (.arkiv/corrections.json)."""
-    return {"rules": corrections.load_rules()}
-
-
-@app.put("/api/corrections")
-def put_corrections(
-    body: CorrectionsBody,
-    request: Request,
-    _tok: dict = Depends(require_scopes("projects_write")),
-):
-    """Replace the dictionary. Returns the cleaned rules actually persisted."""
-    _assert_same_site(request)
-    saved = corrections.save_rules(body.rules)
-    return {"ok": True, "rules": saved, "count": len(saved)}
-
-
-@app.post("/api/recorrect")
-def recorrect(
-    request: Request,
-    background_tasks: BackgroundTasks,
-    dry_run: int = Query(1, description="1 = preview only (default, writes nothing)"),
-    rebuild: int = Query(0, description="1 = rebuild embeddings after applying"),
-    _tok: dict = Depends(require_scopes("ingest_write")),
-):
-    """Batch-apply the dictionary's post-rules to stored transcripts.
-
-    Defaults to dry-run (RP-4): a bare POST previews hits and writes nothing.
-    dry_run=0 applies (transcript + segments_json synced, backup written first);
-    rebuild=1 then chains the existing single-flight embedding rebuild so search
-    reflects the corrected text."""
-    if dry_run:
-        return {"dry_run": True, **corrections.scan()}
-    _assert_same_site(request)  # mutating — same-origin only (audit M14 pattern)
-    result = corrections.apply()
-    embed_started = False
-    if rebuild and result.get("media_updated"):
-        if _embed_guard.acquire():  # audit M8: only start if no rebuild is running
-            background_tasks.add_task(_rebuild_embeddings)
-            embed_started = True
-    return {"dry_run": False, **result, "embed_rebuild_started": embed_started}
-
-
-@app.get("/api/recorrect/backups")
-def recorrect_backups(_tok: dict = Depends(require_scopes("projects_read"))):
-    """Reversible recorrect backups, newest first (for the revert picker)."""
-    return {"backups": corrections.list_backups()}
-
-
-@app.post("/api/recorrect/revert")
-def recorrect_revert(
-    body: RevertBody,
-    request: Request,
-    _tok: dict = Depends(require_scopes("ingest_write")),
-):
-    """Restore transcripts from a recorrect backup (latest if unspecified)."""
-    _assert_same_site(request)
-    return corrections.revert(body.backup)
+#
+# The correction-dictionary + recorrect routes (/api/corrections GET/PUT,
+# /api/recorrect POST, /api/recorrect/backups GET, /api/recorrect/revert POST)
+# with CorrectionsBody / RevertBody moved to routers/recorrect.py (R5-25 / #51),
+# mounted via app.include_router below.
 
 
 # ── Phase 9.6d: project-wide batch retranscribe (2a) ─────────────────────────

--- a/state.py
+++ b/state.py
@@ -18,6 +18,8 @@ from typing import Set
 
 from fastapi import WebSocket
 
+import config
+
 
 # ── Named single-flight guards ────────────────────────────────────────────────
 # R5-22 (#52): embed-rebuild / retranscribe used bare module-global bools
@@ -79,6 +81,24 @@ retranscribe.reset_progress(
 # siblings) — a double-click launched parallel full-library ffmpeg loops and
 # mid-build playback streamed truncated proxies.
 proxy_build = SingleFlight("proxy_build")
+
+
+def _rebuild_embeddings():
+    """Background task: full embedding rebuild via subprocess. Runs embed.py in a
+    child process to isolate its sys.exit() guard and use sys.executable per the
+    platform Python-concurrency rule (not in-process — sys.exit would kill server).
+
+    R5-25 (#51): moved here from server.py (swapping ROOT→config.BASE_DIR) so both
+    /api/embed/rebuild (server) and the /api/recorrect rebuild chain
+    (routers/recorrect.py) share ONE worker + the ONE embed_rebuild guard above."""
+    import subprocess
+    import sys
+    try:
+        subprocess.run([sys.executable, str(config.BASE_DIR / "embed.py"), "--rebuild"], check=False)
+    except Exception as e:
+        print(f"[embed] rebuild failed: {e}")
+    finally:
+        embed_rebuild.release()  # audit M8: always free the single-flight slot
 
 # ── Ingest single-flight guard ────────────────────────────────────────────────
 # One guard for ALL ingest entry points (REST /api/ingest, reingest, WS, bin-copy,

--- a/tests/test_r5_25_router_recorrect.py
+++ b/tests/test_r5_25_router_recorrect.py
@@ -1,0 +1,76 @@
+"""R5-25 (round-5 #51): correction-dictionary + recorrect routes peeled to
+routers/recorrect.py.
+
+Eleventh router peeled. Pins the split: the leaf module owns the 5 routes + its 2
+models, server.py no longer defines them, routes mounted + auth-guarded
+(401-not-404). _rebuild_embeddings moved to state.py (ROOT→config.BASE_DIR) so the
+recorrect rebuild chain and /api/embed/rebuild share ONE worker + the ONE
+embed_rebuild guard. The recorrect apply/backup/revert behaviour is covered by
+test_corrections.py; the embed single-flight by test_r5_22_singleflight.py.
+"""
+import pathlib
+import re
+
+from starlette.testclient import TestClient
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def test_recorrect_router_is_a_leaf_module():
+    src = (_ROOT / "routers" / "recorrect.py").read_text(encoding="utf-8")
+    assert not re.search(r"^\s*import\s+server\b", src, re.M)
+    assert not re.search(r"^\s*from\s+server\b", src, re.M)
+
+
+def test_router_owns_recorrect_routes_and_models():
+    import routers.recorrect as rr
+    pairs = {
+        (r.path, m)
+        for r in rr.router.routes
+        for m in r.methods
+        if m != "HEAD"
+    }
+    assert pairs == {
+        ("/api/corrections", "GET"),
+        ("/api/corrections", "PUT"),
+        ("/api/recorrect", "POST"),
+        ("/api/recorrect/backups", "GET"),
+        ("/api/recorrect/revert", "POST"),
+    }
+    for name in ("CorrectionsBody", "RevertBody", "recorrect",
+                 "get_corrections", "recorrect_revert"):
+        assert hasattr(rr, name)
+
+
+def test_rebuild_embeddings_extracted_to_state_and_shared():
+    # the worker + guard must be the ONE state instance shared with /api/embed/rebuild
+    import routers.recorrect as rr
+    import state
+    import server
+    assert rr._rebuild_embeddings is state._rebuild_embeddings
+    assert server._rebuild_embeddings is state._rebuild_embeddings   # re-export intact
+    assert rr._embed_guard is state.embed_rebuild
+    # _rebuild_embeddings no longer defined in server.py (only re-exported)
+    src = (_ROOT / "server.py").read_text(encoding="utf-8")
+    assert "def _rebuild_embeddings" not in src
+    # state uses config.BASE_DIR for embed.py, not the old server.ROOT
+    state_src = (_ROOT / "state.py").read_text(encoding="utf-8")
+    assert "config.BASE_DIR" in state_src and "embed.py" in state_src
+
+
+def test_server_no_longer_defines_recorrect_handlers():
+    src = (_ROOT / "server.py").read_text(encoding="utf-8")
+    assert "class CorrectionsBody" not in src
+    assert "def get_corrections" not in src
+    assert not re.search(r"@app\.(get|put|post)\(\"/api/(recorrect|corrections)", src)
+    assert "include_router(recorrect_router)" in src
+
+
+def test_recorrect_routes_mounted_and_auth_guarded(server_module):
+    with TestClient(server_module.app) as c:
+        assert c.get("/api/corrections").status_code == 401
+        assert c.put("/api/corrections", json={"rules": []}).status_code == 401
+        assert c.post("/api/recorrect").status_code == 401
+        assert c.get("/api/recorrect/backups").status_code == 401
+        assert c.post("/api/recorrect/revert", json={}).status_code == 401
+        assert c.get("/api/correctionszz").status_code == 404


### PR DESCRIPTION
## R5-25 router split — PR22 (recorrect + correction dictionary)

Eleventh router peeled out of the `server.py` monolith (`#51`, round-5 fable hardening audit).

Moves the correction-dictionary + recorrect group into a leaf `routers/recorrect.py`:
- `GET`/`PUT /api/corrections`
- `POST /api/recorrect` (dry-run preview by default, RP-4)
- `GET /api/recorrect/backups`
- `POST /api/recorrect/revert`
- `CorrectionsBody` / `RevertBody` models

**`_rebuild_embeddings` → `state.py`** (swapping `ROOT`→`config.BASE_DIR`): it's shared by `/api/embed/rebuild` (stays in `server.py`, misc group later) and the recorrect rebuild chain. Both now reference the ONE worker + the ONE `embed_rebuild` single-flight guard from `state`. `server.py` re-exports `_rebuild_embeddings` so the embed route + any `server.`-referencing call site keep working. `state.py` now imports `config` (a leaf — no cycle).

**Behaviour-preserving**: paths/methods/scopes unchanged → SPA + CLI unaffected. `server.py` 2751 → 2682.

### Tests
- New `tests/test_r5_25_router_recorrect.py`: leaf-ness, route ownership, worker+guard shared-identity (`rr._rebuild_embeddings is state._rebuild_embeddings`, `rr._embed_guard is state.embed_rebuild`), `config.BASE_DIR` used for embed.py, server-no-longer-defines, mounted + auth-guarded (401-not-404).
- Route-level `test_corrections.py` + embed single-flight `test_r5_22_singleflight.py` unaffected.
- Full suite green locally: **891 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)