### PR TITLE
refactor(server): peel leftover singleton routes into routers/misc.py (R5-25 PR23)

### DIFF
--- a/routers/misc.py
+++ b/routers/misc.py
@@ -1,0 +1,188 @@
+"""Leftover singleton routes (R5-25 / round-5 #51 router split).
+
+The handlers that don't form a larger group but still leave server.py as a pure
+app shell: /api/stream (range-friendly playback, serves the H.264 proxy when the
+source codec is browser-incompatible), /api/embed/rebuild (single-flight semantic
+index rebuild), /api/open-file (OS-level open/reveal — videos_write gated), and
+the unauthenticated /api/client-log diagnostics sink (+ its _log_safe sanitiser).
+
+_proxy_ready + _resolve_media_path come from pathres; the embed single-flight
+guard + _rebuild_embeddings worker from state (the ONE shared instance);
+_assert_same_site from webguard. No server import, no cycle.
+"""
+import mimetypes
+import os
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from fastapi.responses import FileResponse, JSONResponse
+from pydantic import BaseModel
+
+import codec
+import config
+import db
+import mediatypes
+from auth import require_scopes
+from pathres import _proxy_ready, _resolve_media_path
+from state import _rebuild_embeddings, embed_rebuild as _embed_guard
+from webguard import _assert_same_site
+
+router = APIRouter()
+
+
+def _log_safe(text: str, limit: int) -> str:
+    """Strip control chars (newlines, ANSI/terminal escapes) and truncate, so a
+    value printed to the server terminal/log can't forge lines or fill disk."""
+    if not text:
+        return ""
+    cleaned = "".join(c for c in text if c == " " or (0x20 <= ord(c) < 0x7F) or ord(c) >= 0x80)
+    return cleaned[:limit]
+
+
+class OpenFileRequest(BaseModel):  # audit M22: malformed JSON → clean 422, not a raw 500
+    path: str
+    reveal: bool = False
+
+
+class ClientLogRequest(BaseModel):
+    # audit M22: the model's job is turning malformed JSON into a 422 instead of
+    # a raw 500. Fields stay Any (the WebView occasionally logs non-string
+    # payloads); the handler stringifies + sanitizes as before.
+    level: Any = "info"
+    msg: Any = ""
+
+
+@router.get("/api/stream/{media_id}")
+def stream_media(media_id: int, _tok: dict = Depends(require_scopes("videos_read"))):
+    """Stream a media file with range request support for seeking.
+    Serves H.264 proxy if available (for browser-incompatible codecs like ProRes/HEVC).
+    """
+    rec = db.get_record_by_id(media_id)
+    if not rec:
+        raise HTTPException(404, "找不到媒體")
+    # Proxy filename is hash-scoped by absolute source path so that a
+    # proxies/ directory copied between installations cannot serve another
+    # user's content under the same media_id.
+    resolved_src = _resolve_media_path(rec["path"])
+    proxy_path = config.proxy_path_for(media_id, resolved_src)
+    if _proxy_ready(proxy_path):
+        return FileResponse(
+            path=str(proxy_path),
+            media_type="video/mp4",
+            filename=Path(resolved_src).stem + "_proxy.mp4",
+        )
+    file_path = Path(resolved_src)
+    if not file_path.exists():
+        raise HTTPException(404, "找不到檔案")
+    # Only serve known media extensions
+    if file_path.suffix.lower() not in mediatypes.MEDIA_EXT:
+        raise HTTPException(403, "不是媒體檔案")
+
+    # Phase 7.7g: HEVC/ProRes 沒對應 proxy 時不要 silently 送原檔（Chrome/WKWebView
+    # 都播不出來，使用者只看到「無法播放」），改回 409 + JSON，前端可 surface
+    # 「需先建 proxy」的引導 + POST /api/proxy/build 觸發背景生成。
+    # tri-state: NEEDED → 409；NOT_NEEDED / UNKNOWN（ffprobe 失敗、binary 缺、
+    # NAS unreachable）→ fall through，維持送原檔的舊 fallback 行為。
+    # audit M24: use the codec persisted at ingest instead of re-running ffprobe
+    # on EVERY playback; only probe when the column is NULL (legacy rows) and
+    # backfill so the next play is probe-free. None (probe failed / audio-only)
+    # keeps the UNKNOWN fall-through behavior.
+    stored_codec = (rec.get("codec") or "").strip().lower() or None
+    if stored_codec is None:
+        stored_codec = codec.probe_codec(str(file_path))
+        if stored_codec:
+            try:
+                with db.get_conn() as conn:
+                    conn.execute("UPDATE media SET codec=? WHERE id=?", (stored_codec, media_id))
+            except Exception:
+                pass  # backfill is best-effort; playback must not fail on it
+    if stored_codec and stored_codec in codec.PROXY_CODECS:
+        return JSONResponse(
+            status_code=409,
+            content={
+                "need_proxy": True,
+                "media_id": media_id,
+                "filename": rec.get("filename"),
+                "reason": "browser-incompatible codec (HEVC/ProRes); proxy required for playback",
+                "hint": "POST /api/proxy/build to queue proxy generation",
+            },
+        )
+
+    mime, _ = mimetypes.guess_type(str(file_path))
+    if not mime:
+        mime = "video/mp4"
+    return FileResponse(
+        path=str(file_path),
+        media_type=mime,
+        filename=file_path.name,
+    )
+
+
+@router.post("/api/embed/rebuild")
+def embed_rebuild(request: Request, background_tasks: BackgroundTasks, _tok: dict = Depends(require_scopes("ingest_write"))):
+    """Drop + rebuild the ChromaDB semantic index from all media.
+    Wired to 進階設定 → 搜尋引擎 → 「重建向量索引」button."""
+    _assert_same_site(request)  # audit M14
+    with db.get_conn() as conn:
+        total = conn.execute("SELECT count(*) FROM media").fetchone()[0]
+    if not total:
+        return {"message": "尚無素材可建立索引", "queued": 0}
+    if not _embed_guard.acquire():  # audit M8: refuse concurrent rebuilds
+        raise HTTPException(409, "向量索引重建已在進行中，請稍候")
+    background_tasks.add_task(_rebuild_embeddings)
+    return {"message": f"開始重建向量索引（{total} 筆素材，背景執行）", "queued": total}
+
+
+@router.post("/api/open-file")
+def open_file(
+    body: OpenFileRequest,
+    _tok: dict = Depends(require_scopes("videos_write")),
+):
+    """Open file in OS default app or reveal in file manager. Only allows known media files from DB.
+
+    Requires videos_write: launching an OS app / revealing a file is a privileged
+    side effect on the host. Loopback is token-free (full scope); a remote
+    read-only browse token is correctly refused.
+    """
+    import subprocess, platform
+    file_path = body.path
+    reveal = body.reveal
+    # Validate: only allow paths that exist in our database
+    if not db.is_processed(file_path):
+        raise HTTPException(403, "只能開啟已索引的媒體檔案")
+    resolved_path = _resolve_media_path(file_path)
+    if not Path(resolved_path).exists():
+        raise HTTPException(404, "找不到檔案")
+    system = platform.system()
+    if reveal:
+        if system == "Darwin":
+            subprocess.Popen(["open", "-R", resolved_path])
+        elif system == "Windows":
+            subprocess.Popen(["explorer", "/select,", resolved_path])
+        else:
+            subprocess.Popen(["xdg-open", str(Path(resolved_path).parent)])
+    else:
+        if system == "Darwin":
+            subprocess.Popen(["open", resolved_path])
+        elif system == "Windows":
+            os.startfile(resolved_path)
+        else:
+            subprocess.Popen(["xdg-open", resolved_path])
+    return {"ok": True}
+
+
+@router.post("/api/client-log")
+def client_log(body: ClientLogRequest):
+    """Receive client-side logs (errors, info) and print to server terminal.
+
+    Stays unauthenticated (the WebView logs diagnostics, sometimes before a token
+    is wired), but the attacker-controlled fields are sanitized + truncated:
+    control chars (newlines / ANSI terminal escapes) are stripped so a remote
+    caller can't forge log lines or corrupt the operator's terminal, and lengths
+    are capped so it can't be used to fill a redirected logfile.
+    """
+    level = _log_safe(str(body.level if body.level is not None else "info").upper(), 16)
+    msg = _log_safe(str(body.msg if body.msg is not None else ""), 2000)
+    print(f"[WebView {level}] {msg}", flush=True)
+    return {"ok": True}

--- a/server.py
+++ b/server.py
@@ -150,6 +150,7 @@ from routers.analytics import router as analytics_router  # noqa: E402
 from routers.retranscribe import router as retranscribe_router  # noqa: E402
 from routers.proxy import router as proxy_router  # noqa: E402
 from routers.recorrect import router as recorrect_router  # noqa: E402
+from routers.misc import router as misc_router  # noqa: E402
 app.include_router(admin_router)
 app.include_router(settings_router)
 app.include_router(projects_router)
@@ -161,6 +162,7 @@ app.include_router(analytics_router)
 app.include_router(retranscribe_router)
 app.include_router(proxy_router)
 app.include_router(recorrect_router)
+app.include_router(misc_router)
 
 ROOT = Path(__file__).parent
 # Built Svelte SPA (frontend/dist). Gitignored — produced by `npm run build`.
@@ -1623,13 +1625,8 @@ def reingest_media(
 # (R5-25 / #51), re-exported at the top of this module.
 
 
-def _log_safe(text: str, limit: int) -> str:
-    """Strip control chars (newlines, ANSI/terminal escapes) and truncate, so a
-    value printed to the server terminal/log can't forge lines or fill disk."""
-    if not text:
-        return ""
-    cleaned = "".join(c for c in text if c == " " or (0x20 <= ord(c) < 0x7F) or ord(c) >= 0x80)
-    return cleaned[:limit]
+# _log_safe moved to routers/misc.py (R5-25 / #51) with its only caller,
+# /api/client-log.
 
 
 # _subtitle_ts / _subtitle_text / _edl_timecode / _start_tc_seconds /
@@ -2459,108 +2456,11 @@ async def ingest_media_ws(
 
 
 # ── Video Streaming ──────────────────────────────────────────────────────────
-
-import mimetypes
-
-# _proxy_ready moved to pathres.py (R5-25 / #51) — shared by /api/stream (below)
-# and the proxy routes (routers/proxy.py) — and re-exported at the top of this
-# module.
-
-
-@app.get("/api/stream/{media_id}")
-def stream_media(media_id: int, _tok: dict = Depends(require_scopes("videos_read"))):
-    """Stream a media file with range request support for seeking.
-    Serves H.264 proxy if available (for browser-incompatible codecs like ProRes/HEVC).
-    """
-    rec = db.get_record_by_id(media_id)
-    if not rec:
-        raise HTTPException(404, "找不到媒體")
-    # Proxy filename is hash-scoped by absolute source path so that a
-    # proxies/ directory copied between installations cannot serve another
-    # user's content under the same media_id.
-    resolved_src = _resolve_media_path(rec["path"])
-    proxy_path = config.proxy_path_for(media_id, resolved_src)
-    if _proxy_ready(proxy_path):
-        return FileResponse(
-            path=str(proxy_path),
-            media_type="video/mp4",
-            filename=Path(resolved_src).stem + "_proxy.mp4",
-        )
-    file_path = Path(resolved_src)
-    if not file_path.exists():
-        raise HTTPException(404, "找不到檔案")
-    # Only serve known media extensions
-    if file_path.suffix.lower() not in MEDIA_EXTS:
-        raise HTTPException(403, "不是媒體檔案")
-
-    # Phase 7.7g: HEVC/ProRes 沒對應 proxy 時不要 silently 送原檔（Chrome/WKWebView
-    # 都播不出來，使用者只看到「無法播放」），改回 409 + JSON，前端可 surface
-    # 「需先建 proxy」的引導 + POST /api/proxy/build 觸發背景生成。
-    # tri-state: NEEDED → 409；NOT_NEEDED / UNKNOWN（ffprobe 失敗、binary 缺、
-    # NAS unreachable）→ fall through，維持送原檔的舊 fallback 行為。
-    # audit M24: use the codec persisted at ingest instead of re-running ffprobe
-    # on EVERY playback; only probe when the column is NULL (legacy rows) and
-    # backfill so the next play is probe-free. None (probe failed / audio-only)
-    # keeps the UNKNOWN fall-through behavior.
-    stored_codec = (rec.get("codec") or "").strip().lower() or None
-    if stored_codec is None:
-        stored_codec = codec.probe_codec(str(file_path))
-        if stored_codec:
-            try:
-                with db.get_conn() as conn:
-                    conn.execute("UPDATE media SET codec=? WHERE id=?", (stored_codec, media_id))
-            except Exception:
-                pass  # backfill is best-effort; playback must not fail on it
-    if stored_codec and stored_codec in codec.PROXY_CODECS:
-        return JSONResponse(
-            status_code=409,
-            content={
-                "need_proxy": True,
-                "media_id": media_id,
-                "filename": rec.get("filename"),
-                "reason": "browser-incompatible codec (HEVC/ProRes); proxy required for playback",
-                "hint": "POST /api/proxy/build to queue proxy generation",
-            },
-        )
-
-    mime, _ = mimetypes.guess_type(str(file_path))
-    if not mime:
-        mime = "video/mp4"
-    return FileResponse(
-        path=str(file_path),
-        media_type=mime,
-        filename=file_path.name,
-    )
-
-
-# ── Proxy Management ─────────────────────────────────────────────────────────
-
-# PROXY_CODECS lives in codec.py — single source of truth.
-# The proxy routes (/api/proxy/status, /api/proxy/build, /api/proxy/build/{id})
-# plus the _build_proxies / _build_proxies_all background workers moved to
-# routers/proxy.py (R5-25 / #51), mounted via app.include_router below. The R5-22
-# (#59) single-flight guard is shared from state.py.
-
-
-@app.post("/api/embed/rebuild")
-def embed_rebuild(request: Request, background_tasks: BackgroundTasks, _tok: dict = Depends(require_scopes("ingest_write"))):
-    """Drop + rebuild the ChromaDB semantic index from all media.
-    Wired to 進階設定 → 搜尋引擎 → 「重建向量索引」button."""
-    _assert_same_site(request)  # audit M14
-    with db.get_conn() as conn:
-        total = conn.execute("SELECT count(*) FROM media").fetchone()[0]
-    if not total:
-        return {"message": "尚無素材可建立索引", "queued": 0}
-    if not _embed_guard.acquire():  # audit M8: refuse concurrent rebuilds
-        raise HTTPException(409, "向量索引重建已在進行中，請稍候")
-    background_tasks.add_task(_rebuild_embeddings)
-    return {"message": f"開始重建向量索引（{total} 筆素材，背景執行）", "queued": total}
-
-
-# _rebuild_embeddings moved to state.py (R5-25 / #51, ROOT→config.BASE_DIR) so
-# /api/embed/rebuild (above) and the /api/recorrect rebuild chain
-# (routers/recorrect.py) share ONE worker + the ONE embed_rebuild guard. Re-exported
-# at the top of this module for the embed_rebuild route + backward compat.
+#
+# /api/stream (+ /api/embed/rebuild, /api/open-file, /api/client-log with its
+# _log_safe sanitiser) moved to routers/misc.py (R5-25 / #51), mounted via
+# app.include_router below. _rebuild_embeddings lives in state.py (shared by the
+# embed route + the recorrect rebuild chain), re-exported at the top of this module.
 
 
 # ── Phase 9.6b: per-project correction dictionary ────────────────────────────
@@ -2597,72 +2497,6 @@ def _load_index() -> str:
         "<h1>arkiv</h1><p>UI build not found. Run "
         "<code>cd frontend &amp;&amp; npm ci &amp;&amp; npm run build</code>.</p>"
     )
-
-class OpenFileRequest(BaseModel):  # audit M22: malformed JSON → clean 422, not a raw 500
-    path: str
-    reveal: bool = False
-
-
-@app.post("/api/open-file")
-def open_file(
-    body: OpenFileRequest,
-    _tok: dict = Depends(require_scopes("videos_write")),
-):
-    """Open file in OS default app or reveal in file manager. Only allows known media files from DB.
-
-    Requires videos_write: launching an OS app / revealing a file is a privileged
-    side effect on the host. Loopback is token-free (full scope); a remote
-    read-only browse token is correctly refused.
-    """
-    import subprocess, platform
-    file_path = body.path
-    reveal = body.reveal
-    # Validate: only allow paths that exist in our database
-    if not db.is_processed(file_path):
-        raise HTTPException(403, "只能開啟已索引的媒體檔案")
-    resolved_path = _resolve_media_path(file_path)
-    if not Path(resolved_path).exists():
-        raise HTTPException(404, "找不到檔案")
-    system = platform.system()
-    if reveal:
-        if system == "Darwin":
-            subprocess.Popen(["open", "-R", resolved_path])
-        elif system == "Windows":
-            subprocess.Popen(["explorer", "/select,", resolved_path])
-        else:
-            subprocess.Popen(["xdg-open", str(Path(resolved_path).parent)])
-    else:
-        if system == "Darwin":
-            subprocess.Popen(["open", resolved_path])
-        elif system == "Windows":
-            os.startfile(resolved_path)
-        else:
-            subprocess.Popen(["xdg-open", resolved_path])
-    return {"ok": True}
-
-
-class ClientLogRequest(BaseModel):
-    # audit M22: the model's job is turning malformed JSON into a 422 instead of
-    # a raw 500. Fields stay Any (the WebView occasionally logs non-string
-    # payloads); the handler stringifies + sanitizes as before.
-    level: Any = "info"
-    msg: Any = ""
-
-
-@app.post("/api/client-log")
-def client_log(body: ClientLogRequest):
-    """Receive client-side logs (errors, info) and print to server terminal.
-
-    Stays unauthenticated (the WebView logs diagnostics, sometimes before a token
-    is wired), but the attacker-controlled fields are sanitized + truncated:
-    control chars (newlines / ANSI terminal escapes) are stripped so a remote
-    caller can't forge log lines or corrupt the operator's terminal, and lengths
-    are capped so it can't be used to fill a redirected logfile.
-    """
-    level = _log_safe(str(body.level if body.level is not None else "info").upper(), 16)
-    msg = _log_safe(str(body.msg if body.msg is not None else ""), 2000)
-    print(f"[WebView {level}] {msg}", flush=True)
-    return {"ok": True}
 
 
 @app.get("/", response_class=HTMLResponse)

--- a/tests/test_r5_25_export_builders_module.py
+++ b/tests/test_r5_25_export_builders_module.py
@@ -50,12 +50,19 @@ def test_server_reexports_export_builders_by_identity():
         )
 
 
-def test_http_and_log_helpers_stay_in_server():
+def test_http_and_log_helpers_did_not_go_to_export_builders():
     # _attachment_headers (Content-Disposition) and _log_safe (terminal sanitiser)
-    # are HTTP/logging concerns, not export-format serialisers — they must NOT move.
+    # are HTTP/logging concerns, not export-format serialisers — they must NOT have
+    # been pulled into export_builders. _log_safe later moved to routers/misc.py
+    # with its only caller /api/client-log (R5-25 misc peel); _attachment_headers
+    # still lives in server (moves with the export routes in a later peel).
+    import export_builders
+    assert not hasattr(export_builders, "_attachment_headers")
+    assert not hasattr(export_builders, "_log_safe")
     import server
     assert hasattr(server, "_attachment_headers")
-    assert hasattr(server, "_log_safe")
+    import routers.misc
+    assert hasattr(routers.misc, "_log_safe")
 
 
 # ── injection-hardening / format behaviour preserved by the move ─────────────

--- a/tests/test_r5_25_router_misc.py
+++ b/tests/test_r5_25_router_misc.py
@@ -1,0 +1,79 @@
+"""R5-25 (round-5 #51): leftover singleton routes peeled to routers/misc.py.
+
+Twelfth router peeled. Pins the split: the leaf module owns /api/stream,
+/api/embed/rebuild, /api/open-file, /api/client-log (+ _log_safe + the two request
+models), server.py no longer defines them, routes mounted + auth-guarded. The app
+shell (SPA "/" + /thumbnails + lifespan) stays in server.py. Stream codec /
+proxy-fallback behaviour is covered by test_server.py + test_v081_edges.py; the
+embed single-flight by test_r5_22_singleflight.py; _log_safe by test_server.py.
+"""
+import pathlib
+import re
+
+from starlette.testclient import TestClient
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def test_misc_router_is_a_leaf_module():
+    src = (_ROOT / "routers" / "misc.py").read_text(encoding="utf-8")
+    assert not re.search(r"^\s*import\s+server\b", src, re.M)
+    assert not re.search(r"^\s*from\s+server\b", src, re.M)
+
+
+def test_router_owns_misc_routes_and_helpers():
+    import routers.misc as rm
+    pairs = {
+        (r.path, m)
+        for r in rm.router.routes
+        for m in r.methods
+        if m != "HEAD"
+    }
+    assert pairs == {
+        ("/api/stream/{media_id}", "GET"),
+        ("/api/embed/rebuild", "POST"),
+        ("/api/open-file", "POST"),
+        ("/api/client-log", "POST"),
+    }
+    for name in ("stream_media", "embed_rebuild", "open_file", "client_log",
+                 "_log_safe", "OpenFileRequest", "ClientLogRequest"):
+        assert hasattr(rm, name)
+
+
+def test_log_safe_strips_control_chars_and_truncates():
+    import routers.misc as rm
+    out = rm._log_safe("hello\nFAKE LOG\x1b[31m evil\r\n", 100)
+    assert "\n" not in out and "\r" not in out and "\x1b" not in out
+    assert "hello" in out and "evil" in out
+    assert rm._log_safe("x" * 5000, 16) == "x" * 16
+    assert rm._log_safe("音樂 OK", 100) == "音樂 OK"  # CJK preserved
+
+
+def test_misc_router_shares_state_embed_guard():
+    import routers.misc as rm
+    import state
+    assert rm._embed_guard is state.embed_rebuild
+    assert rm._rebuild_embeddings is state._rebuild_embeddings
+
+
+def test_server_no_longer_defines_misc_handlers_but_keeps_shell():
+    src = (_ROOT / "server.py").read_text(encoding="utf-8")
+    assert "def stream_media" not in src
+    assert "def open_file" not in src
+    assert "def client_log" not in src
+    assert "def _log_safe" not in src
+    assert not re.search(r"@app\.(get|post)\(\"/api/(stream|embed/rebuild|open-file|client-log)", src)
+    assert "include_router(misc_router)" in src
+    # the app shell stays in server.py
+    assert "def serve_index" in src
+    assert "def _load_index" in src
+
+
+def test_misc_routes_mounted_and_auth_guarded(server_module):
+    with TestClient(server_module.app) as c:
+        assert c.get("/api/stream/1").status_code in (401, 403)   # auth dep first
+        assert c.post("/api/embed/rebuild").status_code == 401
+        assert c.post("/api/open-file", json={"path": "/x"}).status_code == 401
+        # client-log is deliberately unauthenticated (WebView diagnostics sink)
+        assert c.post("/api/client-log", json={"level": "info", "msg": "hi"}).status_code == 200
+        assert c.get("/api/streamzz/1").status_code == 404

--- a/tests/test_r5_25_router_proxy.py
+++ b/tests/test_r5_25_router_proxy.py
@@ -60,8 +60,11 @@ def test_server_no_longer_defines_proxy_handlers():
     assert "def _build_proxies" not in src
     assert not re.search(r"@app\.(get|post)\(\"/api/proxy", src)
     assert "include_router(proxy_router)" in src
-    # /api/stream stays in server.py and still uses the (re-exported) _proxy_ready
-    assert "def stream_media" in src
+    # /api/stream also consumes _proxy_ready; it lives in routers/misc.py (peeled
+    # after proxy) and imports _proxy_ready from pathres like the proxy routes do.
+    import routers.misc as rm
+    import pathres
+    assert rm._proxy_ready is pathres._proxy_ready
 
 
 def test_proxy_routes_mounted_and_auth_guarded(server_module):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1279,12 +1279,13 @@ def test_log_safe_strips_control_chars_and_truncates():
     """client-log fields must not carry newlines/ANSI escapes (log injection) or
     be unbounded (disk fill)."""
     import importlib
-    server = importlib.import_module("server")
-    out = server._log_safe("hello\nFAKE LOG\x1b[31m evil\r\n", 100)
+    # _log_safe moved to routers/misc.py with /api/client-log in the R5-25 split.
+    misc = importlib.import_module("routers.misc")
+    out = misc._log_safe("hello\nFAKE LOG\x1b[31m evil\r\n", 100)
     assert "\n" not in out and "\r" not in out and "\x1b" not in out
     assert "hello" in out and "evil" in out
-    assert server._log_safe("x" * 5000, 16) == "x" * 16
-    assert server._log_safe("音樂 OK", 100) == "音樂 OK"  # CJK preserved
+    assert misc._log_safe("x" * 5000, 16) == "x" * 16
+    assert misc._log_safe("音樂 OK", 100) == "音樂 OK"  # CJK preserved
 
 
 # ── Track A hardening: input validation ──────────────────────────────────────


### PR DESCRIPTION
## R5-25 router split — PR23 (misc singletons)

Twelfth router peeled out of the `server.py` monolith (`#51`, round-5 fable hardening audit). These are the standalone handlers that were keeping `server.py` from being a pure app shell:

- `GET /api/stream/{media_id}` (range playback + H.264 proxy fallback for HEVC/ProRes)
- `POST /api/embed/rebuild` (single-flight semantic-index rebuild)
- `POST /api/open-file` (OS open/reveal, `videos_write`-gated)
- `POST /api/client-log` (unauthenticated WebView diagnostics sink) + `_log_safe`
- `OpenFileRequest` / `ClientLogRequest` models

Shared deps come from the leaf modules: `_proxy_ready` + `_resolve_media_path` from `pathres`, the embed single-flight guard + `_rebuild_embeddings` from `state` (the ONE shared instance), `_assert_same_site` from `webguard`; `MEDIA_EXTS` via `mediatypes.MEDIA_EXT`.

**App shell stays in `server.py`**: SPA `/` (`serve_index`/`_load_index`), `/thumbnails`, lifespan, middleware, the `include_router` wiring.

**Behaviour-preserving**: paths/methods/scopes unchanged → SPA + CLI unaffected. `server.py` 2682 → 2516.

### Tests
- New `tests/test_r5_25_router_misc.py`: leaf-ness, route ownership, `_log_safe` semantics, shared embed-guard identity, server-no-longer-defines (+ shell stays), mounted + auth-guarded (client-log stays 200 unauthenticated).
- `test_server.py` `_log_safe` test repointed to `routers.misc`; `test_r5_25_export_builders_module.py` + `test_r5_25_router_proxy.py` boundary assertions updated for the relocated `_log_safe` / `stream_media`.
- Route-level stream/codec/open-file/auth tests (`test_server.py`, `test_v081_edges.py`, `test_auth.py`, `test_phase8.py`, `test_audit_20260612.py`) unaffected — they patch shared modules (codec/config), not server-namespace.
- Full suite green locally: **897 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)