### PR TITLE
refactor(server): peel search routes into routers/search.py (R5-25 PR26)

### DIFF
--- a/routers/search.py
+++ b/routers/search.py
@@ -1,0 +1,198 @@
+"""Search routes (R5-25 / round-5 #51 router split).
+
+Two search surfaces:
+  * GET  /api/search/all   — cross-project federated semantic search (federation.py),
+    with the API-boundary path sanitisation that stops a videos_read client from
+    mapping the operator's cross-project directory layout (Phase 16.2);
+  * POST /api/search/query — structured query: typed field conditions AND/OR-combined
+    (query_builder), with an optional semantic (vector) leg, returning the same
+    {items,total,search} shape as /api/media.
+
+The bulk-fetch helpers (_get_light_records_by_ids / _get_tags_bulk) shared with the
+media group live in mediarecords.py; path sanitisation in pathres.py — imported
+directly. `_split_csv` (only search_all uses it) moves here. No server import, no cycle.
+"""
+import logging as _logging
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+import db
+import federation
+import projects as project_registry
+from auth import require_scopes
+from mediarecords import _get_light_records_by_ids, _get_tags_bulk
+from pathres import _basename_safe, _display_path, _resolve_record
+
+router = APIRouter()
+
+
+def _split_csv(value: Optional[str]) -> Optional[List[str]]:
+    if not value:
+        return None
+    parts = []
+    for chunk in value.split(","):
+        chunk = chunk.strip()
+        if chunk:
+            parts.append(chunk)
+    return parts or None
+
+
+@router.get("/api/search/all")
+def search_all(
+    q: str = Query(..., alias="q"),
+    # audit H13: declarative bounds — limit=-1 silently truncated, and
+    # timeout=999999 parked a threadpool worker on a stalled peer for hours.
+    limit: int = Query(50, ge=1, le=500),
+    per_project_limit: int = Query(20, ge=1, le=100),
+    projects: Optional[str] = None,
+    tag: Optional[str] = None,
+    timeout: float = Query(10.0, gt=0.0, le=30.0),
+    no_fallback_sql: bool = False,
+    _tok: dict = Depends(require_scopes("videos_read")),
+):
+    try:
+        payload = federation.search_all_projects(
+            q,
+            limit=limit,
+            per_project_limit=per_project_limit,
+            project_names=_split_csv(projects),
+            tag=tag,
+            timeout=timeout,
+            fallback_sql=not no_fallback_sql,
+        )
+    except project_registry.RegistryError as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    # Phase 16.2: federation results carry absolute media + project paths; strip
+    # them at the API boundary so a videos_read client can't map the operator's
+    # cross-project directory layout. project_path is reduced to its folder
+    # basename; the internal absolute_path / relative_path fields are dropped so
+    # only the sanitized `path` survives.
+    def _basename_only(value):
+        return _basename_safe(value)
+
+    for item in payload.get("items", []) or []:
+        # Route relative_path through _display_path FIRST: for an out-of-root row
+        # federation's relative_path is actually the *absolute* path (it falls
+        # back to str(stored) when relative_to() fails), so it must be basenamed,
+        # never copied through. Then drop the internal absolute/relative fields —
+        # leaving relative_path in place was the residual leak this closes.
+        chosen = item.get("relative_path")
+        if chosen is None:
+            chosen = item.get("path") or ""
+        item["path"] = _display_path(chosen)
+        item.pop("absolute_path", None)
+        item.pop("relative_path", None)
+        if item.get("project_path"):
+            item["project_path"] = _basename_only(item["project_path"])
+
+    # Errors carry the absolute project_path on timeout / preflight failure
+    # (federation sets project_path=str(project.path)); a failed project must not
+    # leak its absolute root either.
+    for err in payload.get("errors", []) or []:
+        if err.get("project_path"):
+            err["project_path"] = _basename_only(err["project_path"])
+
+    status_code = 200
+    if payload.get("projects_queried") and payload.get("projects_failed", 0) >= payload.get("projects_queried", 0):
+        status_code = 207
+    return JSONResponse(content=payload, status_code=status_code)
+
+
+class StructuredQuery(BaseModel):
+    # Phase 9.7 G6: structured query — AND/OR over typed field conditions, with
+    # an optional semantic (vector) leg. `conditions` is validated by
+    # query_builder.compile_spec; we keep the model permissive and let the
+    # builder raise the precise error.
+    match: str = "all"
+    conditions: List[dict]
+    limit: int = 50
+    offset: int = 0
+    sort: str = "date"
+
+
+def _structured_sort_key(sort: str):
+    if sort == "duration":
+        return lambda r: (r.get("duration_s") or 0), True
+    if sort == "size":
+        return lambda r: (r.get("size_mb") or 0), True
+    if sort == "name":
+        return lambda r: (r.get("filename") or "").lower(), False
+    # default: most recent first
+    return lambda r: (r.get("processed_at") or ""), True
+
+
+@router.post("/api/search/query")
+def structured_query(
+    body: StructuredQuery,
+    _tok: dict = Depends(require_scopes("videos_read")),
+):
+    """Structured query: typed field conditions combined by AND/OR, with an
+    optional semantic leg run through the vector index. Returns the same
+    `{items, total, search}` shape as /api/media so the UI can reuse renderers."""
+    import query_builder
+
+    try:
+        compiled = query_builder.compile_spec(
+            {"match": body.match, "conditions": body.conditions}
+        )
+    except query_builder.QueryError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    where, params = compiled["where"], compiled["params"]
+    terms, match = compiled["semantic_terms"], compiled["match"]
+    warning = None
+
+    sql_ids = None
+    if where:
+        with db.get_conn() as conn:
+            rows = conn.execute(
+                "SELECT id FROM media WHERE " + where, params
+            ).fetchall()
+        sql_ids = {r["id"] for r in rows}
+
+    sem_ids = None
+    if terms:
+        import vectordb as vdb
+        sets = []
+        for term in terms:
+            try:
+                raw = vdb.search(term, n_results=2000)
+                sets.append({int(r["media_id"]) for r in raw})
+            except Exception as exc:  # Ollama down / dim mismatch → degrade, flag it
+                _logging.getLogger(__name__).warning(
+                    "structured query semantic leg failed: %s", exc
+                )
+                warning = "semantic search unavailable (some terms ignored)"
+                sets.append(set())
+        if sets:
+            sem_ids = set.intersection(*sets) if match == "all" else set.union(*sets)
+
+    if sql_ids is not None and sem_ids is not None:
+        final_ids = (sql_ids & sem_ids) if match == "all" else (sql_ids | sem_ids)
+    elif sql_ids is not None:
+        final_ids = sql_ids
+    else:
+        final_ids = sem_ids or set()
+
+    records = _get_light_records_by_ids(list(final_ids))
+    keyfn, reverse = _structured_sort_key(body.sort)
+    records.sort(key=keyfn, reverse=reverse)
+
+    total = len(records)
+    offset = max(0, body.offset)
+    limit = max(1, min(500, body.limit))
+    items = records[offset:offset + limit]
+    tags_by_id = _get_tags_bulk([rec["id"] for rec in items])
+    for rec in items:
+        _resolve_record(rec)
+        rec["tags"] = tags_by_id.get(rec["id"], [])
+
+    resp = {"items": items, "total": total, "search": True, "structured": True}
+    if warning:
+        resp["search_degraded"] = True
+        resp["warning"] = warning
+    return resp

--- a/server.py
+++ b/server.py
@@ -153,6 +153,7 @@ from routers.recorrect import router as recorrect_router  # noqa: E402
 from routers.misc import router as misc_router  # noqa: E402
 from routers.export import router as export_router  # noqa: E402
 from routers.media import router as media_router  # noqa: E402
+from routers.search import router as search_router  # noqa: E402
 app.include_router(admin_router)
 app.include_router(settings_router)
 app.include_router(projects_router)
@@ -167,6 +168,7 @@ app.include_router(recorrect_router)
 app.include_router(misc_router)
 app.include_router(export_router)
 app.include_router(media_router)
+app.include_router(search_router)
 
 ROOT = Path(__file__).parent
 # Built Svelte SPA (frontend/dist). Gitignored — produced by `npm run build`.
@@ -283,15 +285,8 @@ from mediarecords import (  # noqa: F401 (re-exported for backward compat)
 # to routers/chat.py (R5-25 / #51), mounted via app.include_router below.
 
 
-def _split_csv(value: Optional[str]) -> Optional[List[str]]:
-    if not value:
-        return None
-    parts = []
-    for chunk in value.split(","):
-        chunk = chunk.strip()
-        if chunk:
-            parts.append(chunk)
-    return parts or None
+# _split_csv moved to routers/search.py (R5-25 / #51) with its only caller
+# /api/search/all.
 
 
 def _bootstrap_admin_token():
@@ -319,66 +314,10 @@ def _bootstrap_admin_token():
 
 # ── API Routes ───────────────────────────────────────────────────────────────
 
-@app.get("/api/search/all")
-def search_all(
-    q: str = Query(..., alias="q"),
-    # audit H13: declarative bounds — limit=-1 silently truncated, and
-    # timeout=999999 parked a threadpool worker on a stalled peer for hours.
-    limit: int = Query(50, ge=1, le=500),
-    per_project_limit: int = Query(20, ge=1, le=100),
-    projects: Optional[str] = None,
-    tag: Optional[str] = None,
-    timeout: float = Query(10.0, gt=0.0, le=30.0),
-    no_fallback_sql: bool = False,
-    _tok: dict = Depends(require_scopes("videos_read")),
-):
-    try:
-        payload = federation.search_all_projects(
-            q,
-            limit=limit,
-            per_project_limit=per_project_limit,
-            project_names=_split_csv(projects),
-            tag=tag,
-            timeout=timeout,
-            fallback_sql=not no_fallback_sql,
-        )
-    except project_registry.RegistryError as exc:
-        raise HTTPException(status_code=500, detail=str(exc))
-
-    # Phase 16.2: federation results carry absolute media + project paths; strip
-    # them at the API boundary so a videos_read client can't map the operator's
-    # cross-project directory layout. project_path is reduced to its folder
-    # basename; the internal absolute_path / relative_path fields are dropped so
-    # only the sanitized `path` survives.
-    def _basename_only(value):
-        return _basename_safe(value)
-
-    for item in payload.get("items", []) or []:
-        # Route relative_path through _display_path FIRST: for an out-of-root row
-        # federation's relative_path is actually the *absolute* path (it falls
-        # back to str(stored) when relative_to() fails), so it must be basenamed,
-        # never copied through. Then drop the internal absolute/relative fields —
-        # leaving relative_path in place was the residual leak this closes.
-        chosen = item.get("relative_path")
-        if chosen is None:
-            chosen = item.get("path") or ""
-        item["path"] = _display_path(chosen)
-        item.pop("absolute_path", None)
-        item.pop("relative_path", None)
-        if item.get("project_path"):
-            item["project_path"] = _basename_only(item["project_path"])
-
-    # Errors carry the absolute project_path on timeout / preflight failure
-    # (federation sets project_path=str(project.path)); a failed project must not
-    # leak its absolute root either.
-    for err in payload.get("errors", []) or []:
-        if err.get("project_path"):
-            err["project_path"] = _basename_only(err["project_path"])
-
-    status_code = 200
-    if payload.get("projects_queried") and payload.get("projects_failed", 0) >= payload.get("projects_queried", 0):
-        status_code = 207
-    return JSONResponse(content=payload, status_code=status_code)
+# The /api/search/all (federated) + /api/search/query (structured) routes, with
+# StructuredQuery / _structured_sort_key / _split_csv, moved to routers/search.py
+# (R5-25 / #51), mounted via app.include_router below. The shared bulk-fetch
+# helpers live in mediarecords.py; path sanitisation in pathres.py.
 
 
 # _project_paths_visible / _sanitize_project_paths + the 5 /api/projects handlers
@@ -404,102 +343,6 @@ def search_all(
 # semantic/SQL search branches) — moved to routers/media.py (R5-25 / #51), mounted
 # via app.include_router above. _VIDEO_EXTS/_AUDIO_EXTS (re-derived from mediatypes
 # there) and the shared bulk-fetch helpers (now mediarecords.py) went with them.
-
-
-class StructuredQuery(BaseModel):
-    # Phase 9.7 G6: structured query — AND/OR over typed field conditions, with
-    # an optional semantic (vector) leg. `conditions` is validated by
-    # query_builder.compile_spec; we keep the model permissive and let the
-    # builder raise the precise error.
-    match: str = "all"
-    conditions: List[dict]
-    limit: int = 50
-    offset: int = 0
-    sort: str = "date"
-
-
-def _structured_sort_key(sort: str):
-    if sort == "duration":
-        return lambda r: (r.get("duration_s") or 0), True
-    if sort == "size":
-        return lambda r: (r.get("size_mb") or 0), True
-    if sort == "name":
-        return lambda r: (r.get("filename") or "").lower(), False
-    # default: most recent first
-    return lambda r: (r.get("processed_at") or ""), True
-
-
-@app.post("/api/search/query")
-def structured_query(
-    body: StructuredQuery,
-    _tok: dict = Depends(require_scopes("videos_read")),
-):
-    """Structured query: typed field conditions combined by AND/OR, with an
-    optional semantic leg run through the vector index. Returns the same
-    `{items, total, search}` shape as /api/media so the UI can reuse renderers."""
-    import query_builder
-
-    try:
-        compiled = query_builder.compile_spec(
-            {"match": body.match, "conditions": body.conditions}
-        )
-    except query_builder.QueryError as exc:
-        raise HTTPException(status_code=422, detail=str(exc))
-
-    where, params = compiled["where"], compiled["params"]
-    terms, match = compiled["semantic_terms"], compiled["match"]
-    warning = None
-
-    sql_ids = None
-    if where:
-        with db.get_conn() as conn:
-            rows = conn.execute(
-                "SELECT id FROM media WHERE " + where, params
-            ).fetchall()
-        sql_ids = {r["id"] for r in rows}
-
-    sem_ids = None
-    if terms:
-        import vectordb as vdb
-        sets = []
-        for term in terms:
-            try:
-                raw = vdb.search(term, n_results=2000)
-                sets.append({int(r["media_id"]) for r in raw})
-            except Exception as exc:  # Ollama down / dim mismatch → degrade, flag it
-                _logging.getLogger(__name__).warning(
-                    "structured query semantic leg failed: %s", exc
-                )
-                warning = "semantic search unavailable (some terms ignored)"
-                sets.append(set())
-        if sets:
-            sem_ids = set.intersection(*sets) if match == "all" else set.union(*sets)
-
-    if sql_ids is not None and sem_ids is not None:
-        final_ids = (sql_ids & sem_ids) if match == "all" else (sql_ids | sem_ids)
-    elif sql_ids is not None:
-        final_ids = sql_ids
-    else:
-        final_ids = sem_ids or set()
-
-    records = _get_light_records_by_ids(list(final_ids))
-    keyfn, reverse = _structured_sort_key(body.sort)
-    records.sort(key=keyfn, reverse=reverse)
-
-    total = len(records)
-    offset = max(0, body.offset)
-    limit = max(1, min(500, body.limit))
-    items = records[offset:offset + limit]
-    tags_by_id = _get_tags_bulk([rec["id"] for rec in items])
-    for rec in items:
-        _resolve_record(rec)
-        rec["tags"] = tags_by_id.get(rec["id"], [])
-
-    resp = {"items": items, "total": total, "search": True, "structured": True}
-    if warning:
-        resp["search_degraded"] = True
-        resp["warning"] = warning
-    return resp
 
 
 # get_media_detail + the per-clip sub-resources (waveform/scenes/chapters/rating/

--- a/tests/test_r5_25_router_chat.py
+++ b/tests/test_r5_25_router_chat.py
@@ -55,8 +55,11 @@ def test_server_no_longer_defines_chat_handlers():
     assert "def _chat_owner_filter" not in src
     assert not re.search(r"@app\.(get|post)\(\"/api/chat", src)
     assert "include_router(chat_router)" in src
-    # _split_csv (used by search) must NOT have been dragged along
-    assert "def _split_csv" in src
+    # _split_csv (used by search) must NOT have been dragged into the chat router;
+    # it later moved to routers/search.py with /api/search/all (R5-25 search peel).
+    import routers.search
+    assert hasattr(routers.search, "_split_csv")
+    assert "def _split_csv" not in src
 
 
 def test_chat_routes_mounted_and_auth_guarded(server_module):

--- a/tests/test_r5_25_router_search.py
+++ b/tests/test_r5_25_router_search.py
@@ -1,0 +1,78 @@
+"""R5-25 (round-5 #51): search routes peeled to routers/search.py.
+
+Fifteenth router peeled. Pins the split: the leaf module owns /api/search/all
+(federated) + /api/search/query (structured) with StructuredQuery /
+_structured_sort_key / _split_csv, server.py no longer defines them, routes mounted
++ auth-guarded (401-not-404). The two share the mediarecords bulk-fetch helpers
+(same instance) with the media group. Federation path-sanitisation + structured
+query behaviour are covered by test_server.py / test_federation.py.
+"""
+import pathlib
+import re
+
+from starlette.testclient import TestClient
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def test_search_router_is_a_leaf_module():
+    src = (_ROOT / "routers" / "search.py").read_text(encoding="utf-8")
+    assert not re.search(r"^\s*import\s+server\b", src, re.M)
+    assert not re.search(r"^\s*from\s+server\b", src, re.M)
+
+
+def test_router_owns_search_routes_and_helpers():
+    import routers.search as rs
+    pairs = {
+        (r.path, m)
+        for r in rs.router.routes
+        for m in r.methods
+        if m != "HEAD"
+    }
+    assert pairs == {
+        ("/api/search/all", "GET"),
+        ("/api/search/query", "POST"),
+    }
+    for name in ("search_all", "structured_query", "StructuredQuery",
+                 "_structured_sort_key", "_split_csv"):
+        assert hasattr(rs, name)
+
+
+def test_split_csv_semantics():
+    import routers.search as rs
+    assert rs._split_csv(None) is None
+    assert rs._split_csv("") is None
+    assert rs._split_csv(" , ,") is None          # only blanks → None
+    assert rs._split_csv("a, b ,c") == ["a", "b", "c"]
+
+
+def test_structured_sort_key_directions():
+    import routers.search as rs
+    _, rev = rs._structured_sort_key("duration")
+    assert rev is True
+    keyfn, rev = rs._structured_sort_key("name")
+    assert rev is False
+    assert keyfn({"filename": "ABC.mp4"}) == "abc.mp4"
+
+
+def test_router_shares_mediarecords_helpers_by_identity():
+    import routers.search as rs
+    import mediarecords
+    assert rs._get_light_records_by_ids is mediarecords._get_light_records_by_ids
+    assert rs._get_tags_bulk is mediarecords._get_tags_bulk
+
+
+def test_server_no_longer_defines_search_handlers():
+    src = (_ROOT / "server.py").read_text(encoding="utf-8")
+    assert "def search_all" not in src
+    assert "def structured_query" not in src
+    assert "class StructuredQuery" not in src
+    assert not re.search(r"@app\.(get|post)\(\"/api/search", src)
+    assert "include_router(search_router)" in src
+
+
+def test_search_routes_mounted_and_auth_guarded(server_module):
+    with TestClient(server_module.app) as c:
+        assert c.get("/api/search/all", params={"q": "x"}).status_code == 401
+        assert c.post("/api/search/query", json={"conditions": []}).status_code == 401
+        assert c.get("/api/search/nope-zz").status_code == 404


### PR DESCRIPTION
## R5-25 router split — PR26 (search)

Fifteenth router peeled out of the `server.py` monolith (`#51`, round-5 fable hardening audit).

Moves the two search surfaces into a leaf `routers/search.py`:
- `GET /api/search/all` — cross-project federated semantic search (`federation.py`) + the Phase 16.2 API-boundary path sanitisation (a `videos_read` client can't map the operator's cross-project directory layout)
- `POST /api/search/query` — structured query: typed field conditions AND/OR-combined via `query_builder` + an optional semantic (vector) leg, returning the same `{items,total,search}` shape as `/api/media`

Moved with them: `StructuredQuery`, `_structured_sort_key`, and `_split_csv` (its only caller is `search_all`). The bulk-fetch helpers (`_get_light_records_by_ids` / `_get_tags_bulk`) shared with the media group are imported from `mediarecords.py` (the ONE shared instance); path sanitisation from `pathres.py`.

**Behaviour-preserving**: paths/methods/scopes unchanged → SPA + CLI unaffected. `server.py` 1068 → 911.

### Tests
- New `tests/test_r5_25_router_search.py`: leaf-ness, route ownership, `_split_csv`/`_structured_sort_key` semantics, mediarecords shared-helper identity, server-no-longer-defines, mounted + auth-guarded (401-not-404).
- Route-level `test_server.py` + `test_federation.py` unaffected (they patch the `federation` module, which the router reads). Chat-peel guard updated (`_split_csv` moved here).
- Full suite green locally: **919 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)