### PR TITLE
feat(vectordb): optional pgvector backend (shared NAS store) — chroma stays default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@
 # ARKIV_EMBED_MODEL=bge-m3                 # Embedding model name (default bge-m3, multilingual 1024-dim)
 # ARKIV_VISION_MODEL=qwen3-vl:8b           # Vision model for frame analysis
 
+# ── Vector backend ─────────────────────────────────────────
+# ARKIV_VECTOR_BACKEND=chroma              # "chroma" (default, local ChromaDB) or "pg" (shared pgvector)
+# ARKIV_PG_DSN=postgresql://rag:PASSWORD@host:5433/rag   # required when backend=pg; carries the password (keep out of git)
+#   pip install 'psycopg[binary]>=3.1'     # extra dep, only needed for the pg backend
+
 # ── Whisper ────────────────────────────────────────────────
 # macOS Apple Silicon default: mlx-community/whisper-large-v3-turbo
 # Docker / NVIDIA / CPU: large-v3-turbo (faster-whisper format)

--- a/config.py
+++ b/config.py
@@ -481,3 +481,21 @@ def discover_projects():
 
 COLLECTION_NAME = "media_assets"
 EMBED_DIM = 1024  # bge-m3 default; informational only — ChromaDB infers dim from first vector
+
+# ── Vector backend selection (向量庫整併 / pgvector consolidation) ──────────────
+# "chroma" (default) = per-install ChromaDB at CHROMA_PATH — existing behavior,
+# fully non-breaking. "pg" = shared NAS pgvector-rag store (24/7 always-on),
+# letting arkiv/media/OpenClaw converge onto one vector DB instead of scattered
+# per-machine chroma dirs. DSN carries the password — supply it via env, never
+# hardcode. Fails loud at import if pg is selected without a DSN.
+VECTOR_BACKEND = os.getenv("ARKIV_VECTOR_BACKEND", "chroma").strip().lower()
+if VECTOR_BACKEND not in ("chroma", "pg"):
+    raise ValueError(
+        f"ARKIV_VECTOR_BACKEND must be 'chroma' or 'pg', got {VECTOR_BACKEND!r}"
+    )
+ARKIV_PG_DSN = os.getenv("ARKIV_PG_DSN", "").strip()
+if VECTOR_BACKEND == "pg" and not ARKIV_PG_DSN:
+    raise ValueError(
+        "ARKIV_VECTOR_BACKEND=pg requires ARKIV_PG_DSN "
+        "(e.g. postgresql://rag:PASSWORD@100.64.154.6:5433/rag)"
+    )

--- a/pgvector_backend.py
+++ b/pgvector_backend.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+"""
+pgvector backend for vectordb.py — a drop-in ``PgCollection`` that mimics the
+subset of the ChromaDB collection API that :mod:`vectordb` actually uses
+(``metadata`` / ``count`` / ``get`` / ``upsert`` / ``delete`` / ``query``), so
+switching ``ARKIV_VECTOR_BACKEND=pg`` reroutes every caller to a shared
+Postgres + pgvector/VectorChord store **without touching a single call site**.
+
+Why a shim and not a rewrite: all 7 callers go through ``vectordb.*`` functions
+that pass a ``col`` object around. Matching Chroma's method signatures + return
+shapes (nested ``[[...]]`` query results, cosine *distance* in ``distances``)
+keeps ``upsert_record`` / ``search`` / ``find_similar`` / ``_process_query_results``
+byte-for-byte unchanged. Chroma stays the default; this file is only imported
+when the pg backend is selected, so ``psycopg`` is an optional dependency.
+
+Storage model: one wide table per embedding dimension (``emb_1024`` for bge-m3),
+rows tagged by ``collection`` (arkiv → ``media_assets``) so multiple apps can
+share the same store without colliding. ``payload`` (jsonb) holds the same
+metadata dict Chroma stored per chunk; ``doc_id`` is Chroma's id (``{mid}_t{i}``);
+``(collection, doc_id)`` is unique so upsert is idempotent.
+"""
+import json
+from typing import Any, Dict, List, Optional
+
+
+def _vec_literal(vec) -> str:
+    """pgvector text input format: ``[0.1,0.2,...]``. Full float precision so a
+    round-trip through the DB reproduces the source vector."""
+    return "[" + ",".join(str(float(x)) for x in vec) + "]"
+
+
+def _parse_vec(text: str) -> List[float]:
+    """``embedding::text`` comes back as a JSON-shaped array string."""
+    return [float(x) for x in json.loads(text)]
+
+
+class PgCollection:
+    """Chroma-collection look-alike backed by Postgres + pgvector.
+
+    Only the methods/attrs :mod:`vectordb` touches are implemented. Distances
+    use the ``<=>`` cosine-distance operator, matching Chroma's ``hnsw:space=cosine``
+    so downstream ``score = 1 - dist`` is identical.
+    """
+
+    def __init__(self, dsn: str, dim: int, model: str, collection: str,
+                 table: Optional[str] = None):
+        import psycopg  # optional dep — only needed for the pg backend
+        self._psycopg = psycopg
+        self.dsn = dsn
+        self.dim = int(dim)
+        self.collection = collection
+        # table name derived from dim (int → safe to interpolate); shared store
+        # keeps one table per embedding space (emb_1024 for bge-m3).
+        self.table = table or f"emb_{self.dim}"
+        # Stamp mirrors the Chroma metadata so vectordb._assert_collection_compatible
+        # takes the fast stamped-match path (no legacy dimension probe).
+        self.metadata = {"hnsw:space": "cosine", "embed_model": model, "embed_dim": self.dim}
+        self._ensure_schema()
+
+    # ── connection / schema ────────────────────────────────────────────────
+    def _connect(self):
+        return self._psycopg.connect(self.dsn)
+
+    def _ensure_schema(self) -> None:
+        """Idempotent DDL so a fresh (vchord-enabled) pg works out of the box.
+        No-op against the already-provisioned NAS store. The unique index is
+        what makes ``ON CONFLICT (collection, doc_id)`` a real upsert."""
+        ddl = f"""
+        CREATE TABLE IF NOT EXISTS {self.table} (
+            id         bigserial PRIMARY KEY,
+            collection text NOT NULL,
+            namespace  text,
+            doc_id     text,
+            content    text,
+            payload    jsonb,
+            embedding  vector({self.dim}),
+            created_at timestamptz DEFAULT now()
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_{self.table}_coll_docid
+            ON {self.table} (collection, doc_id);
+        CREATE INDEX IF NOT EXISTS ix_{self.table}_coll
+            ON {self.table} (collection);
+        """
+        with self._connect() as conn, conn.cursor() as cur:
+            cur.execute(ddl)
+            conn.commit()
+
+    def reset(self) -> None:
+        """Drop every row for this collection (Chroma ``reset=True`` analogue).
+        Scoped to ``collection`` — never touches other apps' rows in the table."""
+        with self._connect() as conn, conn.cursor() as cur:
+            cur.execute(f"DELETE FROM {self.table} WHERE collection = %s", (self.collection,))
+            conn.commit()
+
+    # ── Chroma-collection API subset ───────────────────────────────────────
+    def count(self) -> int:
+        with self._connect() as conn, conn.cursor() as cur:
+            cur.execute(f"SELECT count(*) FROM {self.table} WHERE collection = %s",
+                        (self.collection,))
+            return int(cur.fetchone()[0])
+
+    def upsert(self, ids, embeddings, documents, metadatas) -> None:
+        rows = []
+        for i in range(len(ids)):
+            meta = metadatas[i] or {}
+            rows.append((
+                self.collection,
+                (meta.get("project_name") or None),
+                ids[i],
+                documents[i],
+                json.dumps(meta, ensure_ascii=False),
+                _vec_literal(embeddings[i]),
+            ))
+        sql = f"""
+            INSERT INTO {self.table}
+                (collection, namespace, doc_id, content, payload, embedding)
+            VALUES (%s, %s, %s, %s, %s::jsonb, %s::vector)
+            ON CONFLICT (collection, doc_id) DO UPDATE SET
+                namespace = EXCLUDED.namespace,
+                content   = EXCLUDED.content,
+                payload   = EXCLUDED.payload,
+                embedding = EXCLUDED.embedding
+        """
+        with self._connect() as conn, conn.cursor() as cur:
+            cur.executemany(sql, rows)
+            conn.commit()
+
+    def delete(self, where: Optional[Dict[str, Any]] = None, **_) -> None:
+        where = where or {}
+        mid = where.get("media_id")
+        if mid is None:  # vectordb only ever deletes by media_id
+            return
+        with self._connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                f"DELETE FROM {self.table} "
+                f"WHERE collection = %s AND payload->>'media_id' = %s",
+                (self.collection, str(mid)),
+            )
+            conn.commit()
+
+    def get(self, where: Optional[Dict[str, Any]] = None,
+            include: Optional[List[str]] = None,
+            limit: Optional[int] = None, **_) -> Dict[str, Any]:
+        """Returns ``{"ids": [...], "embeddings": [[...], ...]}`` — the shape
+        ``find_similar`` / the legacy compat probe read. Ordered by ``doc_id`` so
+        ``limit=1`` deterministically picks a media's first chunk."""
+        where = where or {}
+        clauses = ["collection = %s"]
+        params: List[Any] = [self.collection]
+        if "media_id" in where:
+            clauses.append("payload->>'media_id' = %s")
+            params.append(str(where["media_id"]))
+        sql = (f"SELECT doc_id, embedding::text FROM {self.table} "
+               f"WHERE {' AND '.join(clauses)} ORDER BY doc_id")
+        if limit:
+            sql += f" LIMIT {int(limit)}"
+        with self._connect() as conn, conn.cursor() as cur:
+            cur.execute(sql, params)
+            fetched = cur.fetchall()
+        return {
+            "ids": [r[0] for r in fetched],
+            "embeddings": [_parse_vec(r[1]) for r in fetched],
+        }
+
+    def query(self, query_embeddings, n_results: int = 10,
+              include: Optional[List[str]] = None,
+              where: Optional[Dict[str, Any]] = None, **_) -> Dict[str, Any]:
+        """kNN by cosine distance. ``query_embeddings`` is a list of vectors
+        (vectordb always passes exactly one); results are wrapped one level deep
+        (``[[...]]``) to match Chroma's per-query nesting."""
+        qlit = _vec_literal(query_embeddings[0])
+        clauses = ["collection = %s"]
+        where_params: List[Any] = [self.collection]
+        if where and "project_name" in where:
+            pn = where["project_name"]
+            scope = pn.get("$in") if isinstance(pn, dict) else [pn]
+            clauses.append("payload->>'project_name' = ANY(%s)")
+            where_params.append(list(scope))
+        sql = (
+            f"SELECT content, payload, embedding <=> %s::vector AS dist "
+            f"FROM {self.table} WHERE {' AND '.join(clauses)} "
+            f"ORDER BY embedding <=> %s::vector LIMIT %s"
+        )
+        params = [qlit] + where_params + [qlit, int(n_results)]
+        with self._connect() as conn, conn.cursor() as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+        return {
+            "documents": [[r[0] for r in rows]],
+            "metadatas": [[r[1] for r in rows]],
+            "distances": [[float(r[2]) for r in rows]],
+        }

--- a/pgvector_backend.py
+++ b/pgvector_backend.py
@@ -44,7 +44,18 @@ class PgCollection:
 
     def __init__(self, dsn: str, dim: int, model: str, collection: str,
                  table: Optional[str] = None):
-        import psycopg  # optional dep — only needed for the pg backend
+        # psycopg is an optional dependency — only the pg backend needs it, so it
+        # is NOT in the base requirements. Guard the import (arkiv's optional-dep
+        # convention, cf. health.py's `import mlx`) so a fresh chroma-only install
+        # never imports it, and give an actionable message if pg is selected
+        # without it installed.
+        try:
+            import psycopg
+        except ImportError as exc:
+            raise ImportError(
+                "ARKIV_VECTOR_BACKEND=pg needs psycopg — install it with: "
+                "pip install 'psycopg[binary]>=3.1'"
+            ) from exc
         self._psycopg = psycopg
         self.dsn = dsn
         self.dim = int(dim)

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,12 @@ mlx-whisper>=0.4;platform_system=="Darwin"
 # still supports 3.9 (NAS), where an unconditional entry would break pip install.
 mcp>=1.2; python_version >= "3.10"
 
+# ── Shared pgvector backend (向量庫整併) — install manually if needed ──────
+# Only needed when ARKIV_VECTOR_BACKEND=pg (route vectors to the shared NAS
+# pgvector-rag store instead of a local ChromaDB). The default "chroma" backend
+# never imports psycopg, so it stays out of the base install:
+#   pip install 'psycopg[binary]>=3.1'
+
 # ── CUDA / GPU support (install manually if needed) ──────
 # torch>=2.0              # Required for CUDA Whisper; skip on macOS (MLX)
 

--- a/tests/test_vectordb_pg.py
+++ b/tests/test_vectordb_pg.py
@@ -1,0 +1,232 @@
+"""Tests for the pgvector backend (pgvector_backend.PgCollection).
+
+Three layers, from cheapest to most real:
+  1. Pure helpers (_vec_literal / _parse_vec) — vector text round-trip.
+  2. Fake-connection tests — construct PgCollection against an in-memory fake
+     psycopg, asserting the SQL it emits and that query()/get() return the exact
+     Chroma-collection shapes vectordb.py downstream code depends on. No DB, no
+     psycopg install required, so these run everywhere.
+  3. Live round-trip — only when ARKIV_PG_DSN points at a real vchord pg;
+     skipped otherwise. Proves upsert → count → query → delete end to end.
+"""
+import importlib
+import os
+import sys
+import types
+
+import pytest
+
+
+# ── layer 1: pure helpers ──────────────────────────────────────────────────
+def test_vec_literal_and_parse_roundtrip():
+    pgb = importlib.import_module("pgvector_backend")
+    vec = [0.0, -1.0166817903518677, 3.5, 2e-8]
+    lit = pgb._vec_literal(vec)
+    assert lit.startswith("[") and lit.endswith("]")
+    back = pgb._parse_vec(lit)
+    assert len(back) == len(vec)
+    for a, b in zip(back, vec):
+        assert a == pytest.approx(b)
+
+
+# ── layer 2: fake-connection wiring ─────────────────────────────────────────
+class _Rec:
+    """Shared recorder: captures executed (sql, params) and doles out canned
+    fetch results in call order."""
+    def __init__(self):
+        self.execs = []
+        self.fetchone_vals = []
+        self.fetchall_vals = []
+
+
+class _Cur:
+    def __init__(self, rec):
+        self.rec = rec
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def execute(self, sql, params=None):
+        self.rec.execs.append((sql, params))
+
+    def executemany(self, sql, rows):
+        self.rec.execs.append((sql, list(rows)))
+
+    def fetchone(self):
+        return self.rec.fetchone_vals.pop(0)
+
+    def fetchall(self):
+        return self.rec.fetchall_vals.pop(0)
+
+    def commit(self):
+        pass
+
+
+class _Conn:
+    def __init__(self, rec):
+        self.rec = rec
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def cursor(self):
+        return _Cur(self.rec)
+
+    def commit(self):
+        pass
+
+
+def _fake_psycopg(rec):
+    mod = types.ModuleType("psycopg")
+    mod.connect = lambda dsn: _Conn(rec)
+    return mod
+
+
+@pytest.fixture
+def pg_col(monkeypatch):
+    """A PgCollection wired to a fresh recorder + fake psycopg. Returns
+    (collection, recorder). __init__ runs the idempotent DDL, so exec[0] is the
+    schema statement."""
+    rec = _Rec()
+    monkeypatch.setitem(sys.modules, "psycopg", _fake_psycopg(rec))
+    pgb = importlib.import_module("pgvector_backend")
+    col = pgb.PgCollection(
+        dsn="postgresql://rag@localhost:5433/rag",
+        dim=1024, model="bge-m3", collection="media_assets",
+    )
+    return col, rec
+
+
+def test_init_stamps_metadata_and_runs_ddl(pg_col):
+    col, rec = pg_col
+    # stamp mirrors Chroma so vectordb._assert_collection_compatible fast-paths
+    assert col.metadata["embed_model"] == "bge-m3"
+    assert col.metadata["embed_dim"] == 1024
+    assert col.metadata["hnsw:space"] == "cosine"
+    assert col.table == "emb_1024"
+    ddl_sql = rec.execs[0][0]
+    assert "CREATE TABLE IF NOT EXISTS emb_1024" in ddl_sql
+    assert "UNIQUE INDEX" in ddl_sql and "(collection, doc_id)" in ddl_sql
+
+
+def test_count_scopes_by_collection(pg_col):
+    col, rec = pg_col
+    rec.fetchone_vals.append((7,))
+    assert col.count() == 7
+    sql, params = rec.execs[-1]
+    assert "count(*)" in sql and "collection = %s" in sql
+    assert params == ("media_assets",)
+
+
+def test_upsert_uses_on_conflict_and_payload(pg_col):
+    col, rec = pg_col
+    col.upsert(
+        ids=["12_t0"],
+        embeddings=[[0.1, 0.2, 0.3]],
+        documents=["hello"],
+        metadatas=[{"media_id": "12", "project_name": "demo", "filename": "a.mp4"}],
+    )
+    sql, rows = rec.execs[-1]
+    assert "INSERT INTO emb_1024" in sql
+    assert "ON CONFLICT (collection, doc_id) DO UPDATE" in sql
+    assert len(rows) == 1
+    coll, ns, doc_id, content, payload_json, emb_lit = rows[0]
+    assert coll == "media_assets"
+    assert ns == "demo"           # namespace derived from project_name
+    assert doc_id == "12_t0"
+    assert content == "hello"
+    assert '"media_id": "12"' in payload_json
+    assert emb_lit == "[0.1,0.2,0.3]"
+
+
+def test_delete_scopes_by_media_id(pg_col):
+    col, rec = pg_col
+    col.delete(where={"media_id": "12"})
+    sql, params = rec.execs[-1]
+    assert "DELETE FROM emb_1024" in sql
+    assert "payload->>'media_id' = %s" in sql
+    assert params == ("media_assets", "12")
+
+
+def test_delete_without_media_id_is_noop(pg_col):
+    col, rec = pg_col
+    before = len(rec.execs)
+    col.delete(where={})
+    assert len(rec.execs) == before  # emitted no SQL
+
+
+def test_query_returns_chroma_nested_shape(pg_col):
+    col, rec = pg_col
+    # two candidate rows: (content, payload dict, distance)
+    rec.fetchall_vals.append([
+        ("doc one", {"media_id": "1", "filename": "a.mp4"}, 0.10),
+        ("doc two", {"media_id": "2", "filename": "b.mp4"}, 0.42),
+    ])
+    raw = col.query([[0.1, 0.2, 0.3]], n_results=5)
+    # Chroma wraps each field one level deep (per-query list)
+    assert raw["documents"] == [["doc one", "doc two"]]
+    assert raw["metadatas"][0][0]["media_id"] == "1"
+    assert raw["distances"] == [[0.10, 0.42]]
+    sql, params = rec.execs[-1]
+    assert "embedding <=> %s::vector" in sql
+    assert "ORDER BY embedding <=> %s::vector" in sql
+    assert params[-1] == 5  # LIMIT n_results
+
+
+def test_query_applies_project_scope(pg_col):
+    col, rec = pg_col
+    rec.fetchall_vals.append([])
+    col.query([[0.1]], n_results=3, where={"project_name": {"$in": ["p1", "p2"]}})
+    sql, params = rec.execs[-1]
+    assert "payload->>'project_name' = ANY(%s)" in sql
+    assert ["p1", "p2"] in params
+
+
+def test_get_returns_ids_and_embeddings(pg_col):
+    col, rec = pg_col
+    rec.fetchall_vals.append([("1_t0", "[0.5,0.6]")])
+    out = col.get(where={"media_id": "1"}, include=["embeddings"], limit=1)
+    assert out["ids"] == ["1_t0"]
+    assert out["embeddings"] == [[0.5, 0.6]]
+    sql, params = rec.execs[-1]
+    assert "payload->>'media_id' = %s" in sql
+    assert "LIMIT 1" in sql
+
+
+# ── layer 3: live round-trip (skipped without a real pg) ────────────────────
+_DSN = os.getenv("ARKIV_PG_DSN")
+
+
+@pytest.mark.skipif(not _DSN, reason="ARKIV_PG_DSN not set — no live pgvector store")
+def test_live_roundtrip():
+    pytest.importorskip("psycopg")
+    pgb = importlib.import_module("pgvector_backend")
+    # isolate on a throwaway collection so we never touch real media_assets rows
+    col = pgb.PgCollection(_DSN, dim=1024, model="bge-m3",
+                           collection="__pytest_roundtrip__")
+    col.reset()
+    vec = [0.0] * 1024
+    vec[0] = 1.0
+    col.upsert(
+        ids=["99_t0"],
+        embeddings=[vec],
+        documents=["round trip doc"],
+        metadatas=[{"media_id": "99", "filename": "rt.mp4", "project_name": "pytest"}],
+    )
+    try:
+        assert col.count() == 1
+        raw = col.query([vec], n_results=1)
+        assert raw["documents"][0][0] == "round trip doc"
+        assert raw["distances"][0][0] == pytest.approx(0.0, abs=1e-4)  # self match
+        got = col.get(where={"media_id": "99"}, include=["embeddings"], limit=1)
+        assert got["embeddings"][0][0] == pytest.approx(1.0)
+        col.delete(where={"media_id": "99"})
+        assert col.count() == 0
+    finally:
+        col.reset()

--- a/vectordb.py
+++ b/vectordb.py
@@ -11,7 +11,15 @@ from typing import Any, Dict, List, Optional
 
 import chromadb
 
-from config import CHROMA_PATH, COLLECTION_NAME, EMBED_DIM, EMBED_MODEL, OLLAMA_URL
+from config import (
+    ARKIV_PG_DSN,
+    CHROMA_PATH,
+    COLLECTION_NAME,
+    EMBED_DIM,
+    EMBED_MODEL,
+    OLLAMA_URL,
+    VECTOR_BACKEND,
+)
 from llm import embed
 
 OLLAMA_EMBED_URL = f"{OLLAMA_URL}/api/embeddings"
@@ -206,6 +214,18 @@ def clear_client_cache():
 
 
 def get_collection(reset: bool = False):
+    if VECTOR_BACKEND == "pg":
+        # Shared NAS pgvector store. PgCollection mimics the Chroma collection
+        # API used here, so every caller downstream is unchanged. Its metadata is
+        # stamped with the active model/dim → _assert_collection_compatible takes
+        # the fast match path without a DB probe.
+        from pgvector_backend import PgCollection
+        col = PgCollection(ARKIV_PG_DSN, EMBED_DIM, EMBED_MODEL, COLLECTION_NAME)
+        if reset:
+            col.reset()
+        _assert_collection_compatible(col)
+        return col
+
     with _CHROMA_LOCK:  # audit M11
         client = chromadb.PersistentClient(path=str(CHROMA_PATH))
         if reset:


### PR DESCRIPTION
## 為什麼

向量庫整併：把散在各機（PC / M2Max / mini 各自 per-install ChromaDB）的向量收斂到一個 24/7 always-on 的共用 NAS pgvector-rag 庫（Postgres 14 + VectorChord）。本 PR 讓 arkiv **可選**改寫到那個共用庫，而**不動任何 caller、不改預設行為**。

Phase 1 已把 arkiv 60 筆（media_assets, emb_1024 bge-m3）灌進 NAS 庫並驗過（vector roundtrip + KNN dist=0）；本 PR 是「讓 arkiv 本體 go-forward 也能直接讀寫那個庫」的 feature。

## 設計（最小侵入、非破壞）

`vectordb.py` 只用到 chroma collection 的 6 個介面：`metadata / count / get / upsert / delete / query`。所以做一個 **`PgCollection`（`pgvector_backend.py`）仿這個子集**，`get_collection()` 依 `VECTOR_BACKEND` 分流 —— 其餘 7 個 caller（chat/embed/federation/ingest/mcp_server/search/server）全走 `vectordb.*` 函式，**零改動**。

回傳形狀逐一對齊 chroma：
- `query` 回 `{"documents": [[...]], "metadatas": [[...]], "distances": [[...]]}`（per-query 巢狀一層）。
- `distances` 用 pgvector `<=>` cosine distance → 下游 `score = 1 - dist` 不變。
- `get` 回 `{"ids": [...], "embeddings": [[...]]}`。

儲存模型：一維度一張表（`emb_1024` for bge-m3），row 以 `collection` tag（arkiv → `media_assets`）隔離，多 app 可共用同庫；`(collection, doc_id)` unique → `INSERT ... ON CONFLICT DO UPDATE` 冪等。`_ensure_schema()` 冪等建表/索引 → 對已存在的 NAS 庫是 no-op。

## 變更

- `pgvector_backend.py` (new) — `PgCollection`：chroma-collection look-alike，psycopg backend。
- `vectordb.py` — `get_collection()` 加 `VECTOR_BACKEND=="pg"` 分支；其餘不動。
- `config.py` — `ARKIV_VECTOR_BACKEND`（預設 `chroma`）+ `ARKIV_PG_DSN`（選 pg 而缺 DSN → import 時 fail loud）。
- `requirements.txt` / `.env.example` — `psycopg[binary]` 標為選用（僅 pg backend import，手動裝）+ 新 env 說明。
- `tests/test_vectordb_pg.py` (new) — 見下。

## 測試

- **layer 1 — 純 helper**：`_vec_literal` / `_parse_vec` 向量文字 round-trip。
- **layer 2 — fake-connection**：對記憶體假 psycopg 建 `PgCollection`，斷言它送出的 SQL（`ON CONFLICT (collection, doc_id)`、`<=>`、`payload->>'project_name' = ANY(...)` scope、`payload->>'media_id'` delete）與 query/get 回傳的 chroma 形狀。**無需 DB / psycopg，處處可跑。**
- **layer 3 — live round-trip**：`ARKIV_PG_DSN` 有指真 vchord pg 才跑（upsert→count→query→delete），否則 skip；用一次性 collection 隔離、不碰真 `media_assets`。

驗證結果：
- `tests/test_vectordb_pg.py` → **9 passed, 1 skipped**（live，未設 DSN）。
- 既有 `tests/test_vectordb.py` + `tests/test_config.py` → **37 passed, 4 skipped**（chroma 預設完全非破壞）。
- NAS pg `100.64.154.6:5433` 實測 reachable。

## Cutover

預設仍 `chroma`（非破壞）。設 `ARKIV_VECTOR_BACKEND=pg` + `ARKIV_PG_DSN=...` 才走 pg。建議先在一台（M2Max）驗 ingest + search 對 pg 正常，再決定是否全 fleet 切。舊 chroma 資料不刪、additive。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
