### PR TITLE
fix(mcp): C:/ absolute paths leaked whole — share the HTTP leak guard

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, List, Optional
 import db
 import vectordb as vdb
 from mcp.server.fastmcp import FastMCP
+from pathres import _display_path
 
 # Logging goes to stderr (never stdout — stdout is the MCP stdio channel).
 LOGGER = logging.getLogger(__name__)
@@ -33,36 +34,30 @@ mcp = FastMCP("arkiv")
 
 
 # ── path safety ───────────────────────────────────────────────────────────────
-def _looks_absolute(p: str) -> bool:
-    """True for POSIX (`/x`), Windows drive (`C:\\x`), or UNC (`\\\\host`) absolutes.
-    `os.path.isabs` on a POSIX host misses the Windows forms, which would let a
-    legacy/cross-platform row leak its full path. The Windows drive form requires
-    a backslash after the colon (`C:\\`); a forward-slash `C:/x` is a POSIX
-    relative path under a dir named like a drive letter."""
-    if not p:
-        return False
-    return (
-        p.startswith("/")
-        or p.startswith("\\\\")
-        or (len(p) >= 3 and p[0].isalpha() and p[1] == ":" and p[2] == "\\")
-    )
-
-
 def _safe_path(p: Optional[str]) -> Optional[str]:
     """Return a PROJECT_ROOT-relative path, never an absolute one.
 
-    `db.to_relative` relativizes paths under PROJECT_ROOT but passes out-of-root
-    absolute paths through unchanged — which would leak the operator's directory
-    tree. Fall back to a separator-agnostic basename in that case so a response
-    can never expose an absolute path, POSIX **or** Windows/UNC (red line,
-    mirrors the HTTP API's Phase 16.2 `_display_path`).
+    Thin alias for the HTTP API's `pathres._display_path` — deliberately the SAME
+    guard object, not a same-looking copy. Both do: `db.to_relative`, and if the
+    result is still absolute (out-of-root legacy row) fall back to a
+    separator-agnostic basename, so a response can never expose the operator's
+    directory tree — POSIX, Windows **or** UNC. Red line for this server (see the
+    module docstring).
+
+    This module carried its own copy from 2026-06-08 (a9c0838) because the logic
+    lived in `server.py`, and importing that here would drag in the whole FastAPI
+    app — there was nowhere to share from. R5-25 / round-5 #51 extracted it to the
+    `pathres` leaf (70490fa, 2026-07-13), which is what finally makes one guard
+    possible. And the copy had already drifted: it kept Codex round-1's reading
+    that `C:/x` is a POSIX relative path under a drive-letter-named dir, while
+    round-2 (fc35b8f, four hours later the same day) overruled that — "a Unix
+    media dir literally named 'C:' is pathological… no-leak wins" — and treated
+    `C:/` as a Windows absolute. That correction landed in `server.py` only and
+    never reached here, so `C:/Users/me/x.mov` leaked whole over MCP for 38 days:
+    on the one surface whose stated red line is "no absolute-path leak", and the
+    only one facing untrusted downstream agents.
     """
-    if not p:
-        return p
-    rel = db.to_relative(p)
-    if _looks_absolute(rel):
-        return rel.replace("\\", "/").rstrip("/").rsplit("/", 1)[-1]
-    return rel
+    return _display_path(p)
 
 
 # ── shaping ───────────────────────────────────────────────────────────────────

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5,6 +5,8 @@ exercise the impl functions (the testable core) plus the path-safety red line
 and the JSON tool wrappers.
 """
 import json
+import pathlib
+import re
 
 import pytest
 
@@ -200,8 +202,51 @@ def test_safe_path_windows_and_unc_absolute(monkeypatch):
     monkeypatch.setattr(db, "to_relative", lambda p: p)  # passthrough (out-of-root)
     assert m._safe_path("C:\\Users\\me\\footage\\x.mov") == "x.mov"
     assert m._safe_path("\\\\nas\\share\\clip.mov") == "clip.mov"
-    # forward-slash drive-like dir is a POSIX relative path — preserved
-    assert m._safe_path("C:/camera/clip.mov") == "C:/camera/clip.mov"
+    # `C:/` is a Windows absolute too, and must basename like every other absolute.
+    # This asserted the exact opposite until 2026-07-16: Codex round-1 read `C:/x`
+    # as a POSIX relative path under a drive-letter-named dir and preserved it.
+    # Round-2 (fc35b8f, four hours later) overruled that — "a Unix media dir
+    # literally named 'C:' is pathological… no-leak wins" — but only patched
+    # server.py, so this surface kept leaking `C:/…` whole. See _safe_path's
+    # docstring; the guard is now shared with the HTTP API rather than copied.
+    assert m._safe_path("C:/camera/clip.mov") == "clip.mov"
+
+
+def test_safe_path_is_the_http_guard_not_a_copy(monkeypatch):
+    """Anti-fork pin: the MCP leak guard IS pathres._display_path, not a twin.
+
+    The 38-day `C:/` leak happened because this module had to inline its own copy
+    (the logic lived in server.py, which mcp_server must not import) and the copy
+    missed a later fix to the original. pathres exists now, so there is no reason
+    for a second implementation — and an "inline it to avoid the import" change
+    would silently reopen exactly that drift. Assert parity across the whole
+    input space, not just the case that broke.
+    """
+    import pathres
+
+    monkeypatch.setattr(db, "to_relative", lambda p: p)  # passthrough (out-of-root)
+    for p in (
+        "/abs/posix/x.mov",
+        "C:\\Users\\me\\x.mov",
+        "C:/Users/me/x.mov",
+        "\\\\nas\\share\\x.mov",
+        "footage/clip.mov",
+        "clip.mov",
+        "",
+        None,
+    ):
+        assert m._safe_path(p) == pathres._display_path(p), p
+
+
+def test_mcp_carries_no_second_leak_guard():
+    """Source-level twin of the test above — catches a re-inlined copy even if it
+    is behaviourally identical *on the day it lands* (which the 6/08 copy was).
+    Same idiom as the R5-25 leaf tests: read the source, never import-and-inspect.
+    """
+    src = (pathlib.Path(__file__).resolve().parent.parent / "mcp_server.py").read_text(
+        encoding="utf-8"
+    )
+    assert not re.search(r"^def _looks_absolute\b", src, re.M)
 
 
 def test_library_stats(monkeypatch):


### PR DESCRIPTION
## The bug

`mcp_server._safe_path("C:/Users/me/secret.mov")` returned the path **unchanged** instead of basenaming it. Proven, not inferred:

```
input                                _safe_path (before)
/Users/hevinyeh/secret/private.mov   private.mov            ✅
C:\Users\me\secret.mov               secret.mov             ✅
C:/Users/me/secret.mov               C:/Users/me/secret.mov 🔴 whole path
\\nas\share\secret.mov               secret.mov             ✅
```

This is the surface whose module docstring names *"No absolute-path leak"* as a **red line**, and the only one exposed to untrusted downstream agents.

## Why it drifted — and why it can only be collapsed now

`mcp_server` has carried its own `_looks_absolute` copy since **2026-06-08 (`a9c0838`)**. Not carelessness: the guard lived in `server.py`, and importing that here drags in the whole FastAPI app — which this module deliberately refuses. **There was nowhere to share from.**

Four hours later the same day, **`fc35b8f` — `fix(16.2): treat C:/ and C:\ both as absolute (Codex round-2)`** — overruled round-1's reading that `C:/x` is a POSIX relative path under a drive-letter-named dir:

> a leak guard must not let a Windows-absolute path through, and a Unix media dir literally named `"C:"` is pathological … **no-leak wins**

That commit touched `server.py` + its tests **only**. The MCP copy never got the memo — **38 days**.

The fork is visible in the test suite, which asserts *opposite* things about the same semantic:

```python
# tests/test_search_all_path_leak.py:128   (round-2)
assert server._looks_absolute("C:/Users/me/proj") is True
# tests/test_mcp_server.py:204             (round-1, frozen)
assert m._safe_path("C:/camera/clip.mov") == "C:/camera/clip.mov"
```

**R5-25 / round-5 #51 extracted the guard into the `pathres` leaf (`70490fa`, 2026-07-13)** — `db`+stdlib only, no fastapi, safe for the stdio server to import. That is what makes one shared guard possible for the first time.

So this **deletes the copy rather than patching it**. `_safe_path` was already a line-for-line twin of `pathres._display_path` apart from this single predicate:

```python
# pathres._display_path            |  # mcp_server._safe_path (before)
rel = db.to_relative(path)         |  rel = db.to_relative(p)
if _looks_absolute(rel):           |  if _looks_absolute(rel):
    return _basename_safe(rel)     |      return rel.replace("\\","/").rstrip("/").rsplit("/",1)[-1]
return rel                         |  return rel
```

## Behaviour change

Paths beginning `C:/` now basename like every other absolute. **Every other input is byte-identical** — verified across POSIX / Windows / UNC / relative / bare / empty / `None`.

## Tests

Each of the three added/changed tests **fails independently against the old code** (verified by stashing only the fix and keeping the tests):

```
FAILED test_safe_path_windows_and_unc_absolute      - assert 'C:/camera/clip.mov' == 'clip.mov'
FAILED test_safe_path_is_the_http_guard_not_a_copy  - AssertionError: C:/Users/me/x.mov
FAILED test_mcp_carries_no_second_leak_guard        - match='def _looks_absolute'
```

- **behavioural** — the leaking case
- **parity** — `_safe_path == _display_path` across the input space
- **structural** — no second `_looks_absolute` in source, same read-the-source idiom as the R5-25 leaf tests

The structural one earns its keep: the 6/08 copy was *behaviourally correct the day it landed*. Only drift made it wrong, so pinning behaviour alone wouldn't stop the next copy.

`936 passed / 6 skipped` locally (934 baseline + 2 new).

## Note (not fixed here)

`import os` in `mcp_server.py` is dead — already unused before this change (AST-verified), left alone to keep a security fix's diff pure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)