### PR TITLE
refactor(scenes): extract the per-scene derivation to a scenes.py leaf

### DIFF
--- a/routers/media.py
+++ b/routers/media.py
@@ -34,6 +34,7 @@ from config import BASE_DIR
 from mediarecords import _get_light_records_by_ids, _get_tags_bulk
 from pathres import _display_path, _resolve_frame, _resolve_media_path, _resolve_record
 from reqopts import _parse_ids_query
+from scenes import _scenes_payload
 from webguard import _assert_same_site
 
 router = APIRouter()
@@ -459,52 +460,14 @@ def get_media_scenes(
     media_id: int,
     _tok: dict = Depends(require_scopes("media_read")),
 ):
-    # Per-scene shape (breaking change 2026-06-29): each scene = one scene-detect
-    # boundary persisted in frames table, with computed end_s from the next
-    # frame's start (or media.duration_s for the last). Consumers (smart-edit,
-    # OpenMontage arkiv_clip_search, Vyra, Palmier) expect start/end/duration +
-    # vision metadata per scene, not per-frame flat list.
+    # Per-scene derivation lives in the scenes leaf — mcp_server needs the same
+    # shape and cannot import this module (it refuses `server`/fastapi), so a
+    # copy here would fork the contract. See scenes.py; the body is byte-frozen
+    # by tests/test_scenes_contract.py.
     rec = db.get_record_by_id(media_id)
     if not rec:
         raise HTTPException(404, "找不到")
-    frames = db.get_frames(media_id)
-    media_duration_s = float(rec.get("duration_s") or 0.0)
-    scenes = []
-    for i, frame in enumerate(frames):
-        start_s = float(frame["timestamp_s"])
-        if i + 1 < len(frames):
-            end_s = float(frames[i + 1]["timestamp_s"])
-        else:
-            end_s = media_duration_s
-        if end_s < start_s:
-            end_s = start_s
-        scene = {
-            "scene_index": frame["frame_index"],
-            "start_s": start_s,
-            "end_s": end_s,
-            "duration_s": end_s - start_s,
-            "description": frame.get("description", ""),
-            "content_type": frame.get("content_type"),
-            "focus_score": frame.get("focus_score"),
-            "atmosphere": frame.get("atmosphere"),
-            "energy": frame.get("energy"),
-            "edit_position": frame.get("edit_position"),
-            "edit_reason": frame.get("edit_reason"),
-            "stability": frame.get("stability"),
-            "exposure": frame.get("exposure"),
-            "audio_quality": frame.get("audio_quality"),
-        }
-        if frame.get("thumbnail_path"):
-            scene["keyframe_url"] = "/thumbnails/{0}".format(
-                Path(_resolve_media_path(frame["thumbnail_path"])).name
-            )
-        scenes.append(scene)
-    return {
-        "media_id": media_id,
-        "media_duration_s": media_duration_s,
-        "scenes": scenes,
-        "total": len(scenes),
-    }
+    return _scenes_payload(media_id, rec, db.get_frames(media_id))
 
 
 @router.get("/api/media/{media_id}/chapters")

--- a/scenes.py
+++ b/scenes.py
@@ -1,0 +1,102 @@
+"""Scene-assembly service for the API + MCP layers.
+
+The per-scene derivation (frames → scene boundaries with a computed end_s) is
+needed by two consumers that must not import each other: the HTTP route in
+routers/media.py, and mcp_server.py, which deliberately does NOT import `server`
+— that would pull in the whole FastAPI app + its startup cost. Following the
+R5-25 / round-5 #51 leaf pattern (pathres.py, mediarecords.py): extract the
+shared, server-state-free logic into a leaf both import, so neither side forks
+the shape.
+
+Two divergent scene shapes across MCP and HTTP is precisely the failure mode
+this exists to prevent — and not hypothetically. mcp_server carried its own copy
+of the path-leak guard for exactly this reason (there was nowhere to share from)
+and the copy silently missed a fix to the original for 38 days (#182). Same
+trap, so: one derivation, two callers.
+
+Depends only on `pathres` (itself db+stdlib) and stdlib — no server state, no
+fastapi, no db — so it sits at the bottom of the import graph and is safe for
+the stdio MCP server to import. Callers fetch their own rows and own their own
+error surface: this module returns data and never raises HTTPException; the 404
+stays in routers/media.py.
+"""
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from pathres import _resolve_media_path
+
+
+def _build_scenes(frames: List[Dict[str, Any]], media_duration_s: float) -> List[Dict[str, Any]]:
+    """Frames → per-scene dicts. The shared core; carries NO path/URL field.
+
+    Per-scene shape (breaking change 2026-06-29): each scene = one scene-detect
+    boundary persisted in the frames table, with end_s computed from the next
+    frame's start (or media.duration_s for the last). Consumers (smart-edit,
+    OpenMontage arkiv_clip_search, Vyra, Palmier) expect start/end/duration +
+    vision metadata per scene, not a per-frame flat list.
+
+    Key insertion order is contract — the HTTP body is byte-frozen by
+    tests/test_scenes_contract.py. Do not reorder. Do not swap .get() for a
+    conditional: an absent vision field serialises as null, not omitted, and
+    consumers rely on key presence rather than value presence.
+    """
+    scenes = []
+    for i, frame in enumerate(frames):
+        start_s = float(frame["timestamp_s"])
+        if i + 1 < len(frames):
+            end_s = float(frames[i + 1]["timestamp_s"])
+        else:
+            end_s = media_duration_s
+        if end_s < start_s:
+            # db.get_frames is ORDER BY frame_index — nothing enforces that
+            # timestamp_s rises with it, so clamp rather than emit a negative span.
+            end_s = start_s
+        scenes.append({
+            "scene_index": frame["frame_index"],
+            "start_s": start_s,
+            "end_s": end_s,
+            "duration_s": end_s - start_s,
+            "description": frame.get("description", ""),
+            "content_type": frame.get("content_type"),
+            "focus_score": frame.get("focus_score"),
+            "atmosphere": frame.get("atmosphere"),
+            "energy": frame.get("energy"),
+            "edit_position": frame.get("edit_position"),
+            "edit_reason": frame.get("edit_reason"),
+            "stability": frame.get("stability"),
+            "exposure": frame.get("exposure"),
+            "audio_quality": frame.get("audio_quality"),
+        })
+    return scenes
+
+
+def _media_duration_s(rec: Dict[str, Any]) -> float:
+    """`or` rather than an `is None` check is deliberate and pre-existing: a real
+    0.0 and a NULL both collapse to 0.0. Preserved verbatim from the route."""
+    return float(rec.get("duration_s") or 0.0)
+
+
+def _keyframe_url(thumbnail_path: Optional[str]) -> Optional[str]:
+    """HTTP-only: the /thumbnails/<basename> URL served by the authed thumbnail
+    route. Not used by MCP — a server-relative URL is meaningless over stdio."""
+    if not thumbnail_path:
+        return None
+    return "/thumbnails/{0}".format(Path(_resolve_media_path(thumbnail_path)).name)
+
+
+def _scenes_payload(media_id: int, rec: Dict[str, Any],
+                    frames: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """The exact HTTP response body. Byte-frozen by tests/test_scenes_contract.py."""
+    media_duration_s = _media_duration_s(rec)
+    scenes = _build_scenes(frames, media_duration_s)
+    for scene, frame in zip(scenes, frames):
+        if frame.get("thumbnail_path"):
+            # Appended LAST, and conditionally: key order is contract, and a
+            # scene with no thumbnail omits the key rather than carrying null.
+            scene["keyframe_url"] = _keyframe_url(frame["thumbnail_path"])
+    return {
+        "media_id": media_id,
+        "media_duration_s": media_duration_s,
+        "scenes": scenes,
+        "total": len(scenes),
+    }

--- a/tests/test_r5_25_scenes_module.py
+++ b/tests/test_r5_25_scenes_module.py
@@ -1,0 +1,136 @@
+"""R5-25 (round-5 #51) follow-on: scene assembly extracted to scenes.py.
+
+The per-scene derivation is needed by both routers/media.py and mcp_server.py,
+which must not import each other — mcp_server deliberately avoids `server`, since
+that pulls in the whole FastAPI app. Extracting the derivation to a leaf both
+import is what keeps the HTTP and MCP scene shapes from forking.
+
+That risk is not hypothetical. mcp_server had to inline its own copy of the
+path-leak guard for exactly this reason (nowhere to share from), and the copy
+silently missed a fix to the original for 38 days (#182). These tests pin what a
+future refactor must not quietly regress:
+
+  1. scenes is a genuine leaf — no `server` import, so it sits below the routers.
+  2. scenes is fastapi-free — mcp_server imports it over stdio, and dragging in
+     HTTPException would pull the FastAPI app into the MCP server. The 404 stays
+     in routers/media.py; this module returns data and never raises.
+  3. The derivation semantics the move had to preserve.
+
+The wire format itself is pinned separately and more strictly by
+tests/test_scenes_contract.py (byte-identity golden, authored pre-extraction).
+
+Note there is deliberately no `server` re-export to assert here, unlike the other
+R5-25 leaves: nothing referenced `server._build_scenes`, so adding one would
+create an obligation with zero call sites.
+"""
+import pathlib
+import re
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+_NAMES = (
+    "_build_scenes",
+    "_media_duration_s",
+    "_keyframe_url",
+    "_scenes_payload",
+)
+
+
+# ── module boundary ──────────────────────────────────────────────────────────
+def test_scenes_is_a_leaf_module():
+    # No `import server`, or it can't sit below the routers in the import graph.
+    src = (_ROOT / "scenes.py").read_text(encoding="utf-8")
+    assert not re.search(r"^\s*import\s+server\b", src, re.M)
+    assert not re.search(r"^\s*from\s+server\b", src, re.M)
+
+
+def test_scenes_does_not_import_fastapi():
+    # mcp_server imports this over stdio and is deliberately fastapi-free.
+    # reqopts/webguard import HTTPException; scenes must stay in the stdlib tier.
+    src = (_ROOT / "scenes.py").read_text(encoding="utf-8")
+    assert not re.search(r"^\s*import\s+fastapi\b", src, re.M)
+    assert not re.search(r"^\s*from\s+fastapi\b", src, re.M)
+
+
+def test_scenes_has_no_future_annotations_import():
+    # The 3.9 floor has no linter behind it — the ONLY thing that catches a
+    # PEP604 annotation in a leaf is the 3.9 CI leg blowing up at import time,
+    # and that works precisely because annotations are eagerly evaluated here.
+    # `from __future__ import annotations` would defer them and silently disable
+    # the catch, shipping a break that only surfaces on the NAS.
+    src = (_ROOT / "scenes.py").read_text(encoding="utf-8")
+    assert "from __future__ import annotations" not in src
+
+
+def test_scenes_functions_are_importable_standalone():
+    import scenes
+    for name in _NAMES:
+        assert callable(getattr(scenes, name))
+
+
+# ── derivation semantics preserved by the move ───────────────────────────────
+def test_last_scene_ends_at_media_duration():
+    import scenes
+    out = scenes._build_scenes(
+        [{"frame_index": 0, "timestamp_s": 0.0}, {"frame_index": 1, "timestamp_s": 5.0}],
+        30.0,
+    )
+    assert out[0]["end_s"] == 5.0        # next frame's start
+    assert out[1]["end_s"] == 30.0       # last → media duration
+
+
+def test_end_before_start_is_clamped():
+    # db.get_frames is ORDER BY frame_index; nothing enforces rising timestamps,
+    # so an out-of-order pair must clamp rather than emit a negative span.
+    import scenes
+    out = scenes._build_scenes(
+        [{"frame_index": 0, "timestamp_s": 9.0}, {"frame_index": 1, "timestamp_s": 2.0}],
+        30.0,
+    )
+    assert out[0]["end_s"] == 9.0
+    assert out[0]["duration_s"] == 0.0
+
+
+def test_build_scenes_carries_no_path_field():
+    # The whole reason the split is drawn here: keyframe_url is an HTTP-server
+    # concept, and db.get_frames is SELECT * so every frame dict carries a raw
+    # thumbnail_path — absolute for out-of-root legacy rows. The shared core must
+    # never splat one into its output.
+    import scenes
+    out = scenes._build_scenes(
+        [{"frame_index": 0, "timestamp_s": 0.0,
+          "thumbnail_path": "/Users/someone/private/x.jpg",
+          "id": 99, "media_id": 1}],
+        10.0,
+    )
+    assert "keyframe_url" not in out[0]
+    assert "thumbnail_path" not in out[0]
+    assert not any("private" in str(v) for v in out[0].values())
+
+
+def test_build_scenes_emits_absent_vision_fields_as_none():
+    # Consumers rely on key presence, not value presence — a partial ingest must
+    # still carry all 9 vision keys.
+    import scenes
+    out = scenes._build_scenes([{"frame_index": 0, "timestamp_s": 0.0}], 10.0)
+    for key in ("content_type", "focus_score", "atmosphere", "energy",
+                "edit_position", "edit_reason", "stability", "exposure",
+                "audio_quality"):
+        assert key in out[0]
+        assert out[0][key] is None
+
+
+def test_null_duration_collapses_to_zero():
+    # `or 0.0` (not an `is None` check) is pre-existing: a real 0.0 and NULL both
+    # collapse. Pinned so the move can be shown not to have "fixed" it.
+    import scenes
+    assert scenes._media_duration_s({"duration_s": None}) == 0.0
+    assert scenes._media_duration_s({}) == 0.0
+    assert scenes._media_duration_s({"duration_s": 0.0}) == 0.0
+    assert scenes._media_duration_s({"duration_s": 31.0}) == 31.0
+
+
+def test_keyframe_url_is_none_without_a_thumbnail():
+    import scenes
+    assert scenes._keyframe_url(None) is None
+    assert scenes._keyframe_url("") is None


### PR DESCRIPTION
Behaviour-preserving extraction. **PR #183's golden is not touched by this PR** — that's the whole proof.

## Why a leaf, not a copy

The scene derivation has to be shared with `mcp_server` (a `get_scenes` tool is next), and `mcp_server` **cannot** import `routers/media.py` — it refuses `server`/fastapi, which would pull the entire FastAPI app into a stdio process. Without a leaf, the only option is a second copy.

That cost isn't hypothetical. `mcp_server` inlined its own copy of the path-leak guard for *exactly this reason* — nowhere to share from — and the copy silently missed a fix to the original for **38 days** (#182, merged an hour ago). R5-25 / round-5 #51 built the leaf tier precisely so this stops happening. This applies that pattern **before** the fork exists rather than after.

## The cut line

The loop is pure computation over `rec` + `db.get_frames()`. The fastapi coupling is only at the boundary (`Depends` auth, the 404), and the one in-loop dependency — `_resolve_media_path` — already lives in the `pathres` leaf. So both stay put: the router keeps auth and raises its own 404; `scenes.py` returns data and never raises `HTTPException`.

`scenes.py` imports `pathlib` + `typing` + `pathres`. **Not even `db`** — callers fetch their own rows.

`_build_scenes` deliberately carries **no path field**. `db.get_frames` is `SELECT *`, so every frame dict holds a raw `thumbnail_path` (absolute for out-of-root legacy rows); keeping the shared core path-free is what stops the MCP side from splatting one into a response. `keyframe_url` is appended by `_scenes_payload` — HTTP-only, since a server-relative URL means nothing over stdio.

Route goes 43 lines → 4.

## Byte-identical — three independent proofs

**1. The golden (#183) passes untouched.** It was authored and merged against the pre-extraction route, so it cannot have been shaped to fit this code. `git diff tests/test_scenes_contract.py` → empty. That's the claim.

**2.** `test_phase8.py`'s four scenes tests stay green, unmodified.

**3. Real-data cross-version check** — live 62-row library, 16-frame clip, same DB, two code versions:

| | bytes | sha256 |
|---|---|---|
| pre-extraction (v0.10.0) | 8864 | `e1f1b95aa8f5accd…` |
| post-extraction | 8864 | `e1f1b95aa8f5accd…` |

That corpus has genuinely noisy timestamps (`24.38 / 48.75 / 73.13 / 97.51 …`), so `duration_s` renders values like `24.379999999999995`. It exercises the float-rendering path the synthetic golden deliberately sidesteps — the two checks cover for each other.

## One subtle thing, pinned by a test

`scenes.py` carries **no** `from __future__ import annotations`, matching the other leaves. There's a test asserting that, and it earns its place: the repo has **no linter**, so the 3.9 leg blowing up at import time is the *only* thing that catches a PEP604 annotation here — and it only works because annotations are eagerly evaluated. Adding the future-import "for consistency with `db.py`" would silently disable the catch and ship a break that surfaces on the NAS.

## Not done

No `server` re-export, unlike the other R5-25 leaves — nothing referenced `server._build_scenes`, so one would be an obligation with zero call sites.

`948 passed / 6 skipped` (938 + 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)