### PR TITLE
feat(mcp): get_scenes — timecoded scene breakdown for downstream agents

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -23,6 +23,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 import db
+import scenes
 import vectordb as vdb
 from mcp.server.fastmcp import FastMCP
 from pathres import _display_path
@@ -167,6 +168,21 @@ def get_media_impl(media_id: int) -> Optional[Dict[str, Any]]:
     return out
 
 
+def get_scenes_impl(media_id: int) -> Optional[Dict[str, Any]]:
+    """Per-scene breakdown for one media item, or None if the id is unknown.
+
+    The rec lookup is not redundant with get_frames: db.get_frames on an unknown
+    id returns [], which is indistinguishable from a real clip that has no vision
+    analysis yet. Fetch the record first so "no such media" (None) and "no scenes"
+    (total: 0) stay different answers — and it carries duration_s anyway.
+    """
+    rec = db.get_record_by_id(int(media_id))
+    if not rec:
+        return None
+    frames = db.get_frames(int(media_id))
+    return scenes._scenes_for_mcp(int(media_id), rec, frames)
+
+
 def get_transcript_impl(media_id: int) -> Optional[Dict[str, Any]]:
     """Transcript text for one media item, or None."""
     rec = db.get_record_by_id(int(media_id))
@@ -239,6 +255,43 @@ def get_media(media_id: int) -> str:
     Returns a JSON object, or null if the id is unknown.
     """
     return _j(get_media_impl(media_id))
+
+
+@mcp.tool()
+def get_scenes(media_id: int) -> str:
+    """Timecoded scene breakdown for one media item — what happens, and when.
+
+    Use this to decide WHICH PART of a clip to use: search_media/get_media answer
+    "which clip", this answers "which seconds of it". Each scene is one
+    scene-detect boundary with vision analysis of its keyframe.
+
+    Returns a JSON object, or null if the id is unknown:
+      {media_id, media_duration_s, total, scenes: [...]}
+
+    Each scene:
+      scene_index    int    0-based, in playback order
+      start_s        float  scene start, seconds from clip start
+      end_s          float  = next scene's start_s; the last scene ends at
+                            media_duration_s
+      duration_s     float  end_s - start_s
+      description    str    what the keyframe shows (may be "" if not analysed)
+      content_type   str    e.g. Establishing / B-Roll / A-Roll / Talking-Head
+      focus_score    int    1-5, higher = sharper
+      atmosphere     str
+      energy         str
+      edit_position  str    where this shot would sit in a cut
+      edit_reason    str
+      stability      str
+      exposure       str
+      audio_quality  str
+      keyframe_path  str    PROJECT_ROOT-relative path to the keyframe JPEG.
+                            Present only when a keyframe exists.
+
+    Every vision field is present on every scene, but is null when that clip has
+    not been analysed — check for null rather than for the key. Values are in the
+    library's own language (typically Chinese).
+    """
+    return _j(get_scenes_impl(media_id))
 
 
 @mcp.tool()

--- a/scenes.py
+++ b/scenes.py
@@ -23,7 +23,7 @@ stays in routers/media.py.
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from pathres import _resolve_media_path
+from pathres import _display_path, _resolve_media_path
 
 
 def _build_scenes(frames: List[Dict[str, Any]], media_duration_s: float) -> List[Dict[str, Any]]:
@@ -78,25 +78,65 @@ def _media_duration_s(rec: Dict[str, Any]) -> float:
 
 def _keyframe_url(thumbnail_path: Optional[str]) -> Optional[str]:
     """HTTP-only: the /thumbnails/<basename> URL served by the authed thumbnail
-    route. Not used by MCP — a server-relative URL is meaningless over stdio."""
+    route. Meaningless over stdio — an MCP client has no host and no session to
+    fetch it with, so the MCP surface uses _keyframe_path instead."""
     if not thumbnail_path:
         return None
     return "/thumbnails/{0}".format(Path(_resolve_media_path(thumbnail_path)).name)
 
 
-def _scenes_payload(media_id: int, rec: Dict[str, Any],
-                    frames: List[Dict[str, Any]]) -> Dict[str, Any]:
-    """The exact HTTP response body. Byte-frozen by tests/test_scenes_contract.py."""
+def _keyframe_path(thumbnail_path: Optional[str]) -> Optional[str]:
+    """MCP-only: the PROJECT_ROOT-relative path (basename for an out-of-root
+    legacy row). Data rather than a server URL — a stdio MCP client runs on this
+    same machine, so a path is actionable to it where a URL is not.
+
+    Same leak guard as every other path the MCP server emits (mcp_server._safe_path
+    is this function's `_display_path` too). Never hand a raw frame's
+    thumbnail_path out: db.get_frames is SELECT *, so it is absolute for
+    out-of-root legacy rows.
+    """
+    if not thumbnail_path:
+        return None
+    return _display_path(thumbnail_path)
+
+
+def _scenes_core(media_id: int, rec: Dict[str, Any],
+                 frames: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Envelope + scenes with NO path field. Shared by both surfaces; each one
+    appends its own keyframe representation on top (see below)."""
     media_duration_s = _media_duration_s(rec)
     scenes = _build_scenes(frames, media_duration_s)
-    for scene, frame in zip(scenes, frames):
-        if frame.get("thumbnail_path"):
-            # Appended LAST, and conditionally: key order is contract, and a
-            # scene with no thumbnail omits the key rather than carrying null.
-            scene["keyframe_url"] = _keyframe_url(frame["thumbnail_path"])
     return {
         "media_id": media_id,
         "media_duration_s": media_duration_s,
         "scenes": scenes,
         "total": len(scenes),
     }
+
+
+# The two surface shapes live side by side on purpose: the ONLY difference
+# between them should be the keyframe representation, and that is easiest to keep
+# true when both are visible in one screenful. Everything above the fold —
+# envelope, boundaries, vision fields — is shared by construction.
+
+def _scenes_payload(media_id: int, rec: Dict[str, Any],
+                    frames: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """The exact HTTP response body. Byte-frozen by tests/test_scenes_contract.py."""
+    payload = _scenes_core(media_id, rec, frames)
+    for scene, frame in zip(payload["scenes"], frames):
+        if frame.get("thumbnail_path"):
+            # Appended LAST, and conditionally: key order is contract, and a
+            # scene with no thumbnail omits the key rather than carrying null.
+            scene["keyframe_url"] = _keyframe_url(frame["thumbnail_path"])
+    return payload
+
+
+def _scenes_for_mcp(media_id: int, rec: Dict[str, Any],
+                    frames: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """The MCP tool body. Identical to the HTTP one except keyframe_path replaces
+    keyframe_url — same position (last), same conditionality."""
+    payload = _scenes_core(media_id, rec, frames)
+    for scene, frame in zip(payload["scenes"], frames):
+        if frame.get("thumbnail_path"):
+            scene["keyframe_path"] = _keyframe_path(frame["thumbnail_path"])
+    return payload

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -276,10 +276,146 @@ def test_tool_json_keeps_cjk_readable(monkeypatch):
     assert json.loads(raw)["transcript"] == "中文"
 
 
+# ── get_scenes ────────────────────────────────────────────────────────────────
+def _fake_frames(**over):
+    frame = {
+        "id": 7, "media_id": 1, "frame_index": 0, "timestamp_s": 0.0,
+        "description": "手持走入店內", "content_type": "Establishing",
+        "focus_score": 3, "atmosphere": "紀實", "energy": "中",
+        "edit_position": "開場", "edit_reason": "建立場景",
+        "stability": "穩定", "exposure": "normal", "audio_quality": "清晰",
+        "thumbnail_path": "thumbnails/a.jpg",
+    }
+    frame.update(over)
+    return [frame]
+
+
+def test_get_scenes_impl_shape(monkeypatch):
+    monkeypatch.setattr(db, "get_record_by_id", lambda mid: {"id": 1, "duration_s": 30.0})
+    monkeypatch.setattr(db, "get_frames", lambda mid: _fake_frames())
+    monkeypatch.setattr(db, "to_relative", lambda p: p)
+
+    out = m.get_scenes_impl(1)
+
+    assert out["media_id"] == 1
+    assert out["media_duration_s"] == 30.0
+    assert out["total"] == 1
+    scene = out["scenes"][0]
+    assert scene["start_s"] == 0.0
+    assert scene["end_s"] == 30.0        # only frame → closes at media duration
+    assert scene["duration_s"] == 30.0
+    assert scene["description"] == "手持走入店內"
+    assert scene["keyframe_path"] == "thumbnails/a.jpg"
+
+
+def test_get_scenes_impl_unknown_id_is_none_not_empty(monkeypatch):
+    # The distinction matters: db.get_frames on a bogus id also returns [], so
+    # without the rec lookup "no such media" and "no vision analysis yet" would
+    # give the agent the same answer.
+    monkeypatch.setattr(db, "get_record_by_id", lambda mid: None)
+    assert m.get_scenes_impl(999999) is None
+
+
+def test_get_scenes_no_frames_is_empty_not_none(monkeypatch):
+    monkeypatch.setattr(db, "get_record_by_id", lambda mid: {"id": 1, "duration_s": 30.0})
+    monkeypatch.setattr(db, "get_frames", lambda mid: [])
+    out = m.get_scenes_impl(1)
+    assert out is not None
+    assert out["total"] == 0
+    assert out["scenes"] == []
+
+
+@pytest.mark.parametrize("stored,expected", [
+    ("/Users/secret/footage/x.jpg", "x.jpg"),        # POSIX absolute
+    ("C:\\Users\\me\\x.jpg", "x.jpg"),               # Windows drive, backslash
+    ("C:/Users/me/x.jpg", "x.jpg"),                  # Windows drive, forward slash (#182)
+    ("\\\\nas\\share\\x.jpg", "x.jpg"),              # UNC
+    ("thumbnails/x.jpg", "thumbnails/x.jpg"),        # in-root relative — preserved
+])
+def test_get_scenes_keyframe_path_never_leaks_absolute(monkeypatch, stored, expected):
+    """RED LINE. db.get_frames is SELECT *, so thumbnail_path is raw and absolute
+    for out-of-root legacy rows — handing it out unfiltered is exactly the leak
+    #182 fixed on the other tools. Scenes must go through the same guard."""
+    monkeypatch.setattr(db, "get_record_by_id", lambda mid: {"id": 1, "duration_s": 30.0})
+    monkeypatch.setattr(db, "get_frames", lambda mid: _fake_frames(thumbnail_path=stored))
+    monkeypatch.setattr(db, "to_relative", lambda p: p)  # out-of-root passthrough
+
+    out = m.get_scenes_impl(1)
+
+    assert out["scenes"][0]["keyframe_path"] == expected
+
+
+def test_get_scenes_omits_keyframe_path_without_a_thumbnail(monkeypatch):
+    monkeypatch.setattr(db, "get_record_by_id", lambda mid: {"id": 1, "duration_s": 30.0})
+    monkeypatch.setattr(db, "get_frames", lambda mid: _fake_frames(thumbnail_path=None))
+    out = m.get_scenes_impl(1)
+    assert "keyframe_path" not in out["scenes"][0]
+
+
+def test_get_scenes_never_emits_a_url_or_raw_frame_columns(monkeypatch):
+    """keyframe_url is an HTTP concept (no host, no session over stdio), and the
+    raw frame's id/media_id/thumbnail_path are noise the agent must not see."""
+    monkeypatch.setattr(db, "get_record_by_id", lambda mid: {"id": 1, "duration_s": 30.0})
+    monkeypatch.setattr(db, "get_frames", lambda mid: _fake_frames())
+    monkeypatch.setattr(db, "to_relative", lambda p: p)
+
+    scene = m.get_scenes_impl(1)["scenes"][0]
+
+    assert "keyframe_url" not in scene
+    assert "thumbnail_path" not in scene
+    assert "media_id" not in scene
+    assert not any(isinstance(v, str) and v.startswith("/thumbnails/") for v in scene.values())
+
+
+def test_get_scenes_matches_the_http_shape_except_the_keyframe_key(monkeypatch):
+    """Anti-fork pin, and the reason scenes.py exists at all.
+
+    The MCP and HTTP scene shapes must differ in EXACTLY one way: keyframe_path
+    vs keyframe_url. Everything else — envelope, boundaries, key order, every
+    vision field — comes from the shared derivation. mcp_server already forked a
+    same-looking copy of the leak guard once and drifted for 38 days (#182); this
+    fails the moment someone re-derives scenes on either side.
+    """
+    import scenes as scenes_mod
+
+    monkeypatch.setattr(db, "to_relative", lambda p: p)
+    rec = {"id": 1, "duration_s": 30.0}
+    frames = _fake_frames()
+
+    http = scenes_mod._scenes_payload(1, rec, frames)
+    monkeypatch.setattr(db, "get_record_by_id", lambda mid: rec)
+    monkeypatch.setattr(db, "get_frames", lambda mid: frames)
+    mcp_out = m.get_scenes_impl(1)
+
+    assert list(http.keys()) == list(mcp_out.keys())
+    assert http["media_duration_s"] == mcp_out["media_duration_s"]
+    assert http["total"] == mcp_out["total"]
+
+    for h, c in zip(http["scenes"], mcp_out["scenes"]):
+        assert list(h.keys())[:-1] == list(c.keys())[:-1]   # same keys, same order
+        assert list(h.keys())[-1] == "keyframe_url"          # …differing only in
+        assert list(c.keys())[-1] == "keyframe_path"         #    the last one
+        for key in h:
+            if key != "keyframe_url":
+                assert h[key] == c[key], key
+
+
+def test_get_scenes_tool_returns_valid_json(monkeypatch):
+    monkeypatch.setattr(db, "get_record_by_id", lambda mid: {"id": 1, "duration_s": 30.0})
+    monkeypatch.setattr(db, "get_frames", lambda mid: _fake_frames())
+    monkeypatch.setattr(db, "to_relative", lambda p: p)
+
+    raw = m.get_scenes(1)
+
+    assert "手持走入店內" in raw                       # ensure_ascii=False
+    assert json.loads(raw)["scenes"][0]["start_s"] == 0.0
+
+
 # ── tools are registered with FastMCP ─────────────────────────────────────────
 @pytest.mark.asyncio
 async def test_tools_registered():
     tools = await m.mcp.list_tools()
     names = {t.name for t in tools}
     assert {"search_media", "get_media", "get_transcript",
-            "list_recent", "library_stats", "list_tags"} <= names
+            "list_recent", "library_stats", "list_tags",
+            "get_scenes"} <= names


### PR DESCRIPTION
Closes the **"which clip" → "which seconds of it"** gap.

The MCP server was media-level only: an external editing agent (Vyra / Palmier / OpenMontage-class) could *find* a clip but not learn what happens inside it. arkiv's actual understanding of footage — scene boundaries + per-keyframe vision analysis — stopped at the HTTP API. This is the roadmap item *"MCP tool 回傳結構化時間碼級 metadata，非只回檢索命中"*.

## What an agent gets now

Real output, from the live 62-row library:

```
scene[0]: 24.38s → 48.75s  (24.37s)
  "一名男子穿著黑色T恤和短褲，赤腳坐在室內椅子上手持手機，背景有窗戶、窗簾及音響設備。"
  keyframe_path: thumbnails/A74_20251003_8366_frame0.jpg
```

## Exactly one difference from the HTTP shape

Built on the scenes leaf (#184), so the derivation *is* the code the HTTP route runs — not a copy that looks like it. The surfaces differ in one key, and a test pins that they differ in no other:

| | last key | value |
|---|---|---|
| HTTP | `keyframe_url` | `/thumbnails/<basename>` |
| MCP | `keyframe_path` | `thumbnails/<basename>` |

`keyframe_url` is meaningless over stdio — no host, no session to fetch it with. `keyframe_path` is *data*: a stdio client runs on this machine, so a path is actionable where a URL isn't, and it matches what `get_media` already returns for media-level thumbnails.

The parity test walks both payloads key-by-key and asserts they agree on everything except that final key. `mcp_server` already forked a same-looking copy of the leak guard once and drifted for 38 days (#182) — this fails the moment someone re-derives scenes on either side.

## Path safety

`db.get_frames` is `SELECT *`, so a frame's `thumbnail_path` is raw and **absolute for out-of-root legacy rows**. Two things keep it in:

- `keyframe_path` goes through the same guard as every other MCP path (`pathres._display_path` — the one #182 just unforked)
- `_build_scenes` carries **no path field at all**, so there's nothing to splat by accident

Parametrized over POSIX / `C:\` / `C:/` / UNC / in-root-relative. **The `C:/` case only passes because of #182** — merged an hour ago. Nice demonstration of why that one mattered.

## A small correctness point

`get_scenes_impl` looks the record up *before* the frames on purpose: `db.get_frames` on an unknown id returns `[]`, which would otherwise make **"no such media"** and **"no vision analysis yet"** the same answer to an agent. Unknown id → `null`; known id with no frames → `total: 0`.

## The docstring is the contract

FastMCP reads `__doc__` as the agent-facing tool description, so it documents every key, states that vision fields are **present-but-null** on unanalysed clips (check the value, not the key), and warns that values come back in the library's own language (typically Chinese).

## Verification beyond the mocks

Ran against the real library: 16 scenes, **zero absolute-path leaks**, no `keyframe_url`, no raw frame columns (`id`/`media_id`/`thumbnail_path`), CJK readable, unknown id → `None`.

`960 passed / 6 skipped` (948 + 12). 7 tools registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)