### PR TITLE
feat(mcp): get_transcript carries segment timecodes; word timing opt-in

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -183,17 +183,67 @@ def get_scenes_impl(media_id: int) -> Optional[Dict[str, Any]]:
     return scenes._scenes_for_mcp(int(media_id), rec, frames)
 
 
-def get_transcript_impl(media_id: int) -> Optional[Dict[str, Any]]:
-    """Transcript text for one media item, or None."""
+# segments_json / words_json hold whatever the transcribe backend produced, and
+# the three backends do NOT agree: faster-whisper appends
+# {text,start,end,no_speech_prob,avg_logprob,compression_ratio}; mlx-whisper
+# (Darwin/arm64, i.e. every Mac ingest) passes its native dict through untouched,
+# which additionally carries `seek`, `temperature` and a full `tokens` list —
+# hundreds of token ids per segment; whisperx builds a third shape. So a verbatim
+# passthrough would hand agents a payload whose shape depends on which machine
+# ingested the clip, padded with decoder internals. Project onto the stable
+# subset instead — which is exactly what transcribe.py:223-224 documents as the
+# contract, and all the consumers (export.py, remotion-props) already assume.
+_SEGMENT_KEYS = ("start", "end", "text")
+_WORD_KEYS = ("word", "start", "end", "score")
+
+
+def _json_rows(raw: Optional[str]) -> List[Dict[str, Any]]:
+    """Parse a TEXT column holding a JSON list of dicts. Never raises: a corrupt
+    column degrades to [] rather than taking the tool down (mirrors the defensive
+    parse in export.py:134-141)."""
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [row for row in parsed if isinstance(row, dict)]
+
+
+def _project(rows: List[Dict[str, Any]], keys: tuple) -> List[Dict[str, Any]]:
+    return [{k: row.get(k) for k in keys} for row in rows]
+
+
+def get_transcript_impl(
+    media_id: int,
+    include_words: bool = False,
+    max_words: int = 5000,
+) -> Optional[Dict[str, Any]]:
+    """Transcript + timecodes for one media item, or None."""
     rec = db.get_record_by_id(int(media_id))
     if not rec:
         return None
-    return {
+    word_rows = _json_rows(rec.get("words_json"))
+    out = {
+        # unchanged keys — pre-existing consumers keep working verbatim
         "id": rec.get("id"),
         "filename": rec.get("filename"),
         "lang": rec.get("lang"),
         "transcript": rec.get("transcript"),
+        # new: the timecodes. `segments` is the point of this tool — an agent
+        # that only gets flat text cannot cut on a quote.
+        "duration_s": rec.get("duration_s"),
+        "segments": _project(_json_rows(rec.get("segments_json")), _SEGMENT_KEYS),
+        # advertise word-level availability without paying for it
+        "has_words": bool(word_rows),
     }
+    if include_words:
+        words = _project(word_rows, _WORD_KEYS)
+        out["words"] = words[:max_words]
+        out["words_truncated"] = len(words) > max_words
+    return out
 
 
 def list_recent_impl(limit: int = 20) -> List[Dict[str, Any]]:
@@ -295,12 +345,35 @@ def get_scenes(media_id: int) -> str:
 
 
 @mcp.tool()
-def get_transcript(media_id: int) -> str:
-    """Full transcript text for one media item.
+def get_transcript(media_id: int, include_words: bool = False) -> str:
+    """Speech transcript for one media item, with per-segment timecodes.
 
-    Returns JSON {id, filename, lang, transcript}, or null if unknown.
+    Use `segments` to locate a quote in time: the flat `transcript` string tells
+    you WHAT was said, `segments` tells you WHEN — which is what you need in order
+    to cut on it. Pair with get_scenes for the visual side.
+
+    Returns a JSON object, or null if the id is unknown:
+      id           int
+      filename     str
+      lang         str    detected language, e.g. "zh"
+      transcript   str    the whole transcript as flat text
+      duration_s   float  clip duration, bounding the timecodes below
+      segments     list   [{start, end, text}] — seconds from clip start.
+                          EMPTY for clips transcribed before segment timing was
+                          stored; fall back to `transcript` in that case.
+      has_words    bool   whether word-level timing exists for this clip
+
+    With include_words=true, adds:
+      words            list  [{word, start, end, score}] — score is 0-1 confidence
+      words_truncated  bool  true if the list was capped (at 5000 words)
+
+    Leave include_words FALSE unless you specifically need word-level timing (for
+    caption building, say): a feature-length clip holds tens of thousands of words
+    and that payload can swamp your context. Segment timing is enough to locate
+    and cut a quote. Check has_words first — asking for words on a clip that has
+    none just returns [].
     """
-    return _j(get_transcript_impl(media_id))
+    return _j(get_transcript_impl(media_id, include_words=include_words))
 
 
 @mcp.tool()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -162,7 +162,13 @@ def test_get_transcript(monkeypatch):
         lambda mid: {"id": 2, "filename": "c.mp4", "lang": "ja", "transcript": "テスト"},
     )
     out = m.get_transcript_impl(2)
-    assert out == {"id": 2, "filename": "c.mp4", "lang": "ja", "transcript": "テスト"}
+    # The four original keys are unchanged — pre-existing consumers keep working.
+    # duration_s/segments/has_words joined them when timecodes were added; a clip
+    # with no segment timing (this one) still reports segments: [].
+    assert out == {
+        "id": 2, "filename": "c.mp4", "lang": "ja", "transcript": "テスト",
+        "duration_s": None, "segments": [], "has_words": False,
+    }
 
 
 def test_get_transcript_not_found(monkeypatch):
@@ -274,6 +280,147 @@ def test_tool_json_keeps_cjk_readable(monkeypatch):
     raw = m.get_transcript(1)
     assert "中文" in raw                      # ensure_ascii=False
     assert json.loads(raw)["transcript"] == "中文"
+
+
+# ── get_transcript timecodes ──────────────────────────────────────────────────
+# The shapes below are what the backends ACTUALLY write, not what
+# transcribe.py:223's docstring says. They disagree with each other, which is the
+# whole reason the impl projects rather than passes through.
+_MLX_SEGMENTS = json.dumps([  # transcribe._transcribe_mlx → mlx_whisper native.
+    # These 10 keys are verified, not guessed: mlx-whisper large-v3-turbo run
+    # against 8s of real footage returned exactly
+    #   ['avg_logprob','compression_ratio','end','id','no_speech_prob','seek',
+    #    'start','temperature','text','tokens']
+    {"id": 0, "seek": 0, "start": 0.0, "end": 2.4, "text": "第一句",
+     "tokens": [50364, 2503, 41200, 50484], "temperature": 0.0,
+     "avg_logprob": -0.31, "compression_ratio": 1.2, "no_speech_prob": 0.01},
+    {"id": 1, "seek": 240, "start": 2.4, "end": 5.0, "text": "第二句",
+     "tokens": [50484, 17155, 50614], "temperature": 0.0,
+     "avg_logprob": -0.28, "compression_ratio": 1.1, "no_speech_prob": 0.02},
+], ensure_ascii=False)
+
+_FW_SEGMENTS = json.dumps([  # transcribe._transcribe_faster_whisper
+    {"text": "第一句", "start": 0.0, "end": 2.4, "no_speech_prob": 0.01,
+     "avg_logprob": -0.31, "compression_ratio": 1.2},
+], ensure_ascii=False)
+
+_WORDS = json.dumps(
+    [{"word": "第一", "start": 0.1, "end": 0.4, "score": 0.98},
+     {"word": "句", "start": 0.4, "end": 0.6, "score": 0.97}],
+    ensure_ascii=False,
+)
+
+
+def _rec(**over):
+    base = {"id": 1, "filename": "a.mp4", "lang": "zh", "transcript": "第一句第二句",
+            "duration_s": 5.0, "segments_json": _MLX_SEGMENTS, "words_json": _WORDS}
+    base.update(over)
+    return base
+
+
+def test_get_transcript_parses_segments_into_objects(monkeypatch):
+    monkeypatch.setattr(db, "get_record_by_id", lambda mid: _rec())
+    out = m.get_transcript_impl(1)
+    assert out["segments"] == [
+        {"start": 0.0, "end": 2.4, "text": "第一句"},
+        {"start": 2.4, "end": 5.0, "text": "第二句"},
+    ]
+    assert out["duration_s"] == 5.0
+    assert isinstance(out["segments"][0]["start"], float)   # number, not a string
+
+
+def test_get_transcript_strips_decoder_internals(monkeypatch):
+    """mlx-whisper (every Mac ingest) stores `tokens` — the raw token ids — plus
+    seek/id/temperature/logprob internals. An agent needs none of it. Measured on
+    8s of real footage: 1128 bytes verbatim vs 213 projected, an 81% cut, and it
+    scales linearly with clip length."""
+    monkeypatch.setattr(db, "get_record_by_id", lambda mid: _rec())
+    out = m.get_transcript_impl(1)
+    for seg in out["segments"]:
+        assert set(seg) == {"start", "end", "text"}
+    dumped = json.dumps(out)
+    for internal in ("tokens", "seek", "temperature", "avg_logprob",
+                     "compression_ratio", "no_speech_prob"):
+        assert internal not in dumped
+
+
+def test_get_transcript_shape_is_backend_independent(monkeypatch):
+    """mlx-whisper and faster-whisper write different segment dicts, so without
+    the projection the payload shape would depend on which machine ingested the
+    clip. Same input, same output, either way."""
+    monkeypatch.setattr(db, "get_record_by_id", lambda mid: _rec(segments_json=_MLX_SEGMENTS))
+    mlx = m.get_transcript_impl(1)["segments"][0]
+    monkeypatch.setattr(db, "get_record_by_id", lambda mid: _rec(segments_json=_FW_SEGMENTS))
+    fw = m.get_transcript_impl(1)["segments"][0]
+    assert mlx == fw == {"start": 0.0, "end": 2.4, "text": "第一句"}
+
+
+def test_get_transcript_omits_words_by_default(monkeypatch):
+    monkeypatch.setattr(db, "get_record_by_id", lambda mid: _rec())
+    out = m.get_transcript_impl(1)
+    assert "words" not in out            # omitted, not null — you don't pay for it
+    assert out["has_words"] is True      # …but you're told it exists
+
+
+def test_get_transcript_include_words(monkeypatch):
+    monkeypatch.setattr(db, "get_record_by_id", lambda mid: _rec())
+    out = m.get_transcript_impl(1, include_words=True)
+    assert out["words"] == [
+        {"word": "第一", "start": 0.1, "end": 0.4, "score": 0.98},
+        {"word": "句", "start": 0.4, "end": 0.6, "score": 0.97},
+    ]
+    assert out["words_truncated"] is False
+
+
+def test_get_transcript_truncates_words(monkeypatch):
+    monkeypatch.setattr(db, "get_record_by_id", lambda mid: _rec())
+    out = m.get_transcript_impl(1, include_words=True, max_words=1)
+    assert len(out["words"]) == 1
+    assert out["words_truncated"] is True
+
+
+def test_get_transcript_has_words_false_without_word_timing(monkeypatch):
+    monkeypatch.setattr(db, "get_record_by_id", lambda mid: _rec(words_json=None))
+    out = m.get_transcript_impl(1)
+    assert out["has_words"] is False
+    assert m.get_transcript_impl(1, include_words=True)["words"] == []
+
+
+@pytest.mark.parametrize("bad", [
+    "{not json",           # corrupt
+    '{"a": 1}',            # valid JSON, wrong type (an object, not a list)
+    "[1, 2, 3]",           # a list, but not of dicts
+    "null",
+    "",
+])
+def test_get_transcript_degrades_on_malformed_json(monkeypatch, bad):
+    """A corrupt column must not take the tool down — mirrors export.py:134-141."""
+    monkeypatch.setattr(db, "get_record_by_id", lambda mid: _rec(segments_json=bad, words_json=bad))
+    out = m.get_transcript_impl(1, include_words=True)
+    assert out["segments"] == []
+    assert out["words"] == []
+    assert out["has_words"] is False
+    assert out["transcript"] == "第一句第二句"   # flat text still served
+
+
+def test_get_transcript_pre_segment_era_clip(monkeypatch):
+    """Real case, not hypothetical: the live library's 37 transcripts predate
+    Phase 9.4, so segments_json is NULL on every one. They must still answer."""
+    monkeypatch.setattr(
+        db, "get_record_by_id",
+        lambda mid: {"id": 1, "filename": "old.mp4", "lang": "zh",
+                     "transcript": "舊的逐字稿", "duration_s": 31.0},
+    )
+    out = m.get_transcript_impl(1)
+    assert out["segments"] == []
+    assert out["has_words"] is False
+    assert out["transcript"] == "舊的逐字稿"
+
+
+def test_get_transcript_tool_passes_include_words_through(monkeypatch):
+    monkeypatch.setattr(db, "get_record_by_id", lambda mid: _rec())
+    assert "words" not in json.loads(m.get_transcript(1))
+    assert len(json.loads(m.get_transcript(1, include_words=True))["words"]) == 2
 
 
 # ── get_scenes ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
`get_transcript` returned `{id, filename, lang, transcript}` — flat text, no timing — while `segments_json` and `words_json` sat on the same row, already written by every ingest. An agent could read **what** was said but not **when**, so it couldn't cut on a quote. With `get_scenes` (#185) this closes the roadmap item: MCP now answers *"which seconds"*, visually and in speech.

```
segments         [{start, end, text}]          default ON
duration_s       float                         bounds the timecodes
has_words        bool                          advertises word timing, free
words            [{word, start, end, score}]   include_words=true only
words_truncated  bool                          capped at 5000
```

The four original keys are untouched.

## Segments are projected, not passed through — and that's correctness, not tidiness

The three backends **don't agree on the shape**. Verified by actually running mlx-whisper large-v3-turbo (the Darwin/arm64 path — i.e. *every Mac ingest*) over 8s of real footage:

```
native mlx segment keys = avg_logprob, compression_ratio, end, id,
                          no_speech_prob, seek, start, temperature, text, tokens
```

`tokens` is the raw token-id list. `faster-whisper` writes a 6-key dict instead (text/start/end + three diagnostics); `whisperx` builds a third. `transcribe.py` passes mlx's native dict **straight through**.

So a verbatim response would hand agents a payload **whose shape depends on which machine ingested the clip**, padded with decoder internals. Projecting onto `{start, end, text}` — precisely what `transcribe.py:223-224` documents as the contract, and what `export.py` and remotion-props already assume — makes the tool backend-independent.

Measured on that same 8s sample: **1128 bytes verbatim → 213 projected, an 81% cut**, scaling linearly with clip length.

## Why words are opt-in

Same reason the HTTP detail route already drops `words_json` (`routers/media.py:383-389`, round-5 #26, codex-verified: *"multi-MB… so it isn't shipped over NAS/Tailscale on every arrow-key"*). Same payload, worse failure mode: MCP's is a **blown context window**, not a slow transfer.

Hence also `max_words` — `include_words=true` on a feature-length clip should degrade, not detonate. `has_words` lets an agent know word timing exists without paying to find out.

## Robustness

Malformed columns degrade to `[]` rather than raising, mirroring `export.py:134-141`. Parametrized over corrupt JSON / valid-JSON-wrong-type / list-of-non-dicts / `null` / empty. A bad column must not take a tool down.

## One test changed on purpose

`test_get_transcript` asserted **whole-dict equality**, so it's updated rather than broken silently. The assertion now spells out that the four original keys are unchanged and that a clip with no segment timing still reports `segments: []`.

That path is real, not hypothetical: **the live library's 37 transcripts all predate Phase 9.4**, so `segments_json` is NULL on every one. Verified against it — flat transcript still served, `segments: []`, `has_words: false`, no crash.

`974 passed / 6 skipped` (960 + 14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)