### PR TITLE
feat(inspector): frame-exact IN/OUT marking + frame stepping (spike)

### DIFF
--- a/docs/frame-exact-inout-roadmap.md
+++ b/docs/frame-exact-inout-roadmap.md
@@ -1,0 +1,117 @@
+# Frame-exact IN/OUT — spike result & roadmap
+
+Status: **spike verified, ready to productize.** Branch: `worktree-frame-exact-inout-spike`.
+
+## Context
+
+The inspector's IN/OUT trim marks (`Inspector.svelte`, `setIn`/`setOut`) read
+`playerEl.currentTime` — a float in seconds that snaps to wherever the browser's
+decoder happened to land. For a DAM whose whole job is precise handoff to an
+edit (EDL/FCPXML/SRT export already does frame timecode math in
+`export_builders.py`), "off by a frame" is a real annoyance for the editor.
+
+This came out of exploring whether the WebCodecs techniques from
+[pixel-point/aval](https://github.com/pixel-point/aval) apply to arkiv.
+Frame-exact IN/OUT was the highest-value, lowest-risk fit.
+
+## The key decision: native, not WebCodecs
+
+**Frame-exact IN/OUT does not need WebCodecs.** The spike is entirely native:
+
+- Seeking an H.264 `<video>` to a time IS frame-accurate (just not instant).
+- `requestVideoFrameCallback`'s `mediaTime` reports the exact presentation time
+  of the frame on screen, so we always know which frame we're looking at.
+- The precise fps is already in the DB (`media.fps REAL`, set at ingest from
+  `r_frame_rate`), already in the light query (`LIGHT_COLS`), and already
+  threaded to the frontend (`_raw.fps`).
+- Export already accepts `?in_s/out_s` seconds and does the timecode math, so a
+  mark expressed as `frame/fps` seconds needs **zero backend change**.
+
+No new dependency, no demuxer, no WebCodecs. That is the honest tool for this
+job. WebCodecs would only earn its weight for two *later* things, both out of
+scope here: fast multi-frame scrubbing (decode-forward beats per-frame seek
+latency), and a seamless trim-loop preview (the AVAL seekless-loop trick).
+
+## What the spike does
+
+Frontend-only, ~70 lines, all gated behind `frameExact = useVideo && fps > 0`
+so audio and unknown-fps clips (and every design-mock screen) are untouched.
+
+- `MainLive.svelte`: adds `fpsExact: selected._raw.fps` (unrounded — rounding
+  23.976→24 would drift frame boundaries over a long clip) and passes it as
+  `fps` to `<Inspector>`.
+- `Inspector.svelte`:
+  - a self-re-arming `requestVideoFrameCallback` loop maintains `curFrame`
+    (`round(mediaTime * fps)`) — the frame actually on screen;
+  - `setIn`/`setOut` mark at `curFrame / fps` (exact frame boundary in seconds,
+    export-compatible) instead of raw `currentTime`;
+  - `◂格 / 格▸` step one frame by seeking to the frame **midpoint**
+    `(f + 0.5) / fps` (nudging past the frame edge so float/PTS rounding can't
+    land on the neighbour);
+  - timecode readout upgrades to `HH:MM:SS:FF`, plus a live `f{n}` / fps badge;
+  - IN/OUT duration shown in frames.
+
+## Verification
+
+All against a real Chromium (Playwright) with a test asset whose frame number is
+**burned into the pixels** as a binary strip, read back with `getImageData` as
+ground truth — so a mismatch between what the code thinks and what is on screen
+is caught, not assumed.
+
+| check | result |
+|---|---|
+| Marking math round-trip, 7 rates incl. 23.976/29.97/59.94, ~1h each | exact, 0 drift (Node) |
+| Seek-to-midpoint lands on the exact frame @ 30fps | 30 / 30 |
+| Seek-to-midpoint lands on the exact frame @ 59.94fps | 60 / 60 |
+| Continuous rVFC tracks `curFrame` after paused seeks @ 59.94fps | 8 / 8, matches pixels |
+| `npm run build` | clean |
+
+One notable non-bug caught during verification: `ffmpeg -ss` output-seek lands
+on frame *f+1* for a midpoint seek, because its semantics are "first frame at or
+after t". Browsers use "the frame whose interval contains t" → frame *f*. The
+real-Chromium test confirmed the browser semantics; the midpoint seek is correct.
+
+## Roadmap to production
+
+**P1 — land the spike as the shipped behaviour.**
+- Keep the native approach. Fold the spike's Inspector changes in behind the
+  existing `frameExact` gate (already graceful for audio / unknown fps).
+- Add keyboard shortcuts on the focused player: `,`/`.` step, `i`/`o` mark
+  (guard against firing inside inputs). Editors expect these.
+- Guarantee `fps` reaches the inspector on the **detail** path too, not only the
+  grid `_raw` (confirm `/api/media/{id}` carries `fps`; fall back to grid value).
+- Empty/So-what state: when `fps` is missing or 0, keep today's second-based
+  marking silently (no frame UI) — never show wrong frame numbers.
+
+**P2 — make the marks first-class.**
+- Persist IN/OUT per clip (currently reset on selection change) so a set range
+  survives navigation. Small table or a column on `media`.
+- Round-trip the exact frame through export: verify `_edl_timecode(in_s, fps)`
+  reproduces the intended frame (it should, since `in_s = frame/fps`); add a
+  test in the export suite pinning a few (frame, fps) → timecode pairs,
+  including 23.976 and 29.97 drop/non-drop.
+- Surface `start_tc` (camera-body start timecode, already ingested) so the
+  displayed TC matches the camera, not just 00:00:00:00-relative.
+
+**P3 — where WebCodecs finally earns its place (separate effort, measure first).**
+- Fast scrub: decode-forward through a GOP instead of per-frame `<video>` seek,
+  for the scene-cut filmstrip review (`InspectorFull.svelte`, currently mock).
+  Note the scene boundaries themselves are sample-approximated, not true cuts —
+  fix that data first; frame-exact decode is downstream of it.
+- Seamless trim-loop preview: loop the marked IN/OUT sub-clip without a seam
+  hitch (the AVAL seekless-loop trick). Prototype + measurement lives at
+  `~/Projects/seekless-loop`; on 1080p30 the effect was small, so gate this on a
+  real need (4K/60, weak hardware, many simultaneous previews).
+
+## Caveats
+
+- **Safari**: `requestVideoFrameCallback` is Safari 15.4+. Older Safari falls
+  back to second-based marking (the `frameExact` gate handles this — verify the
+  fallback path on a real old Safari before claiming support).
+- **Test limitation**: the one real clip in the dev DB (`黑沙灘.mov`, 59.94fps,
+  HEVC) has no source file present and no proxy built, so end-to-end against
+  arkiv's own stream endpoint was not run. Verification used a byte-identical
+  H.264 asset through the same `<video>` seek path; re-run against a live proxy
+  before shipping P1.
+- Non-integer fps (23.976/29.97/59.94) only stays exact if the **unrounded**
+  `_raw.fps` is used everywhere — `fpsExact`, not the display-rounded `fps`.

--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -20,8 +20,57 @@
   // mock-derived inspector was missing (the old .controls overlay was a fake
   // scrubber on a still image). null → poster/placeholder behaviour unchanged.
   export let videoSrc = null
+  // Precise frames-per-second (unrounded, e.g. 23.976). When set on a video, the
+  // IN/OUT marks snap to exact frame boundaries and frame stepping is enabled.
+  // null → the old second-based behaviour (audio, or fps unknown) is unchanged.
+  export let fps = null
   $: useVideo = !!videoSrc && !is360 && !!media && media.kind !== 'audio'
   $: useAudio = !!videoSrc && !!media && media.kind === 'audio'
+  // Frame features only make sense for a video with a known, sane fps.
+  $: frameExact = useVideo && typeof fps === 'number' && fps > 0
+
+  // ---- frame-exact machinery ------------------------------------------------
+  // The trick is entirely native: seeking an H.264 <video> IS frame-accurate
+  // (just not instant), and requestVideoFrameCallback's `mediaTime` reports the
+  // EXACT presentation time of the frame now on screen — so we always know which
+  // frame we're looking at, independent of any bookkeeping. No WebCodecs, no
+  // demuxer, no new dependency. (WebCodecs would only earn its place for fast
+  // multi-frame scrubbing or a seamless trim-loop — see the roadmap.)
+  let curFrame = 0 // the frame index actually displayed, from rVFC mediaTime
+  let rvfcId = 0
+  const secToFrame = (s) => Math.round(s * fps)
+  // Seek to a frame's MIDPOINT: nudging past the frame's start time avoids the
+  // browser landing on the previous frame due to float/PTS rounding at the edge.
+  const frameToSeekSec = (f) => (f + 0.5) / fps
+
+  function trackFrame() {
+    if (!playerEl || !playerEl.requestVideoFrameCallback) return
+    rvfcId = playerEl.requestVideoFrameCallback((_now, meta) => {
+      if (frameExact) curFrame = Math.round(meta.mediaTime * fps)
+      trackFrame() // re-arm; rVFC is one-shot
+    })
+  }
+  function stepFrame(delta) {
+    if (!playerEl || !frameExact) return
+    if (playerEl.pause) playerEl.pause()
+    const total = mediaDuration ? Math.round(mediaDuration * fps) : Infinity
+    const target = Math.max(0, Math.min(total - 1, curFrame + delta))
+    playerEl.currentTime = frameToSeekSec(target)
+    curFrame = target // optimistic; rVFC will confirm the true displayed frame
+  }
+  // Timecode with frames: HH:MM:SS:FF (non-drop). Falls back to MM:SS if no fps.
+  function _tcf(sec) {
+    if (sec == null) return '—'
+    if (!frameExact) return _tc(sec)
+    const f = secToFrame(sec)
+    const ff = f % Math.round(fps)
+    const s = Math.floor(f / fps)
+    const hh = Math.floor(s / 3600)
+    const mm = Math.floor((s % 3600) / 60)
+    const ss = s % 60
+    const p2 = (n) => String(n).padStart(2, '0')
+    return `${p2(hh)}:${p2(mm)}:${p2(ss)}:${p2(ff)}`
+  }
   // Real audio waveform peaks (0..1) from the backend; null → flat fallback.
   export let peaks = null
   // The player element (video or audio) — bound so clicking a transcript line or
@@ -48,14 +97,23 @@
   // set range exports just that sub-clip (EDL/SRT/FCPXML). Set at the playhead.
   let inSec = null
   let outSec = null
+  // When frameExact, mark at the exact frame boundary (curFrame from rVFC),
+  // expressed back in seconds so the ?in_s/out_s export contract is unchanged —
+  // the value just now lands precisely on a frame edge instead of wherever the
+  // decoder happened to be.
+  const markSec = () => (frameExact ? curFrame / fps : (playerEl ? playerEl.currentTime : null))
   function setIn() {
     if (!playerEl) return
-    inSec = playerEl.currentTime
+    const t = markSec()
+    if (t == null) return
+    inSec = t
     if (outSec != null && outSec <= inSec) outSec = null
   }
   function setOut() {
     if (!playerEl) return
-    outSec = playerEl.currentTime
+    const t = markSec()
+    if (t == null) return
+    outSec = t
     if (inSec != null && inSec >= outSec) inSec = null
   }
   function clearInOut() { inSec = null; outSec = null }
@@ -73,6 +131,7 @@
   }
   function onLoadedMeta() {
     if (playerEl && playerEl.duration) mediaDuration = playerEl.duration
+    if (frameExact) { curFrame = 0; trackFrame() }
   }
   const _tc = (s) => {
     if (s == null) return '—'
@@ -153,6 +212,13 @@
     inSec = null
     outSec = null
     mediaDuration = 0
+    curFrame = 0
+    // The <video> element is reused across clips (same bind), so a live rVFC
+    // callback from the previous clip must be cancelled; onLoadedMeta re-arms it.
+    if (playerEl && playerEl.cancelVideoFrameCallback && rvfcId) {
+      playerEl.cancelVideoFrameCallback(rvfcId)
+      rvfcId = 0
+    }
   }
   async function doReprocess(action) {
     if (!onReprocess || reBusy) return
@@ -289,16 +355,29 @@
   <div class="block">
     <div class="blockhead">
       <Eyebrow>Waveform</Eyebrow>
-      <Mono dim style="font-size:9.5px;">IN {_tc(inSec)} · OUT {_tc(outSec)}</Mono>
+      <Mono dim style="font-size:9.5px;">IN {_tcf(inSec)} · OUT {_tcf(outSec)}</Mono>
     </div>
     <Waveform {peaks} progress={playProgress} {inFrac} {outFrac} on:seek={(e) => seekFraction(e.detail)} on:trim={onTrim} />
+    {#if frameExact}
+      <!-- frame-exact stepper: step one frame, mark at the exact frame boundary.
+           The readout shows the frame rVFC confirms is actually on screen. -->
+      <div class="frametools">
+        <button class="ak-btn fstep" on:click={() => stepFrame(-1)} title="上一格">◂ 格</button>
+        <button class="ak-btn fstep" on:click={() => stepFrame(1)} title="下一格">格 ▸</button>
+        <Mono dim style="font-size:9.5px;margin-left:6px;align-self:center;">
+          f{curFrame} · {_tcf(curFrame / fps)} · {fps.toFixed(fps % 1 ? 3 : 0)}fps
+        </Mono>
+      </div>
+    {/if}
     {#if useVideo || useAudio}
       <div class="inout">
-        <button class="ak-btn io" on:click={setIn} title="設 IN（目前播放位置）">設 IN</button>
-        <button class="ak-btn io" on:click={setOut} title="設 OUT（目前播放位置）">設 OUT</button>
+        <button class="ak-btn io" on:click={setIn} title={frameExact ? '設 IN（貼齊目前影格）' : '設 IN（目前播放位置）'}>設 IN</button>
+        <button class="ak-btn io" on:click={setOut} title={frameExact ? '設 OUT（貼齊目前影格）' : '設 OUT（目前播放位置）'}>設 OUT</button>
         {#if inSec != null || outSec != null}
           <button class="ak-btn io clr" on:click={clearInOut} title="清除 IN/OUT">清除</button>
-          <Mono dim style="font-size:9.5px;margin-left:auto;align-self:center;">匯出將套用此區間</Mono>
+          <Mono dim style="font-size:9.5px;margin-left:auto;align-self:center;">
+            {#if frameExact && inSec != null && outSec != null}{secToFrame(outSec) - secToFrame(inSec)} 格{:else}匯出將套用此區間{/if}
+          </Mono>
         {/if}
       </div>
     {/if}
@@ -485,6 +564,8 @@
   .inout { display: flex; gap: 6px; margin-top: 8px; }
   .io { font-size: 10.5px; padding: 3px 8px; }
   .io.clr { color: var(--quiet); }
+  .frametools { display: flex; gap: 6px; margin-top: 8px; align-items: center; }
+  .fstep { font-size: 10.5px; padding: 3px 8px; font-variant-numeric: tabular-nums; }
   .previmg { width: 100%; height: 100%; object-fit: cover; display: block; }
   /* the real player: contain (don't crop footage) on black; audio sits at the bottom */
   video.previmg { object-fit: contain; background: #000; }

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -409,6 +409,10 @@
         id: selected.id, name: selected.name, kind: selected.kind,
         dur: selected.dur, size: selected.size,
         fps: selected._raw.fps ? Math.round(selected._raw.fps) : 24,
+        // Precise, unrounded fps for frame-exact IN/OUT. Rounding 23.976→24
+        // would drift frame boundaries over a long clip, so keep the raw value
+        // separate from the display `fps` above. null → frame features off.
+        fpsExact: selected._raw.fps || null,
         res: selected._raw.width ? `${selected._raw.width}×${selected._raw.height}` : '—',
         cam: [selected._raw.camera_make, selected._raw.camera_model].filter(Boolean).join(' ') || '—',
         lens: selected._raw.lens_model || '—',
@@ -758,6 +762,7 @@
         live={true}
         thumbUrl={inspThumb}
         videoSrc={inspVideoSrc}
+        fps={inspectorMedia ? inspectorMedia.fpsExact : null}
         peaks={inspPeaks}
         pathLabel={inspPath}
         transcriptLines={inspTranscript}


### PR DESCRIPTION
## What

Makes the inspector's IN/OUT trim marks **frame-exact**, and adds single-frame stepping. Today `setIn`/`setOut` read `playerEl.currentTime`, which snaps to wherever the browser decoder landed — off-by-a-frame for a DAM whose export already does frame timecode math.

## Approach — native, not WebCodecs

This came out of exploring the [pixel-point/aval](https://github.com/pixel-point/aval) WebCodecs techniques, but frame-exact IN/OUT **doesn't need WebCodecs**:

- H.264 `<video>` seeking is frame-accurate; `requestVideoFrameCallback`'s `mediaTime` tells us the exact frame on screen.
- Precise fps is already in the DB (`media.fps`, set at ingest), already in `LIGHT_COLS`, already at `_raw.fps`.
- Export already takes `?in_s/out_s` seconds → a mark of `frame/fps` seconds needs **zero backend change**.

No new dependency. WebCodecs is reserved for later (fast scrub, seamless trim-loop) — see the roadmap doc.

## Changes

- `MainLive.svelte`: thread unrounded `fpsExact` (`_raw.fps`) to `<Inspector>`.
- `Inspector.svelte` (~70 lines, all behind `frameExact = useVideo && fps>0`): rVFC frame tracking, frame-boundary IN/OUT marks, `◂格/格▸` midpoint-seek stepper, `HH:MM:SS:FF` readout. Audio / unknown-fps / all mock screens untouched.
- `docs/frame-exact-inout-roadmap.md`: spike result + P1–P3 productization plan.

## Verification

Against a **real Chromium** (Playwright) with a test asset whose frame number is burned into the pixels (read back with `getImageData` as ground truth):

| check | result |
|---|---|
| marking math, 7 rates incl. 23.976/29.97/59.94, ~1h each | 0 drift |
| seek-to-midpoint lands on exact frame @30fps | 30/30 |
| seek-to-midpoint lands on exact frame @59.94fps | 60/60 |
| continuous rVFC tracks `curFrame` after paused seeks @59.94fps | 8/8, matches pixels |
| `npm run build` | clean |

## Caveats (why draft)

- **Not** run end-to-end against arkiv's own `/api/stream` — the one real dev-DB clip (`黑沙灘.mov`, HEVC 59.94fps) has no source file / proxy. Verified through a byte-identical H.264 asset on the same `<video>` seek path; re-run against a live proxy before merging P1.
- Safari `rVFC` is 15.4+ — older Safari falls back to second-based marking (gate handles it, but verify the fallback on real old Safari).

🤖 Generated with [Claude Code](https://claude.com/claude-code)