### PR TITLE
fix(ui): toolbar wraps instead of clipping on a narrow window (C1)

### DIFF
--- a/frontend/src/lib/FilterRow.svelte
+++ b/frontend/src/lib/FilterRow.svelte
@@ -21,7 +21,8 @@
 </div>
 
 <style>
-  .filters { display: flex; gap: 4px; }
+  /* wrap so the last kind/rating chip (N·G) doesn't clip in a narrow center column */
+  .filters { display: flex; flex-wrap: wrap; gap: 4px; }
   .fbtn {
     font-family: var(--ak-mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase;
     padding: 4px 9px; background: transparent; color: var(--ink-2);

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -638,7 +638,7 @@
       <div class="toolrow">
         <div class="proj">
           <div class="ak-display projtitle">{projectName}</div>
-          <Mono dim style="font-size:11px;margin-top:5px;letter-spacing:0.04em;">
+          <Mono dim style="font-size:11px;margin-top:5px;letter-spacing:0.04em;white-space:nowrap;">
             {#if stats}{stats.total} items · {Math.round(stats.total_duration_s || 0)}s · {Math.round(stats.total_size_mb || 0)} MB · live{:else}loading…{/if}
           </Mono>
         </div>
@@ -808,10 +808,15 @@
   .artboard { width: 100%; max-width: 1920px; height: 100vh; height: 100dvh; position: relative; display: grid; grid-template-rows: 52px 1fr; background: var(--bg); color: var(--ink); overflow: hidden; margin: 0 auto; }
   .body { display: grid; grid-template-columns: 220px 1fr 340px; min-height: 0; }
   .center { display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
-  .toolrow { display: flex; align-items: center; gap: 14px; padding: 14px 22px; border-bottom: 1px solid var(--rule); }
+  /* flex-wrap so the controls reflow onto a second line on a narrow window instead
+     of clipping off the right edge (the artboard is overflow:hidden, so a non-
+     wrapping toolrow made VIDEO/AUDIO/GOOD/…/GRID-LIST unreachable below ~1000px). */
+  .toolrow { display: flex; align-items: center; flex-wrap: wrap; gap: 10px 14px; padding: 14px 22px; border-bottom: 1px solid var(--rule); }
   .proj { min-width: 0; }
   .projtitle { font-size: 28px; letter-spacing: -0.04em; line-height: 1; color: var(--ink); }
-  .livesearch { flex: 1; max-width: 360px; font-size: 12px; }
+  /* min-width so the search shrinks then WRAPS rather than collapsing the buttons
+     off-screen; the stats line stays on one row (see the nowrap on the Mono). */
+  .livesearch { flex: 1 1 200px; min-width: 160px; max-width: 360px; font-size: 12px; }
   .ranked { font-size: 10px; padding: 6px 10px; }
   .metacsv { font-size: 10px; padding: 6px 10px; white-space: nowrap; }
   .gridwrap { flex: 1; overflow: auto; position: relative; }


### PR DESCRIPTION
## What

Rendered the live UI at the **900px min-width** (Tauri `minWidth`) against the real 62-clip library and confirmed the main toolbar **clipped**: the artboard is `overflow:hidden` and `.toolrow` was a non-wrapping flex, so below ~1000px the VIDEO/AUDIO/GOOD/REVIEW/N·G filters and the GRID/LIST toggle ran off the right edge with **no scroll — unreachable**. The stats line also shattered one-token-per-line.

This is **C1** of the UI-hardening lane — the "layout 截斷 bug".

## Changes (CSS only)

- `.toolrow`: `flex-wrap` so controls reflow onto a second line.
- `.livesearch`: `min-width` so it shrinks then wraps rather than collapsing the buttons off-screen.
- stats `Mono`: `white-space:nowrap` so it stays on one line.
- `FilterRow .filters`: `flex-wrap` so the last chip (N·G) doesn't clip in a narrow center column.

## Verification

Re-rendered (headless Chrome, real data) before/after:
- **900px**: all controls now reachable, filters wrap to a second line, stats on one line.
- **1440px**: unchanged.
- `forbidden-css` gate clean; `npm run build` clean.

## Before → After (900px)

Before: filters clipped after AUDIO, GRID/LIST gone, stats shattered vertically.
After: filters wrap (ALL/VIDEO/AUDIO/GOOD/REVIEW · N·G), GRID/LIST visible, stats on one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)