### PR TITLE
fix(ui): single-source the version label, bump to v0.10.0 (C2)

### DIFF
--- a/frontend/src/lib/TopBar.svelte
+++ b/frontend/src/lib/TopBar.svelte
@@ -1,6 +1,7 @@
 <!-- Top bar: logo · search · all-projects toggle · actions. crossProject is bindable. -->
 <script>
   import { onMount, onDestroy } from 'svelte'
+  import { VERSION } from './version.js'
   import { push } from 'svelte-spa-router'
   import ArkivLogo from './ArkivLogo.svelte'
   import Mono from './Mono.svelte'
@@ -33,7 +34,7 @@
 <div class="topbar">
   <div class="logo">
     <ArkivLogo size={16} />
-    <Mono dim style="font-size:10px;letter-spacing:0.05em;">v0.9.2</Mono>
+    <Mono dim style="font-size:10px;letter-spacing:0.05em;">{VERSION}</Mono>
   </div>
 
   <div class="search">

--- a/frontend/src/lib/version.js
+++ b/frontend/src/lib/version.js
@@ -1,0 +1,5 @@
+// Single source of truth for the displayed app version. Bump here on release.
+// The label had drifted to a stale v0.9.2 across a dozen files while the app
+// shipped v0.10.0, because every route hardcoded its own copy — importing this
+// const keeps the version from going stale per-file again.
+export const VERSION = 'v0.10.0'

--- a/frontend/src/routes/ChatLive.svelte
+++ b/frontend/src/routes/ChatLive.svelte
@@ -4,6 +4,7 @@
      inline. Requires chat_write scope (token-free on loopback). -->
 <script>
   import { onMount, onDestroy, tick } from 'svelte'
+  import { VERSION } from '../lib/version.js'
   import * as api from '../lib/api.js'
   import ArkivLogo from '../lib/ArkivLogo.svelte'
   import Mono from '../lib/Mono.svelte'
@@ -195,7 +196,7 @@
 <div class="artboard" data-theme={theme}>
   <div class="topbar">
     <ArkivLogo size={16} />
-    <Mono dim style="font-size:10px;">v0.9.2</Mono>
+    <Mono dim style="font-size:10px;">{VERSION}</Mono>
     <div class="grow"></div>
     <Mono dim style="font-size:11px;">chat · 5-intent · vector + LLM</Mono>
     <a class="ak-btn" href="#/main-live">← 返回素材庫</a>

--- a/frontend/src/routes/IngestLive.svelte
+++ b/frontend/src/routes/IngestLive.svelte
@@ -18,6 +18,7 @@
      trigger stays here as the empty state for standalone use. -->
 <script>
   import { onMount, onDestroy } from 'svelte'
+  import { VERSION } from '../lib/version.js'
   import { push } from 'svelte-spa-router'
   import * as api from '../lib/api.js'
   import ArkivLogo from '../lib/ArkivLogo.svelte'
@@ -238,7 +239,7 @@
 <div class="artboard" data-theme={theme}>
   <div class="topbar">
     <ArkivLogo size={16} />
-    <Mono dim style="font-size:10px;">v0.9.2</Mono>
+    <Mono dim style="font-size:10px;">{VERSION}</Mono>
     <div class="grow"></div>
     <Mono dim style="font-size:11px;">ws://…/ws/ingest · <span class:on={conn === 'open'} class:off={conn !== 'open'}>{conn.toUpperCase()}</span></Mono>
     <button class="ak-btn" on:click={() => push('/ingest-setup')}>New ingest →</button>

--- a/frontend/src/routes/IngestSetup.svelte
+++ b/frontend/src/routes/IngestSetup.svelte
@@ -10,6 +10,7 @@
      is fully wired to a real endpoint. -->
 <script>
   import { onMount } from 'svelte'
+  import { VERSION } from '../lib/version.js'
   import { push } from 'svelte-spa-router'
   import * as api from '../lib/api.js'
   import ArkivLogo from '../lib/ArkivLogo.svelte'
@@ -102,7 +103,7 @@
 <div class="artboard" data-theme={$resolvedTheme}>
   <div class="topbar">
     <ArkivLogo size={16} />
-    <Mono dim style="font-size:10px;">v0.9.2</Mono>
+    <Mono dim style="font-size:10px;">{VERSION}</Mono>
     <div class="grow"></div>
     <Mono dim style="font-size:11px;">ingest · setup</Mono>
   </div>

--- a/frontend/src/routes/Offload.svelte
+++ b/frontend/src/routes/Offload.svelte
@@ -16,6 +16,7 @@
      Safety: offload.py copies + verifies, NEVER deletes the source. -->
 <script>
   import { push } from 'svelte-spa-router'
+  import { VERSION } from '../lib/version.js'
   import { onDestroy } from 'svelte'
   import * as api from '../lib/api.js'
   import ArkivLogo from '../lib/ArkivLogo.svelte'
@@ -146,7 +147,7 @@
 <div class="artboard" data-theme={$resolvedTheme}>
   <div class="topbar">
     <ArkivLogo size={16} />
-    <Mono dim style="font-size:10px;">v0.9.2</Mono>
+    <Mono dim style="font-size:10px;">{VERSION}</Mono>
     <div class="grow"></div>
     <Mono dim style="font-size:11px;">dit · offload</Mono>
   </div>

--- a/frontend/src/routes/SettingsLive.svelte
+++ b/frontend/src/routes/SettingsLive.svelte
@@ -17,7 +17,7 @@
   import Eyebrow from '../lib/Eyebrow.svelte'
   import { themePref, resolvedTheme, uiScale, SCALE_MIN, SCALE_MAX } from '../lib/prefs.js'
 
-  const VERSION = 'v0.9.2'
+  import { VERSION } from '../lib/version.js'
   // G5 step ①: nav expanded to the design's tab set. Real-backed tabs are
   // interactive; tabs without backend (vision/export) show honest pending rows.
   let section = 'general'


### PR DESCRIPTION
## What

The header showed a stale **v0.9.2** while the app ships **v0.10.0** — the string was hardcoded independently in a dozen files, so it drifted. Add one source of truth (`lib/version.js`) and import it in the six **live** routes that display it (TopBar, Ingest setup/live, Offload, ChatLive, Settings about). Future bumps are one line.

The six `/_design/*` mock artboards keep their frozen label — they're design-reference snapshots, not the product.

**C2** of the UI-hardening lane.

## Verification

- Rendered main screen now shows **arkiv v0.10.0**.
- `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)