### PR TITLE
fix: health check + docs point at bge-m3, not retired nomic-embed (B1)

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -18,7 +18,7 @@ git clone https://github.com/vulture-s/arkiv.git && cd arkiv
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 pip install mlx-whisper          # Apple Silicon
-ollama pull nomic-embed-text && ollama pull qwen3-vl:8b && ollama pull qwen2.5:14b
+ollama pull bge-m3 && ollama pull qwen2.5vl:7b && ollama pull qwen2.5:14b   # + minicpm-v (optional vision fallback)
 python health.py
 ```
 
@@ -35,7 +35,7 @@ python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 pip install faster-whisper torch  # NVIDIA GPU
 # pip install faster-whisper      # CPU fallback
-ollama pull nomic-embed-text && ollama pull qwen3-vl:8b && ollama pull qwen2.5:14b
+ollama pull bge-m3 && ollama pull qwen2.5vl:7b && ollama pull qwen2.5:14b   # + minicpm-v (optional vision fallback)
 python health.py
 ```
 

--- a/health.py
+++ b/health.py
@@ -235,8 +235,9 @@ def main():
         models = [m["name"] for m in r.json().get("models", [])]
         check("ollama server", True, f"({len(models)} models)")
 
-        has_embed = any("nomic-embed" in m for m in models)
-        check("nomic-embed-text", has_embed, "" if has_embed else "(run: ollama pull nomic-embed-text)")
+        embed_model = config.OLLAMA_EMBED_MODEL.split(":")[0]
+        has_embed = any(embed_model in m for m in models)
+        check(config.OLLAMA_EMBED_MODEL, has_embed, "" if has_embed else f"(run: ollama pull {config.OLLAMA_EMBED_MODEL})")
 
         vision_model = config.VISION_MODEL.split(":")[0]
         has_vision = any(vision_model in m for m in models)


### PR DESCRIPTION
## What

`health.py` hardcoded a `"nomic-embed"` model check while `install.sh` and `config` switched the default embedding model to **bge-m3** months ago — so a fresh install that pulled bge-m3 reported the embed model **missing** and told the user to `ollama pull nomic-embed-text` (wrong). Use `config.OLLAMA_EMBED_MODEL` like the vision/chat/intent checks already do. `docs/install.md`'s pull line had the same stale list; align it to `install.sh` (`bge-m3` / `qwen2.5vl:7b` / `qwen2.5:14b`).

**B1** — the option-independent first step of the packaging lane (correct model provisioning is needed under any packaging path).

## Verification

- `pytest` — **985 passed, 6 skipped**.
- `health` now reports `bge-m3`. Remaining `nomic-embed`/`qwen3-vl` strings in the tree are all legitimate history (CHANGELOG) or config comments explaining the qwen2.5-vs-qwen3 choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)