### PR TITLE
feat(packaging): B3 — self-starting Tauri desktop app (Option 1 sidecar backend)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,12 @@ venv/
 *.db-journal
 pages/
 src-tauri/target/
+# Assembled backend bundle (~1.3 GB portable python + site-packages + src).
+# Rebuilt by src-tauri/assemble-backend.sh before `cargo tauri build`. The empty
+# dir shell is kept (.gitkeep) so tauri-build's compile-time resource check passes.
+src-tauri/backend/python/
+src-tauri/backend/site-packages/
+src-tauri/backend/src/
 
 # Frontend (Svelte 4 + Vite) — deps + build + local audit artifacts
 frontend/node_modules/

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arkiv"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/assemble-backend.sh
+++ b/src-tauri/assemble-backend.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Assemble the self-contained backend bundle for the arkiv desktop app (Option 1).
+#
+# Produces src-tauri/backend/{python,site-packages,src}, which tauri.conf.json
+# bundles as an app resource. Run this ONCE before `cargo tauri build` (and again
+# whenever the deps or the SPA change).
+#
+# The backend is python-build-standalone (a portable, self-contained CPython) +
+# the project's already-built site-packages + the arkiv Python source + the built
+# SPA. It is deliberately NOT PyInstaller: the spike (2026-07-17) showed the
+# native-heavy tree (torch / mlx / chromadb / mlx-whisper / silero-vad) imports
+# and boots cleanly under a stock portable interpreter, sidestepping the
+# hidden-import/dylib whack-a-mole PyInstaller would demand for this dep set.
+#
+# The staging dir is git-ignored (it is ~1.3 GB); this script rebuilds it.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"   # src-tauri/
+REPO="$(cd "$HERE/.." && pwd)"          # repo root
+BACKEND="$HERE/backend"
+VENV_SP="$REPO/.venv/lib/python3.12/site-packages"
+
+PY_VERSION="3.12.13"
+PBS_TAG="20260623"
+PBS_URL="https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_TAG}/cpython-${PY_VERSION}%2B${PBS_TAG}-aarch64-apple-darwin-install_only.tar.gz"
+
+if [ ! -d "$VENV_SP" ]; then
+  echo "ERROR: $VENV_SP not found — run install.sh (or build the .venv) first." >&2
+  exit 1
+fi
+
+echo "[assemble] clean staging: $BACKEND (preserving tracked .gitkeep)"
+rm -rf "$BACKEND/python" "$BACKEND/site-packages" "$BACKEND/src"
+mkdir -p "$BACKEND/src"
+
+echo "[assemble] portable python $PY_VERSION (python-build-standalone $PBS_TAG)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+curl -fsSL "$PBS_URL" -o "$TMP/pbs.tar.gz"
+tar xzf "$TMP/pbs.tar.gz" -C "$TMP"     # extracts ./python/
+mv "$TMP/python" "$BACKEND/python"
+
+echo "[assemble] site-packages (trim caches + chromadb transitives arkiv never imports at runtime)"
+mkdir -p "$BACKEND/site-packages"
+# arkiv embeds via ollama, not chromadb's built-in onnx/k8s embedding paths, so
+# kubernetes/ and onnxruntime/ (~155 MB) are dead weight in the bundle. Drop
+# bytecode caches too. If a future feature needs them, remove the excludes.
+rsync -a --delete \
+  --exclude '__pycache__/' --exclude '*.pyc' \
+  --exclude 'kubernetes/' --exclude 'onnxruntime/' \
+  "$VENV_SP/" "$BACKEND/site-packages/"
+
+echo "[assemble] arkiv source (runtime .py + routers + built SPA; no tests/docs/venv)"
+# The server imports many top-level modules + the routers package, and serves the
+# SPA from ./frontend/dist relative to its cwd. Copy generously (repo minus the
+# heavy/irrelevant dirs) so no runtime import is missed.
+rsync -a \
+  --exclude '.git/' --exclude '.venv/' --exclude 'node_modules/' \
+  --exclude 'src-tauri/' --exclude 'tests/' --exclude 'docs/' \
+  --exclude 'frontend/node_modules/' --exclude 'frontend/src/' \
+  --exclude '__pycache__/' --exclude '*.pyc' \
+  --exclude '.arkiv/' --exclude 'chroma_db/' \
+  "$REPO/" "$BACKEND/src/"
+
+if [ ! -f "$BACKEND/src/frontend/dist/index.html" ]; then
+  echo "WARN: frontend/dist/index.html missing — run 'cd frontend && npm run build' first," >&2
+  echo "      or the packaged app will serve the fallback page." >&2
+fi
+
+echo "[assemble] done:"
+du -sh "$BACKEND" "$BACKEND"/python "$BACKEND"/site-packages "$BACKEND"/src 2>/dev/null || true
+echo "[assemble] next: cargo tauri build  (from src-tauri/)"

--- a/src-tauri/gen/schemas/macOS-schema.json
+++ b/src-tauri/gen/schemas/macOS-schema.json
@@ -2313,22 +2313,22 @@
           "markdownDescription": "Denies the unminimize command without any pre-configured scope."
         },
         {
-          "description": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-ask`\n- `allow-confirm`\n- `allow-message`\n- `allow-save`\n- `allow-open`",
+          "description": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-message`\n- `allow-save`\n- `allow-open`",
           "type": "string",
           "const": "dialog:default",
-          "markdownDescription": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-ask`\n- `allow-confirm`\n- `allow-message`\n- `allow-save`\n- `allow-open`"
+          "markdownDescription": "This permission set configures the types of dialogs\navailable from the dialog plugin.\n\n#### Granted Permissions\n\nAll dialog types are enabled.\n\n\n\n#### This default permission set includes:\n\n- `allow-message`\n- `allow-save`\n- `allow-open`"
         },
         {
-          "description": "Enables the ask command without any pre-configured scope.",
+          "description": "Enables the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:allow-ask",
-          "markdownDescription": "Enables the ask command without any pre-configured scope."
+          "markdownDescription": "Enables the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)"
         },
         {
-          "description": "Enables the confirm command without any pre-configured scope.",
+          "description": "Enables the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:allow-confirm",
-          "markdownDescription": "Enables the confirm command without any pre-configured scope."
+          "markdownDescription": "Enables the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `allow-message` and will be removed in v3)"
         },
         {
           "description": "Enables the message command without any pre-configured scope.",
@@ -2349,16 +2349,16 @@
           "markdownDescription": "Enables the save command without any pre-configured scope."
         },
         {
-          "description": "Denies the ask command without any pre-configured scope.",
+          "description": "Denies the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:deny-ask",
-          "markdownDescription": "Denies the ask command without any pre-configured scope."
+          "markdownDescription": "Denies the ask command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)"
         },
         {
-          "description": "Denies the confirm command without any pre-configured scope.",
+          "description": "Denies the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)",
           "type": "string",
           "const": "dialog:deny-confirm",
-          "markdownDescription": "Denies the confirm command without any pre-configured scope."
+          "markdownDescription": "Denies the confirm command without any pre-configured scope. (**DEPRECATED**: This is now an alias to `deny-message` and will be removed in v3)"
         },
         {
           "description": "Denies the message command without any pre-configured scope.",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,16 +1,163 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+// arkiv desktop shell (Option 1 packaging, B3).
+//
+// The app is self-starting: on launch it spawns the bundled Python backend
+// (`python-build-standalone` + the site-packages, NOT PyInstaller — the spike
+// showed the native-heavy tree, torch/mlx/chromadb, loads cleanly under a stock
+// portable interpreter) on a negotiated free port, waits for it to accept
+// connections, then opens the WebView pointed at it. The child is killed on exit.
+//
+// Backend location is resolved in this order:
+//   1. env override (dev): ARKIV_SIDECAR_PYTHON / ARKIV_SIDECAR_PYTHONPATH /
+//      ARKIV_SIDECAR_SRC — lets `cargo tauri dev` drive the real spawn path
+//      against a dev checkout without bundling 1.5 GB.
+//   2. bundled resources: <resources>/backend/{python,site-packages,src}.
+
+use std::net::{TcpListener, TcpStream};
+use std::process::{Child, Command};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
+
+/// Holds the spawned backend so we can kill it on exit.
+struct Backend(Mutex<Option<Child>>);
+
+/// Ask the OS for a free TCP port (bind :0, read the assigned port, drop).
+fn free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .and_then(|l| l.local_addr())
+        .map(|a| a.port())
+        .unwrap_or(8501)
+}
+
+/// Poll until the backend accepts a TCP connection, or the timeout elapses.
+fn wait_ready(port: u16, timeout: Duration) -> bool {
+    let start = Instant::now();
+    let addr = format!("127.0.0.1:{port}").parse().unwrap();
+    while start.elapsed() < timeout {
+        if TcpStream::connect_timeout(&addr, Duration::from_millis(500)).is_ok() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    false
+}
+
+/// Resolve (python_binary, PYTHONPATH, working_dir) for the backend.
+fn resolve_backend(app: &tauri::App) -> Result<(String, String, String), String> {
+    if let Ok(py) = std::env::var("ARKIV_SIDECAR_PYTHON") {
+        // dev / override path
+        let pp = std::env::var("ARKIV_SIDECAR_PYTHONPATH").unwrap_or_default();
+        let src = std::env::var("ARKIV_SIDECAR_SRC").unwrap_or_default();
+        return Ok((py, pp, src));
+    }
+    // bundled resources: <resources>/backend/{python,site-packages,src}
+    let res = app
+        .path()
+        .resource_dir()
+        .map_err(|e| format!("resource_dir: {e}"))?;
+    let backend = res.join("backend");
+    let python = backend.join("python").join("bin").join("python3");
+    let site = backend.join("site-packages");
+    let src = backend.join("src");
+    let pythonpath = format!("{}:{}", site.display(), src.display());
+    Ok((
+        python.to_string_lossy().into_owned(),
+        pythonpath,
+        src.to_string_lossy().into_owned(),
+    ))
+}
+
 fn main() {
     std::panic::set_hook(Box::new(|info| {
         eprintln!("[arkiv-tauri panic] {}", info);
     }));
 
-    // Dev mode: assumes arkiv server is already running on localhost:8501
-    // Production: will add sidecar launch when PyInstaller binary is ready
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .manage(Backend(Mutex::new(None)))
+        .setup(|app| {
+            let port = free_port();
+
+            let (python, pythonpath, src_dir) = match resolve_backend(app) {
+                Ok(t) => t,
+                Err(e) => {
+                    eprintln!("[arkiv-tauri] cannot resolve backend: {e}");
+                    return Err(e.into());
+                }
+            };
+
+            // Project root must be OUTSIDE the read-only .app bundle. app_local_data_dir
+            // is per-user writable; the server's init_db creates the DB/dirs on first run.
+            let proj_root = app
+                .path()
+                .app_local_data_dir()
+                .map(|d| d.join("arkiv"))
+                .unwrap_or_else(|_| {
+                    std::path::PathBuf::from(std::env::var("HOME").unwrap_or_default())
+                        .join(".arkiv")
+                });
+            let _ = std::fs::create_dir_all(&proj_root);
+
+            eprintln!(
+                "[arkiv-tauri] starting backend: {python} (cwd={src_dir}) on 127.0.0.1:{port}, root={}",
+                proj_root.display()
+            );
+
+            let child = Command::new(&python)
+                .args([
+                    "-m",
+                    "uvicorn",
+                    "server:app",
+                    "--host",
+                    "127.0.0.1",
+                    "--port",
+                    &port.to_string(),
+                ])
+                .current_dir(&src_dir)
+                .env("PYTHONPATH", &pythonpath)
+                .env("ARKIV_PROJECT_ROOT", &proj_root)
+                .env("ARKIV_PORT", port.to_string())
+                .env("ARKIV_TRUST_LOOPBACK", "1")
+                .spawn();
+
+            let child = match child {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("[arkiv-tauri] failed to spawn backend: {e}");
+                    return Err(Box::new(e));
+                }
+            };
+            app.state::<Backend>().0.lock().unwrap().replace(child);
+
+            if !wait_ready(port, Duration::from_secs(45)) {
+                eprintln!("[arkiv-tauri] backend not ready after 45s on port {port} — opening anyway");
+            }
+
+            let url = format!("http://127.0.0.1:{port}");
+            WebviewWindowBuilder::new(app, "main", WebviewUrl::External(url.parse().unwrap()))
+                .title("arkiv")
+                .inner_size(1400.0, 900.0)
+                .min_inner_size(900.0, 600.0)
+                .build()?;
+
+            Ok(())
+        })
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app_handle, event| {
+            // Kill the backend child when the app is exiting, so no orphan uvicorn
+            // survives the window closing.
+            if let tauri::RunEvent::ExitRequested { .. } = event {
+                if let Some(state) = app_handle.try_state::<Backend>() {
+                    if let Some(mut child) = state.0.lock().unwrap().take() {
+                        let _ = child.kill();
+                    }
+                }
+            }
+        });
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -9,19 +9,7 @@
   },
   "app": {
     "withGlobalTauri": true,
-    "windows": [
-      {
-        "title": "arkiv — Media Asset Manager",
-        "width": 1400,
-        "height": 900,
-        "minWidth": 900,
-        "minHeight": 600,
-        "center": true,
-        "decorations": true,
-        "resizable": true,
-        "url": "http://localhost:8501"
-      }
-    ],
+    "windows": [],
     "security": {
       "csp": "default-src * 'unsafe-inline' 'unsafe-eval' data: blob:"
     }
@@ -36,10 +24,12 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "resources": [],
+    "resources": {
+      "backend": "backend"
+    },
     "externalBin": [],
     "macOS": {
-      "minimumSystemVersion": "10.15"
+      "minimumSystemVersion": "12.0"
     }
   },
   "plugins": {}


### PR DESCRIPTION
## What

Wire the Tauri desktop shell into a **self-starting** app: on launch it spawns the bundled Python backend on a negotiated free port, waits for it to accept connections, then opens the WebView pointed at it — no separate `uvicorn` terminal dance. This is **Option 1** (local, unsigned, for-me); signing/notarization/auto-update (Option 2) is deliberately deferred.

## Changes
- **`src-tauri/src/main.rs`** — sidecar spawn: `free_port()` → `python -m uvicorn server:app` (child cwd = backend src, `PYTHONPATH = site-packages:src`, `ARKIV_PROJECT_ROOT = app_local_data_dir/arkiv` writable outside the read-only bundle, `ARKIV_TRUST_LOOPBACK=1`) → `wait_ready()` TCP poll (45s) → `WebviewWindowBuilder` External URL → `RunEvent::ExitRequested` kills the child (no orphan uvicorn). Backend resolved via `ARKIV_SIDECAR_*` env override (dev) or bundled `<resources>/backend/{python,site-packages,src}` (packaged).
- **`src-tauri/tauri.conf.json`** — `windows: []` (built programmatically), `resources: {backend}`, `minimumSystemVersion` 12.0.
- **`src-tauri/assemble-backend.sh`** — rebuilds the git-ignored ~1.3 GB staging bundle (python-build-standalone + trimmed site-packages + arkiv src + built SPA). **Not PyInstaller** — the spike showed the native-heavy tree (torch/mlx/chromadb/mlx-whisper/silero-vad) boots cleanly under a stock portable interpreter.
- **`backend/.gitkeep` + `.gitignore`** — keep the empty shell tracked so tauri-build's compile-time resource check passes without the 1.3 GB bundle present.
- **`Cargo.lock` / `gen/schemas`** — benign build byproducts (arkiv 0.1.0→0.2.0 sync; dialog plugin v2.7.0 schema).

## Verification (real, not "should work")
Dev-override run of the built binary: Rust `setup()` spawned the backend, the WKWebView loaded the SPA from `127.0.0.1:<port>`, and the SPA startup calls (`/api/collections`, `/api/tags`, `/api/media?limit=500`, `/api/stats`, `/api/bins`, `/api/ingest/engines`) all returned **200** — full spawn → wait → window → serve path. Clean teardown, no orphan backend.

No Python behavior changed → Python CI unaffected.