### PR TITLE
docs(packaging): B3 — record CI=true dmg build recipe (skip-jenkins)

### DIFF
--- a/src-tauri/assemble-backend.sh
+++ b/src-tauri/assemble-backend.sh
@@ -69,4 +69,8 @@ fi
 
 echo "[assemble] done:"
 du -sh "$BACKEND" "$BACKEND"/python "$BACKEND"/site-packages "$BACKEND"/src 2>/dev/null || true
-echo "[assemble] next: cargo tauri build  (from src-tauri/)"
+echo "[assemble] next:  CI=true cargo tauri build   (from src-tauri/)"
+echo "[assemble]        ^^^^^^^ CI=true makes tauri pass --skip-jenkins to bundle_dmg.sh,"
+echo "[assemble]        skipping the Finder-prettifying AppleScript. Without it the dmg step"
+echo "[assemble]        fails with AppleEvent timeout -1712 in any non-GUI / background build"
+echo "[assemble]        (the .app still builds; only the cosmetic dmg layout needs a live Finder)."


### PR DESCRIPTION
Follow-up to #199. Captures the reproducible dmg build recipe so the AppleEvent `-1712` timeout isn't rediscovered.

**Problem**: `cargo tauri build` dmg step runs `bundle_dmg.sh`, which invokes a Finder-prettifying AppleScript needing a live, Automation-permitted Finder. In any non-GUI / background build it fails: `Finder … AppleEvent逾時 (-1712)`. The `.app` still builds fine; only the cosmetic dmg-layout step needs Finder.

**Fix**: `CI=true cargo tauri build` → tauri passes `--skip-jenkins` → skips the AppleScript. The dmg still contains `arkiv.app` + the `Applications` drag-target symlink; it just lacks the custom background/icon positioning.

**Verified**: `CI=true cargo tauri build --bundles dmg` → `arkiv_0.2.0_aarch64.dmg` (399 MB), `hdiutil verify` checksum VALID, mounts at `/Volumes/arkiv` with `arkiv.app` (bundled `Contents/Resources/backend/python/bin/python3` intact) + `Applications → /Applications`.

Doc/comment-only change to `assemble-backend.sh` — no code, Python CI unaffected.