### PR TITLE
docs: fix vision-model drift + add Mac quickstart (W0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@
 # ── Ollama ─────────────────────────────────────────────────
 # ARKIV_OLLAMA_URL=http://localhost:11434   # Ollama API endpoint
 # ARKIV_EMBED_MODEL=bge-m3                 # Embedding model name (default bge-m3, multilingual 1024-dim)
-# ARKIV_VISION_MODEL=qwen3-vl:8b           # Vision model for frame analysis
+# ARKIV_VISION_MODEL=qwen2.5vl:7b          # Vision model (default; qwen3-vl:8b = higher quality but ~10x slower)
 
 # ── Vector backend ─────────────────────────────────────────
 # ARKIV_VECTOR_BACKEND=chroma              # "chroma" (default, local ChromaDB) or "pg" (shared pgvector)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Designed for solo DITs and small crews who own their data: local-first, self-hos
   Phase 2: Vision (after unloading LLM from VRAM)
   ┌─────────┐  ┌──────────────┐
   │frames.py│→ │  vision.py   │
-  │(extract)│  │(qwen3-vl:8b) │
+  │(extract)│  │(qwen2.5vl:7b) │
   └─────────┘  └──────────────┘
 ```
 
@@ -57,7 +57,7 @@ Designed for solo DITs and small crews who own their data: local-first, self-hos
 - **Chat RAG over your video library** — 5-intent assistant for compilation searches, refinement, similarity, analytics, and general questions with persisted conversation memory
 - **AI transcription** — Whisper large-v3-turbo + Silero VAD + LLM polish (Apple Silicon MLX / NVIDIA CUDA)
 - **4-layer anti-hallucination guard** — VAD silence filter → no_speech threshold → blank/repeat filter → LLM correction
-- **Frame analysis** — qwen3-vl:8b vision descriptions with brand/object recognition
+- **Frame analysis** — qwen2.5vl:7b vision descriptions with brand/object recognition
 - **2-phase pipeline** — transcribe first, unload LLM, then vision (avoids VRAM conflict on 12GB GPUs)
 - **Rating system** — GOOD / NG / Review with notes + clip color in Resolve
 - **Tag system** — auto (AI) + manual tags with autocomplete
@@ -169,7 +169,7 @@ cd arkiv
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 pip install mlx-whisper          # Apple Silicon (Metal GPU)
-ollama pull bge-m3 && ollama pull qwen3-vl:8b && ollama pull qwen2.5:14b
+ollama pull bge-m3 && ollama pull qwen2.5vl:7b && ollama pull qwen2.5:14b
 python health.py
 ```
 
@@ -183,7 +183,7 @@ python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 pip install faster-whisper torch  # NVIDIA CUDA GPU
 # pip install faster-whisper      # CPU fallback
-ollama pull bge-m3 && ollama pull qwen3-vl:8b && ollama pull qwen2.5:14b
+ollama pull bge-m3 && ollama pull qwen2.5vl:7b && ollama pull qwen2.5:14b
 python health.py
 ```
 
@@ -198,7 +198,7 @@ python -m venv .venv
 pip install -r requirements.txt
 pip install faster-whisper torch  # NVIDIA CUDA GPU
 # pip install faster-whisper      # CPU fallback
-ollama pull bge-m3; ollama pull qwen3-vl:8b; ollama pull qwen2.5:14b
+ollama pull bge-m3; ollama pull qwen2.5vl:7b; ollama pull qwen2.5:14b
 $env:PYTHONUTF8=1; python health.py
 ```
 
@@ -297,7 +297,7 @@ Copy `.env.example` to `.env` and customize:
 | `ARKIV_THUMBNAILS_DIR` | `./thumbnails` | Thumbnail output dir |
 | `ARKIV_OLLAMA_URL` | `http://localhost:11434` | Ollama API endpoint |
 | `ARKIV_EMBED_MODEL` | `bge-m3` | Embedding model — **do not change after indexing** (see note below) |
-| `ARKIV_VISION_MODEL` | `qwen3-vl:8b` | Vision model for frame descriptions |
+| `ARKIV_VISION_MODEL` | `qwen2.5vl:7b` | Vision model for frame descriptions |
 | `ARKIV_CHAT_MODEL` | `qwen2.5:14b` | Chat model — answers and (by default) intent classification |
 | `ARKIV_INTENT_MODEL` | *(= `ARKIV_CHAT_MODEL`)* | Optional faster model for intent classification only; must be installed |
 | `ARKIV_WHISPER_MODEL` | `mlx-community/whisper-large-v3-turbo` (macOS) / `large-v3-turbo` (other) | Whisper model |
@@ -325,7 +325,7 @@ Copy `.env.example` to `.env` and customize:
 | Transcription | mlx-whisper / faster-whisper (large-v3-turbo) |
 | VAD | Silero VAD (silence filter before Whisper) |
 | LLM Polish + Chat | Ollama qwen2.5:14b (transcript polish + 5-intent chat RAG) |
-| Vision | Ollama qwen3-vl:8b (brand/object recognition) |
+| Vision | Ollama qwen2.5vl:7b (brand/object recognition) |
 | Media | FFmpeg (probe, thumbnails, frame extraction) |
 | Metadata | ExifTool (12 fields, sidecar-aware, cross-platform auto-detect) |
 | Export | SRT, VTT, TXT, EDL (DF/NDF), FCPXML 1.8 |
@@ -378,7 +378,7 @@ SKIP items are **optional dependencies** — they do not affect functionality. A
 | FFmpeg / ffprobe | Required | Required | Required | |
 | Ollama server | Required | Required | Required | |
 | bge-m3 | Required | Required | Required | |
-| qwen3-vl:8b | Optional | Optional | Optional | For frame descriptions |
+| qwen2.5vl:7b | Optional | Optional | Optional | For frame descriptions |
 | qwen2.5:14b | Optional | Optional | Optional | Transcript polish + chat (required for `/api/chat`) |
 | ExifTool | Optional | Optional | Optional | For rich metadata |
 | faster-whisper | Required | Optional | Required | CUDA/CPU whisper |

--- a/docs/install.md
+++ b/docs/install.md
@@ -51,7 +51,7 @@ python -m venv .venv; .\.venv\Scripts\activate
 pip install -r requirements.txt
 pip install faster-whisper torch  # NVIDIA GPU
 # pip install faster-whisper      # CPU fallback
-ollama pull nomic-embed-text; ollama pull qwen3-vl:8b; ollama pull qwen2.5:14b
+ollama pull bge-m3; ollama pull qwen2.5vl:7b; ollama pull qwen2.5:14b
 $env:PYTHONUTF8=1; python health.py
 ```
 

--- a/docs/quickstart-mac.md
+++ b/docs/quickstart-mac.md
@@ -1,0 +1,104 @@
+# arkiv — Mac Quickstart (Apple Silicon)
+
+A 10-minute hand-holding guide to get arkiv running on an Apple Silicon Mac.
+arkiv runs **100% locally** — nothing is uploaded. It needs three helpers on your
+machine first (Ollama for the AI models, FFmpeg for video, ExifTool for camera
+metadata), then it does the rest.
+
+> **Heads up on size:** the AI models are ~15 GB total and download once. Budget a
+> few minutes on first pull, and let the first ingest run overnight for a big library.
+
+---
+
+## 1. Install the three helpers
+
+```bash
+brew install ollama ffmpeg exiftool
+```
+
+Start Ollama (leave it running — arkiv talks to it in the background):
+
+```bash
+ollama serve   # or just open the Ollama.app once; it stays running
+```
+
+Pull the three models arkiv uses (embeddings + vision + chat):
+
+```bash
+ollama pull bge-m3          # semantic search embeddings (multilingual)
+ollama pull qwen2.5vl:7b    # frame descriptions (vision)
+ollama pull qwen2.5:14b     # chat / RAG
+```
+
+> These are the **defaults**. `qwen3-vl:8b` is a higher-quality vision model but
+> ~10× slower — don't pull it unless you specifically want it and set
+> `ARKIV_VISION_MODEL=qwen3-vl:8b`.
+
+---
+
+## 2. Open the app
+
+**If you got the `arkiv.app` / `.dmg`** (unsigned, so macOS Gatekeeper will warn once):
+
+1. Open the `.dmg` and drag **arkiv** to **Applications** (or just keep the `.app`).
+2. **First launch only**: right-click (or Control-click) `arkiv.app` → **Open** →
+   **Open** again in the dialog. This clears the "unidentified developer" warning
+   *once*; after that you can double-click normally. (Double-clicking the first
+   time just shows a dead-end "can't be opened" dialog — use right-click → Open.)
+
+The app starts its own backend and opens a window. Your library lives in
+`~/Library/Application Support/com.hevin.arkiv/arkiv/` (DB, thumbnails, logs).
+
+**If you're running from source** instead:
+
+```bash
+git clone https://github.com/vulture-s/arkiv.git && cd arkiv
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt && pip install mlx-whisper
+python health.py        # confirm everything is READY (see step 3)
+python server.py        # then open http://localhost:8501
+```
+
+---
+
+## 3. Confirm it's ready BEFORE your first ingest
+
+From a source checkout (or the bundled python), run the health check:
+
+```bash
+python health.py
+# All required checks: PASS. SKIP = optional, does not affect functionality.
+```
+
+If it reports Ollama unreachable or a model missing, fix that first — otherwise
+ingest/search will fail quietly. Common causes: Ollama not running (`ollama serve`),
+or a model not pulled yet (step 1).
+
+---
+
+## 4. Ingest your first footage
+
+Point arkiv at a folder of clips. **If your footage is not Chinese, pass the
+language** — arkiv defaults to `zh` and will otherwise transcribe e.g. English
+audio as garbled Chinese:
+
+```bash
+python ingest.py --dir "/path/to/your/clips" --language en   # zh / en / ja / ko
+```
+
+Then search in plain language (中文 or English) in the app. That's the moment
+arkiv is built for: type a phrase, and matching clips from years of footage surface.
+
+---
+
+## Troubleshooting
+
+- **Empty grid / search returns nothing** → Ollama isn't running or models aren't
+  pulled. Re-run `python health.py`.
+- **A `.mov`/HEVC clip won't play in the preview** → arkiv builds a proxy on
+  ingest; give it a moment, or use the "build proxy" action.
+- **Pro-camera files (`.mxf`/`.braw`/`.r3d`) don't show up** → not yet supported
+  for indexing (ffmpeg can't decode them without vendor SDKs).
+- **Something broke** → send the log: `~/Library/Application Support/com.hevin.arkiv/arkiv/logs/backend.log`
+  (and `backend.log.prev` for the previous run). That's exactly what's needed to
+  debug it.


### PR DESCRIPTION
**Wave 0 onboarding** (2 fixes from the launch-readiness audit).

1. **Vision-model doc drift** — README (pull commands + tables), `.env.example`, and `docs/install.md` (Windows) said `qwen3-vl:8b` / `nomic-embed-text`, but `config.py:135` default + `install.sh` pull `qwen2.5vl:7b` / `bge-m3`. A README-follower pulled the wrong (~10× slower) model that `health.py` then reported as MISSING. Aligned to defaults; kept one note that `qwen3-vl:8b` is an optional higher-quality/slower override.
2. **New `docs/quickstart-mac.md`** — hand-holding Apple-Silicon guide: install Ollama/ffmpeg/exiftool, pull the 3 correct models, Gatekeeper right-click→Open, `health.py` READY before first ingest, `--language` for non-zh footage, and where `backend.log` lives.

Docs-only.