### PR TITLE
feat(ingest): loud skips + timeout cap + language notice (W0)

### DIFF
--- a/frames.py
+++ b/frames.py
@@ -253,7 +253,10 @@ def _extract_scene_persistent(
     # Full-file scene-detect pass scales with clip length — bound it so one
     # bad file can't hang the whole batch; timeout falls back to fixed frames
     # via the caller (audit H6).
-    scene_timeout = max(120.0, duration_s * 2)
+    # Cap at 30 min: a corrupt/misauthored file can report a bogus huge duration,
+    # and duration_s*2 would let one wedged ffmpeg hang the whole batch for hours.
+    # (The audio path already uses a fixed cap; this mirrors it for scene-detect.)
+    scene_timeout = min(max(120.0, duration_s * 2), 1800.0)
     try:
         proc = subprocess.run(
             cmd, capture_output=True, text=True, encoding="utf-8", errors="replace",

--- a/ingest.py
+++ b/ingest.py
@@ -48,6 +48,34 @@ _STAGE_EVENTS = os.environ.get("ARKIV_STAGE_EVENTS") == "1"
 # hint, the default). Set from --language in main(), read at the transcribe call.
 _LANGUAGE_OVERRIDE = None
 
+# Pro/cinema codecs ffmpeg can't decode without vendor SDKs — a --dir scan drops
+# them silently, so a user who dumps a C300/RED/BRAW card sees "Found 0 media
+# files" and thinks arkiv is broken. Named here so the skip notice can call them out.
+_PRO_UNSUPPORTED_EXT = {".mxf", ".braw", ".r3d", ".m2ts", ".ari", ".dng", ".cine", ".crm", ".rmf"}
+
+
+def _report_unsupported(all_files, supported_files):
+    """Print a visible summary of files a --dir scan skipped (unsupported ext),
+    so pro-format footage isn't dropped with zero feedback. No-op if none."""
+    n = len(all_files) - len(supported_files)
+    if n <= 0:
+        return
+    from collections import Counter
+    exts = Counter(
+        (f.suffix.lower() or "(no ext)")
+        for f in all_files
+        if f.suffix.lower() not in SUPPORTED
+    )
+    top = ", ".join("{0}×{1}".format(e, c) for e, c in exts.most_common(6))
+    print("⚠  Skipped {0} unsupported file(s): {1}".format(n, top))
+    pro = sorted(e for e in exts if e in _PRO_UNSUPPORTED_EXT)
+    if pro:
+        print(
+            "   Pro/cinema formats {0} aren't indexable (ffmpeg has no decoder "
+            "without vendor SDKs).".format(", ".join(pro))
+        )
+    print("   arkiv indexes: {0}".format(", ".join(sorted(SUPPORTED))))
+
 
 def _emit_progress(obj: Dict) -> None:
     """One JSON progress event on its own flushed line (sentinel-prefixed). No-op
@@ -1460,6 +1488,14 @@ def main():
         tr._apply_whisper_guard_mode(tr._resolve_whisper_guard_mode(args.whisper_guard))
     global _LANGUAGE_OVERRIDE
     _LANGUAGE_OVERRIDE = args.language or None
+    # One-time notice: with no explicit --language, Whisper falls back to zh, so
+    # English/Japanese footage gets silently transcribed as garbled Chinese.
+    if _LANGUAGE_OVERRIDE is None and (getattr(args, "dir", None) or getattr(args, "files", None)):
+        print(
+            "ℹ  No --language given; non-Chinese audio will transcribe as 'zh' "
+            "(Whisper default) and come out garbled. Pass --language en/ja/ko if "
+            "your footage isn't Chinese.\n"
+        )
 
     # --dir validation: required only when actually ingesting
     maintenance_mode = (
@@ -1575,15 +1611,19 @@ def main():
             # Single-file mode (used by watch.py for new-arrival ingest)
             files = [media_dir] if media_dir.suffix.lower() in SUPPORTED else []
         elif args.recursive:
-            files = sorted(
+            all_files = [
                 f for f in media_dir.rglob("*")
-                if f.is_file() and f.suffix.lower() in SUPPORTED
-            )
+                if f.is_file() and not f.name.startswith(".")
+            ]
+            files = sorted(f for f in all_files if f.suffix.lower() in SUPPORTED)
+            _report_unsupported(all_files, files)
         else:
-            files = sorted(
+            all_files = [
                 f for f in media_dir.iterdir()
-                if f.is_file() and f.suffix.lower() in SUPPORTED
-            )
+                if f.is_file() and not f.name.startswith(".")
+            ]
+            files = sorted(f for f in all_files if f.suffix.lower() in SUPPORTED)
+            _report_unsupported(all_files, files)
 
     total = len(files)
 

--- a/tests/test_w0_ingest_robustness.py
+++ b/tests/test_w0_ingest_robustness.py
@@ -1,0 +1,36 @@
+"""Wave-0 ingest robustness: --dir unsupported-file skip notice.
+
+The #1 silent trust-breaker for a first-wave user was a --dir scan dropping
+pro/cinema footage (.mxf/.braw/.r3d) with zero feedback → "Found 0 media files".
+_report_unsupported gives that a visible summary. (scene-timeout cap + forced-zh
+notice in this PR are inline one-liners, exercised via the ingest path.)
+"""
+from pathlib import Path
+
+import ingest
+
+
+def test_report_unsupported_names_pro_codecs(capsys):
+    all_files = [Path("/card/a.mp4"), Path("/card/b.MXF"), Path("/card/c.braw"), Path("/card/d.mov")]
+    supported = [Path("/card/a.mp4"), Path("/card/d.mov")]
+    ingest._report_unsupported(all_files, supported)
+    out = capsys.readouterr().out
+    assert "Skipped 2 unsupported" in out
+    assert ".mxf" in out and ".braw" in out          # case-folded
+    assert "Pro/cinema" in out                        # pro-codec callout fired
+
+
+def test_report_unsupported_noop_when_all_supported(capsys):
+    files = [Path("/x/a.mp4"), Path("/x/b.mov")]
+    ingest._report_unsupported(files, files)
+    assert capsys.readouterr().out == ""
+
+
+def test_report_unsupported_generic_only_no_pro_line(capsys):
+    # unsupported but non-pro (e.g. a stray .txt) → count shown, no Pro/cinema line
+    all_files = [Path("/x/a.mp4"), Path("/x/notes.txt")]
+    supported = [Path("/x/a.mp4")]
+    ingest._report_unsupported(all_files, supported)
+    out = capsys.readouterr().out
+    assert "Skipped 1 unsupported" in out
+    assert "Pro/cinema" not in out


### PR DESCRIPTION
**Wave 0 ingest robustness** — three silent-failure fixes from the launch-readiness audit so a first-wave user's own footage doesn't fail quietly.

1. **`--dir` skip notice** — a scan silently dropped pro/cinema footage (`.mxf/.braw/.r3d/.m2ts/…`); a user dumping a C300/RED/BRAW card saw "Found 0 media files" and assumed arkiv was broken. Now prints `Skipped N unsupported file(s): …` with a pro-codec callout. Dotfiles excluded.
2. **scene-detect timeout cap** (`frames.py`) — was `max(120, duration_s*2)`; a corrupt file lying about a huge duration could wedge one ffmpeg for hours. Capped at 30 min (mirrors the audio path).
3. **forced-zh language notice** (`ingest.py`) — with no `--language`, Whisper defaults to `zh` and silently garbles English/Japanese audio. One-time upfront notice.

3 new tests + 48 existing ingest/frames tests green.

**Follow-up (not here):** Phase-1 consecutive-failure halt (drive-loss guard) — deferred, lower likelihood for a local-folder wave-0 run.