### PR TITLE
feat(api): unauthenticated /api/health + /api/version (W0)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,14 @@ labels: bug
 - **Whisper backend**: (mlx-whisper / faster-whisper CUDA / faster-whisper CPU)
 - **GPU**: (e.g., Apple M2 Max / RTX 4070 / None)
 
-## `python health.py` output
+## Diagnostics
+
+Paste **one** of these (whichever you can run):
+
+- **From source/CLI:** `python health.py` output, or
+- **Desktop app:** the health JSON — `curl http://127.0.0.1:<port>/api/health`
+  (the port is in the app's log, below), or just paste the tail of the log file:
+  `~/Library/Application Support/com.hevin.arkiv/arkiv/logs/backend.log`
 
 ```
 (paste output here)

--- a/config.py
+++ b/config.py
@@ -7,6 +7,11 @@ from urllib.parse import urlparse
 
 BASE_DIR = Path(__file__).parent
 
+# Backend product version. Keep in sync with the release tag + frontend
+# version.js at release time. Served by GET /api/version and included in
+# GET /api/health so a user/support can identify the build.
+VERSION = "0.10.0"
+
 # Codex Round-2 audit (J3): without bounds, ARKIV_PROXIES_DIR=/etc would have
 # arkiv write generated proxy mp4 files into /etc on every HEVC ingest. Same
 # risk for THUMBNAILS_DIR / CHROMA_PATH / DB_PATH (any operator-tunable

--- a/routers/misc.py
+++ b/routers/misc.py
@@ -186,3 +186,55 @@ def client_log(body: ClientLogRequest):
     msg = _log_safe(str(body.msg if body.msg is not None else ""), 2000)
     print(f"[WebView {level}] {msg}", flush=True)
     return {"ok": True}
+
+
+@router.get("/api/version")
+def api_version():
+    """Unauthenticated: identify the build. `curl <host>/api/version`."""
+    return {"version": config.VERSION}
+
+
+@router.get("/api/health")
+def api_health():
+    """Unauthenticated self-diagnostic — a user (or support) curls this ONE URL to
+    see if the runtime deps are present, without a terminal or a token. Returns
+    booleans + model names only (NO absolute paths) so it's safe to expose. Mirrors
+    the checks in python health.py. The desktop app / a helper can hit it directly."""
+    import shutil
+
+    out = {"version": config.VERSION, "ready": True, "checks": {}}
+
+    def _mark(name, ok, detail=""):
+        out["checks"][name] = {"ok": bool(ok), "detail": detail}
+        if not ok:
+            out["ready"] = False
+
+    # external binaries (ffmpeg/ffprobe required; exiftool optional)
+    _mark("ffmpeg", shutil.which(config.FFMPEG_PATH) is not None)
+    _mark("ffprobe", shutil.which(config.FFPROBE_PATH) is not None)
+    exif = getattr(config, "EXIFTOOL_PATH", "") or "exiftool"
+    out["checks"]["exiftool"] = {  # optional — doesn't flip ready
+        "ok": shutil.which(exif) is not None,
+        "detail": "optional",
+    }
+
+    # ollama reachable + the three configured models pulled
+    try:
+        import requests
+
+        r = requests.get(f"{config.OLLAMA_URL}/api/tags", timeout=3)
+        r.raise_for_status()
+        models = [m.get("name", "") for m in r.json().get("models", [])]
+        _mark("ollama", True, f"{len(models)} models")
+        for label, want in (
+            ("embed", config.OLLAMA_EMBED_MODEL),
+            ("vision", config.OLLAMA_VISION_MODEL),
+            ("chat", config.OLLAMA_CHAT_MODEL),
+        ):
+            base = want.split(":")[0]
+            present = any(base in m for m in models)
+            _mark(f"model:{want}", present, "" if present else f"ollama pull {want}")
+    except Exception:
+        _mark("ollama", False, "unreachable — is `ollama serve` running?")
+
+    return JSONResponse(out, status_code=200 if out["ready"] else 503)

--- a/tests/test_r5_25_router_misc.py
+++ b/tests/test_r5_25_router_misc.py
@@ -34,8 +34,11 @@ def test_router_owns_misc_routes_and_helpers():
         ("/api/embed/rebuild", "POST"),
         ("/api/open-file", "POST"),
         ("/api/client-log", "POST"),
+        ("/api/version", "GET"),
+        ("/api/health", "GET"),
     }
     for name in ("stream_media", "embed_rebuild", "open_file", "client_log",
+                 "api_version", "api_health",
                  "_log_safe", "OpenFileRequest", "ClientLogRequest"):
         assert hasattr(rm, name)
 

--- a/tests/test_w0_health_endpoint.py
+++ b/tests/test_w0_health_endpoint.py
@@ -1,0 +1,39 @@
+"""Wave-0 support: GET /api/health (JSON self-diagnostic) + GET /api/version.
+
+A packaged .app user has no terminal to run `python health.py`, so a broken box
+was un-diagnosable. These unauthenticated endpoints let a user (or support) curl
+ONE URL for a machine-readable readiness report — booleans + model names only,
+no absolute paths.
+"""
+import json
+
+import config
+
+
+def test_api_version(fastapi_client):
+    r = fastapi_client.get("/api/version")
+    assert r.status_code == 200
+    assert r.json()["version"] == config.VERSION
+    assert r.json()["version"]  # non-empty
+
+
+def test_api_health_shape_and_no_path_leak(fastapi_client):
+    r = fastapi_client.get("/api/health")
+    # 200 when every required dep is present, 503 otherwise (e.g. ollama down in CI)
+    assert r.status_code in (200, 503)
+    body = r.json()
+    assert body["version"] == config.VERSION
+    assert isinstance(body["ready"], bool)
+    checks = body["checks"]
+    # the key runtime deps are reported
+    for k in ("ffmpeg", "ffprobe", "ollama", "exiftool"):
+        assert k in checks and isinstance(checks[k]["ok"], bool)
+    # NO absolute filesystem paths leak (safe to expose unauthenticated)
+    blob = json.dumps(body)
+    assert "/Users/" not in blob and "/home/" not in blob and "C:\\" not in blob
+
+
+def test_api_health_status_matches_ready(fastapi_client):
+    r = fastapi_client.get("/api/health")
+    ready = r.json()["ready"]
+    assert (r.status_code == 200) == ready


### PR DESCRIPTION
**Wave 0 support tooling.** A packaged `.app` user has no terminal to run `python health.py`, so a broken box was un-diagnosable remotely.

- `GET /api/version` → `{version}` (`config.VERSION` = backend single-source).
- `GET /api/health` → JSON readiness mirroring `health.py`: ffmpeg/ffprobe (required), exiftool (optional), ollama reachable + the 3 configured models pulled. **Booleans + model names only, no absolute paths** → safe to expose unauthenticated. `200` ready / `503` not.
- Bug-report template now accepts `curl /api/health` JSON or the `backend.log` tail (desktop users can't run the terminal-only `health.py`).

3 new tests + 7 spa-serving green.