### PR TITLE
feat(api): /api/sample/seed + /api/logs/tail (first-run support endpoints)

### DIFF
--- a/config.py
+++ b/config.py
@@ -76,6 +76,10 @@ PROJECT_ROOT = _validate_writable_path(
 )
 _ARKIV_DIR = PROJECT_ROOT / ".arkiv"
 _ASCMHL_DIR = PROJECT_ROOT / "ascmhl"
+# The Tauri sidecar writes the backend's stdout/stderr here (src-tauri/src/main.rs);
+# GET /api/logs/tail reads it for the in-app "Report a problem". Not created here —
+# under bare uvicorn PROJECT_ROOT falls back to BASE_DIR and the dir simply won't exist.
+LOGS_DIR = PROJECT_ROOT / "logs"
 
 DB_PATH = _validate_writable_path(
     Path(os.getenv("ARKIV_DB_PATH", str(_ARKIV_DIR / "project.db"))), "ARKIV_DB_PATH"

--- a/routers/misc.py
+++ b/routers/misc.py
@@ -238,3 +238,27 @@ def api_health():
         _mark("ollama", False, "unreachable — is `ollama serve` running?")
 
     return JSONResponse(out, status_code=200 if out["ready"] else 503)
+
+
+@router.get("/api/logs/tail")
+def logs_tail(n: int = 200, _tok: dict = Depends(require_scopes("projects_read"))):
+    """Last `n` lines of the backend log (the Tauri sidecar writes it) for the in-app
+    "Report a problem". AUTHED — the log can carry absolute paths / tracebacks, so it
+    is NOT open like /api/health; loopback trust lets the local WebView reach it
+    token-free. Each line is control-char sanitized. Missing file → 200 with
+    available:false (a bare-uvicorn dev run has no such log)."""
+    n = max(1, min(int(n or 200), 2000))
+    log_path = config.LOGS_DIR / "backend.log"
+    try:
+        if not log_path.exists():
+            return {"lines": [], "available": False, "detail": "no log file (bare uvicorn?)"}
+        # bounded tail read: only the last ~256 KB, so a huge log can't blow memory
+        size = log_path.stat().st_size
+        with open(log_path, "rb") as fh:
+            if size > 262144:
+                fh.seek(-262144, 2)
+            raw = fh.read()
+        lines = [_log_safe(ln, 2000) for ln in raw.decode("utf-8", "replace").splitlines()[-n:]]
+        return {"lines": lines, "available": True}
+    except Exception as e:  # noqa: BLE001
+        return {"lines": [], "available": False, "detail": "log read error: {0}".format(type(e).__name__)}

--- a/routers/sample.py
+++ b/routers/sample.py
@@ -1,0 +1,106 @@
+"""First-run sample-library loader (single-flight + progress poll).
+
+POST /api/sample/seed ingests the bundled CC-BY sample clips (sample/clips/) so a
+fresh library delivers the search-awe before the user has their own footage —
+driven from the in-app "Load sample library" CTA (no terminal needed). Long-running
+→ single-flight background task that also holds the shared H3 ingest slot (the seed
+spawns ingest.py = whisper, so it must NOT run alongside a real /api/ingest, or a
+second whisper OOMs a 16 GB box). Poll GET /api/sample/seed/status. Idempotent:
+no-op when the clips are already indexed.
+
+Imports the ONE shared guard from state.py (never a copy) — no server import, no cycle.
+"""
+import subprocess
+import sys
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+
+import config
+import db
+from auth import require_scopes
+from state import (
+    sample_seed as _sample_guard,
+    _acquire_ingest_slot,
+    _release_ingest_slot,
+)
+from webguard import _assert_same_site
+
+router = APIRouter()
+
+_CLIPS_DIR = config.BASE_DIR / "sample" / "clips"
+
+
+def _sample_basenames():
+    return sorted(p.name for p in _CLIPS_DIR.glob("*.mp4"))
+
+
+def _run_sample_seed():
+    """Background worker: run seed_sample.py in a child process (idempotent, and it
+    auto-embeds so search works immediately). Isolated like the other ingest workers
+    (state._rebuild_embeddings). Releases both locks in finally so a wedged child
+    can't pin them."""
+    prog = _sample_guard.progress
+    try:
+        r = subprocess.run(
+            [sys.executable, str(config.BASE_DIR / "scripts" / "seed_sample.py")],
+            check=False, capture_output=True, text=True, timeout=1800,
+        )
+        prog["returncode"] = r.returncode
+        prog["ok"] = r.returncode == 0
+        prog["message"] = "done" if r.returncode == 0 else "seed failed — see Settings → System"
+    except subprocess.TimeoutExpired:
+        prog["returncode"], prog["ok"], prog["message"] = -1, False, "seed timed out"
+    except Exception as e:  # noqa: BLE001
+        prog["returncode"], prog["ok"], prog["message"] = -1, False, "seed error: {0}".format(type(e).__name__)
+    finally:
+        prog["running"] = False
+        _sample_guard.release()
+        _release_ingest_slot()
+
+
+def _already_seeded(names):
+    """True if every sample basename is already in the media table. Defensive: a
+    missing/uninitialised DB counts as not-seeded (→ proceed to seed)."""
+    try:
+        with db.get_conn() as conn:
+            known = {r[0] for r in conn.execute("SELECT filename FROM media").fetchall()}
+    except Exception:  # noqa: BLE001
+        return False
+    return all(n in known for n in names)
+
+
+@router.post("/api/sample/seed")
+def sample_seed(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    _tok: dict = Depends(require_scopes("ingest_write")),
+):
+    """Load the bundled CC-BY sample clips into the current project so a fresh
+    library is instantly searchable. Idempotent; single-flight; holds the shared
+    ingest slot. Poll GET /api/sample/seed/status."""
+    _assert_same_site(request)
+    names = _sample_basenames()
+    if not names:
+        raise HTTPException(500, "no sample clips bundled")
+    # Idempotency BEFORE any lock: if already seeded, don't grab the ingest slot
+    # just to no-op (that would 409 a concurrent real ingest for nothing).
+    if _already_seeded(names):
+        return {"queued": 0, "message": "sample already loaded"}
+    if not _sample_guard.acquire():
+        raise HTTPException(409, "sample 載入已在進行中")
+    # The seed spawns whisper — it must hold the H3 ingest slot. If a real ingest
+    # holds it, refuse (free our own guard first so a later retry isn't rejected).
+    if not _acquire_ingest_slot():
+        _sample_guard.release()
+        raise HTTPException(409, "已有匯入任務進行中，請稍候")
+    _sample_guard.reset_progress(
+        running=True, ok=False, returncode=None, message="loading…", clips=len(names),
+    )
+    background_tasks.add_task(_run_sample_seed)
+    return {"queued": len(names)}
+
+
+@router.get("/api/sample/seed/status")
+def sample_seed_status(_tok: dict = Depends(require_scopes("projects_read"))):
+    """Poll sample-seed progress {running, ok, returncode, message, clips}."""
+    return dict(_sample_guard.progress)

--- a/server.py
+++ b/server.py
@@ -147,6 +147,7 @@ from routers.retranscribe import router as retranscribe_router  # noqa: E402
 from routers.proxy import router as proxy_router  # noqa: E402
 from routers.recorrect import router as recorrect_router  # noqa: E402
 from routers.misc import router as misc_router  # noqa: E402
+from routers.sample import router as sample_router  # noqa: E402
 from routers.export import router as export_router  # noqa: E402
 from routers.media import router as media_router  # noqa: E402
 from routers.search import router as search_router  # noqa: E402
@@ -163,6 +164,7 @@ app.include_router(retranscribe_router)
 app.include_router(proxy_router)
 app.include_router(recorrect_router)
 app.include_router(misc_router)
+app.include_router(sample_router)
 app.include_router(export_router)
 app.include_router(media_router)
 app.include_router(search_router)

--- a/state.py
+++ b/state.py
@@ -82,6 +82,12 @@ retranscribe.reset_progress(
 # mid-build playback streamed truncated proxies.
 proxy_build = SingleFlight("proxy_build")
 
+# First-run: /api/sample/seed loads the bundled CC-BY sample clips (single-flight +
+# progress poll). Seed the poll shape so GET /api/sample/seed/status returns the
+# full dict even before the first run.
+sample_seed = SingleFlight("sample_seed")
+sample_seed.reset_progress(running=False, ok=False, returncode=None, message="", clips=0)
+
 
 def _rebuild_embeddings():
     """Background task: full embedding rebuild via subprocess. Runs embed.py in a

--- a/tests/test_r5_25_router_misc.py
+++ b/tests/test_r5_25_router_misc.py
@@ -36,9 +36,10 @@ def test_router_owns_misc_routes_and_helpers():
         ("/api/client-log", "POST"),
         ("/api/version", "GET"),
         ("/api/health", "GET"),
+        ("/api/logs/tail", "GET"),
     }
     for name in ("stream_media", "embed_rebuild", "open_file", "client_log",
-                 "api_version", "api_health",
+                 "api_version", "api_health", "logs_tail",
                  "_log_safe", "OpenFileRequest", "ClientLogRequest"):
         assert hasattr(rm, name)
 
@@ -79,4 +80,25 @@ def test_misc_routes_mounted_and_auth_guarded(server_module):
         assert c.post("/api/open-file", json={"path": "/x"}).status_code == 401
         # client-log is deliberately unauthenticated (WebView diagnostics sink)
         assert c.post("/api/client-log", json={"level": "info", "msg": "hi"}).status_code == 200
+        # logs/tail is AUTHED (raw log may carry paths) — 401 without a token
+        assert c.get("/api/logs/tail").status_code in (401, 403)
         assert c.get("/api/streamzz/1").status_code == 404
+
+
+def test_logs_tail_missing_file_graceful(monkeypatch, tmp_path):
+    import routers.misc as rm
+    import config
+    monkeypatch.setattr(config, "LOGS_DIR", tmp_path)  # no backend.log here
+    res = rm.logs_tail(n=50, _tok={})
+    assert res["available"] is False and res["lines"] == []
+
+
+def test_logs_tail_reads_and_sanitizes(monkeypatch, tmp_path):
+    import routers.misc as rm
+    import config
+    (tmp_path / "backend.log").write_text("line1\nFAKE\x1b[31m evil\nline3\n", encoding="utf-8")
+    monkeypatch.setattr(config, "LOGS_DIR", tmp_path)
+    res = rm.logs_tail(n=2, _tok={})
+    assert res["available"] is True
+    assert len(res["lines"]) == 2 and "line3" in res["lines"][-1]
+    assert all("\x1b" not in ln for ln in res["lines"])  # sanitized per line

--- a/tests/test_r5_25_router_sample.py
+++ b/tests/test_r5_25_router_sample.py
@@ -1,0 +1,76 @@
+"""First-run sample-seed router (routers/sample.py): pins the route surface, the
+shared-guard identity, auth, the idempotency short-circuit, and the seed-during-ingest
+409 contention path (which must free its own guard)."""
+import pathlib
+import re
+
+import pytest
+from starlette.testclient import TestClient
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def test_sample_router_is_a_leaf_module():
+    src = (_ROOT / "routers" / "sample.py").read_text(encoding="utf-8")
+    assert not re.search(r"^\s*import\s+server\b", src, re.M)
+    assert not re.search(r"^\s*from\s+server\b", src, re.M)
+
+
+def test_router_owns_exactly_the_two_sample_routes():
+    import routers.sample as rs
+    pairs = {(r.path, m) for r in rs.router.routes for m in r.methods if m != "HEAD"}
+    assert pairs == {("/api/sample/seed", "POST"), ("/api/sample/seed/status", "GET")}
+    for name in ("sample_seed", "sample_seed_status", "_run_sample_seed",
+                 "_sample_basenames", "_already_seeded"):
+        assert hasattr(rs, name)
+
+
+def test_uses_the_one_shared_state_guard():
+    import routers.sample as rs
+    import state
+    assert rs._sample_guard is state.sample_seed
+
+
+def test_sample_basenames_are_the_bundled_clips():
+    import routers.sample as rs
+    assert set(rs._sample_basenames()) == {
+        "caminandes_llama.mp4", "coffee_run.mp4", "glass_half.mp4", "wing_it.mp4",
+    }
+
+
+def test_routes_mounted_and_auth_guarded(server_module):
+    with TestClient(server_module.app) as c:
+        assert c.post("/api/sample/seed").status_code == 401          # ingest_write
+        assert c.get("/api/sample/seed/status").status_code == 401    # projects_read
+
+
+class _BG:
+    def __init__(self):
+        self.queued = False
+
+    def add_task(self, *a, **k):
+        self.queued = True
+
+
+def test_idempotent_shortcircuit_when_already_seeded(monkeypatch):
+    import routers.sample as rs
+    monkeypatch.setattr(rs, "_assert_same_site", lambda r: None)
+    monkeypatch.setattr(rs, "_already_seeded", lambda names: True)  # all clips present
+    bg = _BG()
+    res = rs.sample_seed(request=None, background_tasks=bg, _tok={})
+    assert res["queued"] == 0 and not bg.queued  # no lock grabbed, no task queued
+
+
+def test_refuses_when_ingest_busy_and_frees_its_guard(monkeypatch):
+    import routers.sample as rs
+    import state
+    from fastapi import HTTPException
+    monkeypatch.setattr(rs, "_assert_same_site", lambda r: None)
+    monkeypatch.setattr(rs, "_already_seeded", lambda names: False)
+    monkeypatch.setattr(rs, "_acquire_ingest_slot", lambda: False)  # a real ingest holds the slot
+    with pytest.raises(HTTPException) as ei:
+        rs.sample_seed(request=None, background_tasks=_BG(), _tok={})
+    assert ei.value.status_code == 409
+    # must have released its own single-flight guard so a later retry isn't rejected
+    assert state.sample_seed.acquire() is True
+    state.sample_seed.release()


### PR DESCRIPTION
**First-run backend** (frontend consumes these in the next PR).

- **POST `/api/sample/seed`** + **GET `/api/sample/seed/status`** (new `routers/sample.py`) — powers the in-app "Load sample library" CTA without a terminal. `SingleFlight` guard + `BackgroundTasks` subprocess to `seed_sample.py`, mirroring `retranscribe.py`'s two-lock ordering (guard → shared H3 ingest slot; the seed spawns whisper so it must not run alongside a real `/api/ingest`). **Idempotency short-circuits before any lock** so an already-seeded no-op doesn't 409 a concurrent ingest. Scoped `ingest_write` + same-site; status `projects_read`.
- **GET `/api/logs/tail`** (`misc.py`) — last N lines of `config.LOGS_DIR/backend.log` (bounded 256 KB tail, `_log_safe` per line) for "Report a problem". **AUTHED** (`projects_read`) since the log can carry paths/tracebacks; loopback trust lets the local WebView reach it token-free. Missing file → 200 `{available:false}`.
- `config.LOGS_DIR = PROJECT_ROOT/logs` (where the Tauri sidecar writes; absent under bare uvicorn).

**Verified on a live server**: status → seeded dict; logs/tail → graceful `available:false`. New `test_r5_25_router_sample.py` (routes + guard identity + idempotency + 409-frees-guard) + updated `test_r5_25_router_misc.py`. Full suite **1004 passed**.