### PR TITLE
feat(ui): first-run readiness gate + Load-sample CTA + report-a-problem

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -72,6 +72,21 @@ const qs = (params = {}) => {
 export const getStats = (opts) => req('/api/stats', opts)
 export const getProjects = (opts) => req('/api/projects', opts)
 export const getProjectsHealth = (opts) => req('/api/projects/health', opts)
+// ---- first-run: version / sample seed / log tail ----
+export const getVersion = (opts) => req('/api/version', opts)
+export const seedSample = (opts) => req('/api/sample/seed', { method: 'POST', ...opts })
+export const getSeedStatus = (opts) => req('/api/sample/seed/status', opts)
+export const getLogsTail = (n = 200, opts) => req(`/api/logs/tail${qs({ n })}`, opts)
+
+// /api/health returns 503 when deps are missing — req() would throw ApiError and
+// collapse "not ready" into "server down". Bespoke fetch so 200 AND 503 both
+// surface `checks`; a fetch rejection distinguishes an unreachable backend.
+export async function getHealth({ signal } = {}) {
+  const res = await fetch(`${BASE}/api/health`, { cache: 'no-store', signal })
+  let body = null
+  try { body = await res.json() } catch { /* non-json */ }
+  return { ok: res.ok, status: res.status, ...(body || {}) }
+}
 // ---- project registry mutations (projects_write; token-free on loopback) ----
 // POST /api/projects {name, path, tags} → project dict (409 if name exists).
 export const addProject = (body, opts) => req('/api/projects', { method: 'POST', body, ...opts })

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -31,6 +31,11 @@
   let moreParams = null
   let loadingMore = false
   let stats = null
+  // First-run readiness gate: 'checking' until /api/health answers, then
+  // 'ready' | 'notready' (deps missing, 503) | 'unreachable' (backend down).
+  let health = null
+  let readyState = 'checking'
+  let seeding = false
   let selectedId = null
   let hoverId = null
   let activeFilter = 'all'
@@ -176,8 +181,49 @@
     try { await api.openFile(path, true) } catch (e) { pushToast(`在 Finder 顯示失敗: ${e.message}`, 'error') }
   }
 
+  // Poll /api/health, distinguishing deps-missing (503, immediate) from a still-
+  // starting backend (fetch rejects → brief debounce before calling it unreachable).
+  async function checkReady() {
+    for (let i = 0; i < 3; i++) {
+      health = await api.getHealth().catch(() => null)
+      if (health) return health.ready ? 'ready' : 'notready' // got 200 or 503
+      await new Promise((r) => setTimeout(r, 1000 * (i + 1)))
+    }
+    return 'unreachable'
+  }
+
+  async function onSeed() {
+    if (seeding) return
+    seeding = true
+    try {
+      const r = await api.seedSample()
+      if (r.queued === 0) { await load(); return } // already loaded
+      await pollSeed()
+    } catch (e) {
+      pushToast(e.status === 409 ? '有匯入任務進行中，稍後再試' : '載入失敗: ' + e.message, 'error')
+    } finally { seeding = false }
+  }
+
+  async function pollSeed() {
+    const t0 = Date.now()
+    for (;;) {
+      await new Promise((r) => setTimeout(r, 1500))
+      let s = null
+      try { s = await api.getSeedStatus() } catch { /* transient */ }
+      if (s && !s.running) {
+        if (s.ok) { pushToast('sample library ready — 試搜 "llama"'); await load() }
+        else { pushToast('載入失敗 — 見 Settings → System', 'error') }
+        return
+      }
+      if (Date.now() - t0 > 20 * 60 * 1000) { pushToast('sample 載入逾時', 'error'); return }
+    }
+  }
+
   async function load() {
     state = 'loading'
+    readyState = 'checking'
+    readyState = await checkReady()
+    if (readyState === 'unreachable') { state = 'ok'; return } // panel renders via readyState
     try {
       const [s, m, t, c] = await Promise.all([
         api.getStats(), api.getMedia({ limit: PAGE }), api.getTags(), api.getCollections(),
@@ -692,10 +738,41 @@
       <div class="gridwrap">
         {#if state === 'loading'}
           <div class="msg"><Mono dim>loading…</Mono></div>
+        {:else if readyState === 'unreachable'}
+          <div class="msg readypanel">
+            <Eyebrow>◇ BACKEND UNREACHABLE</Eyebrow>
+            <Mono dim>後端沒有回應 — 伺服器還在啟動、或還沒開。</Mono>
+            <div class="readyactions"><button class="ak-btn" on:click={load}>Retry</button></div>
+          </div>
+        {:else if readyState === 'notready' && !stats?.total}
+          <div class="msg readypanel">
+            <Eyebrow>◇ SETUP INCOMPLETE</Eyebrow>
+            <Mono dim>arkiv 需要這些才能索引 / 搜尋：</Mono>
+            <ul class="checklist">
+              {#each Object.entries(health?.checks || {}) as [name, c]}
+                {#if !c.ok}
+                  <li><Mono>✗ {name}{c.detail ? ' — ' + c.detail : ''}</Mono></li>
+                {/if}
+              {/each}
+            </ul>
+            <div class="readyactions">
+              <button class="ak-btn" on:click={load}>Recheck</button>
+              <a class="ak-btn" href="#/settings">Settings</a>
+            </div>
+          </div>
         {:else if state === 'error'}
           <div class="msg"><Mono style="color:var(--cyan);">ERROR: {err}</Mono></div>
+        {:else if readyState === 'ready' && stats?.total === 0}
+          <div class="msg readypanel">
+            <Eyebrow>Library is empty</Eyebrow>
+            <Mono dim>打一句中文或英文，五年素材唰跳出 — 先載個範例庫試搜。</Mono>
+            <div class="readyactions">
+              <button class="ak-btn" on:click={onSeed} disabled={seeding}>{seeding ? 'Loading…' : 'Load sample library'}</button>
+              <a class="ak-btn" href="#/ingest-setup">or ingest your footage</a>
+            </div>
+          </div>
         {:else if visible.length === 0}
-          <div class="msg"><Eyebrow>No media</Eyebrow><Mono dim>ingest 一些素材,或清搜尋。</Mono></div>
+          <div class="msg"><Eyebrow>No media</Eyebrow><Mono dim>清搜尋或篩選。</Mono></div>
         {:else if view === 'list'}
           <table class="medialist">
             <thead>
@@ -851,6 +928,10 @@
   .lthumbph.audio { background: repeating-linear-gradient(90deg, var(--rule-hi) 0 2px, transparent 2px 4px); }
 
   .msg { padding: 40px 22px; display: flex; flex-direction: column; gap: 8px; }
+  .readypanel { align-items: flex-start; max-width: 580px; gap: 12px; }
+  .readypanel .checklist { list-style: none; margin: 2px 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+  .readyactions { display: flex; gap: 10px; margin-top: 6px; flex-wrap: wrap; align-items: center; }
+  .readyactions .ak-btn { text-decoration: none; }
   .loadmore { display: flex; align-items: center; justify-content: center; gap: 14px; padding: 20px 22px; border-top: 1px solid var(--rule); }
   .exportbar {
     display: flex; align-items: center; justify-content: space-between; gap: 14px;

--- a/frontend/src/routes/SettingsLive.svelte
+++ b/frontend/src/routes/SettingsLive.svelte
@@ -120,6 +120,40 @@
   // re-poll the status a couple of times after kicking a build off).
   let proxy = null // {total, proxied, size_mb}
   let proxyMsg = ''
+
+  // Report-a-problem: bundle version + health + backend.log tail into a diagnostic
+  // the user can copy/download and send. Each fetch degrades independently.
+  let diagBusy = false
+  let diagMsg = ''
+  async function buildDiagnostic() {
+    const [v, h] = await Promise.all([api.getVersion().catch(() => null), api.getHealth().catch(() => null)])
+    const logs = await api.getLogsTail(200).catch(() => null)
+    const checks = Object.entries(h?.checks || {}).map(
+      ([k, c]) => `  ${k}: ${c.ok ? 'ok' : 'FAIL'}${c.detail ? '  ' + c.detail : ''}`
+    )
+    return [
+      `arkiv diagnostic — ${new Date().toISOString()}`,
+      `frontend ${VERSION}   backend ${v?.version ?? '?'}   ready ${h?.ready ?? '?'}`,
+      `library ${stats?.total ?? '?'} media`,
+      'checks:',
+      ...checks,
+      '--- backend.log (last 200) ---',
+      logs?.available ? (logs.lines || []).join('\n') : 'no log file available',
+    ].join('\n')
+  }
+  async function copyDiagnostic() {
+    diagBusy = true; diagMsg = ''
+    try {
+      const text = await buildDiagnostic()
+      if (navigator.clipboard?.writeText) { await navigator.clipboard.writeText(text); diagMsg = 'copied ✓' }
+      else { api.downloadText(text, 'arkiv-diagnostic.txt', 'text/plain'); diagMsg = 'downloaded ✓' }
+    } catch (e) { diagMsg = 'failed: ' + e.message } finally { diagBusy = false }
+  }
+  async function downloadDiagnostic() {
+    diagBusy = true; diagMsg = ''
+    try { api.downloadText(await buildDiagnostic(), 'arkiv-diagnostic.txt', 'text/plain'); diagMsg = 'downloaded ✓' }
+    catch (e) { diagMsg = 'failed: ' + e.message } finally { diagBusy = false }
+  }
   let proxyBusy = false
   async function loadProxy() {
     try { proxy = await api.getProxyStatus() } catch { proxy = null }
@@ -570,6 +604,13 @@
                 </div>
               {/if}
               <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Privacy</Mono><Mono dim style="font-size:11.5px;">Everything runs locally. Nothing leaves this machine.</Mono></div>
+              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Report a problem</Mono>
+                <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+                  <button class="ak-btn" on:click={copyDiagnostic} disabled={diagBusy}>Copy diagnostic</button>
+                  <button class="ak-btn" on:click={downloadDiagnostic} disabled={diagBusy}>Download</button>
+                  {#if diagMsg}<Mono dim style="font-size:11.5px;">{diagMsg}</Mono>{/if}
+                </div>
+              </div>
             </div>
           </section>
         {/if}


### PR DESCRIPTION
**Removes the audit's #1 binding constraint** — MainLive booted to an empty grid with silent runtime failures when Ollama/models/FFmpeg were missing. The landing surface now consumes `/api/health` and guides the user. (Folds in the planned PR-4 Settings change — both are frontend consuming the same endpoints.)

- **api.js**: `getVersion`/`seedSample`/`getSeedStatus`/`getLogsTail` + a **bespoke `getHealth()`** (`req()` throws `ApiError` on the 503 `/api/health` returns when not-ready; the bespoke fetch surfaces `checks` for both 200 and 503 and distinguishes unreachable-backend from deps-missing).
- **MainLive**: `readyState` machine (`checking`/`ready`/`notready`/`unreachable`) with a debounce on fetch-rejection. Render branches (reusing the `.dbanner` look): **unreachable** → Retry; **notready+empty** → the failing `/api/health` checks with their fix + Recheck/Settings; **ready+empty** (`stats.total===0`) → **"Load sample library"** (POST → poll → reload) + "or ingest your footage". Filtered-empty branch unchanged.
- **SettingsLive System**: **"Report a problem"** — Copy/Download a diagnostic bundling VERSION + `/api/version` + `/api/health` + `/api/logs/tail` (each degrades independently).

**Verified in the dev harness (vite + backend, headless Playwright):** empty+ready → sample CTA; dead-Ollama backend (503) → "SETUP INCOMPLETE ✗ ollama unreachable…"; CTA click fires the seed (`running:true, clips:4`, button→Loading…); diagnostic assembles from the three endpoints. `npm run build` green.