### PR TITLE
feat(transcribe): Taiwan Traditional zh transcripts via OpenCC (Phase 9.8b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
             "fastapi>=0.100.0" "uvicorn>=0.20.0" "pydantic>=2.0,<3" \
             "pillow>=9.0" "requests>=2.28" "xxhash>=2.0.0" "nanoid>=2.0.0" \
             "psutil>=5.9" "whisper-guard>=0.3" numpy mlx-whisper \
+            "opencc; python_version >= '3.10'" \
             "mcp>=1.2; python_version >= '3.10'"
 
       - name: Run tests
@@ -89,7 +90,8 @@ jobs:
           pip install \
             "fastapi>=0.100.0" "uvicorn>=0.20.0" "pydantic>=2.0,<3" \
             "pillow>=9.0" "requests>=2.28" "xxhash>=2.0.0" "nanoid>=2.0.0" \
-            "psutil>=5.9" "whisper-guard>=0.3" numpy mlx-whisper "mcp>=1.2"
+            "psutil>=5.9" "whisper-guard>=0.3" numpy mlx-whisper \
+            "opencc; python_version >= '3.10'" "mcp>=1.2"
       - name: Coverage
         run: pytest -q --cov=. --cov-config=pyproject.toml --cov-report=term:skip-covered --cov-fail-under=55
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,11 @@ nanoid>=2.0.0
 # Media processing
 pillow>=9.0
 soundfile>=0.12
+# Phase 9.8b: Simplified→Traditional (Taiwan) transcript conversion. Whisper zh
+# output is Simplified; the TA is Taiwan. Gated to >=3.10: opencc ships no cp39
+# arm64 wheel (3.9 would source-build), and prod is 3.12 — code degrades to
+# identity if absent (zh_convert.py), so a missing wheel never breaks transcribe.
+opencc>=1.1; python_version >= "3.10"
 
 # Resource-aware pipeline (Phase 11.5) — soft dependency: arkiv runs without it
 # (probe degrades the memory fields to None), but installing it enables

--- a/tag_quality.py
+++ b/tag_quality.py
@@ -80,10 +80,12 @@ _VARIANT_MAP = {
 # Simplified → Traditional character normalization. qwen2.5vl leaks Simplified
 # chars into its (prompted-Traditional) output, so 电子/電子, 维修/維修, 电线/電線
 # coexist as separate tags across a library — a major, cross-project source of
-# duplication. We have no opencc dependency, so this is a curated map of the
-# high-frequency Simplified characters that actually appear in vision tags (a
-# few hundred); extend as new ones surface. Per-CHARACTER (not word), so it
-# composes with everything (个→個 fixes 个/個, 零个件 → 零個件, etc.).
+# duplication. Tags stay on this curated per-character map (not opencc, though it
+# is now a dependency for transcripts — Phase 9.8b): tags are short free-vocab
+# fragments where a lightweight char map is enough and avoids opencc's phrase
+# segmentation reshaping a single-word tag. Per-CHARACTER (not word), so it
+# composes with everything (个→個 fixes 个/個, 零个件 → 零個件, etc.); extend as
+# new Simplified leaks surface.
 _SIMP_TO_TRAD = {
     "电": "電", "线": "線", "维": "維", "缆": "纜", "个": "個", "纸": "紙",
     "这": "這", "们": "們", "时": "時", "应": "應", "实": "實", "现": "現",

--- a/tests/test_zh_convert.py
+++ b/tests/test_zh_convert.py
@@ -1,0 +1,89 @@
+"""Phase 9.8b: Simplified→Traditional (Taiwan) transcript conversion.
+
+Verifies the two-config contract: transcript + segments get Taiwan idioms (s2twp),
+word tokens get char-level s2t (timing-safe), non-zh passes through, and a missing
+opencc degrades to identity (never crashes a transcribe)."""
+import importlib
+
+import pytest
+
+zh = importlib.import_module("zh_convert")
+
+_HAVE_OPENCC = zh._converter("s2t") is not None
+_skip_no_opencc = pytest.mark.skipif(not _HAVE_OPENCC, reason="opencc not installed")
+
+
+@_skip_no_opencc
+def test_s2t_is_neutral_traditional_and_length_preserving():
+    simp = "我在看这个视频，内存和软件"
+    trad = zh.to_traditional(simp)
+    assert len(trad) == len(simp)      # char-level → word-timing-safe
+    assert "视" not in trad            # simplified converted
+    assert "記憶體" not in trad        # s2t is NEUTRAL: 内存 stays 內存, no idiom
+
+
+@_skip_no_opencc
+def test_s2twp_applies_taiwan_idioms():
+    tw = zh.to_taiwan("内存和软件的视频")
+    assert "記憶體" in tw and "軟體" in tw and "影片" in tw  # Taiwan phrase idioms
+
+
+@_skip_no_opencc
+def test_convert_result_idioms_everywhere_and_timing_safe():
+    text = "内存和软件"
+    segments = [{"start": 0.0, "end": 1.0, "text": "内存和软件"}]
+    words = [{"word": "内存", "start": 0.0, "end": 0.5, "score": 0.9}]
+    t, lang, segs, wds = zh.convert_result(text, "zh", segments, words)
+    assert "記憶體" in t                                       # transcript idioms
+    assert "記憶體" in segs[0]["text"]                         # segment idioms
+    assert segs[0]["start"] == 0.0 and segs[0]["end"] == 1.0   # segment timing intact
+    # word token ALSO gets Taiwan idioms (內存→記憶體) — and its timestamps survive
+    # despite the length change (2→3 chars), because start/end/score are copied.
+    assert wds[0]["word"] == "記憶體"
+    assert wds[0]["start"] == 0.0 and wds[0]["end"] == 0.5 and wds[0]["score"] == 0.9
+
+
+def test_convert_result_non_zh_passthrough():
+    text, lang, segs, wds = zh.convert_result(
+        "hello world", "en",
+        [{"start": 0, "end": 1, "text": "hello"}],
+        [{"word": "hello", "start": 0, "end": 1}],
+    )
+    assert text == "hello world" and segs[0]["text"] == "hello" and wds[0]["word"] == "hello"
+
+
+def test_degrades_to_identity_without_opencc(monkeypatch):
+    monkeypatch.setattr(zh, "_converter", lambda cfg: None)  # simulate missing opencc
+    assert zh.to_taiwan("内存") == "内存"        # passthrough, no crash
+    assert zh.to_traditional("视频") == "视频"
+    t, _, segs, wds = zh.convert_result(
+        "内存", "zh",
+        [{"start": 0, "end": 1, "text": "内存"}],
+        [{"word": "内存", "start": 0, "end": 1}],
+    )
+    assert t == "内存" and segs[0]["text"] == "内存" and wds[0]["word"] == "内存"
+
+
+def test_empty_and_none_are_safe():
+    assert zh.to_taiwan("") == "" and zh.to_traditional("") == ""
+    assert zh.convert_result("", "zh", [], []) == ("", "zh", [], [])
+    assert zh.is_zh("zh") and zh.is_zh("ZH-CN") and not zh.is_zh("en") and not zh.is_zh(None)
+
+
+@_skip_no_opencc
+def test_transcribe_wires_zh_conversion(monkeypatch):
+    """transcribe() must apply the store-time conversion to whatever the backend
+    returns — the single wiring point (transcribe.py return zh_convert.convert_result)."""
+    import importlib
+    tr = importlib.import_module("transcribe")
+    monkeypatch.setattr(tr, "_to_wav", lambda p: "/tmp/arkiv_zhwire_nonexistent.wav")
+    monkeypatch.setattr(tr, "_USE_MLX", True)
+    monkeypatch.setattr(tr, "_vad_filter", lambda w: w)  # pass through, no cleanup branch
+    monkeypatch.setattr(tr, "_transcribe_mlx", lambda w, lang: (
+        "内存和软件", "zh",
+        [{"start": 0.0, "end": 1.0, "text": "内存和软件"}],
+        [{"word": "内存", "start": 0.0, "end": 0.5}],
+    ))
+    text, lang, segs, words = tr.transcribe("dummy.mp4", language="zh")
+    assert "記憶體" in text and "記憶體" in segs[0]["text"]  # idioms applied via s2twp
+    assert words[0]["word"] == "記憶體"                      # words get idioms too

--- a/transcribe.py
+++ b/transcribe.py
@@ -15,6 +15,7 @@ from silero_vad import load_silero_vad, get_speech_timestamps
 import torch
 
 import whisper_guard
+import zh_convert
 
 from config import (
     WHISPER_MODEL,
@@ -236,23 +237,26 @@ def transcribe(media_path: str, language=None) -> tuple:
             if vad_wav is None:
                 return "", "", [], []
             try:
-                return _transcribe_mlx(vad_wav, language)
+                result = _transcribe_mlx(vad_wav, language)
             finally:
                 if vad_wav != wav:
                     Path(vad_wav).unlink(missing_ok=True)
         elif _non_mac_backend() == "whisperx":
-            return _transcribe_whisperx(wav, language)
+            result = _transcribe_whisperx(wav, language)
         else:
             vad_wav = _vad_filter(wav)
             if vad_wav is None:
                 return "", "", [], []
             try:
-                return _transcribe_faster_whisper(vad_wav, language)
+                result = _transcribe_faster_whisper(vad_wav, language)
             finally:
                 if vad_wav != wav:
                     Path(vad_wav).unlink(missing_ok=True)
     finally:
         Path(wav).unlink(missing_ok=True)
+    # Phase 9.8b: whisper emits Simplified for zh — store Taiwan Traditional so the
+    # search index / UI / every export are Traditional (write-path; see zh_convert).
+    return zh_convert.convert_result(*result)
 
 def _custom_terms() -> list:
     """Merged hotword list: comma-separated ARKIV_CUSTOM_VOCABULARY env first,

--- a/zh_convert.py
+++ b/zh_convert.py
@@ -1,0 +1,73 @@
+"""Simplified→Traditional (Taiwan) conversion for zh transcripts (Phase 9.8b).
+
+Whisper large-v3 emits Simplified Chinese for zh; arkiv's TA is Taiwan. Applied at
+TRANSCRIBE time so the STORED transcript / segments are Traditional — search recall,
+UI, and every export get Traditional for free. It has to be write-path, not a
+display filter: the semantic + lexical search INDEX is built from the stored text,
+so only converting on display would leave recall broken (a 記憶體 query missing a
+內存-indexed clip).
+
+Conversion is s2twp (Taiwan idioms: 内存→記憶體 / 软件→軟體 / 视频→影片) across the
+transcript, segment, AND word text. It is timing-safe on every field because
+start/end/score are COPIED verbatim — a phrase idiom that changes a token's length
+can never shift its timestamps (timings are explicit boundaries, not char-derived).
+(t2twp does not exist in OpenCC and Taiwan idioms only exist on the Simplified→ path,
+which is why the idiom pass runs here at store time, not as an export-time layer over
+already-converted text.) `to_traditional` (s2t, neutral Traditional, length-preserving)
+stays available as a utility but is not the default — the TA wants Taiwan idioms.
+
+Degrades to identity if opencc is unavailable — a missing wheel must never break a
+transcribe; it just leaves that clip Simplified until re-transcribed. Existing
+Simplified transcripts are NOT retroactively converted (write-path only) — batch
+backfill of the stored transcript/segments/words columns + re-embed is a documented
+follow-up (roadmap Phase 9.8b), not silent.
+"""
+import functools
+
+
+@functools.lru_cache(maxsize=4)
+def _converter(config):
+    try:
+        import opencc
+        return opencc.OpenCC(config)
+    except Exception:  # noqa: BLE001 — missing/broken opencc → identity passthrough
+        return None
+
+
+def _convert(config, text):
+    if not text:
+        return text
+    conv = _converter(config)
+    if conv is None:
+        return text
+    try:
+        return conv.convert(text)
+    except Exception:  # noqa: BLE001
+        return text
+
+
+def to_taiwan(text: str) -> str:
+    """s2twp — Taiwan Traditional + idioms. Phrase-level (may change length)."""
+    return _convert("s2twp", text)
+
+
+def to_traditional(text: str) -> str:
+    """s2t — neutral Traditional, length-preserving. Utility (not the default path)."""
+    return _convert("s2t", text)
+
+
+def is_zh(lang) -> bool:
+    return (lang or "").lower().startswith("zh")
+
+
+def convert_result(text, lang, segments, words):
+    """Convert one whisper zh result to Taiwan Traditional (s2twp — with idioms) across
+    transcript, segment, AND word text. Timing-safe on every field: start/end/score are
+    copied verbatim (`{**s}`/`{**w}`), so a phrase idiom that changes a token's length
+    can't shift its timestamps. Non-zh → untouched."""
+    if not is_zh(lang):
+        return text, lang, segments, words
+    text = to_taiwan(text)
+    segments = [{**s, "text": to_taiwan(s.get("text", ""))} for s in (segments or [])]
+    words = [{**w, "word": to_taiwan(w.get("word", ""))} for w in (words or [])]
+    return text, lang, segments, words


### PR DESCRIPTION
## Phase 9.8b — Simplified→Traditional (Taiwan) transcripts

Whisper large-v3 emits **Simplified** Chinese for zh; arkiv's TA is Taiwan. `zh_convert.convert_result` applies OpenCC **`s2twp`** (Taiwan idioms: 内存→記憶體, 软件→軟體, 视频→影片) to the transcript / segments / words at **transcribe time (write-path)** — so the search index, UI, and every export are Traditional. (Converting only on display can't fix search recall — the index is built from the stored text.)

- **Timing-safe on every field**: `start`/`end`/`score` copied verbatim (`{**s}`/`{**w}`), so a phrase idiom changing a token's length can never shift its timestamps.
- **Degrades to identity** if opencc is absent — a missing wheel never breaks a transcribe.
- **Single wiring point**: `transcribe()` restructured from multiple `return` to one `return zh_convert.convert_result(*result)` (behavior-preserving; all 3 prod callers go through it).

### Adversarial audit (pre-commit) — findings fixed
- **HIGH** — opencc has no cp39/arm64 wheel → the required `test (3.9)` leg would source-build 1.4.1 and could red the check. **Fixed**: gated opencc to `python_version >= "3.10"` in `requirements.txt` + both CI install blocks (prod is 3.12; the 3.9 leg now exercises the degrade path).
- **LOW/MED** — words were on neutral `s2t` → karaoke showed `內存` not `記憶體`. **Fixed**: words use `s2twp` too (timing-safe since timestamps are copied, not char-derived).
- **MED** — backfill of existing Simplified transcripts is a **documented** follow-up (write-path only; cheap batch column-convert + re-embed, its own unit).
- Nits: docstring wording; stale `tag_quality.py` "no opencc" comment.

### Verification
- Full suite **1026 passed / 6 skipped**; 7 new `test_zh_convert.py` (incl. an end-to-end transcribe wiring test). Reviewer confirmed the restructure behavior-preserving, timings safe, configs correct, degrade path clean, no bypass callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)