### PR TITLE
fix(federation): fall back to media.db when project.db is an empty stub / honor explicit DB path

### DIFF
--- a/federation.py
+++ b/federation.py
@@ -12,8 +12,9 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 import chromadb
 
 import config
+import db
 from health import HealthStatus, project_health
-from projects import ProjectMeta
+from projects import ProjectMeta, resolve_project_db
 
 
 LOGGER = logging.getLogger(__name__)
@@ -134,8 +135,25 @@ def _resolve_paths(project: ProjectMeta, stored_path: str) -> Tuple[str, str]:
     return str(stored), absolute
 
 
+def _explicit_db_for(project: ProjectMeta) -> Optional[Path]:
+    """The configured DB override to honor for `project`, or None.
+
+    A single global override (ARKIV_DB_PATH / a ``--db`` run) can only
+    meaningfully apply to the current install's OWN root, so we honor
+    db.get_db_path() only when this federated project IS that root. Every other
+    project falls through to resolve_project_db's project.db → media.db
+    resolution. Returns None on any resolution error (best-effort, never fatal)."""
+    try:
+        root = _project_root(project).resolve(strict=False)
+        if root == config.PROJECT_ROOT.expanduser().resolve(strict=False):
+            return db.get_db_path()
+    except OSError:
+        pass
+    return None
+
+
 def _connect_project_db(project: ProjectMeta) -> sqlite3.Connection:
-    db_path = _project_root(project) / ".arkiv" / "project.db"
+    db_path = resolve_project_db(_project_root(project), explicit=_explicit_db_for(project))
     conn = sqlite3.connect(str(db_path), timeout=30, check_same_thread=False)
     conn.row_factory = sqlite3.Row
     return conn

--- a/projects.py
+++ b/projects.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sqlite3
 import sys
 import threading
 from dataclasses import dataclass, field
@@ -45,6 +46,67 @@ def _split_roots(value: str) -> List[str]:
             if part:
                 roots.append(part)
     return roots
+
+
+# Phase 8.0c renamed the per-project SQLite DB media.db → project.db. Libraries
+# indexed before that rename still keep their corpus in the legacy
+# .arkiv/media.db and may carry only an EMPTY .arkiv/project.db stub, so any code
+# that hardcodes project.db (federation search, registry sync) reads an empty DB
+# and returns nothing for those projects. resolve_project_db() falls back to the
+# legacy name in exactly that case, while a real, populated project.db (the
+# common case) is unaffected. Mirrors config.DB_PATH's env-override-then-default
+# style: an explicit path always wins.
+_DEFAULT_DB_NAME = "project.db"
+_LEGACY_DB_NAME = "media.db"
+
+
+def _media_row_count(db_path: Path) -> int:
+    """Rows in the ``media`` table, or -1 when the DB is missing / unreadable /
+    has no media table. Opened read-only (URI ``mode=ro``) so probing a project's
+    DB never creates a stub file nor writes -wal/-shm side files against it."""
+    try:
+        if not db_path.exists():
+            return -1
+        uri = db_path.resolve(strict=False).as_uri() + "?mode=ro"
+    except (OSError, ValueError):
+        return -1
+    try:
+        conn = sqlite3.connect(uri, uri=True, timeout=5)
+    except sqlite3.Error:
+        return -1
+    try:
+        row = conn.execute("SELECT COUNT(*) FROM media").fetchone()
+        return int(row[0]) if row else 0
+    except sqlite3.Error:
+        return -1
+    finally:
+        conn.close()
+
+
+def resolve_project_db(project_root, explicit=None) -> Path:
+    """Resolve the SQLite DB path for a project root.
+
+    Precedence:
+      1. ``explicit`` — an operator-configured override (e.g. ARKIV_DB_PATH /
+         ``--db`` for the current install) — when provided;
+      2. ``.arkiv/project.db`` — the Phase 8.0c default;
+      3. ``.arkiv/media.db`` — the pre-8.0c legacy name — but ONLY as a fallback
+         when project.db is absent or an empty stub (0 media rows) while media.db
+         exists and holds data.
+
+    A project with a real, populated project.db always resolves to it (the legacy
+    DB is not even opened), so existing libraries are completely unaffected."""
+    if explicit is not None:
+        return Path(explicit).expanduser()
+    arkiv_dir = Path(project_root).expanduser() / ".arkiv"
+    project_db = arkiv_dir / _DEFAULT_DB_NAME
+    # Short-circuit on the common case: a populated project.db wins immediately
+    # and media.db is never touched.
+    if _media_row_count(project_db) <= 0:
+        legacy_db = arkiv_dir / _LEGACY_DB_NAME
+        if _media_row_count(legacy_db) > 0:
+            return legacy_db
+    return project_db
 
 
 @dataclass
@@ -237,7 +299,7 @@ def sync_projects() -> List[ProjectMeta]:
         projects = [ProjectMeta.from_mapping(raw) for raw in registry.get("projects", [])]
         updated = []
         for project in projects:
-            db_path = project.path / ".arkiv" / "project.db"
+            db_path = resolve_project_db(project.path)
             if db_path.exists():
                 project.last_indexed_at = _iso_from_mtime(db_path)
             updated.append(project)

--- a/tests/test_project_db_resolver.py
+++ b/tests/test_project_db_resolver.py
@@ -1,0 +1,150 @@
+"""Per-project DB resolver (projects.resolve_project_db).
+
+Phase 8.0c renamed the per-project SQLite DB media.db → project.db. Libraries
+indexed before the rename keep their corpus in the legacy .arkiv/media.db and
+may carry only an empty .arkiv/project.db stub. Federation search + registry
+sync used to hardcode project.db, so those projects returned nothing. The
+resolver falls back to media.db in exactly that case while leaving a real,
+populated project.db untouched.
+"""
+import importlib
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+def _write_media_db(db_path: Path, rows: int) -> None:
+    """Create a SQLite DB with a `media` table holding `rows` rows."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "CREATE TABLE media (id INTEGER PRIMARY KEY, path TEXT, filename TEXT, "
+            "duration_s REAL, rating TEXT, lang TEXT, ext TEXT, transcript TEXT)"
+        )
+        for idx in range(1, rows + 1):
+            conn.execute(
+                "INSERT INTO media (id, path, filename, transcript) VALUES (?, ?, ?, ?)",
+                (idx, "clips/{0}.mp4".format(idx), "clip_{0}.mov".format(idx), "token {0}".format(idx)),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_falls_back_to_media_db_when_project_db_is_empty_stub(tmp_path):
+    """The core bug: empty project.db stub + populated legacy media.db."""
+    projects = importlib.import_module("projects")
+    root = tmp_path / "legacy-project"
+    arkiv = root / ".arkiv"
+    _write_media_db(arkiv / "project.db", rows=0)   # schema-only stub, 0 rows
+    _write_media_db(arkiv / "media.db", rows=480)   # legacy corpus with data
+
+    resolved = projects.resolve_project_db(root)
+    assert resolved == arkiv / "media.db"
+
+
+def test_falls_back_when_project_db_is_zero_byte_stub(tmp_path):
+    """A literal 0-byte project.db (no schema at all) is also treated as empty."""
+    projects = importlib.import_module("projects")
+    root = tmp_path / "zero-byte"
+    arkiv = root / ".arkiv"
+    arkiv.mkdir(parents=True)
+    (arkiv / "project.db").write_bytes(b"")         # 0-byte file
+    _write_media_db(arkiv / "media.db", rows=12)
+
+    assert projects.resolve_project_db(root) == arkiv / "media.db"
+
+
+def test_populated_project_db_is_unaffected(tmp_path):
+    """A real, populated project.db always wins — even if a legacy media.db with
+    data sits beside it. Backward-compat guarantee for existing libraries."""
+    projects = importlib.import_module("projects")
+    root = tmp_path / "modern-project"
+    arkiv = root / ".arkiv"
+    _write_media_db(arkiv / "project.db", rows=50)  # populated → must be chosen
+    _write_media_db(arkiv / "media.db", rows=999)   # stale legacy copy, ignored
+
+    assert projects.resolve_project_db(root) == arkiv / "project.db"
+
+
+def test_absent_both_defaults_to_project_db(tmp_path):
+    """No DB at all → default project.db path (health preflight flags it as
+    db_missing downstream, same as before)."""
+    projects = importlib.import_module("projects")
+    root = tmp_path / "fresh-project"
+    (root / ".arkiv").mkdir(parents=True)
+    assert projects.resolve_project_db(root) == root / ".arkiv" / "project.db"
+
+
+def test_empty_project_db_and_empty_media_db_defaults_to_project_db(tmp_path):
+    """Neither DB has data → keep the modern default (nothing to prefer)."""
+    projects = importlib.import_module("projects")
+    root = tmp_path / "both-empty"
+    arkiv = root / ".arkiv"
+    _write_media_db(arkiv / "project.db", rows=0)
+    _write_media_db(arkiv / "media.db", rows=0)
+    assert projects.resolve_project_db(root) == arkiv / "project.db"
+
+
+def test_explicit_override_always_wins(tmp_path):
+    """An explicit path takes precedence over both project.db and media.db and
+    is returned verbatim (honor explicit DB-path overrides)."""
+    projects = importlib.import_module("projects")
+    root = tmp_path / "overridden"
+    arkiv = root / ".arkiv"
+    _write_media_db(arkiv / "project.db", rows=5)
+    _write_media_db(arkiv / "media.db", rows=5)
+    override = tmp_path / "elsewhere" / "custom.db"
+    assert projects.resolve_project_db(root, explicit=override) == override
+
+
+def test_sync_projects_uses_legacy_media_db_mtime(tmp_path, monkeypatch):
+    """The second hardcode site: registry sync records last_indexed_at from the
+    resolved DB, so a legacy project reflects media.db's mtime, not the stub's."""
+    monkeypatch.setenv("ARKIV_PROJECTS_REGISTRY", str(tmp_path / "projects.json"))
+    projects = importlib.import_module("projects")
+
+    root = tmp_path / "legacy-sync"
+    arkiv = root / ".arkiv"
+    _write_media_db(arkiv / "project.db", rows=0)
+    _write_media_db(arkiv / "media.db", rows=7)
+
+    # Distinct mtimes so we can prove which file sync read.
+    media_mtime = datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+    stub_mtime = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+    os.utime(arkiv / "media.db", (media_mtime, media_mtime))
+    os.utime(arkiv / "project.db", (stub_mtime, stub_mtime))
+
+    projects.add_project("legacy-sync", str(root))
+    synced = projects.sync_projects()
+    assert len(synced) == 1
+    expected = projects._iso_from_mtime(arkiv / "media.db")
+    assert synced[0].last_indexed_at == expected
+
+
+# ── Optional real-library check (opt-in via env, skipped otherwise) ───────────
+# Point ARKIV_TEST_LEGACY_PROJECT at a real project root whose corpus lives in
+# the legacy .arkiv/media.db behind an empty .arkiv/project.db stub to exercise
+# the resolver + federation against a real database end-to-end.
+_REAL_ROOT = os.getenv("ARKIV_TEST_LEGACY_PROJECT", "")
+
+
+@pytest.mark.skipif(
+    not (_REAL_ROOT and (Path(_REAL_ROOT) / ".arkiv" / "media.db").exists()),
+    reason="set ARKIV_TEST_LEGACY_PROJECT to a mounted legacy project to run",
+)
+def test_real_legacy_project_prefers_media_db_and_federation_returns_results():
+    projects = importlib.import_module("projects")
+    federation = importlib.import_module("federation")
+    root = Path(_REAL_ROOT)
+
+    assert projects.resolve_project_db(root) == root / ".arkiv" / "media.db"
+
+    proj = projects.ProjectMeta(name="legacy-real", path=root)
+    res = federation.query_single_project(proj, "A", limit=5, q_embed=None, fallback_sql=True)
+    assert res.status == "ok", res.error
+    assert len(res.items) > 0


### PR DESCRIPTION
## Problem

Phase 8.0c renamed the per-project SQLite DB `media.db` → `project.db`. Libraries indexed **before** that rename still keep their corpus in the legacy `.arkiv/media.db` and can carry only an **empty `.arkiv/project.db` stub**. Federation / multi-project code hardcoded `.arkiv/project.db`, so federated and multi-project search returned **empty** for those projects, and registry sync stamped `last_indexed_at` from the empty stub.

Two hardcode sites:
- `federation.py` — `_connect_project_db` connected to `.arkiv/project.db`.
- `projects.py` — `sync_projects` read `.arkiv/project.db` mtime.

## Fix

Add a small resolver `projects.resolve_project_db(project_root, explicit=None)`:

1. an **explicit** override (e.g. `ARKIV_DB_PATH` / `--db` for the current install) wins;
2. else `.arkiv/project.db` — the 8.0c default;
3. else fall back to `.arkiv/media.db` **only** when `project.db` is absent or an empty stub (0 media rows) while `media.db` exists and holds data.

The row-count probe (`_media_row_count`) opens each DB **read-only** (URI `mode=ro`) so it never creates a stub file or writes `-wal`/`-shm` side files. A real, populated `project.db` wins immediately via short-circuit — the legacy DB is not even opened — so existing libraries are completely unaffected and the single-project path (`config.DB_PATH` / `db.get_db_path()`) is unchanged.

In federation, the explicit override is wired to `db.get_db_path()` only when the federated project IS the current install's own root (the only project a single global override can meaningfully apply to); every other project uses the `project.db` → `media.db` resolution.

## Tests

New `tests/test_project_db_resolver.py`:
- empty-stub `project.db` + populated `media.db` → resolver picks `media.db`
- 0-byte `project.db` stub → same fallback
- populated `project.db` (+ stale `media.db`) → `project.db` (no-op, backward-compat)
- absent both → default `project.db`
- both empty → default `project.db`
- explicit override always wins
- `sync_projects` records the legacy `media.db` mtime
- opt-in real-library end-to-end check gated on `ARKIV_TEST_LEGACY_PROJECT`

Full suite: `1044 passed, 6 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)