### PR TITLE
fix(zh): probe s2tw, not s2t, when detecting Simplified characters

### DIFF
--- a/tests/test_retraditionalize.py
+++ b/tests/test_retraditionalize.py
@@ -97,6 +97,24 @@ def test_already_traditional_row_is_never_corrupted(tmp_db):
 
 
 @_skip_no_opencc
+def test_taiwan_standard_chars_are_not_flagged_simplified():
+    """Neutral s2t "corrects" exactly ten Taiwan-STANDARD chars to archaic variants
+    (吃→喫 唇→脣 峰→峯 床→牀 灶→竈 痴→癡 皂→皁 秘→祕 粽→糉 群→羣). Probing with s2t
+    therefore mis-read ordinary Taiwan text as Simplified: such rows landed in "mixed",
+    and one carrying no Traditional-only char could reach the "simplified" bucket and be
+    handed to phrase-level s2twp — the input that corrupts Traditional. Detection probes
+    s2tw instead."""
+    for ch in "吃唇峰床灶痴皂秘粽群":
+        assert not zh._char_is_simplified(ch), ch
+        assert zh.to_traditional_charwise(ch) == ch, ch
+    # a plain Taiwan sentence carrying them reads clean, not "mixed"
+    assert zh.classify_zh("我今天吃飯，那群人在床邊") == "traditional"
+    # genuinely Simplified chars are still caught
+    assert zh._char_is_simplified("软")
+    assert zh.classify_zh("我吃软件") == "simplified"
+
+
+@_skip_no_opencc
 def test_charwise_is_corruption_free_and_carries_no_idioms():
     # already-Traditional bait: char-wise must be exact identity (no re-segmentation)
     assert zh.to_traditional_charwise(_TRAD_TRANSCRIPT) == _TRAD_TRANSCRIPT

--- a/zh_convert.py
+++ b/zh_convert.py
@@ -63,9 +63,17 @@ def to_simplified(text: str) -> str:
 
 
 def _char_is_simplified(ch) -> bool:
-    """A char neutral s2t rewrites — evaluated on a SINGLE char, so there's no phrase
-    context to mis-fire (系 alone → 系, never 係)."""
-    return to_traditional(ch) != ch
+    """Does Taiwan-Traditional conversion actually rewrite this char? Evaluated on a
+    SINGLE char, so there's no phrase context to mis-fire (系 alone → 系, never 係).
+
+    Probes with s2tw, NOT neutral s2t. s2t "corrects" exactly ten Taiwan-STANDARD chars
+    to archaic variants — 吃→喫 唇→脣 峰→峯 床→牀 灶→竈 痴→癡 皂→皁 秘→祕 粽→糉 群→羣 —
+    so an s2t probe mis-flags ordinary Taiwan text as Simplified. Those are common
+    characters: a transcript with 吃 or 群 in it read as "mixed", and one that happened
+    to carry no Traditional-only char could even land in the "simplified" bucket and be
+    handed to phrase-level s2twp — the exact input that corrupts Traditional. s2tw keeps
+    all ten and still rewrites every genuinely Simplified char (软→軟)."""
+    return _convert("s2tw", ch) != ch
 
 
 def to_traditional_charwise(text: str) -> str:
@@ -94,7 +102,8 @@ def classify_zh(text):
     already-Traditional text: opencc's S→T phrase maps assume Simplified input and
     re-segment valid Traditional (系統→係統, 音樂類型→型別, 設備→裝置). Detection is
     per-CHARACTER (single chars carry no phrase context, so 系 alone → 系, never 係):
-      - simplified char  = to_traditional(ch) != ch   (s2t changes it)
+      - simplified char  = _char_is_simplified(ch)     (s2tw changes it — NOT s2t, which
+                                                        over-flags Taiwan-standard 吃/群)
       - traditional-only = to_simplified(ch) != ch     (t2s changes it)
     A genuine Mainland-Simplified whisper transcript has Simplified chars and NO
     Traditional-only chars → "simplified". Anything already carrying Traditional-only
@@ -103,7 +112,7 @@ def classify_zh(text):
     → the backfill safely converts nothing."""
     if not text or not text.strip():
         return "empty"
-    has_simp = any(to_traditional(ch) != ch for ch in text)
+    has_simp = any(_char_is_simplified(ch) for ch in text)
     has_trad_only = any(to_simplified(ch) != ch for ch in text)
     if has_simp and not has_trad_only:
         return "simplified"


### PR DESCRIPTION
Follow-up to #211.

## The bug

`_char_is_simplified` — and through it `classify_zh`, the gate that decides which rows the 9.8b backfill converts — asked **neutral s2t** whether a character changes. s2t "corrects" exactly ten **Taiwan-standard** characters to archaic variants:

```
吃→喫  唇→脣  峰→峯  床→牀  灶→竈  痴→癡  皂→皁  秘→祕  粽→糉  群→羣
```

These are common characters. Any transcript containing 吃 or 群 was read as carrying Simplified text, so it classified as **"mixed"** instead of "traditional". Worse: a row that happened to carry **no Traditional-only character** could reach the **"simplified"** bucket and be handed to phrase-level `s2twp` — precisely the input that re-segments and corrupts valid Traditional (`系統→係統`, `音樂類型→型別`, `設備→裝置`), which is the whole reason #211 is gated.

## The fix

Probe **s2tw** instead. It keeps all ten Taiwan-standard forms and still rewrites every genuinely Simplified character (`软→軟`). The classifier gate and the char-wise converter (which already converted with s2tw) now agree exactly, so a flagged character can no longer convert to itself.

## No output change on already-correct data

The mis-flagged rows went down the char-wise path, which was already a **no-op** on them — nothing was ever written wrong. What this removes is the wasted conversion pass and the residual mis-bucketing risk.

## Verification

- **1037 tests** pass. New case pins all ten characters as unflagged and char-wise-identity, asserts a plain Taiwan sentence (`我今天吃飯，那群人在床邊`) classifies `traditional`, and asserts `软` is still caught / `我吃软件` still classifies `simplified`.
- **Real library A (122 zh rows)**: the 3 rows previously mis-read as "mixed" now classify Traditional — `skipped 122 already-Traditional, 0 empty`, 0 conversions.
- **Real library B (37 zh rows)**: classification byte-identical old-vs-new (34 traditional / 3 mixed), with every genuine Simplified char still detected and converted (`会→會 台→臺 帮→幫 软→軟 视→視 内→內`) — genuine detection does not regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)