### PR TITLE
fix(ingest): constrain tag-merge LLM output with a JSON Schema + guard the shape

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -1281,6 +1281,25 @@ _CANON_PROMPT = (
 )
 
 
+# Shape contract for the merge proposal. json_mode alone only guarantees valid
+# JSON — qwen2.5:14b answers this very prompt with {"慢跑":"路跑"}, which has no
+# "tags" key at all, so the merge was silently dropped. Constrain at the source.
+_CANON_SCHEMA = {
+    "type": "object",
+    "properties": {"tags": {"type": "array", "items": {"type": "string"}}},
+    "required": ["tags"],
+}
+
+
+def _str_list(value) -> list:
+    """Keep only the strings in a parsed LLM list. Schema adherence is
+    model-dependent, so a stray dict/int must degrade to "ignored", never reach
+    canonicalize() and raise AttributeError mid-run (same discipline as chat.py)."""
+    if not isinstance(value, list):
+        return []
+    return [v for v in value if isinstance(v, str)]
+
+
 def _run_canonicalize_tags(args):
     """Populate media.canonical_tags via one LLM semantic-merge per media. Reads
     the raw vision tags (rank_media_tags over frame_tags), asks the chat model to
@@ -1305,8 +1324,13 @@ def _run_canonicalize_tags(args):
             db.set_canonical_tags(r["id"], [])
             continue
         try:
-            resp = llm.chat(_CANON_PROMPT + _json.dumps(raw, ensure_ascii=False), json_mode=True)
-            proposed = _json.loads(resp["text"]).get("tags", [])
+            resp = llm.chat(
+                _CANON_PROMPT + _json.dumps(raw, ensure_ascii=False),
+                json_mode=True,
+                schema=_CANON_SCHEMA,
+            )
+            parsed = _json.loads(resp["text"])
+            proposed = _str_list(parsed.get("tags") if isinstance(parsed, dict) else None)
         except Exception as e:
             failed += 1
             print("  media {0}: LLM 失敗 ({1}) → 跳過".format(r["id"], e))
@@ -1328,6 +1352,25 @@ _ALIAS_JUDGE_PROMPT = (
     "**只能用清單裡出現的詞，絕對不可創造新詞，也不要把不同距離/不同事物硬合(例：路跑≠馬拉松)**。"
     "回傳 {\"groups\":[{\"pref\":\"...\",\"alts\":[\"...\"]}]}，只輸出 JSON。\n候選標籤："
 )
+
+
+_ALIAS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "groups": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "pref": {"type": "string"},
+                    "alts": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["pref", "alts"],
+            },
+        }
+    },
+    "required": ["groups"],
+}
 
 
 def _cosine(a, b):
@@ -1389,14 +1432,25 @@ def _run_propose_aliases(args):
     for cl in clusters:
         cl_set = set(cl)
         try:
-            resp = llm.chat(_ALIAS_JUDGE_PROMPT + _json.dumps(cl, ensure_ascii=False), json_mode=True)
-            proposed = _json.loads(resp["text"]).get("groups", [])
+            resp = llm.chat(
+                _ALIAS_JUDGE_PROMPT + _json.dumps(cl, ensure_ascii=False),
+                json_mode=True,
+                schema=_ALIAS_SCHEMA,
+            )
+            parsed = _json.loads(resp["text"])
+            proposed = parsed.get("groups") if isinstance(parsed, dict) else None
+            proposed = proposed if isinstance(proposed, list) else []
         except Exception as e:
             print("  cluster {0}: LLM 失敗 ({1}) → 跳過".format(cl, e))
             continue
         for g in proposed:
+            # A bare string here used to raise AttributeError OUTSIDE the try
+            # above, killing the whole run and discarding every cluster judged so
+            # far (out_groups is only written after the loop).
+            if not isinstance(g, dict):
+                continue
             pref = tag_quality.canonicalize(g.get("pref") or "")
-            alts = [tag_quality.canonicalize(a) for a in (g.get("alts") or [])]
+            alts = [tag_quality.canonicalize(a) for a in _str_list(g.get("alts"))]
             # guard: pref + every alt must be a real tag from THIS cluster (no
             # invention, no cross-cluster bleed); need >=1 alt or there's no merge.
             alts = [a for a in alts if a and a in cl_set and a != pref]

--- a/llm.py
+++ b/llm.py
@@ -40,8 +40,16 @@ def chat(
     system: Optional[str] = None,
     conversation: Optional[List[Dict[str, Any]]] = None,
     json_mode: bool = False,
+    schema: Optional[Dict[str, Any]] = None,
     provider: Provider = Provider.OLLAMA,
 ) -> Dict[str, Any]:
+    """Call the chat model. `json_mode` asks for syntactically valid JSON; it does
+    NOT constrain the shape, so the model can answer a "return {"groups":[...]}"
+    prompt with {"慢跑":"路跑"} and the caller silently gets nothing. Pass
+    `schema` (a JSON Schema dict) to constrain the structure at the source —
+    Ollama has supported this in `format` since 0.5. Callers must STILL validate
+    the parsed result (see chat.py): schema adherence is model-dependent and a
+    non-conforming provider must not be able to crash the caller."""
     model = model or OLLAMA_CHAT_MODEL
     start = time.time()
 
@@ -55,7 +63,9 @@ def chat(
         "messages": messages,
         "stream": False,
     }
-    if json_mode:
+    if schema:
+        payload["format"] = schema
+    elif json_mode:
         payload["format"] = "json"
 
     response = _ollama_post("/api/chat", payload, timeout=120)

--- a/tests/test_ingest_llm_shape.py
+++ b/tests/test_ingest_llm_shape.py
@@ -1,0 +1,136 @@
+"""Malformed-but-valid-JSON LLM replies must not crash or silently drop work.
+
+`json_mode` only guarantees syntactic JSON, never the shape the prompt asked
+for. Measured against the real model (qwen2.5:14b, ollama 0.30.7) the alias
+prompt that says `回傳 {"groups":[...]}` answered `{"慢跑":"路跑"}` — no
+"groups" key at all, so the judged merge was silently discarded. Under the same
+free-form mode a list-of-strings reply raised AttributeError *outside* the
+try/except in _run_propose_aliases, killing the whole run.
+
+These tests pin both halves of the fix: the schema is sent to the provider, and
+the parsing still survives a provider that ignores it.
+"""
+import importlib
+
+import pytest
+
+
+ingest = importlib.import_module("ingest")
+llm = importlib.import_module("llm")
+
+
+class _FakeResponse(object):
+    def __init__(self, content):
+        self._content = content
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return {"message": {"content": self._content}}
+
+
+def _capture_post(monkeypatch, content):
+    captured = {}
+
+    def fake_post(url, json, timeout):
+        captured["payload"] = json
+        return _FakeResponse(content)
+
+    monkeypatch.setattr(llm.requests, "post", fake_post)
+    return captured
+
+
+# ── layer 2: the structural constraint actually reaches the provider ──
+
+def test_schema_is_sent_as_format(monkeypatch):
+    captured = _capture_post(monkeypatch, '{"tags": []}')
+    llm.chat("x", json_mode=True, schema=ingest._CANON_SCHEMA)
+    assert captured["payload"]["format"] == ingest._CANON_SCHEMA
+
+
+def test_schema_takes_precedence_over_plain_json_mode(monkeypatch):
+    captured = _capture_post(monkeypatch, '{"groups": []}')
+    llm.chat("x", json_mode=True, schema=ingest._ALIAS_SCHEMA)
+    assert captured["payload"]["format"] != "json"
+
+
+def test_json_mode_alone_still_supported(monkeypatch):
+    captured = _capture_post(monkeypatch, "{}")
+    llm.chat("x", json_mode=True)
+    assert captured["payload"]["format"] == "json"
+
+
+def test_no_format_key_when_neither_requested(monkeypatch):
+    captured = _capture_post(monkeypatch, "hi")
+    llm.chat("x")
+    assert "format" not in captured["payload"]
+
+
+def test_alias_schema_requires_object_items():
+    """The shape that free-form mode got wrong must be mandatory in the schema."""
+    item = ingest._ALIAS_SCHEMA["properties"]["groups"]["items"]
+    assert item["type"] == "object"
+    assert set(item["required"]) == {"pref", "alts"}
+
+
+# ── layer 3: caller survives a provider that ignores the schema ──
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        ["馬拉松", {"name": "路跑"}, 42, None],  # mixed junk
+        "not-a-list",
+        None,
+        {"tags": "nested"},
+    ],
+)
+def test_str_list_only_keeps_strings(value):
+    out = ingest._str_list(value)
+    assert all(isinstance(v, str) for v in out)
+
+
+def test_str_list_preserves_order_and_strings():
+    assert ingest._str_list(["a", 1, "b"]) == ["a", "b"]
+
+
+def test_canonicalize_survives_dict_items(monkeypatch):
+    """{"tags":[{"name":"肉類"}]} used to reach canonicalize() → AttributeError
+    ('dict' object has no attribute 'strip') outside the try, aborting the run."""
+    tag_quality = importlib.import_module("tag_quality")
+    proposed = ingest._str_list([{"name": "肉類"}])
+    clean = tag_quality.guard_canonical(["生肉", "生魚", "肉類"], proposed)
+    # nothing usable proposed → guard falls back to raw, run continues
+    assert clean == ["生肉", "生魚", "肉類"]
+
+
+def test_alias_loop_skips_non_dict_groups():
+    """A list-of-strings reply must degrade to "no merge", not AttributeError."""
+    tag_quality = importlib.import_module("tag_quality")
+    cl_set = {"馬拉松", "路跑"}
+    out_groups = []
+    for g in ["馬拉松", "路跑"]:  # the shape that used to crash
+        if not isinstance(g, dict):
+            continue
+        pref = tag_quality.canonicalize(g.get("pref") or "")
+        alts = [tag_quality.canonicalize(a) for a in ingest._str_list(g.get("alts"))]
+        alts = [a for a in alts if a and a in cl_set and a != pref]
+        if pref in cl_set and alts:
+            out_groups.append({"pref": pref, "alts": alts})
+    assert out_groups == []
+
+
+def test_alias_loop_accepts_wellformed_groups():
+    """The fix must not break the happy path the schema now guarantees."""
+    tag_quality = importlib.import_module("tag_quality")
+    cl_set = {"馬拉松", "路跑", "慢跑"}
+    out_groups = []
+    for g in [{"pref": "馬拉松", "alts": ["路跑", 7, None]}]:
+        if not isinstance(g, dict):
+            continue
+        pref = tag_quality.canonicalize(g.get("pref") or "")
+        alts = [tag_quality.canonicalize(a) for a in ingest._str_list(g.get("alts"))]
+        alts = [a for a in alts if a and a in cl_set and a != pref]
+        if pref in cl_set and alts:
+            out_groups.append({"pref": pref, "alts": alts})
+    assert out_groups == [{"pref": "馬拉松", "alts": ["路跑"]}]


### PR DESCRIPTION
## 問題

`json_mode` 只保證**語法**合法的 JSON，**不保證形狀**。`chat.py` 早就學到這件事（M1/H9 審計）並對每個解析欄位做驗證，但 `ingest.py` 的兩處標籤正規化從沒套用同樣紀律。

對真實 provider 實測（qwen2.5:14b / ollama 0.30.7），那句字面寫著 `回傳 {"groups":[...]}` 的 prompt 回答：

```json
{"慢跑":"路跑"}
```

**完全沒有 `groups` key** → `.get("groups", [])` 得到 `[]` → 迴圈不執行 → 該 cluster 的判定被**靜默丟棄**。模型其實判對了（慢跑/路跑同義），arkiv 一聲不響地扔掉。靜默失敗比崩潰更糟，因為沒有任何東西會浮現它。

同一條路徑上另外兩個更硬的故障：

| 輸入（皆為合法 JSON） | 後果 |
|---|---|
| `{"groups":["馬拉松","路跑"]}` | `g.get("pref")` → AttributeError，**在 try/except 之外** → 整個 propose-aliases run 中斷，先前所有已判定 cluster 全丟（`out_groups` 要到迴圈後才寫檔） |
| `{"tags":[{"name":"肉類"}]}` | 進到 `canonicalize()` → `'dict' object has no attribute 'strip'`，canonicalize 路徑同樣中斷（`guard_canonical` 也在 try 之外） |

## 修法（兩層：源頭約束 + 下游不信任）

1. **`llm.chat()` 新增 `schema` 參數** —— 有值時作為 ollama `format` 送出（0.5 起支援），在源頭鎖住結構。
2. **呼叫端仍然驗證** —— schema 遵從度取決於模型，不合規的 provider 絕不能弄崩整個 run。非 dict 的 group 跳過，非 str 的清單元素由 `_str_list()` 濾掉。

`guard_canonical()` 既有的語意防護（禁造詞 / 過度合併退回 / 非破壞性儲存）本來就紮實，**未更動** —— 這次的缺口是結構層，不是語意層。

## 驗證

- **端對端對真實模型**：同一組輸入，修法前產出空的，修法後正確回 `{"pref":"慢跑","alts":["路跑"]}`
- **新增 13 個測試**：schema 確實送達 provider、schema 優先於 json_mode、兩種崩潰形狀都降級為 no-op、happy path 不被破壞
- **全套 1057 passed / 7 skipped**

## 出處

這條來自拆解 OneAD 2025 廣告AI高峰會時的一條借鏡（幻覺控制三層法：RAG + **結構化 I/O schema 約束** + 知識圖譜）。他們解的是「拿鐵在不同通路歸類」的語意歧義，與 arkiv 標籤合併同構。第 2 層正是我們缺的那層。

🤖 Generated with [Claude Code](https://claude.com/claude-code)