### PR TITLE
chore: use neutral placeholders in examples and test fixtures

### DIFF
--- a/export_builders.py
+++ b/export_builders.py
@@ -44,7 +44,7 @@ def _csv_safe(value: str) -> str:
 def _parse_frame_tags(frame_tags_value):
     """Decode frame_tags JSON list into structured fields used by CSV export.
 
-    Real-world DB（example: 恬馨庫 427 rows）每筆 frame_tags 是 vision pipeline
+    Real-world DB（example: 某商業案素材庫 427 rows）每筆 frame_tags 是 vision pipeline
     寫入的 JSON list，每個 frame 都是 dict：
       {description, tags, content_type, focus_score, exposure, stability,
        audio_quality, atmosphere, energy, edit_position, edit_reason}

--- a/routers/analytics.py
+++ b/routers/analytics.py
@@ -71,7 +71,7 @@ def get_stats(
     # per project) each report their own name.
     stats["project"] = config.PROJECT_ROOT.name if config.PROJECT_ROOT else None
     # The REGISTRY name for the currently-loaded project (may differ from the dir
-    # basename — a library registered as "恬馨庫" can live in a dir named "tianxin").
+    # basename — a library registered as "婚禮案素材庫" can live in a dir named "wedding").
     # A cross-library 精選集 item is keyed by registry name, so the grid's
     # "加入精選集" needs this — null when the current project isn't registered
     # (then a grid-added item couldn't be resolved back → the UI disables the add).

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -63,7 +63,8 @@ def test_exiftool_camera_falls_back_to_embedded_xml_device(monkeypatch):
     """Sony XAVC without an M01.XML sidecar leaves standard Make/Model blank but
     carries device identity in the embedded XML as DeviceManufacturer /
     DeviceModelName. Read them in the same exiftool call so camera_make/model
-    populate instead of staying NULL (445/480 恬馨 clips were empty for this)."""
+    populate instead of staying NULL (445/480 clips in one real XAVC shoot were
+    empty for this)."""
     import sys, os, json
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     import ingest

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1557,9 +1557,9 @@ def test_search_all_strips_absolute_and_project_paths(fastapi_client, monkeypatc
         "items": [{
             "media_id": "1", "filename": "clip.mp4",
             "relative_path": "A001/clip.mp4",
-            "absolute_path": "/Volumes/home/影片專案/恬馨/A001/clip.mp4",
-            "path": "/Volumes/home/影片專案/恬馨/A001/clip.mp4",
-            "project_path": "/Volumes/home/影片專案/恬馨",
+            "absolute_path": "/Volumes/home/影片專案/示範案/A001/clip.mp4",
+            "path": "/Volumes/home/影片專案/示範案/A001/clip.mp4",
+            "project_path": "/Volumes/home/影片專案/示範案",
         }],
         "projects_queried": 1, "projects_failed": 0,
     }
@@ -1570,7 +1570,7 @@ def test_search_all_strips_absolute_and_project_paths(fastapi_client, monkeypatc
     assert "absolute_path" not in item
     assert item["path"] == "A001/clip.mp4"
     assert "/Volumes" not in item["path"]
-    assert item["project_path"] == "恬馨"
+    assert item["project_path"] == "示範案"
     assert "/Volumes" not in item["project_path"]
 
 

--- a/tests/test_transcribe_faster_whisper.py
+++ b/tests/test_transcribe_faster_whisper.py
@@ -170,11 +170,11 @@ def test_custom_terms_env_only(monkeypatch):
 
 def test_custom_terms_file_only(monkeypatch, tmp_path):
     vf = tmp_path / "vocabulary.txt"
-    vf.write_text("# 影視人名詞庫\n恬馨\n\nWaffle House\n  明燒肉  \n", encoding="utf-8")
+    vf.write_text("# 影視人名詞庫\n王小明\n\nWaffle House\n  明燒肉  \n", encoding="utf-8")
     monkeypatch.setattr(transcribe, "CUSTOM_VOCABULARY", "")
     monkeypatch.setattr(transcribe, "VOCABULARY_FILE", str(vf))
     # comments + blank lines ignored, surrounding whitespace trimmed
-    assert transcribe._custom_terms() == ["恬馨", "Waffle House", "明燒肉"]
+    assert transcribe._custom_terms() == ["王小明", "Waffle House", "明燒肉"]
 
 
 def test_custom_terms_env_and_file_merge_dedup(monkeypatch, tmp_path):

--- a/vectordb.py
+++ b/vectordb.py
@@ -260,7 +260,7 @@ def build_doc_text(record: dict) -> str:
 
     audit Round-1 critical fix（2026-05-05）：原本只讀 frame_tags 裡的 `keywords`
     key，但 production vision pipeline（vision.py）寫的是 `description` + `tags`，
-    根本沒有 `keywords` 欄。實測恬馨庫 427 row × 5 frame 的 vision 描述 + tag
+    根本沒有 `keywords` 欄。實測某商業案素材庫 427 row × 5 frame 的 vision 描述 + tag
     全部 silently 沒進 vector index，semantic search 對視覺內容召回極差。
 
     現在順序：description（每 frame 完整敘述，最有 semantic value）+ tags list


### PR DESCRIPTION
Docstrings, one code comment, and several test fixtures referenced a specific real-world library by name, plus a machine-specific media path. This swaps in neutral placeholders while keeping every example's teaching value.

| File | Change |
|---|---|
| `export_builders.py` · `vectordb.py` | example library → `某商業案素材庫` (row counts kept — the empirical point stands) |
| `routers/analytics.py` | registry-name vs dir-basename example → `婚禮案素材庫` / `wedding` (still CJK-name vs latin-dir, which is the whole point of the comment) |
| `tests/test_ingest.py` | `445/480 clips in one real XAVC shoot` |
| `tests/test_server.py` | project path → `示範案` (fixture **and** assertion changed together) |
| `tests/test_transcribe_faster_whisper.py` | vocabulary term → `王小明` (still CJK, still exercises the CJK wordlist path) |

## Verification

- **Full suite: 1044 passed, 7 skipped**
- **Reverse-proof on the path-leak test** — editing a fixture risks making its assertion vacuous, so I checked it still bites: disabling `_basename_only` in `routers/search.py` makes `test_search_all_strips_absolute_and_project_paths` **FAIL**. Restored clean (no diff).
- Placeholders keep the properties each test was written for: CJK path handling, CJK wordlist parsing, basename stripping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)