### PR TITLE
feat(media): /api/media/{id}/segments endpoint + words_json reconciliation (three-piece W1a)

### DIFF
--- a/routers/media.py
+++ b/routers/media.py
@@ -487,6 +487,45 @@ def get_media_scenes(
     return _scenes_payload(media_id, rec, db.get_frames(media_id))
 
 
+def _segments_payload(segments_json):
+    """Project the stored `segments_json` TEXT column onto the stable
+    {start,end,text} subset. Never raises — a corrupt column degrades to [] rather
+    than 500ing (mirrors mcp_server._json_rows and export.py's defensive parse)."""
+    if not segments_json:
+        return []
+    try:
+        rows = json.loads(segments_json)
+    except (ValueError, TypeError):
+        return []
+    if not isinstance(rows, list):
+        return []
+    return [
+        {"start": r.get("start"), "end": r.get("end"), "text": r.get("text")}
+        for r in rows
+        if isinstance(r, dict)
+    ]
+
+
+@router.get("/api/media/{media_id}/segments")
+def get_media_segments(
+    media_id: int,
+    _tok: dict = Depends(require_scopes("videos_read")),
+):
+    """Sentence-level transcript timecodes for one clip: `[{start,end,text}]`.
+
+    The lightweight cutting surface for downstream edit agents (smart-edit). The
+    detail route ships `segments_json` only as a raw string and drops words_json
+    for transport size, so an agent that just needs to place an in/out on a quote
+    had to re-parse the whole record. This returns the projected segment array and
+    NOTHING else — no words (word-level lives in /remotion-props), no frames/tags.
+    Sentence granularity is enough to locate and cut a line; word-level would only
+    bloat the payload (the same reason MCP get_transcript defaults words off)."""
+    rec = db.get_record_by_id(media_id)
+    if not rec:
+        raise HTTPException(404, "找不到")
+    return _segments_payload(rec.get("segments_json"))
+
+
 @router.get("/api/media/{media_id}/chapters")
 def get_media_chapters(
     media_id: int,

--- a/tests/test_r5_25_router_media.py
+++ b/tests/test_r5_25_router_media.py
@@ -1,7 +1,7 @@
 """R5-25 (round-5 #51): media routes peeled to routers/media.py.
 
 The 14th router peeled — the clip-centric surface. Pins the split: the leaf module
-owns exactly the 16 media routes (list + per-clip sub-resources), server.py no
+owns exactly the 18 media routes (list + per-clip sub-resources), server.py no
 longer defines them, the two specific routes (/api/media/pool + /api/media/
 position/{media_id}) precede the dynamic /api/media/{media_id} so it can't shadow
 them, and the shared bulk-fetch helpers are re-exported by identity from
@@ -22,6 +22,7 @@ _EXPECTED_ROUTES = {
     ("/api/media/{media_id}", "GET"),
     ("/api/media/{media_id}/waveform", "GET"),
     ("/api/media/{media_id}/scenes", "GET"),
+    ("/api/media/{media_id}/segments", "GET"),
     ("/api/media/{media_id}/chapters", "GET"),
     ("/api/media/{media_id}/rating", "PATCH"),
     ("/api/media/{media_id}/inout", "PATCH"),
@@ -42,7 +43,7 @@ def test_media_router_is_a_leaf_module():
     assert not re.search(r"^\s*from\s+server\b", src, re.M)
 
 
-def test_router_owns_exactly_the_17_media_routes():
+def test_router_owns_exactly_the_18_media_routes():
     import routers.media as rm
     pairs = {
         (r.path, m)

--- a/tests/test_router_media_segments.py
+++ b/tests/test_router_media_segments.py
@@ -1,0 +1,60 @@
+"""A-seg: GET /api/media/{id}/segments — the lightweight sentence-level cut surface
+for downstream edit agents (smart-edit). Returns the projected [{start,end,text}]
+array only; never words, never the full record."""
+import importlib
+
+from starlette.testclient import TestClient
+
+
+def test_segments_endpoint_returns_projected_array_without_words(fastapi_client):
+    db = importlib.import_module("db")
+    with db.get_conn() as c:
+        c.execute(
+            "INSERT INTO media (path, filename, ext, transcript, segments_json, words_json) "
+            "VALUES (?,?,?,?,?,?)",
+            ("m.mp4", "m.mp4", ".mp4", "hi there",
+             '[{"start":0,"end":1,"text":"hi"},{"start":1,"end":2,"text":"there"}]',
+             '[{"word":"hi","start":0,"end":1,"score":0.9}]'),
+        )
+    r = fastapi_client.get("/api/media/1/segments")
+    assert r.status_code == 200, r.text
+    # projected to exactly {start,end,text} — no words leaked in
+    assert r.json() == [
+        {"start": 0, "end": 1, "text": "hi"},
+        {"start": 1, "end": 2, "text": "there"},
+    ]
+
+
+def test_segments_endpoint_missing_media_404(fastapi_client):
+    r = fastapi_client.get("/api/media/99999/segments")
+    assert r.status_code == 404
+
+
+def test_segments_endpoint_empty_when_no_transcript(fastapi_client):
+    db = importlib.import_module("db")
+    with db.get_conn() as c:
+        c.execute(
+            "INSERT INTO media (path, filename, ext) VALUES (?,?,?)",
+            ("silent.mp4", "silent.mp4", ".mp4"),
+        )
+    r = fastapi_client.get("/api/media/1/segments")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_segments_endpoint_tolerates_corrupt_segments_json(fastapi_client):
+    """A corrupt column degrades to [] rather than 500ing."""
+    db = importlib.import_module("db")
+    with db.get_conn() as c:
+        c.execute(
+            "INSERT INTO media (path, filename, ext, segments_json) VALUES (?,?,?,?)",
+            ("bad.mp4", "bad.mp4", ".mp4", "{not valid json"),
+        )
+    r = fastapi_client.get("/api/media/1/segments")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_segments_endpoint_requires_auth(server_module):
+    with TestClient(server_module.app) as c:
+        assert c.get("/api/media/1/segments").status_code == 401

--- a/tests/test_transcribe_guards.py
+++ b/tests/test_transcribe_guards.py
@@ -153,3 +153,38 @@ def test_postprocess_filters_configured_words_from_text_and_segments(monkeypatch
         "text": "這是保留內容",
     }]
     assert words == []
+
+
+def test_postprocess_reconciles_words_to_kept_segments(monkeypatch):
+    """A-wordfix: the per-segment filter rebuilds timed_segments from the SURVIVING
+    segments, but the raw `words` list still carries words from segments dropped as
+    hallucinations. Reconciliation keeps only words whose midpoint falls inside a
+    kept segment — so words_json can't reintroduce filtered-out content."""
+    transcribe = importlib.import_module("transcribe")
+    monkeypatch.setattr(transcribe, "LLM_POLISH", False)
+    segments = [
+        {  # KEPT — clean segment [0.0, 2.0]
+            "text": "保留這一段的語音內容。",
+            "no_speech_prob": 0.1, "avg_logprob": -0.2, "compression_ratio": 1.0,
+            "start": 0.0, "end": 2.0,
+        },
+        {  # DROPPED — low-confidence hallucination [2.8, 4.5]
+            "text": "低信心幻覺段落",
+            "no_speech_prob": 0.1, "avg_logprob": -1.6, "compression_ratio": 1.0,
+            "start": 2.8, "end": 4.5,
+        },
+    ]
+    words = [
+        {"word": "保", "start": 0.2, "end": 0.5, "score": 0.9},   # inside kept
+        {"word": "留", "start": 1.4, "end": 1.8, "score": 0.9},   # inside kept
+        {"word": "幻", "start": 3.0, "end": 3.4, "score": 0.4},   # inside dropped seg
+        {"word": "覺", "start": 4.0, "end": 4.3, "score": 0.4},   # inside dropped seg
+    ]
+    cleaned, _, timed_segments, out_words = transcribe._postprocess(
+        "原始文字", "zh", segments, "zh", words=words,
+    )
+    assert timed_segments == [{
+        "start": 0.0, "end": 2.0, "text": "保留這一段的語音內容。",
+    }]
+    # only words landing inside the surviving segment survive; dropped-segment words gone
+    assert [w["word"] for w in out_words] == ["保", "留"]

--- a/transcribe.py
+++ b/transcribe.py
@@ -499,6 +499,27 @@ def _postprocess(text: str, lang: str, segments: list, language: str, words: lis
     if LLM_POLISH and len(filtered_text) > 10:
         filtered_text = _llm_polish(filtered_text, language)
 
+    # Step 6: words_json reconciliation. The per-segment filter above rebuilt
+    # timed_segments from the SURVIVING segments, but `words` still carries every
+    # word from the raw segment list — including words that belonged to segments
+    # dropped as hallucinations (silence / low-logprob / high compression). Keep
+    # only words whose midpoint falls inside a kept segment's time range, so
+    # words_json can't reintroduce content the text/segment filters already removed
+    # (frame-accurate cutting and subtitle rendering read words_json directly).
+    if words:
+        kept_ranges = [(ts["start"], ts["end"]) for ts in timed_segments]
+        eps = 0.05  # tolerance for start/end rounded to 3 dp above vs raw word times
+
+        def _in_kept_segment(w):
+            ws = w.get("start")
+            if ws is None:
+                return False
+            we = w.get("end")
+            mid = ws if we is None else (ws + we) / 2.0
+            return any(lo - eps <= mid <= hi + eps for lo, hi in kept_ranges)
+
+        words = [w for w in words if _in_kept_segment(w)]
+
     return filtered_text, lang, timed_segments, words or []
 
 


### PR DESCRIPTION
Wave 1a of the auto-edit three-piece (arkiv 供料 side). Two atomic commits.

## A-seg — `GET /api/media/{id}/segments`
Lightweight sentence-level cut surface for downstream edit agents (smart-edit).
Returns projected `[{start,end,text}]` only — no words (word-level stays in
`/remotion-props`), no frames/tags. The detail route ships `segments_json` only
as a raw string and drops `words_json` for transport size, so an agent that just
needs to place an in/out on a quote previously had to re-parse the whole record.
Reuses the same defensive JSON projection as `mcp_server` (degrades to `[]` on a
corrupt column, never 500s). Route-contract test bumped 17→18.

## A-wordfix 🐛 — `words_json` reconciliation
`_postprocess` rebuilt `timed_segments` from the segments that survived the
anti-hallucination filters, but the raw `words` list flowed straight through —
still carrying words from dropped (hallucinated) segments. `words_json` is read
directly by frame-accurate cutting / subtitle rendering, so it could reintroduce
filtered-out content. Now keeps only words whose midpoint lands inside a surviving
segment (small tolerance for 3-dp rounding). No live consumer today; prerequisite
before anything cuts/captions off `words_json`.

## Verification
- New: `tests/test_router_media_segments.py` (5 cases: projection, 404, empty,
  corrupt-json tolerance, auth), `test_transcribe_guards.py::test_postprocess_reconciles_words_to_kept_segments`.
- Full suite: **1063 passed, 7 skipped** (local, py3.12 .venv).

Downstream: unblocks smart-edit **S4.3** (in/out guessed → timecode-aligned), tracked in
`hevin-ai-os/references/plans/arkiv/2026-07-20-auto-edit-three-piece-roadmap.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)