### PR TITLE
fix(vision): preflight model-installed + cause-accurate halt remedy (#218, #219)

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -214,6 +214,40 @@ def _ensure_vision_ready(max_wait_s=None, _probe=None, _sleep=None):
     return result
 
 
+def _vision_model_abort_message(model, installed_vision_models):
+    """Actionable error shown when the effective vision model isn't installed
+    (issue #218). Kept pure (no I/O) so it's unit-testable."""
+    lines = [
+        "",
+        "!" * 60,
+        "VISION ABORTED: model '{0}' is not installed in Ollama.".format(model),
+        "  Every frame would 404. Fix one of:",
+    ]
+    if installed_vision_models:
+        lines.append("    - use an installed vision model: {0}".format(", ".join(installed_vision_models)))
+        lines.append("      set ARKIV_OLLAMA_VISION_MODEL=<model>  (or vision.model via PUT /api/settings)")
+    else:
+        lines.append("    - no vision models installed — pull one, e.g. `ollama pull qwen3-vl:8b`,")
+        lines.append("      then set ARKIV_OLLAMA_VISION_MODEL=<model>")
+    lines.append("    - or install this exact tag: `ollama pull {0}`".format(model))
+    lines.append("!" * 60)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _preflight_vision_model():
+    """Fail loud before a vision batch when the effective model is confirmably not
+    installed (issue #218) — instead of 404-spamming every frame and then halting
+    with a confusing 'Fix Ollama' message. No-op when Ollama is unreachable (the
+    strict check returns None → absence unconfirmable), respecting the
+    sensor-not-gate philosophy; warm-up surfaces that case."""
+    import settings as _settings
+    model = _settings.vision_model()
+    if vis.is_model_installed(model) is False:
+        print(_vision_model_abort_message(model, vis.list_vision_models()))
+        sys.exit(2)
+
+
 def _normalize_bmd_tag(value):
     if value is None:
         return None
@@ -904,19 +938,39 @@ def _describe_frames_with_fallback(frame_paths):
 def _vision_halt_decision(file_failed, file_total, total_failed, consecutive_failed,
                           max_failures, skip_failed):
     """Decide whether to halt after a file with `file_failed`/`file_total` still-failing
-    frames. Returns (should_halt, reason); reason is "" when continuing.
+    frames. Returns (should_halt, reason, ollama_suspected); reason is "" when
+    continuing and ollama_suspected says whether the halt implicates Ollama.
 
     Order matters: the consecutive-failure guard is checked first and ignores the
     tolerance flags — an Ollama outage must stop an unattended run even under
-    --skip-failed.
+    --skip-failed. The two halt reasons are semantically different (issue #219):
+    a consecutive streak points at Ollama being down; exceeding --max-failures is
+    just isolated frame failures with Ollama healthy — the caller must not tell
+    the operator to "Fix Ollama" in the latter case.
     """
     if consecutive_failed >= _VISION_CONSECUTIVE_HALT:
-        return True, "{0} consecutive frame failures — Ollama likely down / model crash".format(consecutive_failed)
+        return True, "{0} consecutive frame failures — Ollama likely down / model crash".format(consecutive_failed), True
     if skip_failed:
-        return False, ""
+        return False, "", False
     if total_failed > max_failures:
-        return True, "{0} failed frame(s) exceeded --max-failures={1}".format(total_failed, max_failures)
-    return False, ""
+        return True, "{0} failed frame(s) exceeded --max-failures={1}".format(total_failed, max_failures), False
+    return False, "", False
+
+
+def _vision_halt_remedy(ollama_suspected):
+    """Cause-accurate remedy lines for a vision halt (issue #219). Only points at
+    Ollama when the halt actually implicates it (consecutive-failure streak); an
+    exceeded --max-failures is just isolated frames with Ollama healthy, so the
+    remedy there is --skip-failed, not 'Fix Ollama'."""
+    if ollama_suspected:
+        return [
+            "  Ollama looks down — check it's running (`ollama ps`, restart if needed),",
+            "  then resume: py -3.12 ingest.py --vision-only",
+        ]
+    return [
+        "  Ollama is up — the frame(s) above failed to parse. Resume skipping them:",
+        "    py -3.12 ingest.py --vision-only --skip-failed   (or tolerate more: --max-failures N)",
+    ]
 
 
 def _run_vision_only(args):
@@ -949,6 +1003,7 @@ def _run_vision_only(args):
 
     print(f"Found {len(rows)} frames across {len(media_frames)} files\n")
 
+    _preflight_vision_model()  # issue #218: fail loud if the model isn't installed
     _unload_ollama_model("qwen2.5:14b")
     _ensure_vision_ready()
 
@@ -1021,15 +1076,15 @@ def _run_vision_only(args):
             consecutive_failed = consecutive_failed + n_failed if n_failed == len(frame_paths) else 0
             failed_files.append((fname, n_failed, len(frame_paths)))
             print(f" [{v_elapsed:.1f}s] [{n_failed}/{len(frame_paths)} FAILED]")
-            should_halt, reason = _vision_halt_decision(
+            should_halt, reason, ollama_suspected = _vision_halt_decision(
                 n_failed, len(frame_paths), total_failed, consecutive_failed, max_failures, skip_failed)
             if should_halt:
                 remaining = len(media_frames) - vi
                 print(f"\n\n{'!'*60}")
                 print(f"VISION HALTED: {reason}")
                 print(f"  Completed: {ok}  |  Remaining: {remaining}  |  Failed frames: {total_failed}")
-                print(f"  Fix Ollama, then resume: py -3.12 ingest.py --vision-only")
-                print(f"  (skip persistent failures: add --skip-failed)")
+                for _line in _vision_halt_remedy(ollama_suspected):
+                    print(_line)
                 print(f"{'!'*60}\n")
                 halted = True
                 break
@@ -1905,6 +1960,7 @@ def main():
     if phase1_results:
         print(f"\n{'─'*60}")
         print(f"Phase 2: Vision — {len(phase1_results)} files, unloading LLM to free VRAM...")
+        _preflight_vision_model()  # issue #218: fail loud if the model isn't installed
         _unload_ollama_model("qwen2.5:14b")
         _ensure_vision_ready()
         for vi, (fpath, (record, frames)) in enumerate(phase1_results.items(), 1):
@@ -1997,7 +2053,7 @@ def main():
                     consecutive_empty_frames = consecutive_empty_frames + n_failed if n_failed == len(video_frames) else 0
                     vision_failed_files.append((fname, n_failed, len(video_frames)))
                     print(f" [{v_elapsed:.1f}s] [{n_failed}/{len(video_frames)} FAILED]")
-                    should_halt, reason = _vision_halt_decision(
+                    should_halt, reason, ollama_suspected = _vision_halt_decision(
                         n_failed, len(video_frames), total_failed, consecutive_empty_frames, max_failures, skip_failed)
                     if should_halt:
                         vision_halted = True
@@ -2005,8 +2061,8 @@ def main():
                         print(f"\n\n{'!'*60}")
                         print(f"VISION HALTED: {reason}")
                         print(f"  Completed: {vision_ok}  |  Remaining: {remaining}  |  Failed frames: {total_failed}")
-                        print(f"  Fix Ollama, then resume: py -3.12 ingest.py --vision-only")
-                        print(f"  (skip persistent failures: add --skip-failed)")
+                        for _line in _vision_halt_remedy(ollama_suspected):
+                            print(_line)
                         print(f"{'!'*60}\n")
                         break
                 else:

--- a/tests/test_vision_preflight.py
+++ b/tests/test_vision_preflight.py
@@ -1,0 +1,89 @@
+"""Tests for issue #218 — preflight the vision model before a batch.
+
+A fresh project whose settings table is empty resolves the vision model to the
+hardcoded default; if that model isn't pulled, the old behavior was to 404 on
+every frame and then halt with a misleading message. `is_model_installed` gives
+the ingest preflight a strict, tag-exact signal so it can fail loud instead.
+"""
+import importlib
+import types
+
+import pytest
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+@pytest.fixture
+def vision():
+    return importlib.import_module("vision")
+
+
+@pytest.fixture
+def ingest():
+    return importlib.import_module("ingest")
+
+
+def _patch_tags(vision, monkeypatch, names, raise_exc=False):
+    def fake_get(url, timeout=None):
+        if raise_exc:
+            raise OSError("connection refused")
+        return _FakeResp({"models": [{"name": n} for n in names]})
+    monkeypatch.setattr(vision.requests, "get", fake_get)
+
+
+# ── vision.is_model_installed ───────────────────────────────────────────────
+def test_installed_exact_tag_true(vision, monkeypatch):
+    _patch_tags(vision, monkeypatch, ["qwen3-vl:8b", "bge-m3:latest"])
+    assert vision.is_model_installed("qwen3-vl:8b") is True
+
+
+def test_absent_but_reachable_false(vision, monkeypatch):
+    # The exact 404-spam scenario: a bare model whose tag isn't pulled.
+    _patch_tags(vision, monkeypatch, ["qwen3-vl:8b"])
+    assert vision.is_model_installed("qwen2.5vl:7b") is False
+
+
+def test_same_base_different_tag_is_false(vision, monkeypatch):
+    # model_available() would say True by base match; the strict check must not,
+    # because /api/generate needs the exact tag.
+    _patch_tags(vision, monkeypatch, ["qwen2.5vl:3b"])
+    assert vision.is_model_installed("qwen2.5vl:7b") is False
+
+
+def test_bare_name_normalizes_to_latest(vision, monkeypatch):
+    _patch_tags(vision, monkeypatch, ["llava:latest"])
+    assert vision.is_model_installed("llava") is True
+
+
+def test_unreachable_returns_none(vision, monkeypatch):
+    _patch_tags(vision, monkeypatch, [], raise_exc=True)
+    assert vision.is_model_installed("qwen3-vl:8b") is None
+
+
+def test_empty_tags_unconfirmable_none(vision, monkeypatch):
+    _patch_tags(vision, monkeypatch, [])
+    assert vision.is_model_installed("qwen3-vl:8b") is None
+
+
+def test_empty_name_none(vision):
+    assert vision.is_model_installed("") is None
+
+
+# ── ingest._vision_model_abort_message ──────────────────────────────────────
+def test_abort_message_lists_installed_vision_models(ingest):
+    msg = ingest._vision_model_abort_message("qwen2.5vl:7b", ["qwen3-vl:8b", "llava:latest"])
+    assert "qwen2.5vl:7b" in msg                     # names the offending model
+    assert "not installed" in msg
+    assert "qwen3-vl:8b" in msg and "llava:latest" in msg
+    assert "ARKIV_OLLAMA_VISION_MODEL" in msg        # actionable
+
+
+def test_abort_message_no_vision_models_suggests_pull(ingest):
+    msg = ingest._vision_model_abort_message("qwen2.5vl:7b", [])
+    assert "ollama pull" in msg

--- a/tests/test_vision_tolerance.py
+++ b/tests/test_vision_tolerance.py
@@ -22,9 +22,10 @@ def _decide(ing, total, consecutive, max_failures=0, skip_failed=False, file_fai
 
 
 def test_default_zero_tolerance_halts_on_first_failure(ing):
-    halt, reason = _decide(ing, total=1, consecutive=1, max_failures=0)
+    halt, reason, ollama_suspected = _decide(ing, total=1, consecutive=1, max_failures=0)
     assert halt is True
     assert "max-failures=0" in reason
+    assert ollama_suspected is False  # issue #219: not an Ollama problem
 
 
 def test_max_failures_tolerates_up_to_n_then_halts(ing):
@@ -33,24 +34,40 @@ def test_max_failures_tolerates_up_to_n_then_halts(ing):
 
 
 def test_skip_failed_never_halts_on_frame_failures(ing):
-    halt, _ = _decide(ing, total=999, consecutive=1, skip_failed=True)
+    halt, _, _ = _decide(ing, total=999, consecutive=1, skip_failed=True)
     assert halt is False
 
 
 def test_consecutive_guard_fires_at_threshold(ing):
     k = ing._VISION_CONSECUTIVE_HALT
     assert _decide(ing, total=k, consecutive=k - 1, max_failures=10_000)[0] is False
-    halt, reason = _decide(ing, total=k, consecutive=k, max_failures=10_000)
+    halt, reason, ollama_suspected = _decide(ing, total=k, consecutive=k, max_failures=10_000)
     assert halt is True
     assert "consecutive" in reason
+    assert ollama_suspected is True  # issue #219: consecutive streak implicates Ollama
 
 
 def test_consecutive_guard_overrides_skip_failed(ing):
     # An Ollama outage must stop even an explicit --skip-failed run.
     k = ing._VISION_CONSECUTIVE_HALT
-    halt, reason = _decide(ing, total=k, consecutive=k, skip_failed=True)
+    halt, reason, ollama_suspected = _decide(ing, total=k, consecutive=k, skip_failed=True)
     assert halt is True
     assert "consecutive" in reason
+    assert ollama_suspected is True
+
+
+# ── issue #219: cause-accurate halt remedy ──────────────────────────────────
+def test_halt_remedy_ollama_down_points_at_ollama(ing):
+    lines = "\n".join(ing._vision_halt_remedy(ollama_suspected=True))
+    assert "Ollama looks down" in lines
+    assert "--skip-failed" not in lines  # don't tell them to skip when Ollama is the problem
+
+
+def test_halt_remedy_tolerance_points_at_skip_failed_not_ollama(ing):
+    lines = "\n".join(ing._vision_halt_remedy(ollama_suspected=False))
+    assert "--skip-failed" in lines
+    assert "Ollama is up" in lines
+    assert "Fix Ollama" not in lines  # the whole point of #219
 
 
 # ── _describe_frames_with_fallback ──────────────────────────────────────────
@@ -95,6 +112,7 @@ def vision_db(tmp_db, monkeypatch):
     db = importlib.import_module("db")
     monkeypatch.setattr(ing, "_unload_ollama_model", lambda *a, **k: None)
     monkeypatch.setattr(ing, "_ensure_vision_ready", lambda *a, **k: None)
+    monkeypatch.setattr(ing, "_preflight_vision_model", lambda *a, **k: None)  # issue #218: stub the install gate
     _install_fake_vision(ing, monkeypatch)
 
     def make(thumb_names):

--- a/vision.py
+++ b/vision.py
@@ -34,6 +34,38 @@ def model_available(name: str) -> bool:
     return avail
 
 
+def _norm_tag(name: str) -> str:
+    """Normalize an Ollama model reference the way the daemon resolves it: a bare
+    name (no ':') means the ':latest' tag. Used for exact install checks."""
+    return name if ":" in name else name + ":latest"
+
+
+def is_model_installed(name: str) -> Optional[bool]:
+    """Strict, tag-exact install check for the ingest preflight (issue #218).
+
+    Unlike model_available() — which matches by base name and so can say "yes"
+    when only a *different* tag of the same base is pulled — this compares the
+    exact tag Ollama's /api/generate would need (bare name → ':latest'). Returns:
+      True  — the exact tag is installed,
+      False — Ollama is reachable and the exact tag is definitively absent,
+      None  — Ollama is unreachable, so absence can't be confirmed (caller should
+              proceed rather than block; warm-up surfaces the real error).
+    A confirmed False is what lets the preflight fail loud instead of grinding
+    every frame into a 404 on a fresh project."""
+    if not name:
+        return None
+    try:
+        r = requests.get(f"{config.OLLAMA_URL}/api/tags", timeout=5)
+        installed = {_norm_tag(m.get("name", "")) for m in r.json().get("models", []) if m.get("name")}
+    except Exception:
+        return None
+    if not installed:
+        # Reachable but no models at all — treat as unconfirmable (don't hard-fail
+        # on a transient empty/garbled /api/tags reading).
+        return None
+    return _norm_tag(name) in installed
+
+
 # Vision-capable model name families — used as a fallback when Ollama's
 # /api/show doesn't report capabilities (older Ollama) or is unreachable.
 _VISION_NAME_RE = re.compile(


### PR DESCRIPTION
Both fixes surfaced by the first large real-corpus stress test (G corpus, 1506 files). Closes #218, closes #219.

## #218 — vision model preflight
A fresh project (empty settings table) resolves the vision model to the hardcoded default (`config.OLLAMA_VISION_MODEL`); if that model isn't pulled, ingest 404'd every frame then halted with a confusing message.

- `vision.is_model_installed(name)` — strict, tag-exact check (bare name → `:latest`, unlike `model_available()`'s base-name match). Returns `True`/`False`/`None`; `None` when Ollama is unreachable so the preflight never blocks on a missing signal.
- `ingest._preflight_vision_model()` — called before both vision entry points (`_run_vision_only` and the `--dir` Phase 2 loop). On a confirmed-absent model it prints an actionable message (installed vision models + how to set `ARKIV_OLLAMA_VISION_MODEL` / `vision.model` / `ollama pull`) and exits 2, instead of grinding into 404s.

## #219 — cause-accurate halt remedy
`_vision_halt_decision` has two semantically different halt reasons but both print sites printed `Fix Ollama` unconditionally.

- Decision now returns `ollama_suspected`. Consecutive-failure guard → Ollama implicated; exceeding `--max-failures` → isolated frame failures, Ollama healthy.
- New `_vision_halt_remedy(ollama_suspected)` points at Ollama only for the former, and at `--skip-failed` for the latter.

## Tests
64 pass. New `tests/test_vision_preflight.py` (9) covers `is_model_installed` (exact / same-base-different-tag / `:latest` / unreachable / empty) and the abort message; tolerance suite updated to the 3-tuple decision and asserts the remedy split.

Note: `--skip-failed`/`--max-failures` already exist (#48/#50); the stress-test halt was a launcher not passing `--skip-failed`. This PR fixes the two genuine product defects the run exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)