### PR TITLE
feat(transcribe): A4 — attach speaker_id to segments via speaker-align

### DIFF
--- a/config.py
+++ b/config.py
@@ -322,6 +322,15 @@ PROXY_HWDECODE_DEFAULT = _IS_MLX if _hwd in ("", "auto") else _hwd in ("1", "tru
 _DEFAULT_WHISPER = "mlx-community/whisper-large-v3-turbo" if _IS_MLX else "large-v3-turbo"
 WHISPER_MODEL = os.getenv("ARKIV_WHISPER_MODEL", _DEFAULT_WHISPER)
 
+# Speaker diarization (A4) — attach a speaker_id to each transcript segment via
+# the speaker-align package. OFF by default: it needs the optional speaker-align
+# (+ pyannote) install and a HuggingFace token, and it roughly doubles transcribe
+# time. When off, transcription is byte-for-byte unchanged. Soft dependency —
+# transcribe.py degrades to no speaker_id if speaker-align/pyannote/token is absent.
+_diar = os.getenv("ARKIV_DIARIZATION_ENABLED", "").strip().lower()
+DIARIZATION_ENABLED = _diar in ("1", "true", "yes", "on")
+PYANNOTE_TOKEN = os.getenv("ARKIV_PYANNOTE_TOKEN", "").strip()
+
 WHISPER_GUARD_DEFAULT_MODE = 4
 WHISPER_GUARD_LAYERS = {
     0: {

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -263,6 +263,20 @@ def _project(rows: List[Dict[str, Any]], keys: tuple) -> List[Dict[str, Any]]:
     return [{k: row.get(k) for k in keys} for row in rows]
 
 
+def _project_segments(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Project segments onto {start,end,text}, plus speaker_id ONLY when present
+    (A4). Keeping speaker_id conditional means non-diarized clips return the exact
+    pre-A4 shape, so existing get_transcript consumers are unaffected."""
+    out = []
+    for row in rows:
+        seg = {k: row.get(k) for k in _SEGMENT_KEYS}
+        sid = row.get("speaker_id")
+        if sid:
+            seg["speaker_id"] = sid
+        out.append(seg)
+    return out
+
+
 def get_transcript_impl(
     media_id: int,
     include_words: bool = False,
@@ -282,7 +296,7 @@ def get_transcript_impl(
         # new: the timecodes. `segments` is the point of this tool — an agent
         # that only gets flat text cannot cut on a quote.
         "duration_s": rec.get("duration_s"),
-        "segments": _project(_json_rows(rec.get("segments_json")), _SEGMENT_KEYS),
+        "segments": _project_segments(_json_rows(rec.get("segments_json"))),
         # advertise word-level availability without paying for it
         "has_words": bool(word_rows),
     }

--- a/routers/media.py
+++ b/routers/media.py
@@ -499,11 +499,17 @@ def _segments_payload(segments_json):
         return []
     if not isinstance(rows, list):
         return []
-    return [
-        {"start": r.get("start"), "end": r.get("end"), "text": r.get("text")}
-        for r in rows
-        if isinstance(r, dict)
-    ]
+    out = []
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        seg = {"start": r.get("start"), "end": r.get("end"), "text": r.get("text")}
+        # A4: surface speaker_id only when present, so non-diarized clips keep the
+        # exact {start,end,text} shape (backward-compatible with existing consumers).
+        if r.get("speaker_id"):
+            seg["speaker_id"] = r.get("speaker_id")
+        out.append(seg)
+    return out
 
 
 @router.get("/api/media/{media_id}/segments")

--- a/tests/test_diarize_a4.py
+++ b/tests/test_diarize_a4.py
@@ -1,0 +1,135 @@
+"""A4 — speaker diarization: attach speaker_id to transcript segments.
+
+The alignment logic itself lives in (and is tested by) the speaker-align package;
+these tests cover arkiv's integration: the _attach_speaker_ids adapter (token gate,
+soft-fail, speaker→speaker_id rename) and the _postprocess hook (off by default,
+runs only when enabled + a wav_path is supplied).
+
+speaker-align is an optional (M2-local, not-yet-on-PyPI) dependency, so the tests
+that exercise real alignment self-skip when it isn't installed — same idiom as the
+opencc / mcp / psycopg tests.
+"""
+import json
+
+import pytest
+
+import config
+import transcribe
+
+try:
+    from speaker_align import SpeakerSegment, DiarizationResult
+    _HAVE_SPEAKER_ALIGN = True
+except ImportError:  # pragma: no cover - env without the optional dep
+    _HAVE_SPEAKER_ALIGN = False
+
+_needs_sa = pytest.mark.skipif(
+    not _HAVE_SPEAKER_ALIGN, reason="speaker-align not installed")
+
+
+class _FakeDiarizer:
+    def __init__(self, turns):
+        self._turns = turns
+
+    def diarize(self, wav_path):
+        return DiarizationResult(segments=self._turns, num_speakers=2)
+
+
+class _BoomDiarizer:
+    def diarize(self, wav_path):
+        raise RuntimeError("pyannote exploded")
+
+
+@_needs_sa
+def test_attach_renames_speaker_to_speaker_id(monkeypatch):
+    import speaker_align
+    turns = [SpeakerSegment("SPEAKER_00", 0.0, 5.0),
+             SpeakerSegment("SPEAKER_01", 5.0, 10.0)]
+    monkeypatch.setattr(speaker_align, "get_diarizer", lambda **kw: _FakeDiarizer(turns))
+    monkeypatch.setattr(transcribe, "PYANNOTE_TOKEN", "tok")
+
+    segs = [{"start": 0.0, "end": 3.0, "text": "早安"},
+            {"start": 6.0, "end": 9.0, "text": "午安"}]
+    out = transcribe._attach_speaker_ids(segs, "/tmp/fake.wav")
+
+    assert out[0]["speaker_id"] == "SPEAKER_00"
+    assert out[1]["speaker_id"] == "SPEAKER_01"
+    # speaker-align's own key must not leak through arkiv's contract.
+    assert "speaker" not in out[0]
+    # original text/timing preserved.
+    assert out[0]["text"] == "早安" and out[0]["start"] == 0.0
+
+
+@_needs_sa
+def test_attach_passes_configured_token(monkeypatch):
+    import speaker_align
+    seen = {}
+
+    def _spy(**kw):
+        seen["auth_token"] = kw.get("auth_token")
+        return _FakeDiarizer([SpeakerSegment("SPEAKER_00", 0.0, 10.0)])
+
+    monkeypatch.setattr(speaker_align, "get_diarizer", _spy)
+    monkeypatch.setattr(transcribe, "PYANNOTE_TOKEN", "hf-secret")
+    transcribe._attach_speaker_ids([{"start": 0.0, "end": 3.0, "text": "x"}], "/tmp/f.wav")
+    assert seen["auth_token"] == "hf-secret"
+
+
+def test_attach_no_token_is_soft(monkeypatch):
+    monkeypatch.setattr(transcribe, "PYANNOTE_TOKEN", "")
+    segs = [{"start": 0.0, "end": 3.0, "text": "x"}]
+    out = transcribe._attach_speaker_ids(segs, "/tmp/f.wav")
+    assert out == segs  # unchanged; no speaker_id, no raise
+
+
+@_needs_sa
+def test_attach_diarize_error_is_soft(monkeypatch):
+    import speaker_align
+    monkeypatch.setattr(speaker_align, "get_diarizer", lambda **kw: _BoomDiarizer())
+    monkeypatch.setattr(transcribe, "PYANNOTE_TOKEN", "tok")
+    segs = [{"start": 0.0, "end": 3.0, "text": "x"}]
+    out = transcribe._attach_speaker_ids(segs, "/tmp/f.wav")
+    assert out == segs  # a diarizer blowing up must not break transcription
+
+
+def test_attach_empty_or_no_wav_noops():
+    assert transcribe._attach_speaker_ids([], "/tmp/f.wav") == []
+    segs = [{"start": 0.0, "end": 1.0, "text": "x"}]
+    assert transcribe._attach_speaker_ids(segs, "") == segs
+
+
+# --- _postprocess hook wiring ---
+
+_RAW = [{"text": "第一句話很清楚", "start": 0.0, "end": 3.0,
+         "no_speech_prob": 0.0, "avg_logprob": -0.2, "compression_ratio": 1.2}]
+
+
+def test_postprocess_no_speaker_id_when_disabled(monkeypatch):
+    monkeypatch.setattr(transcribe, "DIARIZATION_ENABLED", False)
+    monkeypatch.setattr(transcribe, "LLM_POLISH", False)
+    _, _, segs, _ = transcribe._postprocess("第一句話很清楚", "zh", list(_RAW),
+                                            "zh", words=[], wav_path="/tmp/f.wav")
+    assert segs and "speaker_id" not in segs[0]
+
+
+def test_postprocess_calls_attach_when_enabled(monkeypatch):
+    monkeypatch.setattr(transcribe, "DIARIZATION_ENABLED", True)
+    monkeypatch.setattr(transcribe, "LLM_POLISH", False)
+
+    def _fake_attach(timed, wav):
+        return [dict(s, speaker_id="SPEAKER_00") for s in timed]
+
+    monkeypatch.setattr(transcribe, "_attach_speaker_ids", _fake_attach)
+    _, _, segs, _ = transcribe._postprocess("第一句話很清楚", "zh", list(_RAW),
+                                            "zh", words=[], wav_path="/tmp/f.wav")
+    assert segs[0]["speaker_id"] == "SPEAKER_00"
+
+
+def test_postprocess_no_attach_without_wav(monkeypatch):
+    # Enabled but no wav_path (e.g. an old caller) → hook must not fire.
+    monkeypatch.setattr(transcribe, "DIARIZATION_ENABLED", True)
+    monkeypatch.setattr(transcribe, "LLM_POLISH", False)
+    called = {"n": 0}
+    monkeypatch.setattr(transcribe, "_attach_speaker_ids",
+                        lambda t, w: called.__setitem__("n", called["n"] + 1) or t)
+    transcribe._postprocess("第一句話很清楚", "zh", list(_RAW), "zh", words=[])
+    assert called["n"] == 0

--- a/transcribe.py
+++ b/transcribe.py
@@ -26,6 +26,8 @@ from config import (
     WHISPER_GUARD_LAYERS,
     OLLAMA_CHAT_MODEL,
     FFMPEG_PATH,
+    DIARIZATION_ENABLED,
+    PYANNOTE_TOKEN,
 )
 from llm import chat
 NO_SPEECH_THRESHOLD = 0.6
@@ -316,7 +318,7 @@ def _transcribe_mlx(wav: str, language: str) -> tuple:
     text = result.get("text", "").strip()
     lang = result.get("language", language)
     raw_segments = result.get("segments", [])
-    return _postprocess(text, lang, raw_segments, language, words=[])
+    return _postprocess(text, lang, raw_segments, language, words=[], wav_path=wav)
 
 def _transcribe_faster_whisper(wav: str, language: str) -> tuple:
     """Transcribe using faster-whisper (non-Mac / CUDA).
@@ -368,7 +370,7 @@ def _transcribe_faster_whisper(wav: str, language: str) -> tuple:
 
     text = " ".join(s["text"] for s in parsed_segments).strip()
     lang = (info.language if info is not None else None) or language
-    return _postprocess(text, lang, parsed_segments, language, words=all_words)
+    return _postprocess(text, lang, parsed_segments, language, words=all_words, wav_path=wav)
 
 def _transcribe_whisperx(wav: str, language: str) -> tuple:
     """Transcribe using WhisperX (CUDA) with forced alignment."""
@@ -429,11 +431,48 @@ def _transcribe_whisperx(wav: str, language: str) -> tuple:
                 })
 
     text = " ".join(seg["text"] for seg in segments).strip()
-    return _postprocess(text, lang, segments, language, words=all_words)
+    return _postprocess(text, lang, segments, language, words=all_words, wav_path=wav)
 
-def _postprocess(text: str, lang: str, segments: list, language: str, words: list = None) -> tuple:
-    """Shared post-processing: anti-hallucination + LLM polish.
-    Returns (text, lang, clean_segments, words) where clean_segments has start/end/text."""
+def _attach_speaker_ids(timed_segments: list, wav_path: str) -> list:
+    """Attach a `speaker_id` to each segment via the speaker-align package (A4).
+
+    Diarizes `wav_path` — which MUST be the same (VAD-filtered) audio the segments
+    were timed against, or the labels won't line up — and tags each segment with
+    whichever speaker turn overlaps it most. Soft dependency + soft failure: if
+    speaker-align/pyannote isn't installed, no token is set, or diarization errors,
+    the segments are returned unchanged (transcription must never break because of
+    an optional label).
+    """
+    if not timed_segments or not wav_path:
+        return timed_segments
+    if not PYANNOTE_TOKEN:
+        print("[diarize] skipped: no ARKIV_PYANNOTE_TOKEN set", flush=True)
+        return timed_segments
+    try:
+        from speaker_align import get_diarizer, align_speakers_to_transcript
+    except ImportError:
+        print("[diarize] skipped: speaker-align not installed "
+              "(pip install 'speaker-align[pyannote]')", flush=True)
+        return timed_segments
+    try:
+        diarizer = get_diarizer(auth_token=PYANNOTE_TOKEN)
+        result = diarizer.diarize(wav_path)
+        aligned = align_speakers_to_transcript(result.segments, timed_segments)
+        for seg in aligned:
+            # arkiv's segment contract uses `speaker_id`; speaker-align emits `speaker`.
+            seg["speaker_id"] = seg.pop("speaker", "")
+        return aligned
+    except Exception as e:  # noqa: BLE001 — an optional label must never break transcribe
+        print("[diarize] skipped (%s): %s" % (type(e).__name__, e), flush=True)
+        return timed_segments
+
+
+def _postprocess(text: str, lang: str, segments: list, language: str,
+                 words: list = None, wav_path: str = None) -> tuple:
+    """Shared post-processing: anti-hallucination + LLM polish (+ optional A4
+    speaker diarization when config.DIARIZATION_ENABLED and a wav_path is given).
+    Returns (text, lang, clean_segments, words) where clean_segments has
+    start/end/text (+ speaker_id when diarization ran)."""
     if not segments:
         return text, lang, [], words or []
 
@@ -519,6 +558,12 @@ def _postprocess(text: str, lang: str, segments: list, language: str, words: lis
             return any(lo - eps <= mid <= hi + eps for lo, hi in kept_ranges)
 
         words = [w for w in words if _in_kept_segment(w)]
+
+    # A4: tag each segment with a speaker_id (optional, gated, soft-fail). Runs on
+    # the same VAD-filtered wav the segments were timed against (passed by each
+    # backend), so the labels line up with the timecodes.
+    if wav_path and DIARIZATION_ENABLED:
+        timed_segments = _attach_speaker_ids(timed_segments, wav_path)
 
     return filtered_text, lang, timed_segments, words or []
 


### PR DESCRIPTION
## 什麼

三件套 roadmap A4：arkiv 之前**沒有 diarization**。這個 PR 加上 —— 轉錄後用 [`speaker-align`](https://github.com/vulture-s/speaker-align) 套件對音檔做語者分離，替每個 transcript segment 標上 `speaker_id`（契約 `{start,end,text,speaker_id}`）。**可選、預設關、soft-fail**。

## 改動

- **config**：`ARKIV_DIARIZATION_ENABLED`（預設 off）+ `ARKIV_PYANNOTE_TOKEN`。
- **`transcribe._attach_speaker_ids`**：`get_diarizer(token)` → `diarize(wav)` → `align_speakers_to_transcript` → rename `speaker`→`speaker_id`。**soft dependency + soft failure**：沒 token / speaker-align 沒裝 / diarizer 出錯，都原樣返回 segments —— 一個可選標籤絕不該弄壞轉錄。
- **`_postprocess` 加 `wav_path=`**，各 backend 傳自己的 `wav`。**關鍵**：那個 wav 必須是 segment 時間碼所依據的 **VAD 後音檔**（backend 的 `wav`），不是原始 media —— VAD 把語音塊串接、壓縮了時間軸，用錯 wav 標籤會對不齊。
- **讀路徑投影**：`/api/media/{id}/segments` 與 MCP `get_transcript` 現在會吐 `speaker_id`，但**只在有值時**——沒跑 diarization 的 clip 保持原本 `{start,end,text}` 形狀（**向後相容**，既有 contract 測試不動）。
- speaker-align 目前 M2-local（未上 PyPI）；缺套件時整個功能 + 測試自動 self-skip。

## 驗證

全套件 **1082 passed, 7 skipped**（M2 arkiv .venv + speaker-align editable）。新增 `tests/test_diarize_a4.py`（8 測：real alignment via fake diarizer、token 注入、三條 soft-fail 路徑、hook 預設 off / enabled 時觸發 / 無 wav 不觸發）。

## 依賴說明

要啟用：`pip install -e speaker-align[pyannote]` + 設 `ARKIV_PYANNOTE_TOKEN` + `ARKIV_DIARIZATION_ENABLED=1`。CI/一般安裝不受影響（預設 off、缺套件 self-skip）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)