### PR TITLE
feat(collections): Smart Collections honor manual tags (A-roll/B-roll)

### DIFF
--- a/routers/analytics.py
+++ b/routers/analytics.py
@@ -114,12 +114,17 @@ def list_collections(
             "rating, processed_at "
             "FROM media ORDER BY id"
         ).fetchall()
-        # Manual/confirmed tags live in the `tags` table, not frame_tags. Pull
-        # them (one bulk query) so tag-keyed collections match USER tags, not
-        # only vision output — otherwise a hand-tagged a-roll/b-roll can never
-        # form a collection. media_signal already merges media["tags"].
+        # Manual tags live in the `tags` table, not frame_tags. Pull them (one
+        # bulk query) so tag-keyed collections match USER tags, not only vision
+        # output. Filter to source='manual': the tags table ALSO holds
+        # source='auto' vision copies (ingest.py), and an auto tag that happened
+        # to be named 'a-roll' must not silently join an editorial collection
+        # without the user's hand (Codex audit). media_signal merges
+        # media["tags"] into the scored signal.
         tag_map = {}
-        for tid, tname in conn.execute("SELECT media_id, name FROM tags"):
+        for tid, tname in conn.execute(
+            "SELECT media_id, name FROM tags WHERE source = 'manual'"
+        ):
             tag_map.setdefault(tid, []).append(tname)
     for rec in (dict(r) for r in rows):
         rec["tags"] = tag_map.get(rec["id"], [])

--- a/routers/analytics.py
+++ b/routers/analytics.py
@@ -114,7 +114,15 @@ def list_collections(
             "rating, processed_at "
             "FROM media ORDER BY id"
         ).fetchall()
+        # Manual/confirmed tags live in the `tags` table, not frame_tags. Pull
+        # them (one bulk query) so tag-keyed collections match USER tags, not
+        # only vision output — otherwise a hand-tagged a-roll/b-roll can never
+        # form a collection. media_signal already merges media["tags"].
+        tag_map = {}
+        for tid, tname in conn.execute("SELECT media_id, name FROM tags"):
+            tag_map.setdefault(tid, []).append(tname)
     for rec in (dict(r) for r in rows):
+        rec["tags"] = tag_map.get(rec["id"], [])
         for hit in smart_collections.classify(rec, defs):
             buckets[hit["key"]]["items"].append({
                 "id": rec["id"],

--- a/smart_collections.py
+++ b/smart_collections.py
@@ -260,4 +260,20 @@ DEFAULT_COLLECTIONS: List[Collection] = [
         category="quality",
         tags=["模糊", "模糊畫面", "低解析度", "低解析", "不明物體", "屏幕", "電視"],
     ),
+    # Edit-role collections keyed on MANUAL tags (a-roll / b-roll). They populate
+    # only when a clip carries the hand-added tag; a library that never tags this
+    # way shows 0 members and the collection is hidden, so they cost nothing.
+    # Requires list_collections to feed the `tags` table into the classifier.
+    Collection(
+        key="a_roll",
+        title="A-roll · 主軸",
+        category="edit",
+        tags=["a-roll"],
+    ),
+    Collection(
+        key="b_roll",
+        title="B-roll · 輔助",
+        category="edit",
+        tags=["b-roll"],
+    ),
 ]

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -182,6 +182,33 @@ def test_signal_null_island_gps_is_no_location():
     assert sc.media_signal(raw)["location"] is None
 
 
+# ── edit-role collections keyed on MANUAL tags (a-roll / b-roll) ─────────────
+# These populate from the `tags` table (hand-added), which list_collections now
+# feeds into the classifier. media_signal already merges media["tags"], so at the
+# engine level a clip carrying the manual tag is enough to join the collection.
+def test_manual_a_roll_tag_joins_a_roll_collection():
+    clip = {"duration_s": 60, "has_audio": 1, "tags": ["a-roll"], "frames": []}
+    assert "a_roll" in _keys(clip)
+
+
+def test_manual_b_roll_tag_joins_b_roll_collection():
+    clip = {"duration_s": 6, "has_audio": 0, "tags": ["b-roll"], "frames": []}
+    assert "b_roll" in _keys(clip)
+
+
+def test_untagged_clip_in_neither_edit_role_collection():
+    clip = {"duration_s": 6, "has_audio": 1, "tags": ["拉麵", "碗"], "frames": []}
+    keys = _keys(clip)
+    assert "a_roll" not in keys and "b_roll" not in keys
+
+
+def test_edit_role_collections_do_not_cross_leak():
+    a_only = {"duration_s": 60, "has_audio": 1, "tags": ["a-roll"], "frames": []}
+    b_only = {"duration_s": 6, "has_audio": 1, "tags": ["b-roll"], "frames": []}
+    assert "b_roll" not in _keys(a_only)
+    assert "a_roll" not in _keys(b_only)
+
+
 def test_location_booster_gates_on_label():
     col = sc.Collection(
         key="t", title="t", category="c", tags=["吧檯"],

--- a/tests/test_r5_25_router_analytics.py
+++ b/tests/test_r5_25_router_analytics.py
@@ -64,3 +64,42 @@ def test_analytics_routes_mounted_and_auth_guarded(server_module):
                      "/api/duration-by-lang", "/api/size-by-ext"):
             assert c.get(path).status_code == 401, path
         assert c.get("/api/statszz").status_code == 404
+
+
+# ── manual-tag collections end-to-end (list_collections joins the tags table) ─
+def _seed_clip(db, name):
+    db.upsert({
+        "path": "/tmp/{0}".format(name), "filename": name, "ext": ".mp4",
+        "duration_s": 30.0, "size_mb": 5.0, "width": 1920, "height": 1080,
+        "fps": 30.0, "has_audio": 1, "transcript": "", "lang": "zh",
+        "frame_tags": "", "thumbnail_path": "",
+        "processed_at": "2026-05-01T09:00:00",
+    })
+
+
+def test_collections_surfaces_manual_tag_collection(fastapi_client):
+    import importlib
+    db = importlib.import_module("db")
+    _seed_clip(db, "a.mp4")
+    db.add_tag(1, "a-roll", "manual")
+    r = fastapi_client.get("/api/collections")
+    assert r.status_code == 200, r.text
+    cols = {c["key"]: c for c in r.json()["collections"]}
+    assert "a_roll" in cols, "manual a-roll tag should form the a_roll collection"
+    assert any(it["id"] == 1 for it in cols["a_roll"]["items"])
+
+
+def test_collections_ignore_auto_source_editorial_tag(fastapi_client):
+    # An auto (vision) tag that happens to be named 'a-roll' must NOT enter an
+    # editorial collection without the user's hand — list_collections filters
+    # the tags table to source='manual' (Codex audit).
+    import importlib
+    db = importlib.import_module("db")
+    _seed_clip(db, "b.mp4")
+    db.add_tag(1, "a-roll", "auto")
+    r = fastapi_client.get("/api/collections")
+    assert r.status_code == 200, r.text
+    cols = {c["key"]: c for c in r.json()["collections"]}
+    assert "a_roll" not in cols or all(
+        it["id"] != 1 for it in cols["a_roll"]["items"]
+    ), "an auto-source 'a-roll' tag must not create editorial membership"


### PR DESCRIPTION
## What
Smart Collections classifier only saw vision `frame_tags`, so a hand-added tag (`POST /api/media/{id}/tags`) could never form a sidebar collection — `list_collections` never joined the `tags` table. Hand-tagging clips `a-roll`/`b-roll` gave no clickable collection, only a Query Builder workaround.

## Change
- `routers/analytics.py` `list_collections`: one bulk `SELECT media_id, name FROM tags` → attach each clip's manual tags as `rec["tags"]`. `media_signal` already merges `media["tags"]`, so existing vision-tag collections are unaffected.
- `smart_collections.py`: two edit-role collections keyed on manual tags — `a_roll` / `b_roll`. Hidden (0 members) on libraries that don't use them.
- `tests/test_collections.py`: +4 cases.

## Verification
Against a real 20-clip library: A-roll→5, B-roll→14, structural collections unchanged. `test_collections.py` (24) + `test_r5_25_router_analytics.py` (5) green.

## Status
Draft — part of this session's arkiv work, to be reviewed/merged together with related changes. Codex audit pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)