### PR TITLE
Wave A: Windows correctness + audit hardening (offload deny-policy host-independent)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,13 +169,18 @@ jobs:
       - name: pip-audit
         run: |
           python -m pip install --upgrade pip pip-audit
-          # PYSEC-2026-311 (chromadb, CVE-2026-45829): a pre-auth code-injection in
-          # chromadb's SERVER mode with NO fixed version (OSV: affected 1.0.0+, fix
-          # none). Arkiv embeds chromadb in-process (PersistentClient) and never runs
-          # its HTTP server, so the vulnerable surface isn't reachable. Ignored
-          # EXPLICITLY (not `|| true`) so the gate still blocks on any other/new
-          # advisory; revisit when a fix ships or chromadb is dropped.
-          pip-audit -r requirements.txt -r requirements-dev.txt --ignore-vuln PYSEC-2026-311
+          # chromadb PYSEC-2026-311 / CVE-2026-45829 / GHSA-f4j7-r4q5-qw2c: a
+          # pre-auth code-injection in chromadb's SERVER mode with NO fixed version
+          # (OSV: affected 1.0.0+, fix none). Arkiv embeds chromadb in-process
+          # (PersistentClient) and never runs its HTTP server, so the vulnerable
+          # surface isn't reachable. Ignored EXPLICITLY (not `|| true`) by BOTH the
+          # PYSEC id and its GHSA alias, so a pip-audit id switch can't red the gate
+          # on the very advisory it means to skip — the gate still blocks on any
+          # other/new advisory. Revisit when a fix ships or chromadb is dropped.
+          # NOTE: this only gates MERGES if `dependency-audit` (and `test-windows`)
+          # are set as REQUIRED checks in branch protection — verify in repo settings.
+          pip-audit -r requirements.txt -r requirements-dev.txt \
+            --ignore-vuln PYSEC-2026-311 --ignore-vuln GHSA-f4j7-r4q5-qw2c
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,45 @@ jobs:
       - name: Run tests
         run: pytest -q
 
+  test-windows:
+    name: test-windows
+    runs-on: windows-latest
+    # F2 (2026-07-25): the macOS `test` job above was the ONLY correctness gate,
+    # so a Windows-only failure never surfaced — e.g. the offload deny-policy that
+    # resolve() silently breaks on Windows (Path('/etc') -> C:\etc), which went
+    # 4-fail on this runner before the webguard fix. This adds a Windows correctness
+    # leg. It is SCOPED, not the full suite: a full install pins mlx-whisper (no
+    # Windows wheel) and test_install.py AST-walks server.py's imports, so a full
+    # run would red for a platform reason, not a real one. conftest.py fakes the
+    # heavy backends (incl. mlx_whisper) via sys.modules, so the guard suite runs
+    # with just the lean FastAPI deps. Full-suite Windows 0-fail is tracked as
+    # separate evidence in the 2026-07-24 arkiv-health-hardening handoff; the MCP
+    # stdio hang (F3) is deferred to that handoff's SDK version x OS matrix rather
+    # than imported into CI as a known-red.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install deps
+        # Same lean set as `test`, MINUS mlx-whisper (no Windows wheel; faked by
+        # conftest) and opencc (lazy import in zh_convert.py, degrades to identity).
+        # shell: bash so the `\` line-continuation + quoting match the macOS job
+        # (windows-latest defaults to PowerShell).
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install \
+            "fastapi>=0.100.0" "uvicorn>=0.20.0" "pydantic>=2.0,<3" \
+            "pillow>=9.0" "requests>=2.28" "xxhash>=2.0.0" "nanoid>=2.0.0" \
+            "psutil>=5.9" "whisper-guard>=0.3" numpy mcp
+      - name: Run Windows correctness tests (offload deny-policy contract)
+        shell: bash
+        run: pytest tests/test_hardening_round4.py -q
+
   coverage:
     name: coverage
     # Coverage floor as a regression RATCHET (not a quality claim — the conftest
@@ -116,9 +155,12 @@ jobs:
   audit:
     name: dependency-audit
     runs-on: ubuntu-latest
-    # Non-blocking: surfaces known-vuln deps without gating merges. Flip to
-    # blocking once the initial findings are triaged (expect transitive noise).
-    continue-on-error: true
+    # Real gate (2026-07-25): this job previously carried BOTH job-level
+    # `continue-on-error: true` AND per-step `|| true`, so a known-vuln dep could
+    # never fail CI — the "audit" was decorative. Now a high+ finding fails the
+    # job. If a specific transitive advisory is triaged as non-actionable, ignore
+    # it EXPLICITLY (pip-audit --ignore-vuln GHSA-xxxx, or an npm allowlist) with a
+    # one-line reason — never a blanket `|| true`.
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -127,10 +169,16 @@ jobs:
       - name: pip-audit
         run: |
           python -m pip install --upgrade pip pip-audit
-          pip-audit -r requirements.txt -r requirements-dev.txt || true
+          # PYSEC-2026-311 (chromadb, CVE-2026-45829): a pre-auth code-injection in
+          # chromadb's SERVER mode with NO fixed version (OSV: affected 1.0.0+, fix
+          # none). Arkiv embeds chromadb in-process (PersistentClient) and never runs
+          # its HTTP server, so the vulnerable surface isn't reachable. Ignored
+          # EXPLICITLY (not `|| true`) so the gate still blocks on any other/new
+          # advisory; revisit when a fix ships or chromadb is dropped.
+          pip-audit -r requirements.txt -r requirements-dev.txt --ignore-vuln PYSEC-2026-311
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
       - name: npm audit
         working-directory: frontend
-        run: npm audit --omit=dev --audit-level=high || true
+        run: npm audit --omit=dev --audit-level=high

--- a/tests/test_hardening_round4.py
+++ b/tests/test_hardening_round4.py
@@ -145,6 +145,50 @@ def test_offload_route_403s_system_dst_without_spawning(fastapi_client, tmp_path
     assert resp.status_code == 403
 
 
+# ── #1 (Windows correctness, 2026-07-25): the deny decision is host-independent ─
+# On Windows, Path('/etc').resolve() drive-anchors to 'C:\etc', so the old
+# '/'-rooted string match silently opened the 403 gate (4-fail on windows-latest).
+# These feed already-normalised Windows-shaped strings straight to the pure
+# denylist helper, so the Windows behaviour is provable on ANY host — no Windows
+# runner needed. (The full-suite Windows run is separate evidence; see the
+# 2026-07-24 arkiv-health-hardening handoff.)
+
+@pytest.mark.parametrize("denied", [
+    "c:/etc",                          # a POSIX literal after resolve() drive-anchors it
+    "c:/windows",
+    "c:/windows/system32",
+    "d:/windows/system32/drivers",     # drive-agnostic
+    "c:/program files",
+    "c:/program files (x86)/evil",
+    "c:/programdata/evil",
+    "c:/users/me/appdata/roaming/microsoft/windows/start menu/programs/startup",
+])
+def test_offload_deny_reason_denies_windows_system_dirs(denied):
+    import webguard
+    assert webguard._offload_deny_reason(denied) != ""
+
+
+@pytest.mark.parametrize("allowed", [
+    "d:/backup/2026",
+    "e:/dit/card01",
+    "f:/volumes/program files backup",  # 'program files' as a leaf, not a root
+    "c:/users/me/movies/exports",
+])
+def test_offload_deny_reason_allows_windows_backup_targets(allowed):
+    import webguard
+    assert webguard._offload_deny_reason(allowed) == ""
+
+
+def test_offload_deny_reason_denies_posix_literal_host_independently():
+    # The raw (pre-resolve) pass must deny a POSIX-absolute sensitive literal even
+    # where resolve() would drive-anchor it off the '/'-rooted denylist — the exact
+    # bug that let '/etc' through on windows-latest.
+    import webguard
+    assert webguard._offload_deny_reason("/etc") == "system"
+    assert webguard._offload_deny_reason("/system/library") == "system"
+    assert webguard._offload_deny_reason("/users/me/.ssh") == "sensitive"
+
+
 # ── #10: /api/retranscribe-all language validator ────────────────────────────
 
 def test_retranscribe_all_rejects_non_iso639_language(fastapi_client):

--- a/tests/test_hardening_round4.py
+++ b/tests/test_hardening_round4.py
@@ -189,6 +189,36 @@ def test_offload_deny_reason_denies_posix_literal_host_independently():
     assert webguard._offload_deny_reason("/users/me/.ssh") == "sensitive"
 
 
+# ── #1 (2026-07-25 audit follow-up): Windows namespace / DOS-device / admin-share
+# forms must not slip past the deny roots, and a non-letter "drive" must not be
+# stripped. These run the FULL pipeline (_norm_offload_path -> _offload_deny_reason)
+# so the prefix canonicalisation is exercised. \\?\C:\Windows etc. previously
+# normalised to '//?/c:/windows' and returned '' (a false negative on windows-latest).
+
+@pytest.mark.parametrize("raw", [
+    r"\\?\C:\Windows\System32",              # extended-length device path
+    r"\\.\C:\Windows",                        # DOS-device path
+    r"\\localhost\C$\Windows",               # admin drive share (\\host\C$)
+    r"\\127.0.0.1\C$\Windows\System32",      # admin share addressed by IP
+    r"\\?\UNC\fileserver\C$\Windows",        # UNC via the device namespace
+    "C:\\Windows.",                          # trailing dot — Win32 strips it
+    "C:\\Windows ",                          # trailing space — Win32 strips it
+])
+def test_offload_deny_reason_denies_windows_namespace_forms(raw):
+    import webguard
+    assert webguard._offload_deny_reason(webguard._norm_offload_path(raw)) != ""
+
+
+@pytest.mark.parametrize("raw", [
+    r"\\NAS\media\footage\2026",             # legit network share — not a system dir
+    r"\\?\D:\Backup\2026",                    # extended-length path to a backup drive
+    "1:/etc",                                 # non-letter 'drive' must NOT be drive-stripped
+])
+def test_offload_deny_reason_allows_legit_unc_extended_and_nonletter_drive(raw):
+    import webguard
+    assert webguard._offload_deny_reason(webguard._norm_offload_path(raw)) == ""
+
+
 # ── #10: /api/retranscribe-all language validator ────────────────────────────
 
 def test_retranscribe_all_rejects_non_iso639_language(fastapi_client):

--- a/tests/test_mcp_e2e.py
+++ b/tests/test_mcp_e2e.py
@@ -29,10 +29,41 @@ import pytest
 
 pytest.importorskip("mcp")
 
+import anyio  # ships with mcp/fastapi; only reached past the importorskip gate
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
 _REPO = Path(__file__).resolve().parent.parent
+
+# F3 / AC2 (2026-07-25): the stdio handshake, tool calls and teardown have no
+# native timeout, so a Windows-specific stall blocks the whole suite (>180s
+# observed on windows-latest + mcp 1.28). Bound each session with anyio.fail_after
+# so a hang fails FAST with a stage label instead of hanging. This makes the
+# FAILURE bounded — it does NOT diagnose the hang (root cause = MCP SDK version ×
+# OS matrix, tracked in the arkiv-health-hardening handoff). anyio is already a
+# transitive dep (no new requirement); mcp is intentionally NOT pinned here.
+_MCP_SESSION_TIMEOUT = 90.0  # generous for a healthy run (~seconds); trips well under 180s
+
+
+async def _run_bounded_mcp(params, body):
+    """Open an MCP stdio session, run ``await body(session)``, and return its
+    result — all under a single bounded scope. On timeout, fail with the stage
+    (connect / initialize / call / cleanup) the session was in, so a Windows hang
+    is legible instead of silent."""
+    stage = "connect"
+    result = None
+    try:
+        with anyio.fail_after(_MCP_SESSION_TIMEOUT):
+            async with stdio_client(params) as (read, write):
+                async with ClientSession(read, write) as session:
+                    stage = "initialize"
+                    await session.initialize()
+                    stage = "call"
+                    result = await body(session)
+                    stage = "cleanup"  # body done; the async-with exits (teardown) next
+    except TimeoutError:
+        pytest.fail("MCP stdio E2E timed out (stage: {0})".format(stage))
+    return result
 
 # Seeds a project the same way an ingest would, in a subprocess so that this
 # test's own config/db import state is untouched — the server subprocess must
@@ -85,63 +116,62 @@ async def test_mcp_stdio_end_to_end(seeded_project):
         args=[str(_REPO / "mcp_server.py")],
         env=seeded_project,
     )
-    async with stdio_client(params) as (read, write):
-        async with ClientSession(read, write) as session:
-            await session.initialize()
+    async def _body(session):
+        # ── the server is reachable and advertises what it should ──────────
+        tools = {t.name for t in (await session.list_tools()).tools}
+        assert {
+            "search_media", "get_media", "get_transcript",
+            "list_recent", "library_stats", "list_tags", "get_scenes",
+        } <= tools
 
-            # ── the server is reachable and advertises what it should ──────────
-            tools = {t.name for t in (await session.list_tools()).tools}
-            assert {
-                "search_media", "get_media", "get_transcript",
-                "list_recent", "library_stats", "list_tags", "get_scenes",
-            } <= tools
+        # ── get_scenes: the timecoded breakdown, over the real protocol ────
+        scenes = await _call(session, "get_scenes", media_id=1)
+        assert scenes["media_id"] == 1
+        assert scenes["media_duration_s"] == 30.0
+        assert scenes["total"] == 2
+        first = scenes["scenes"][0]
+        assert first["start_s"] == 0.0
+        assert first["end_s"] == 12.0            # next frame's start
+        assert first["description"] == "手持走入店內"
+        assert first["keyframe_path"] == "thumbnails/e2e_f0.jpg"
+        assert scenes["scenes"][1]["end_s"] == 30.0   # last → media duration
+        # the MCP surface must never emit the HTTP URL form
+        assert "keyframe_url" not in first
 
-            # ── get_scenes: the timecoded breakdown, over the real protocol ────
-            scenes = await _call(session, "get_scenes", media_id=1)
-            assert scenes["media_id"] == 1
-            assert scenes["media_duration_s"] == 30.0
-            assert scenes["total"] == 2
-            first = scenes["scenes"][0]
-            assert first["start_s"] == 0.0
-            assert first["end_s"] == 12.0            # next frame's start
-            assert first["description"] == "手持走入店內"
-            assert first["keyframe_path"] == "thumbnails/e2e_f0.jpg"
-            assert scenes["scenes"][1]["end_s"] == 30.0   # last → media duration
-            # the MCP surface must never emit the HTTP URL form
-            assert "keyframe_url" not in first
+        # ── unknown id is null, not an error and not an empty list ─────────
+        assert await _call(session, "get_scenes", media_id=999999) is None
 
-            # ── unknown id is null, not an error and not an empty list ─────────
-            assert await _call(session, "get_scenes", media_id=999999) is None
+        # ── get_transcript: segments on by default, words off ─────────────
+        tr = await _call(session, "get_transcript", media_id=1)
+        assert tr["duration_s"] == 30.0
+        assert tr["segments"] == [{"start": 0.0, "end": 2.4, "text": "第一句"}]
+        assert tr["has_words"] is True
+        assert "words" not in tr
+        # decoder internals must not survive the round trip
+        assert "tokens" not in json.dumps(tr)
 
-            # ── get_transcript: segments on by default, words off ─────────────
-            tr = await _call(session, "get_transcript", media_id=1)
-            assert tr["duration_s"] == 30.0
-            assert tr["segments"] == [{"start": 0.0, "end": 2.4, "text": "第一句"}]
-            assert tr["has_words"] is True
-            assert "words" not in tr
-            # decoder internals must not survive the round trip
-            assert "tokens" not in json.dumps(tr)
+        # ── …and on request ───────────────────────────────────────────────
+        tr_w = await _call(session, "get_transcript", media_id=1, include_words=True)
+        assert tr_w["words"] == [
+            {"word": "第一", "start": 0.1, "end": 0.4, "score": 0.98}
+        ]
+        assert tr_w["words_truncated"] is False
 
-            # ── …and on request ───────────────────────────────────────────────
-            tr_w = await _call(session, "get_transcript", media_id=1, include_words=True)
-            assert tr_w["words"] == [
-                {"word": "第一", "start": 0.1, "end": 0.4, "score": 0.98}
-            ]
-            assert tr_w["words_truncated"] is False
+        # ── the pre-existing tools still answer ────────────────────────────
+        stats = await _call(session, "library_stats")
+        assert stats["total"] == 1
 
-            # ── the pre-existing tools still answer ────────────────────────────
-            stats = await _call(session, "library_stats")
-            assert stats["total"] == 1
+        # ── search_media works with NO vector backend (the CI reality) ─────
+        # On CI chromadb isn't installed, so the lazy `import vectordb` in
+        # search_media_impl fails and it degrades to a SQL filename/transcript
+        # LIKE. The seeded row is filename "e2e.mp4" — a text match finds it.
+        # (Normal shape is a bare list; a stale index would wrap it in
+        # {items, search_degraded} — accept either.)
+        sm = await _call(session, "search_media", query="e2e")
+        hits = sm["items"] if isinstance(sm, dict) else sm
+        assert any(h["id"] == 1 for h in hits), sm
 
-            # ── search_media works with NO vector backend (the CI reality) ─────
-            # On CI chromadb isn't installed, so the lazy `import vectordb` in
-            # search_media_impl fails and it degrades to a SQL filename/transcript
-            # LIKE. The seeded row is filename "e2e.mp4" — a text match finds it.
-            # (Normal shape is a bare list; a stale index would wrap it in
-            # {items, search_degraded} — accept either.)
-            sm = await _call(session, "search_media", query="e2e")
-            hits = sm["items"] if isinstance(sm, dict) else sm
-            assert any(h["id"] == 1 for h in hits), sm
+    await _run_bounded_mcp(params, _body)
 
 
 @pytest.mark.asyncio
@@ -172,13 +202,13 @@ db.upsert_frame(media_id=1, frame_index=0, timestamp_s=0.0,
     params = StdioServerParameters(
         command=sys.executable, args=[str(_REPO / "mcp_server.py")], env=env,
     )
-    async with stdio_client(params) as (read, write):
-        async with ClientSession(read, write) as session:
-            await session.initialize()
+    async def _body(session):
+        media = json.dumps(await _call(session, "get_media", media_id=1))
+        scenes = json.dumps(await _call(session, "get_scenes", media_id=1))
+        recent = json.dumps(await _call(session, "list_recent"))
+        return media, scenes, recent
 
-            media = json.dumps(await _call(session, "get_media", media_id=1))
-            scenes = json.dumps(await _call(session, "get_scenes", media_id=1))
-            recent = json.dumps(await _call(session, "list_recent"))
+    media, scenes, recent = await _run_bounded_mcp(params, _body)
 
     for surface, payload in (("get_media", media), ("get_scenes", scenes),
                              ("list_recent", recent)):
@@ -238,17 +268,17 @@ async def test_mcp_uninitialised_root_gives_clear_error(tmp_path):
     params = StdioServerParameters(
         command=sys.executable, args=[str(_REPO / "mcp_server.py")], env=env,
     )
-    async with stdio_client(params) as (read, write):
-        async with ClientSession(read, write) as session:
-            await session.initialize()
-            # the server is up and advertises its tools despite the empty root
-            tools = {t.name for t in (await session.list_tools()).tools}
-            assert "library_stats" in tools
-            # …but a call fails with a clear, actionable message
-            result = await session.call_tool("library_stats", {})
-            assert result.isError
-            msg = result.content[0].text
-            assert "not initialised" in msg, msg
-            assert "media" in msg, msg
-            # the raw driver string must NOT be what reaches the agent
-            assert "no such table" not in msg, msg
+    async def _body(session):
+        # the server is up and advertises its tools despite the empty root
+        tools = {t.name for t in (await session.list_tools()).tools}
+        assert "library_stats" in tools
+        # …but a call fails with a clear, actionable message
+        result = await session.call_tool("library_stats", {})
+        assert result.isError
+        msg = result.content[0].text
+        assert "not initialised" in msg, msg
+        assert "media" in msg, msg
+        # the raw driver string must NOT be what reaches the agent
+        assert "no such table" not in msg, msg
+
+    await _run_bounded_mcp(params, _body)

--- a/tests/test_mcp_e2e.py
+++ b/tests/test_mcp_e2e.py
@@ -59,8 +59,11 @@ async def _run_bounded_mcp(params, body):
                     stage = "initialize"
                     await session.initialize()
                     stage = "call"
-                    result = await body(session)
-                    stage = "cleanup"  # body done; the async-with exits (teardown) next
+                    try:
+                        result = await body(session)
+                    finally:
+                        stage = "cleanup"  # even if body raised: teardown runs next,
+                        # still inside fail_after, so a cleanup hang is labelled correctly
     except TimeoutError:
         pytest.fail("MCP stdio E2E timed out (stage: {0})".format(stage))
     return result

--- a/webguard.py
+++ b/webguard.py
@@ -111,17 +111,69 @@ _OFFLOAD_DENY_SUBSTR = (
 _OFFLOAD_DENY_ROOTS = (
     "/system", "/bin", "/sbin", "/usr/bin", "/usr/sbin", "/etc", "/private/etc",
 )
+# Windows-native equivalents. On Windows resolve() anchors a rootless/POSIX path
+# to the CURRENT drive (Path('/etc') -> C:\etc; Path('C:\\Windows') stays), so
+# these match against a drive-letter-stripped form and are themselves drive-
+# agnostic (X:\Windows, D:\Windows, …). The per-user Startup folder is the
+# Windows analog of LaunchAgents — a file copied there gains logon persistence.
+_OFFLOAD_DENY_WIN_ROOTS = (
+    "/windows", "/program files", "/program files (x86)", "/programdata",
+)
+_OFFLOAD_DENY_WIN_SUBSTR = (
+    "/appdata/roaming/microsoft/windows/start menu/programs/startup",
+)
+
+
+def _norm_offload_path(path_str):
+    """Fold to the lower-case, forward-slash, no-trailing-slash form the offload
+    denylist compares against."""
+    return path_str.replace("\\", "/").lower().rstrip("/")
+
+
+def _strip_win_drive(path):
+    """Drop a leading Windows drive letter, keeping the path root-anchored
+    ('c:/etc' -> '/etc', 'c:/windows' -> '/windows'), so a POSIX deny root or a
+    (also root-anchored) Windows deny root matches regardless of which drive
+    resolve() anchored the path to."""
+    if len(path) >= 2 and path[1] == ":":
+        return path[2:]
+    return path
+
+
+def _offload_deny_reason(path):
+    """Deny category for ONE already-normalised path (see _norm_offload_path), or
+    '' if allowed. 'sensitive' = an execution/persistence location; 'system' = an
+    OS system root. Pure and host-independent: it evaluates the denylist over both
+    the path as given AND its drive-stripped form, so a POSIX literal that resolve()
+    drive-anchored on Windows ('/etc' -> 'c:/etc') still matches the '/etc' root."""
+    for form in (path, _strip_win_drive(path)):
+        probe = form + "/"
+        for bad in _OFFLOAD_DENY_SUBSTR + _OFFLOAD_DENY_WIN_SUBSTR:
+            if bad in probe:
+                return "sensitive"
+        for root in _OFFLOAD_DENY_ROOTS + _OFFLOAD_DENY_WIN_ROOTS:
+            if form == root or probe.startswith(root + "/"):
+                return "system"
+    return ""
 
 
 def _assert_offload_dst_safe(dst: str) -> None:
-    """Reject offload destinations that land inside OS-sensitive/executable dirs."""
-    canonical = str(Path(dst).expanduser().resolve()).replace("\\", "/").lower().rstrip("/")
-    probe = canonical + "/"
-    for bad in _OFFLOAD_DENY_SUBSTR:
-        if bad in probe:
+    """Reject offload destinations that land inside OS-sensitive/executable dirs.
+
+    Windows-correctness (2026-07-25): the deny roots are POSIX-anchored literals
+    (/etc, /system, …). On Windows, Path('/etc').resolve() drive-anchors to
+    'C:\\etc', which no longer string-matches '/etc' — silently opening the 403
+    gate (tests/test_hardening_round4.py went 4-fail on windows-latest). Fix:
+    evaluate the denylist over BOTH the raw (pre-resolve) literal AND the resolved
+    canonical path, so a POSIX-absolute sensitive literal denies on any host; and
+    add drive-agnostic Windows system/persistence roots. resolve() still catches
+    '..' escapes; the raw pass catches the drive-anchor bypass."""
+    expanded = Path(dst).expanduser()
+    for candidate in (str(expanded), str(expanded.resolve())):
+        reason = _offload_deny_reason(_norm_offload_path(candidate))
+        if reason == "sensitive":
             raise HTTPException(403, "拒絕寫入系統敏感目錄（LaunchAgents / .ssh / cron / systemd 等）")
-    for root in _OFFLOAD_DENY_ROOTS:
-        if canonical == root or probe.startswith(root + "/"):
+        if reason == "system":
             raise HTTPException(403, "拒絕寫入系統目錄")
 
 

--- a/webguard.py
+++ b/webguard.py
@@ -124,18 +124,45 @@ _OFFLOAD_DENY_WIN_SUBSTR = (
 )
 
 
+def _strip_offload_segment(seg):
+    """Drop trailing dots/spaces that Win32 ignores ('windows.' -> 'windows'),
+    but keep '.'/'..' navigation and any all-dot/space segment intact."""
+    stripped = seg.rstrip(" .")
+    return stripped if stripped else seg
+
+
 def _norm_offload_path(path_str):
-    """Fold to the lower-case, forward-slash, no-trailing-slash form the offload
-    denylist compares against."""
-    return path_str.replace("\\", "/").lower().rstrip("/")
+    r"""Fold to the lower-case, forward-slash, no-trailing-slash form the offload
+    denylist compares against, canonicalising the Windows forms that would else
+    slip past the deny roots (2026-07-25 audit follow-up):
+      \\?\C:\..  and  \\.\C:\..  (extended-length / DOS-device)  -> c:/..
+      \\?\UNC\host\share\..                                       -> //host/share/..
+      \\host\C$\..              (admin drive share)               -> c:/..
+      plus trailing dots/spaces Win32 strips from each path segment.
+    Residual (accepted): 8.3 short names (C:\PROGRA~1) and other existing-dir
+    aliases are left to Windows resolve() in the caller, which only expands them
+    for paths that actually exist on disk."""
+    p = path_str.replace("\\", "/").lower()
+    if p.startswith("//?/unc/"):
+        p = "//" + p[len("//?/unc/"):]          # device-namespace UNC -> plain UNC
+    elif p.startswith(("//?/", "//./")):
+        p = p[4:]                                 # //?/c:/windows -> c:/windows
+    if p.startswith("//"):
+        host, _sep, tail = p[2:].partition("/")   # host, '/', 'share/rest'
+        share, _sep2, rest = tail.partition("/")
+        if len(share) == 2 and "a" <= share[0] <= "z" and share[1] == "$":
+            p = share[0] + ":/" + rest            # \\host\C$\.. addresses the whole drive
+    p = "/".join(_strip_offload_segment(seg) for seg in p.split("/"))
+    return p.rstrip("/")
 
 
 def _strip_win_drive(path):
     """Drop a leading Windows drive letter, keeping the path root-anchored
     ('c:/etc' -> '/etc', 'c:/windows' -> '/windows'), so a POSIX deny root or a
     (also root-anchored) Windows deny root matches regardless of which drive
-    resolve() anchored the path to."""
-    if len(path) >= 2 and path[1] == ":":
+    resolve() anchored the path to. Requires an ASCII letter drive so a POSIX
+    path like '1:/etc' is not mistaken for a drive and wrongly denied."""
+    if len(path) >= 2 and "a" <= path[0] <= "z" and path[1] == ":":
         return path[2:]
     return path
 
@@ -169,7 +196,13 @@ def _assert_offload_dst_safe(dst: str) -> None:
     add drive-agnostic Windows system/persistence roots. resolve() still catches
     '..' escapes; the raw pass catches the drive-anchor bypass."""
     expanded = Path(dst).expanduser()
-    for candidate in (str(expanded), str(expanded.resolve())):
+    candidates = [str(expanded)]
+    try:
+        candidates.append(str(expanded.resolve()))
+    except (OSError, ValueError):
+        pass  # malformed dst (reserved name / illegal char) can make resolve() raise
+              # on Windows; the raw pass above still guards and no write has happened.
+    for candidate in candidates:
         reason = _offload_deny_reason(_norm_offload_path(candidate))
         if reason == "sensitive":
             raise HTTPException(403, "拒絕寫入系統敏感目錄（LaunchAgents / .ssh / cron / systemd 等）")


### PR DESCRIPTION
## Wave A — Windows correctness + audit hardening (M2 part)

Implements the M2-doable half of **Wave A** from the 2026-07-24 arkiv-health-hardening audit (handoff lives in the control-plane repo). Windows real-host confirmation and the MCP root-cause matrix are the remaining PC-side evidence — this PR stays **draft** until those land.

### What's fixed

**F1 — offload deny-policy is now host-independent** (`webguard.py`)
The guard compared `resolve()`'d paths against `/`-anchored POSIX literals. On Windows `Path('/etc').resolve()` → `C:\etc`, which no longer matches `/etc`, so the 403 silently opened (`test_hardening_round4.py`: 4-fail on `windows-latest`). The denylist is now evaluated over the raw pre-resolve literal, the resolved canonical path, **and** a drive-stripped form — so a POSIX-absolute sensitive path denies on any host — plus drive-agnostic Windows system/persistence roots (`Windows`, `Program Files`, `ProgramData`, per-user Startup). Deny logic extracted to a pure `_offload_deny_reason` helper, unit-tested with Windows-shaped strings so the Windows behaviour is provable on any host.

**F2 — Windows correctness CI** (`ci.yml`)
New scoped `test-windows` (`windows-latest`, py3.12) job runs the offload guard contract. Scoped, not the full suite: `mlx-whisper` has no Windows wheel and `test_install.py` AST-walks server imports; `conftest.py` fakes `mlx_whisper`, so the guard suite needs only the lean FastAPI deps.

**F3 — MCP stdio E2E is bounded** (`test_mcp_e2e.py`)
`anyio.fail_after` wraps the stdio session so a Windows hang fails fast with a stage label (initialize / call / cleanup) instead of blocking >180s. This bounds the **failure** — it is **not** a root-cause fix, and `mcp` is intentionally not pinned (root cause deferred to the SDK version × OS matrix). No new dependency (`anyio` is already transitive).

**F4 — dependency-audit is a real gate** (`ci.yml`)
Dropped the job-level `continue-on-error` and the per-step `|| true` that made it decorative. `chromadb` **PYSEC-2026-311** is ignored explicitly (pre-auth server code-injection, **no fix version**, not reachable in Arkiv's embedded `PersistentClient` use) — the gate now blocks on any other/new advisory.

### Verified on macOS
- Full suite: **1087 passed / 7 skipped / 0 failed**
- Hardening: **34 passed** incl. the new Windows-shaped `_offload_deny_reason` cases
- `pip-audit`: clean with the one scoped ignore; `npm audit`: 0 vulns

### Remaining — PC / Windows evidence (why this is draft)
- [ ] Real Windows host: `test_hardening_round4.py` 4-fail → 0-fail confirmation (AC1)
- [ ] Full Windows suite 0-fail / 0-unexpected-skip (AC3) — can't run on `windows-latest` (mlx wheel), so PC evidence
- [ ] MCP SDK version × OS matrix → F3 root cause; confirm the bounded timeout reports the right stage on a real hang (AC2)
- [ ] `test-windows` job green on this PR

### Flags for review
- The **chromadb PYSEC-2026-311** ignore is a security-posture call — confirm the "embedded use, not reachable" reasoning, or upgrade/drop chromadb when a fix ships.
- **AC3 vs AC4**: the Windows CI job runs the *scoped* correctness subset; full-suite Windows 0-fail is PC evidence, not a CI gate (mlx blocks a full runner install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
