### PR TITLE
feat(api): A-cam — per-clip camera_id + angle for multicam (S-cam data premise)

### DIFF
--- a/db.py
+++ b/db.py
@@ -302,6 +302,15 @@ def init_db():
             # re-ingest/refresh can never clobber a user's marks), same as canonical_tags.
             ("in_point", "REAL"),
             ("out_point", "REAL"),
+            # A-cam (multicam): which physical camera a clip is from (camera_id,
+            # e.g. "A"/"B") and its framing (angle, e.g. "wide"/"CU"). arkiv already
+            # carries camera *identity* (make/model/reel) but not which angle in a
+            # multicam shoot — that is editorial, written ONLY by the dedicated
+            # /api/media/{id}/camera endpoint and, like in/out, kept OUT of
+            # _ALLOWED_COLS so a re-ingest/refresh can never clobber it. This is the
+            # data premise for multicam edit decisions (S-cam).
+            ("camera_id", "TEXT"),
+            ("angle", "TEXT"),
         ]:
             _add_column_if_missing(conn, "media", col, typ)  # audit L10
         for col, typ in [
@@ -655,7 +664,9 @@ LIGHT_COLS = (
     "editability_score, "
     # so the grid/inspector can show camera provenance without a per-clip detail
     # fetch (these live in the DB but were absent from the list shape).
-    "camera_make, camera_model, lens_model, reel_name, start_tc, codec"
+    "camera_make, camera_model, lens_model, reel_name, start_tc, codec, "
+    # A-cam: multicam angle annotation, so list/grid views can group by camera.
+    "camera_id, angle"
 )
 
 

--- a/routers/media.py
+++ b/routers/media.py
@@ -66,6 +66,28 @@ class InOutUpdate(BaseModel):
         return v
 
 
+class CameraUpdate(BaseModel):
+    # Per-clip multicam annotation (A-cam): which physical camera (camera_id,
+    # e.g. "A"/"B"/"cam1") and its framing (angle, e.g. "wide"/"CU"). Free-form
+    # editorial labels — a multicam rig's labelling convention is the operator's,
+    # not ours — so validated only for sanity (trimmed + bounded). A blank string
+    # normalizes to None, i.e. clears the mark, same as an explicit null.
+    camera_id: Optional[str] = None
+    angle: Optional[str] = None
+
+    @field_validator("camera_id", "angle")
+    @classmethod
+    def _clean_label(cls, v):
+        if v is None:
+            return v
+        v = v.strip()
+        if not v:
+            return None
+        if len(v) > 64:
+            raise ValueError("label too long (max 64 chars)")
+        return v
+
+
 class TagCreate(BaseModel):
     name: str
     # Public callers may not mint 'auto' tags — those are owned by the vision
@@ -620,6 +642,42 @@ def update_inout(
                 (*params, media_id),
             )
     return {"ok": True, "in_point": new_in, "out_point": new_out}
+
+
+@router.patch("/api/media/{media_id}/camera")
+def update_camera(
+    media_id: int,
+    body: CameraUpdate,
+    _tok: dict = Depends(require_scopes("videos_write")),
+):
+    """Persist a clip's multicam annotation: camera_id + angle (A-cam).
+
+    arkiv already carries camera *identity* (make/model/reel) but not which angle
+    a clip is in a multicam shoot — that is editorial, so it's a human/API mark,
+    the data premise for multicam edit decisions (S-cam). PATCH semantics (same as
+    inout/rating): an OMITTED field is left untouched; an explicit null (or blank)
+    clears it. Kept out of _ALLOWED_COLS so a re-ingest never overwrites the mark.
+    """
+    rec = db.get_record_by_id(media_id)
+    if not rec:
+        raise HTTPException(404, "找不到")
+    provided = body.model_fields_set
+    sets, params = [], []
+    if "camera_id" in provided:
+        sets.append("camera_id = ?")
+        params.append(body.camera_id)
+    if "angle" in provided:
+        sets.append("angle = ?")
+        params.append(body.angle)
+    if sets:
+        with db.get_conn() as conn:
+            conn.execute(
+                "UPDATE media SET {0} WHERE id = ?".format(", ".join(sets)),
+                (*params, media_id),
+            )
+    new_camera_id = body.camera_id if "camera_id" in provided else rec.get("camera_id")
+    new_angle = body.angle if "angle" in provided else rec.get("angle")
+    return {"ok": True, "camera_id": new_camera_id, "angle": new_angle}
 
 
 @router.get("/api/media/{media_id}/tags")

--- a/tests/test_r5_25_router_media.py
+++ b/tests/test_r5_25_router_media.py
@@ -1,7 +1,7 @@
 """R5-25 (round-5 #51): media routes peeled to routers/media.py.
 
 The 14th router peeled — the clip-centric surface. Pins the split: the leaf module
-owns exactly the 18 media routes (list + per-clip sub-resources), server.py no
+owns exactly the 19 media routes (list + per-clip sub-resources), server.py no
 longer defines them, the two specific routes (/api/media/pool + /api/media/
 position/{media_id}) precede the dynamic /api/media/{media_id} so it can't shadow
 them, and the shared bulk-fetch helpers are re-exported by identity from
@@ -26,6 +26,7 @@ _EXPECTED_ROUTES = {
     ("/api/media/{media_id}/chapters", "GET"),
     ("/api/media/{media_id}/rating", "PATCH"),
     ("/api/media/{media_id}/inout", "PATCH"),
+    ("/api/media/{media_id}/camera", "PATCH"),
     ("/api/media/{media_id}/tags", "GET"),
     ("/api/media/{media_id}/tags", "POST"),
     ("/api/media/{media_id}/tags/{tag_name}", "DELETE"),
@@ -43,7 +44,7 @@ def test_media_router_is_a_leaf_module():
     assert not re.search(r"^\s*from\s+server\b", src, re.M)
 
 
-def test_router_owns_exactly_the_18_media_routes():
+def test_router_owns_exactly_the_19_media_routes():
     import routers.media as rm
     pairs = {
         (r.path, m)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -132,6 +132,55 @@ def test_inout_update_persist_restore_semantics_and_validation(fastapi_client, s
     assert fastapi_client.patch("/api/media/999/inout", json={"in_point": 1.0}).status_code == 404
 
 
+def test_camera_update_persist_restore_semantics_and_validation(fastapi_client, sample_record):
+    db = _insert_media(sample_record)
+
+    # set the multicam annotation (A-cam)
+    r = fastapi_client.patch("/api/media/1/camera", json={"camera_id": "A", "angle": "wide"})
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "camera_id": "A", "angle": "wide"}
+    rec = db.get_record_by_id(1)
+    assert rec["camera_id"] == "A" and rec["angle"] == "wide"
+
+    # the detail endpoint surfaces them (SELECT * → whole record) so S-cam can read them
+    detail = fastapi_client.get("/api/media/1").json()
+    assert detail["camera_id"] == "A" and detail["angle"] == "wide"
+
+    # PATCH semantics: an omitted field is untouched (change angle, keep camera_id)
+    r = fastapi_client.patch("/api/media/1/camera", json={"angle": "CU"})
+    assert r.status_code == 200
+    rec = db.get_record_by_id(1)
+    assert rec["camera_id"] == "A" and rec["angle"] == "CU"
+
+    # a blank label normalizes to None (clears), same as an explicit null
+    assert fastapi_client.patch("/api/media/1/camera", json={"camera_id": "  "}).status_code == 200
+    assert db.get_record_by_id(1)["camera_id"] is None
+    assert fastapi_client.patch("/api/media/1/camera", json={"angle": None}).status_code == 200
+    assert db.get_record_by_id(1)["angle"] is None
+
+    # an over-long label is rejected by the model
+    assert fastapi_client.patch(
+        "/api/media/1/camera", json={"camera_id": "x" * 65}).status_code == 422
+
+    # missing record → 404
+    assert fastapi_client.patch("/api/media/999/camera", json={"camera_id": "A"}).status_code == 404
+
+
+def test_camera_fields_survive_reingest(tmp_db, sample_record):
+    # camera_id/angle are editorial marks kept OUT of _ALLOWED_COLS, so a
+    # re-ingest/refresh (which writes through upsert / update_media_by_id) must not
+    # clobber them — the same guarantee in_point/out_point rely on.
+    db = _insert_media(sample_record)
+    with db.get_conn() as conn:
+        conn.execute("UPDATE media SET camera_id='A', angle='wide' WHERE id=1")
+    # a refresh carrying camera_id/angle (and a legitimately-updatable field) must
+    # NOT win on the camera marks, but SHOULD update the allowlisted field.
+    db.update_media_by_id(1, {"camera_id": "Z", "angle": "tele", "duration_s": 123.0})
+    rec = db.get_record_by_id(1)
+    assert rec["camera_id"] == "A" and rec["angle"] == "wide"   # human marks preserved
+    assert rec["duration_s"] == 123.0                            # allowlisted field updated
+
+
 def test_tag_stats_and_tag_catalog_endpoints(fastapi_client, sample_record):
     _insert_media(sample_record)
 


### PR DESCRIPTION
## 什麼

三件套 roadmap A-cam：arkiv 有 camera **identity**（make/model/reel）但**沒有** multicam 的「哪支機位 / 什麼景別」。A-cam 加 `camera_id` + `angle` 兩個**編輯型、re-ingest-safe** 的 media 欄位——這是 multicam 剪輯決策（S-cam）的資料前提。

## 設計：完全鏡像既有 in_point/out_point 人工標註 pattern

- **db**：兩個新 media 欄位（`camera_id`/`angle` TEXT）+ 加進 `LIGHT_COLS`，讓 REST 列表/detail 帶上。
- **routers/media.py**：`PATCH /api/media/{id}/camera`（`CameraUpdate` model，free-form 標籤只做 sanity 驗證：trim、≤64 字、blank→clear）。PATCH 語意（omitted 不動 / null 清除）、inline UPDATE——跟 `/inout` 一模一樣。
- **刻意不進 `_ALLOWED_COLS`**：所以 re-ingest/refresh **永遠不會覆蓋**人工標記（in/out 被排除的同一個理由）。有測試守。
- **曝露**：detail route + `get_media`（`SELECT *`）+ REST 列表（`LIGHT_COLS`）自動帶上；smart-edit 的 clip 列表直接拿得到 → S-cam 可讀。MCP 的薄 `_LIGHT_FIELDS` + `get_transcript` **不動**（跟 `camera_make/model` 一致——薄 MCP 列表本就不放 camera provenance）。

## 為什麼是 per-clip 不是 per-segment

arkiv 的資料模型裡一個 clip = 一支相機的一段錄影，所以 camera_id/angle 是 **media-level**（整段共用），segment 內共享。S-cam 在 clip 層讀機位、在 segment 層讀時間碼/講者。

## 驗證

- 功能測試：PATCH persist/restore、PATCH 語意（omitted 不動）、blank/null 清除、超長 422、404。
- **re-ingest-safety 測試**：`upsert`/`update_media_by_id` 帶 camera_id/angle 進來也不會覆蓋人工標記，但 allowlisted 欄位（duration_s）照常更新。
- route inventory 18→19。
- 全套件 **1076 passed, 7 skipped**。

**解鎖 S-cam**（差異點——LLM 讀 IR 決定機位對跳，離線原型已驗 GO）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)