### PR TITLE
chore(license): relicense MIT → PolyForm Noncommercial 1.0.0 + Output Exception

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,153 @@
-MIT License
+arkiv is licensed under the PolyForm Noncommercial License 1.0.0, with the
+Commercial Output Exception stated below.
 
-Copyright (c) 2026 Hevin Yeh
+Required Notice: Copyright (c) 2026 Hevin Yeh (https://github.com/vulture-s/arkiv)
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+================================================================================
+Commercial Output Exception
+================================================================================
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Media, files, and works produced using this software — including rendered
+videos, edited timelines, EDL/FCPXML/OTIO exports, thumbnails, and any other
+output — MAY be used for any purpose, including commercial purposes, by the
+person or organization that produced them.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+The Noncommercial limitation in the license below applies only to Use of the
+software itself (running, copying, modifying, and distributing arkiv), NOT to
+works you create with it. Making commercial videos with arkiv is permitted;
+selling, hosting, or repackaging arkiv itself (or a fork of it) as or within a
+commercial product or service is not.
+
+================================================================================
+PolyForm Noncommercial License 1.0.0
+================================================================================
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose.  However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license
+to distribute copies of the software.  Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization.  **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # arkiv
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License: PolyForm NC](https://img.shields.io/badge/License-PolyForm--NC--1.0.0-orange.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/Python-3.9%2B-3776AB.svg)](https://python.org)
 [![Tauri](https://img.shields.io/badge/Tauri-Desktop_App-FFC131.svg)](https://tauri.app)
 
-**Open-source AI metadata layer for DIT workflows — Resolve-native, CJK-first.**
+**Source-available AI metadata layer for DIT workflows — Resolve-native, CJK-first.**
 
 > 🌐 **English** | [繁體中文](README.zh-TW.md)
 
 arkiv sits between your media drive and DaVinci Resolve: it ingests your footage, attaches AI-generated metadata (transcript, vision tags, atmosphere, energy, edit position), and surfaces clips via semantic search in any language — Chinese, Japanese, or English. The Resolve plugin lets you search, import with clip color, and drop frame markers without leaving the NLE.
 
-Designed for solo DITs and small crews who own their data: local-first, self-hosted, MIT license, no cloud dependency.
+Designed for solo DITs and small crews who own their data: local-first, self-hosted, source-available (PolyForm Noncommercial), no cloud dependency.
 
 ---
 
@@ -397,4 +397,6 @@ SKIP items are **optional dependencies** — they do not affect functionality. A
 
 ## License
 
-MIT
+PolyForm Noncommercial License 1.0.0, with a Commercial Output Exception — see [LICENSE](LICENSE).
+
+Videos, timelines and exports you produce with arkiv are yours and may be used commercially. Using arkiv itself is free for any noncommercial purpose; selling, hosting, or repackaging arkiv (or a fork) as a commercial product or service is not permitted.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,16 +1,16 @@
 # arkiv
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License: PolyForm NC](https://img.shields.io/badge/License-PolyForm--NC--1.0.0-orange.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/Python-3.9%2B-3776AB.svg)](https://python.org)
 [![Tauri](https://img.shields.io/badge/Tauri-Desktop_App-FFC131.svg)](https://tauri.app)
 
-**DIT 工作流的開源 AI 素材標註層 — Resolve 原生、CJK 優先。**
+**DIT 工作流的 source-available AI 素材標註層 — Resolve 原生、CJK 優先。**
 
 > 🌐 [English](README.md) | **繁體中文**
 
 arkiv 介於素材硬碟與 DaVinci Resolve 之間：自動 ingest footage、附上 AI 標註（逐字稿、視覺標籤、氛圍、能量、剪輯位置），並用任何語言（中文、日文、英文）的語義搜尋找回 clip。Resolve plugin 讓你搜尋、帶 clip color 匯入、加 frame marker，不用離開 NLE。
 
-為 solo DIT 與小團隊設計，資料自己持有：本地優先、自架、MIT license、零雲端依賴。
+為 solo DIT 與小團隊設計，資料自己持有：本地優先、自架、source-available（PolyForm Noncommercial），零雲端依賴。
 
 ---
 
@@ -395,4 +395,6 @@ SKIP 項目是**選用的相依套件** — 不影響功能。通過的結果是
 
 ## 授權
 
-MIT
+PolyForm Noncommercial License 1.0.0，附 Commercial Output Exception — 見 [LICENSE](LICENSE)。
+
+你用 arkiv 剪出的影片、時間軸、匯出檔都是你的，可商用；arkiv 軟體本身任何非商業用途皆免費，但**不得**把 arkiv（或其 fork）當商業產品/服務販售、架站或重新包裝。


### PR DESCRIPTION
## What
Relicense arkiv from **MIT** to **source-available (PolyForm Noncommercial 1.0.0)** + a **Commercial Output Exception**.

## Why
If arkiv is to become a paid product, MIT lets anyone (incl. a larger player) fork it into a competing commercial product. PolyForm-NC keeps arkiv **free for any noncommercial use, auditable (source public), but not resellable/repackageable as a commercial product** — the same defensive posture buttercut uses. Videos/timelines/exports made with arkiv stay fully commercial (Output Exception).

## Changes
- `LICENSE`: canonical PolyForm-NC 1.0.0 (SPDX text) + Commercial Output Exception + Required Notice copyright.
- `README.md` / `README.zh-TW.md`: license badge, one-liner, License section; **'open-source' → 'source-available'** (PolyForm-NC is source-available, **not** OSI open source).

## Caveats
- **Applies going forward.** Already-released MIT commits stay MIT-forkable — relicensing early limits that window.
- Contributors are Hevin + Claude co-author only (no third-party human rights to clear).
- **reel-scout stays MIT** (the open-source funnel of the three-piece).
- **Legal review advisable** before a commercial launch: the Output Exception wording, and whether to hold IP under a business entity (buttercut uses TubeSalt LLC).

Draft — license decision, review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)