### PR TITLE
ci(coverage): isolate flaky MCP stdio e2e from --cov + document ratchet (Wave B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,11 +109,13 @@ jobs:
   coverage:
     name: coverage
     # Coverage floor as a regression RATCHET (not a quality claim — the conftest
-    # backend fakes flatter the number). Kept as its OWN job and NON-BLOCKING for
-    # now: a pre-existing intermittent flake in a subprocess-CLI test surfaces
-    # under `--cov`, so we don't import that instability into the correctness legs
-    # above. Floor is set conservatively below the measured ~63%. Flip to blocking
-    # once the flaky test is fixed (see CONTRIBUTING / follow-up).
+    # backend fakes flatter the number). Kept as its OWN job and NON-BLOCKING; the
+    # decision + flip-to-blocking condition live in CONTRIBUTING.md § Testing &
+    # Coverage. The subprocess-stdio MCP e2e is deselected below (-m "not
+    # subprocess_stdio"): under --cov the parent-side tracer slows the stdio pump
+    # into the anyio.fail_after bound and it flakes — the F3 MCP SDK×OS stall
+    # deferred to the health-hardening handoff, not a coverage bug (and the child is
+    # un-instrumented, so excluding it costs ~0 coverage). Floor is below ~63%.
     runs-on: macos-latest  # same as `test`: mlx-whisper has no Linux wheel
     continue-on-error: true
     steps:
@@ -132,7 +134,7 @@ jobs:
             "psutil>=5.9" "whisper-guard>=0.3" numpy mlx-whisper \
             "opencc; python_version >= '3.10'" "mcp>=1.2"
       - name: Coverage
-        run: pytest -q --cov=. --cov-config=pyproject.toml --cov-report=term:skip-covered --cov-fail-under=55
+        run: pytest -q -m "not subprocess_stdio" --cov=. --cov-config=pyproject.toml --cov-report=term:skip-covered --cov-fail-under=55
 
   frontend:
     name: frontend-build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,30 @@ chore: update requirements.txt
 - Keep modules small and focused — each `.py` file has a single responsibility
 - Use `config.py` for all configurable values (never hardcode paths/URLs)
 
+## Testing & Coverage
+
+Run the suite with `pytest -q`. CI runs it on macOS (Python 3.9 + 3.12) plus a scoped
+Windows correctness leg — those are the blocking correctness gates.
+
+**Coverage is a non-blocking regression ratchet, not a quality bar.** The `coverage` CI
+job is `continue-on-error` on purpose:
+
+- The percentage (~63%) is *flattered* — `tests/conftest.py` fakes the heavy backends
+  (torch, chromadb, mlx_whisper, whisperx, …) via `sys.modules`, so those branches never
+  execute and the denominator shrinks. Treat it as a relative ratchet, not an absolute claim.
+- The floor (`--cov-fail-under=55`) sits conservatively below the measured ~63%.
+- The MCP stdio e2e (`tests/test_mcp_e2e.py`, marked `subprocess_stdio`) is **excluded from
+  the `--cov` leg** (`-m "not subprocess_stdio"`). It spawns a real subprocess; under
+  coverage the parent-side tracer slows the stdio pump so the async handshake/teardown flakes
+  against its `anyio.fail_after` bound. That is the same F3 MCP-SDK×OS stall tracked in the
+  health-hardening handoff — not a coverage bug — and the child is un-instrumented, so
+  excluding it costs ~0 coverage. The `test` job still runs it (no filter).
+
+**Flip-to-blocking condition:** make coverage a required check only once (a) the F3 MCP stdio
+stall has a root-cause fix (so the e2e can rejoin the `--cov` leg) and (b) coverage is
+re-measured on a matrix rather than the single `macos-latest` runner. Until then it stays a
+ratchet.
+
 ## Project Structure
 
 ```

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,5 @@ testpaths = tests
 asyncio_mode = auto
 pythonpath = .
 addopts = -p no:cacheprovider
+markers =
+    subprocess_stdio: spawns a real subprocess over async stdio (MCP e2e); deselected from the --cov leg because coverage's parent-side tracer slows the stdio pump into the anyio.fail_after bound (see CONTRIBUTING.md § Testing & Coverage).

--- a/tests/test_mcp_e2e.py
+++ b/tests/test_mcp_e2e.py
@@ -33,6 +33,14 @@ import anyio  # ships with mcp/fastapi; only reached past the importorskip gate
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
+# Every test here drives a real `python mcp_server.py` subprocess over async stdio.
+# Marked so the coverage CI leg can `-m "not subprocess_stdio"` deselect them: under
+# --cov the parent-side tracer slows the stdio pump into the anyio.fail_after bound and
+# teardown flakes (the F3 MCP SDK×OS stall, deferred to the health-hardening handoff).
+# The child is un-instrumented, so these contribute ~0 coverage. The `test` job still
+# runs them (no marker filter) for correctness.
+pytestmark = pytest.mark.subprocess_stdio
+
 _REPO = Path(__file__).resolve().parent.parent
 
 # F3 / AC2 (2026-07-25): the stdio handshake, tool calls and teardown have no


### PR DESCRIPTION
Wave B item B1. Isolates the subprocess-stdio MCP e2e from the coverage `--cov` leg (it flakes because coverage slows the stdio pump into the `anyio.fail_after` bound — the F3 SDK×OS stall, not a coverage bug; child is un-instrumented so ~0 coverage cost), and documents the non-blocking-ratchet decision + flip-to-blocking condition in CONTRIBUTING.md (makes the dangling `see CONTRIBUTING` pointer truthful).

- `pytest.ini`: register `subprocess_stdio` marker
- `tests/test_mcp_e2e.py`: module-level `pytestmark`
- `ci.yml` coverage job: `-m "not subprocess_stdio"`; `test`/`test-windows` still run the e2e
- `CONTRIBUTING.md`: Testing & Coverage section

Verified locally: coverage leg green at 67% (≥55); plain `pytest` still runs the e2e (4 passed). Coverage stays non-blocking (not added to required checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)