### PR TITLE
ci(docker): add docker-build + boot-smoke gate; compose waits for ollama healthy (Wave B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,18 +227,14 @@ jobs:
     # wheel, but requirements.txt gates it by platform marker (faster-whisper on Linux,
     # mlx-whisper only on Darwin), so a full Linux build is green-able. Runtime smoke is
     # scoped to arkiv's OWN /api/stats (the Dockerfile HEALTHCHECK target) — no ollama
-    # models / GPU, which a per-PR runner can't provide.
+    # models / GPU, which a per-PR runner can't provide. Uses the runner's BUILT-IN
+    # docker/buildkit (not docker/setup-buildx-action, whose buildkit builder image is
+    # pulled from Docker Hub and flaked with a registry timeout). No layer cache — a gate
+    # can afford the ~10 min; base-image pulls still hit Docker Hub.
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
       - name: Build image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          load: true
-          tags: arkiv:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        run: docker build -t arkiv:ci .
       - name: Boot smoke (arkiv /api/stats via loopback — ollama not required)
         run: |
           docker run -d --name arkiv-ci arkiv:ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,3 +218,39 @@ jobs:
       - name: npm audit
         working-directory: frontend
         run: npm audit --omit=dev --audit-level=high
+
+  docker-build:
+    name: docker-build
+    runs-on: ubuntu-latest
+    # Before this CI only did `docker compose config` (YAML parse) — a broken Dockerfile
+    # could merge silently. This builds the REAL image and boots it. mlx has no Linux
+    # wheel, but requirements.txt gates it by platform marker (faster-whisper on Linux,
+    # mlx-whisper only on Darwin), so a full Linux build is green-able. Runtime smoke is
+    # scoped to arkiv's OWN /api/stats (the Dockerfile HEALTHCHECK target) — no ollama
+    # models / GPU, which a per-PR runner can't provide.
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: arkiv:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Boot smoke (arkiv /api/stats via loopback — ollama not required)
+        run: |
+          docker run -d --name arkiv-ci arkiv:ci
+          ok=0
+          for i in $(seq 1 30); do
+            # arkiv trusts loopback and 401s external callers, so curl INSIDE the
+            # container (same as the Dockerfile HEALTHCHECK) — not the mapped port.
+            if docker exec arkiv-ci curl -fsS http://localhost:8501/api/stats >/dev/null 2>&1; then
+              echo "arkiv /api/stats up (loopback) after ${i} attempt(s)"; ok=1; break
+            fi
+            sleep 3
+          done
+          if [ "$ok" != "1" ]; then echo "arkiv did not become healthy"; docker logs arkiv-ci; fi
+          docker rm -f arkiv-ci
+          [ "$ok" = "1" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
       - ARKIV_HOST=0.0.0.0
       - ARKIV_PORT=8501
     depends_on:
-      - ollama
+      ollama:
+        condition: service_healthy   # F6: wait for ollama READY, not just container-start
     restart: unless-stopped
 
   ollama:
@@ -29,6 +30,15 @@ services:
       - "11434:11434"
     volumes:
       - ollama_data:/root/.ollama
+    healthcheck:
+      # `ollama list` returns 0 only once the server is answering (readiness, not
+      # just container-start). Does NOT wait for models to be pulled — that stays a
+      # runtime/deploy step, not a compose gate.
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
     # NVIDIA GPU passthrough (uncomment for CUDA):
     # deploy:
     #   resources:


### PR DESCRIPTION
Wave B item B3. CI only did `docker compose config` (YAML parse) — a broken Dockerfile could merge silently.

- New `docker-build` job (ubuntu): builds the real image (mlx skipped on Linux by the requirements platform marker → `faster-whisper`, so green-able) + a scoped boot smoke that curls `/api/stats` via loopback **inside** the container (arkiv 401s external callers; matches the Dockerfile HEALTHCHECK). No ollama models / GPU.
- F6 fix: `docker-compose.yml` ollama `healthcheck` + arkiv `depends_on: condition: service_healthy` → waits for readiness, not just container-start.

Verified locally: `docker build` → image built (mlx correctly skipped); loopback smoke → `/api/stats` 200; `docker compose config` valid. After the `docker-build` job is green here it'll be added to required checks.

**Out of scope (documented, not hidden):** full compose with real ollama models (~6 GB + GPU), `cargo tauri build` (.app/.dmg), Windows Tauri build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)