### PR TITLE
security(federation): lock explicit-embeddings-only invariant on external chroma (Wave B)

### DIFF
--- a/federation.py
+++ b/federation.py
@@ -175,6 +175,12 @@ def _score_from_distance(distance: Any) -> float:
 
 
 def _query_chroma(project: ProjectMeta, query_embeddings, limit: int) -> List[Dict[str, Any]]:
+    # SECURITY (2026-07-26 audit): this opens an EXTERNAL, semi-trusted project's chroma dir.
+    # A collection's persisted embedding_function config is untrusted here — chromadb builds
+    # (and runs) it lazily ONLY when a caller passes query_texts= / documents-without-embeddings
+    # (the ChromaToast / chroma#6717 client-SDK-RCE class). So federation MUST query external
+    # collections with explicit query_embeddings= only, and never query_texts= / add(documents=).
+    # tests/test_federation.py::test_query_chroma_uses_explicit_embeddings_only locks this.
     client = chromadb.PersistentClient(path=str(_project_root(project) / ".arkiv" / "chroma_db"))
     collection = client.get_collection(config.COLLECTION_NAME)
     try:

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -207,3 +207,46 @@ def test_api_media_q_route_stays_compatible(fastapi_client, sample_record):
     payload = response.json()
     assert payload["search"] is True
     assert payload["total"] >= 1
+
+
+def test_query_chroma_uses_explicit_embeddings_only(tmp_path, monkeypatch):
+    """SECURITY invariant guard (2026-07-26 audit): federation opens EXTERNAL, semi-trusted
+    project chroma dirs. chromadb builds+runs a collection's PERSISTED embedding_function only
+    when a caller passes query_texts= / documents-without-embeddings (ChromaToast / chroma#6717
+    client-SDK-RCE class). Federation must ALWAYS query with explicit query_embeddings= and
+    never query_texts= / add(documents=), so a poisoned external collection's EF config is never
+    instantiated. This fails if _query_chroma regresses to a text-embedding path."""
+    federation = importlib.import_module("federation")
+    root = _make_project(tmp_path, "ext")
+    project = importlib.import_module("projects").ProjectMeta(name="ext", path=root)
+
+    seen = {"query_kwargs": None}
+
+    class SpyCollection(object):
+        def query(self, **kwargs):
+            seen["query_kwargs"] = kwargs
+            return {"documents": [[]], "metadatas": [[]], "distances": [[]]}
+
+        def add(self, *args, **kwargs):  # tripwire: never write to an external project's collection
+            raise AssertionError("federation must not add() to an external project collection")
+
+    class SpyClient(object):
+        def __init__(self, path):
+            self.path = path
+
+        def get_collection(self, name, **kwargs):
+            return SpyCollection()
+
+    monkeypatch.setattr(federation, "embed_query", lambda query: [0.1, 0.2, 0.3])
+    monkeypatch.setattr(federation.config, "discover_projects", lambda: [project])
+    monkeypatch.setattr(federation, "chromadb", types.SimpleNamespace(PersistentClient=SpyClient))
+
+    federation.search_all_projects("query token", limit=5, per_project_limit=2, timeout=2.0)
+
+    kwargs = seen["query_kwargs"]
+    assert kwargs is not None, "federation never queried the external chroma collection"
+    assert "query_embeddings" in kwargs, "federation must query external chroma with explicit query_embeddings="
+    assert "query_texts" not in kwargs, (
+        "federation must NOT pass query_texts= to an external collection — that builds+runs "
+        "its (untrusted) persisted embedding_function config"
+    )


### PR DESCRIPTION
Wave B item B4 — defensive guard for the 2026-07-25/26 chromadb residual.

`federation._query_chroma` opens **external, semi-trusted** project chroma dirs. Tracing chromadb 1.5.9 confirmed the persisted `embedding_function` config is built+run **only** on `query_texts=`/documents-without-embeddings (the ChromaToast / chroma#6717 client-SDK-RCE class) — federation uses `query_embeddings=` exclusively, so it's **unreachable today**. This locks that invariant against a future regression:

- `federation.py`: SECURITY comment on `_query_chroma`.
- `tests/test_federation.py`: spy the external collection's `query()`, assert `query_embeddings=` present and `query_texts=`/`add(documents=)` never used.

pgvector migration does **not** retire this (federation hardcodes `chromadb.PersistentClient` regardless of `ARKIV_VECTOR_BACKEND`), so the guard lives here. Verified: 6 federation tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)