### PR TITLE
ci(docker): digest-pin base images + ollama for reproducible rebuilds (Wave C)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@
 # Stage 0: Build the Svelte SPA (frontend/dist) that server.py serves at /.
 # .dockerignore excludes dist/ + node_modules, so this stage builds from clean
 # source. The built dist is copied into the app stage below.
-FROM node:20-slim AS ui
+# Digest-pinned for reproducible rebuilds (Wave C); the tag stays for readability,
+# the digest is authoritative. Refresh via dependabot (docker ecosystem).
+FROM node:20-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0 AS ui
 WORKDIR /ui
 COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci --no-audit --no-fund
@@ -10,7 +12,8 @@ COPY frontend/ ./
 RUN npm run build
 
 # Stage 1: Dependencies
-FROM python:3.11-slim AS deps
+# Digest-pinned for reproducible rebuilds (Wave C); refresh via dependabot.
+FROM python:3.11-slim@sha256:db3ff2e1800a8581e2c48a27c3995339d47bdf046da21c7627accd3d51053a93 AS deps
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,9 @@ services:
     restart: unless-stopped
 
   ollama:
-    image: ollama/ollama:latest
+    # Digest-pinned (Wave C): `:latest` on a frequently-pushed image was the worst drift
+    # source. Tag kept for readability, digest authoritative; refresh via dependabot.
+    image: ollama/ollama:latest@sha256:10c13eb515db310990527d36ca14a136da4bcc0fbf2bf3b15e9c1f111e9d3cd4
     ports:
       - "11434:11434"
     volumes:


### PR DESCRIPTION
Wave C item C1. Pins the Docker build-path bases (`node:20-slim`, `python:3.11-slim`) and the runtime `ollama/ollama` image by `@sha256` digest (tag kept for readability). Closes the audit's F5 build-drift; the `docker-build` gate re-verifies. C2 adds dependabot (docker ecosystem) to auto-refresh these.

Verified locally: `docker build` with pinned digests → image built; `docker compose config` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)