### PR TITLE
ci(frontend): svelte-check gate at zero warnings + fix the 5 pre-existing (Wave D)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,8 +139,9 @@ jobs:
   frontend:
     name: frontend-build
     runs-on: ubuntu-latest
-    # Nothing in CI touched frontend/ before this — a broken Svelte build could
-    # merge silently. Build-only for now; lint/svelte-check are a follow-up.
+    # Build + svelte-check gate (Wave D). `npm run check` = svelte-check --fail-on-warnings,
+    # so a NEW svelte warning (unused export/CSS, a11y, empty ruleset) reds CI. Baseline = 0
+    # warnings (the 5 pre-existing were fixed in this wave). Runs in the already-required job.
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -153,6 +154,9 @@ jobs:
         run: |
           npm ci
           npm run build
+      - name: svelte-check (gate at zero warnings)
+        working-directory: frontend
+        run: npm run check
 
   tauri-check:
     name: tauri-check

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,8 @@
         "@sveltejs/vite-plugin-svelte": "^3.1.2",
         "puppeteer-core": "^23.0.0",
         "svelte": "^4.2.20",
+        "svelte-check": "^4.7.4",
+        "typescript": "^6.0.3",
         "vite": "^5.4.21"
       }
     },
@@ -875,6 +877,16 @@
         "win32"
       ]
     },
+    "node_modules/@sveltejs/load-config": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.1.tgz",
+      "integrity": "sha512-5m3B2cbqQ4TbwW6Xkh66Ntw6dD7gNc77cCxABTTesWcq9jxIzMgTk97pZx5vEtvQx8iokgi7GIphqZe+PGwcZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
     "node_modules/@sveltejs/vite-plugin-svelte": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-3.1.2.tgz",
@@ -1212,6 +1224,22 @@
         "node": "*"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/chromium-bidi": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.11.0.tgz",
@@ -1529,6 +1557,24 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1714,6 +1760,16 @@
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1916,6 +1972,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/regexparam": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
@@ -1986,6 +2056,19 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/semver": {
       "version": "7.8.1",
@@ -2128,6 +2211,31 @@
         "node": ">=16"
       }
     },
+    "node_modules/svelte-check": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.4.tgz",
+      "integrity": "sha512-IW9ot9YqAoyv8FvyN+eb4ZTe8zgcKZrJLNYU6dzSKkGwEBsSPc4K7lmQ8bKn8W2YMXM6WDfZSSVOaGtekyUfOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@sveltejs/load-config": "^0.2.1",
+        "chokidar": "^4.0.1",
+        "fdir": "^6.2.0",
+        "picocolors": "^1.0.0",
+        "sade": "^1.7.4"
+      },
+      "bin": {
+        "svelte-check": "bin/svelte-check"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "typescript": "^5.0.0 || ^6.0.0"
+      }
+    },
     "node_modules/svelte-hmr": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.16.0.tgz",
@@ -2227,6 +2335,20 @@
       "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,12 +6,15 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "check": "svelte-check --fail-on-warnings"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^3.1.2",
     "puppeteer-core": "^23.0.0",
     "svelte": "^4.2.20",
+    "svelte-check": "^4.7.4",
+    "typescript": "^6.0.3",
     "vite": "^5.4.21"
   },
   "dependencies": {

--- a/frontend/src/lib/ArkivLogo.svelte
+++ b/frontend/src/lib/ArkivLogo.svelte
@@ -1,7 +1,7 @@
 <!-- 1px frame around 'arkiv.' wordmark (vulture.s 'tv.' style). -->
 <script>
   export let size = 18
-  export let theme = 'dark' // API parity; styling is theme-agnostic (CSS vars)
+  export const theme = 'dark' // API parity (external ref only); styling is theme-agnostic (CSS vars)
 </script>
 
 <div

--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -640,8 +640,7 @@
   .metagrid { display: grid; grid-template-columns: 64px 1fr; row-gap: 4px; column-gap: 12px; font-size: 11.5px; }
   .blockhead { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 8px; }
   /* transcript flows naturally now — the whole inspector scrolls (see .inspector),
-     so a long transcript extends the panel and is reached by scrolling it. */
-  .transcript { }
+     so a long transcript extends the panel and is reached by scrolling it; no rule needed. */
   .langtabs { display: flex; align-items: center; gap: 4px; margin-bottom: 10px; flex-wrap: wrap; }
   .langtab {
     appearance: none; background: transparent; border: 1px solid var(--rule);

--- a/frontend/src/lib/Thumb.svelte
+++ b/frontend/src/lib/Thumb.svelte
@@ -4,7 +4,7 @@
 <script>
   export let seed = 0
   export let kind = 'video'
-  export let state = undefined // API parity (not visualized here)
+  export const state = undefined // API parity (external ref only; not visualized here)
   export let theme = 'dark'
 
   const palettesDark = [

--- a/frontend/src/routes/Bins.svelte
+++ b/frontend/src/routes/Bins.svelte
@@ -238,6 +238,8 @@
       {:else}
         <div class="dhead">
           {#if renaming}
+            <!-- the rename field intentionally focuses when it opens (inline-edit UX) -->
+            <!-- svelte-ignore a11y-autofocus -->
             <input class="ak-input renameinput" bind:value={renameVal} autofocus
                    on:keydown={(e) => { if (e.key === 'Enter') saveRename(); if (e.key === 'Escape') renaming = false }} />
             <button class="ak-btn" on:click={saveRename}>存</button>

--- a/frontend/src/routes/IngestSetup.svelte
+++ b/frontend/src/routes/IngestSetup.svelte
@@ -241,7 +241,6 @@
   .seg { font-family: var(--ak-mono); font-size: 10px; letter-spacing: 0.08em; width: 46px; flex: 0 0 46px; padding: 5px 0; border: 1px solid var(--rule-hi); background: transparent; color: var(--quiet); cursor: pointer; }
   .seg.on { background: var(--invert); color: var(--invert-ink); border-color: var(--invert); font-weight: 700; }
 
-  .deferred { opacity: 0.6; }
   .pendrow, .estimated { display: flex; align-items: baseline; justify-content: space-between; }
   .pend { font-family: var(--ak-mono); font-size: 9.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--quiet-2); border: 1px dashed var(--rule-hi); padding: 1px 6px; }
 


### PR DESCRIPTION
Wave D item D1. Adds `svelte-check --fail-on-warnings` to the (already-required) `frontend-build` job and fixes the 5 pre-existing warnings so the baseline is zero:

- ArkivLogo/Thumb: unused `export let` → `export const` (verified no caller sets them; API parity kept)
- Bins: intentional rename-field autofocus → `svelte-ignore a11y-autofocus` + reason
- IngestSetup: delete unused `.deferred` CSS
- Inspector: remove empty `.transcript {}` ruleset

Verified locally: `npm run check` → 0/0; `npm run build` green. No new required check (runs in frontend-build). D2 (bundle budget) is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)