### PR TITLE
chore(release): fix version drift (0.2.0 -> 0.10.0) + document release process (Wave E)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,31 @@ upstream changelog and a one-click rollback:
   single frozen lockfile can't honestly represent all environments. The `dependency-audit`
   gate + deliberate bumps are the reproducibility contract instead.
 
+## Releases
+
+arkiv ships as a macOS (Apple Silicon) app. Releases are cut from `main` by tag:
+
+1. Move `## Unreleased` in `CHANGELOG.md` to `## vX.Y.Z - YYYY-MM-DD`; leave a fresh
+   `## Unreleased` on top.
+2. Bump the version to `X.Y.Z` in **both** `src-tauri/tauri.conf.json` and
+   `src-tauri/Cargo.toml` so it matches the tag (these historically drifted — stuck at 0.2.0
+   across the whole v0.2→v0.10 tag history, so every built DMG embedded 0.2.0).
+3. Commit (`docs(changelog): cut vX.Y.Z`), then push an **annotated** tag: `git tag -a vX.Y.Z -m …`.
+4. The tag-triggered `release.yml` workflow builds the `.app`/`.dmg` on a macOS-arm runner. It
+   **stamps the version from the tag**, so the bundle can't drift from the tag; signs +
+   notarizes if the Apple secrets are configured (else builds unsigned — the app already ships
+   with a documented right-click→Open Gatekeeper step); and uploads the artifact to the Release.
+
+**Release-artifact matrix:**
+
+| Target | Artifact | Signed | Status |
+|---|---|---|---|
+| macOS arm64 (Apple Silicon) | `.app` + `.dmg` | yes, if Apple secrets set | supported |
+| macOS x86_64 (Intel) | — | — | N/A — `assemble-backend.sh` bundles an aarch64-apple-darwin Python |
+| Windows | — | — | deferred — mac-arm-locked backend; `mlx-whisper` has no Windows wheel |
+
+Rollback = the prior tag's artifact; delete the GitHub Release (and tag) if a release is bad.
+
 ## Project Structure
 
 ```

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arkiv"
-version = "0.2.0"
+version = "0.10.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arkiv"
-version = "0.2.0"
+version = "0.10.0"
 description = "arkiv — Local Media Asset Manager"
 authors = ["Hevin Yeh"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui-org/nicegui/main/tauri/src-tauri/tauri.conf.json",
   "productName": "arkiv",
-  "version": "0.2.0",
+  "version": "0.10.0",
   "identifier": "com.hevin.arkiv",
   "build": {
     "devUrl": "http://localhost:8501",


### PR DESCRIPTION
Wave E item E1. Fixes a real bug: `tauri.conf.json` + `Cargo.toml` were stuck at **0.2.0 across the whole v0.2→v0.10 tag history**, so every built DMG embedded 0.2.0. Bumps both (+ the `Cargo.lock` root entry) to 0.10.0 (the last tag), and adds a CONTRIBUTING **§ Releases** with the changelog-cut/annotated-tag process + a release-artifact matrix (macOS arm64 supported; Intel/Windows N/A/deferred).

E2 (next) adds the tag-triggered `release.yml` that **stamps the version from the tag** so it can't drift again.

Verified: `cargo check --locked` passes with arkiv v0.10.0; `tauri.conf.json` valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)