### PR TITLE
fix(release): ad-hoc sign the unsigned build path (empty identity broke bundling)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,13 +91,25 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
           p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
 
-      - name: Build app (Tauri signs + notarizes iff Apple env is set, else unsigned)
+      # Two build paths — signed vs ad-hoc — because an EMPTY APPLE_SIGNING_IDENTITY is a trap:
+      # Tauri codesigns with "" -> `codesign --sign ""` -> "no identity found" -> bundle fails.
+      # And an arm64 binary MUST be at least ad-hoc signed to exec at all, so the no-secrets
+      # path uses "-" (ad-hoc) rather than leaving the identity unset/empty.
+      - name: Build signed + notarized app (Apple secrets present)
+        if: env.HAS_APPLE_CERT == 'true'
         env:
           CI: "true"   # skips the Finder AppleScript so the .dmg builds headless (assemble-backend.sh:72-76)
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: cargo tauri build
+
+      - name: Build unsigned app (no Apple secrets — ad-hoc sign so arm64 still launches)
+        if: env.HAS_APPLE_CERT != 'true'
+        env:
+          CI: "true"
+          APPLE_SIGNING_IDENTITY: "-"   # ad-hoc; unnotarized (documented right-click->Open on download)
         run: cargo tauri build
 
       - name: Attach artifacts to the GitHub Release (tag only)


### PR DESCRIPTION
Follow-up to #245. The unsigned `workflow_dispatch` dry-run (run 30292148615) validated the whole pipeline — frontend build, venv+torch install, the 1.3 GB `assemble-backend.sh`, tauri-cli, and `cargo tauri build` all ran — then failed at the final bundle step:

```
Signing with identity ""
: no identity found
Error failed to bundle project: failed codesign application
```

**Root cause:** an unset GitHub secret expands to an empty string, so `APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}` became `""`. Tauri treats an empty identity as "sign with this identity" and runs `codesign --sign ""` → *no identity found*. Separately, an **arm64** binary must be at least ad-hoc signed to launch at all, so leaving the identity empty is wrong even in principle.

**Fix:** two build steps gated on `env.HAS_APPLE_CERT` — real Developer ID identity + notarization when the Apple secrets are present, **ad-hoc `-`** otherwise (bundles headless, unnotarized → the existing right-click→Open model). No PR gates change (release.yml is tag/dispatch-triggered). I'll re-run the unsigned dry-run on main after merge to confirm it produces a `.dmg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)