### PR TITLE
fix(tests): seed G2 rows with an OS-absolute temp path (Windows escape)

### DIFF
--- a/tests/test_transcripts_g2.py
+++ b/tests/test_transcripts_g2.py
@@ -7,6 +7,7 @@ stubbed (the archive/activate logic is what's under test, not the model).
 """
 import importlib
 import json
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -14,7 +15,14 @@ import pytest
 
 def _seed(transcript="原始中文逐字稿", lang="zh"):
     # retranscribe checks the media file exists → back it with a real temp file.
-    p = Path("/tmp/arkiv-g2-clip.mp4")
+    # The seeded row is the legacy-absolute shape (`resolve_path` passes absolutes
+    # through), so the literal must be absolute ON THE RUNNING OS. A hardcoded
+    # "/tmp/..." is only absolute on POSIX: on Windows `str(Path("/tmp/x"))` is
+    # `\tmp\x` — rooted but drive-less, so `is_absolute()` is False, the row takes
+    # the *relative* branch, and the join drive-anchors to `C:\tmp\x`, escaping
+    # PROJECT_ROOT (the guard then correctly raises). gettempdir() is absolute on
+    # both, so the row keeps its intended meaning cross-platform.
+    p = Path(tempfile.gettempdir()) / "arkiv-g2-clip.mp4"
     p.write_bytes(b"\x00")
     db = importlib.import_module("db")
     with db.get_conn() as conn:


### PR DESCRIPTION
Part B (PC / Windows) of the 2026-07-24 arkiv health-hardening handoff — first of the two remaining Windows failures found by the full local Windows suite.

## Root cause

`tests/test_transcripts_g2.py::_seed` hardcoded `Path("/tmp/arkiv-g2-clip.mp4")`. That literal is absolute **only on POSIX**. On Windows:

```
>>> str(Path('/tmp/arkiv-g2-clip.mp4'))
'\tmp\arkiv-g2-clip.mp4'
>>> Path('\tmp\arkiv-g2-clip.mp4').is_absolute()
False                                   # rooted, but drive-less
>>> (Path('C:/Users/user/projects/arkiv') / _).resolve()
WindowsPath('C:/tmp/arkiv-g2-clip.mp4') # drive-anchored -> escapes PROJECT_ROOT
```

So the seeded row never reaches `db.resolve_path`'s legacy-absolute pass-through — it takes the *relative* branch, the join drive-anchors to `C:\tmp\...`, and the J2 containment guard correctly raises:

```
ValueError: DB rel_path 解析後逃出 PROJECT_ROOT 邊界：'\tmp\arkiv-g2-clip.mp4'
```

This is the same class as the F1 offload finding already fixed in #223: **a POSIX literal on Windows is not the absolute path it looks like.**

Only the two tests that actually resolve the media path fail (`retranscribe`, `activate`); the pure-db ones never call `resolve_path`, which is why the file was 2-failed/4-passed rather than fully red — and why macOS CI is green (there `/tmp/...` *is* absolute).

## Fix

The guard is right to raise; the defect is the non-portable seed. `tempfile.gettempdir()` is absolute on both platforms, so the row keeps its intended legacy-absolute meaning cross-OS.

Test-only change. No product code touched, no skip / xfail / `--ignore`.

## Evidence (Windows 11, Python 3.12.10, mcp 1.27.0)

```
before: 2 failed, 4 passed   tests/test_transcripts_g2.py
after:  6 passed in 1.90s
```

Full-suite Windows context (same machine, before this fix): `3 failed, 1110 passed, 8 skipped in 215.46s` — the other failure is the F3 MCP stdio hang, tracked separately (its `anyio.fail_after` bound now reports `stage: cleanup`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)