### PR TITLE
docs(changelog): cut v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## v0.11.0 - 2026-07-28
+
+First release built and published by the automated `release.yml` pipeline — arkiv now
+ships a downloadable macOS (Apple Silicon) `.dmg` instead of build-it-yourself. Bundles a
+month of Phase 9.x editor / timeline / MCP work (below) plus the repo health-hardening
+waves A–E (Windows correctness, CI truthfulness, dependency reproducibility, frontend
+quality gates, and version/release hygiene). The `.dmg` is unsigned — right-click → Open
+on first launch — until Apple signing secrets are configured.
+
 ### Security
 - **MCP `_safe_path` leaked `C:/…` absolute paths whole (#182).** `mcp_server` carried its own copy of the leak guard because the original lived in `server.py`, which it must not import (that pulls in the whole FastAPI app) — there was nowhere to share from. Four hours after that copy landed on 2026-06-08, Codex round-2 (`fc35b8f`) overruled round-1 and made `C:/` count as a Windows absolute alongside `C:\`; the fix touched `server.py` only, so the MCP copy kept passing `C:/Users/me/secret.mov` through unchanged for 38 days — on the one surface whose stated red line is "no absolute-path leak", and the only one facing untrusted downstream agents. R5-25 extracted the guard into the `pathres` leaf, so the copy is now deleted rather than patched: `_safe_path` delegates to `pathres._display_path`, one guard, nothing left to drift. Paths beginning `C:/` now basename like every other absolute; every other input is byte-identical.
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arkiv"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arkiv"
-version = "0.10.0"
+version = "0.11.0"
 description = "arkiv — Local Media Asset Manager"
 authors = ["Hevin Yeh"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui-org/nicegui/main/tauri/src-tauri/tauri.conf.json",
   "productName": "arkiv",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "identifier": "com.hevin.arkiv",
   "build": {
     "devUrl": "http://localhost:8501",


### PR DESCRIPTION
Cuts **v0.11.0** — the version-bump + changelog commit that the annotated `v0.11.0` tag will point at (per CONTRIBUTING § Releases).

**Why minor, not patch:** `## Unreleased` carried a month of Phase 9.x *features* since v0.10.0 (editor IN/OUT keyboard shortcuts, per-clip IN/OUT persistence + `PATCH /api/media/{id}/inout`, hardware-decode proxy, timeline export of marked sub-clips, MCP timecode tools) plus a security fix (#182). New backward-compatible features → minor bump.

**Changes:** `## Unreleased` → `## v0.11.0 - 2026-07-28` (fresh empty Unreleased on top); version 0.10.0 → 0.11.0 in `tauri.conf.json` + `Cargo.toml` + `Cargo.lock` (so the source stops drifting from the tag — the E1 fix).

**After merge:** an annotated `v0.11.0` tag on the merge commit triggers `release.yml` → builds + publishes the macOS-arm `.dmg` to a GitHub Release. First release through the new pipeline; the `.dmg` is unsigned (right-click → Open) until the Apple secrets are set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)