### PR TITLE
fix(mcp): prewarm vectordb before stdio starts (Windows numpy deadlock)

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -465,7 +465,39 @@ def list_tags(limit: int = 30) -> str:
     return _j(list_tags_impl(limit))
 
 
+def _prewarm_vectordb() -> None:
+    """Load vectordb (→ chromadb → numpy) BEFORE the stdio transport starts.
+
+    F3 / AC2 (2026-07-28, Windows root cause). `search_media_impl` imports
+    vectordb lazily, which is right for callers in general — but inside the stdio
+    server that import happens while the transport is already running, and on
+    Windows that deadlocks the process permanently:
+
+      mcp.server.stdio parks a worker thread in a blocking `readline()` on the
+      stdin PIPE (anyio's AsyncFile iteration). Importing numpy while a thread
+      sits in that pipe read never returns — numpy's import stops at
+      `numpy._core._multiarray_umath` (the OpenBLAS-linked extension) and the
+      whole interpreter wedges. Reproduced without mcp at all: two idle threads
+      + `import numpy` = 0.09s; one thread blocked on a stdin pipe read +
+      `import numpy` = deadlock. Not version-driven — identical on mcp 1.2.1,
+      1.27.0 and 1.28.1 (SDK × Windows matrix, 2026-07-28).
+
+    Doing the import here — on the main thread, before `mcp.run()` spawns that
+    reader — loads the DLLs while nothing is parked on the pipe, so the first
+    `search_media` call is also fast instead of paying import cost mid-session.
+
+    Deliberately silent on failure: a box with no vector backend must still boot
+    and serve the six tools that never touch an index (the lazy import in
+    `search_media_impl` stays as the real fallback and degrades to SQL there).
+    """
+    try:
+        import vectordb  # noqa: F401
+    except Exception:
+        pass
+
+
 def main() -> None:
+    _prewarm_vectordb()
     mcp.run()
 
 

--- a/tests/test_mcp_e2e.py
+++ b/tests/test_mcp_e2e.py
@@ -67,11 +67,15 @@ async def _run_bounded_mcp(params, body):
                     stage = "initialize"
                     await session.initialize()
                     stage = "call"
-                    try:
-                        result = await body(session)
-                    finally:
-                        stage = "cleanup"  # even if body raised: teardown runs next,
-                        # still inside fail_after, so a cleanup hang is labelled correctly
+                    # `else`, NOT `finally`: a `finally` also runs when the
+                    # fail_after cancellation unwinds THROUGH this frame, so a
+                    # hang inside `body` was relabelled "cleanup" on its way out
+                    # — the F3 Windows deadlock reported stage "cleanup" for two
+                    # rounds when it was really stuck mid-call. Advance the label
+                    # only once body has actually returned; if body raises, the
+                    # stage stays where the failure happened.
+                    result = await body(session)
+                    stage = "cleanup"  # body done; teardown runs next, still bounded
     except TimeoutError:
         pytest.fail("MCP stdio E2E timed out (stage: {0})".format(stage))
     return result
@@ -266,6 +270,45 @@ def test_mcp_boots_and_degrades_without_chromadb(seeded_project):
         proc.stdout, proc.stderr
     )
     assert "NOCHROMA_OK" in proc.stdout, proc.stdout
+
+
+def test_vectordb_is_prewarmed_before_the_stdio_transport_starts(monkeypatch):
+    """The vector backend must be imported BEFORE `mcp.run()`, not on first use.
+
+    On Windows the stdio transport parks a worker thread in a blocking readline()
+    on the stdin pipe; importing numpy (via chromadb) while a thread sits in that
+    pipe read deadlocks the interpreter permanently — the server stops answering
+    and only the client's timeout ends the session. Order is the whole fix, so it
+    is what this test pins: a refactor that drops the prewarm, or moves it after
+    `mcp.run()`, brings the deadlock back on Windows while macOS CI stays green.
+    """
+    import mcp_server
+
+    calls = []
+    monkeypatch.setattr(mcp_server, "_prewarm_vectordb", lambda: calls.append("prewarm"))
+    monkeypatch.setattr(mcp_server.mcp, "run", lambda: calls.append("run"))
+
+    mcp_server.main()
+
+    assert calls == ["prewarm", "run"], calls
+
+
+def test_prewarm_is_silent_without_a_vector_backend(monkeypatch):
+    """…and it must not take the server down on a box with no chromadb: the six
+    tools that never touch an index still have to boot and serve."""
+    import builtins
+
+    import mcp_server
+
+    real_import = builtins.__import__
+
+    def _boom(name, *a, **kw):
+        if name == "vectordb":
+            raise ImportError("no vector backend")
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(builtins, "__import__", _boom)
+    mcp_server._prewarm_vectordb()  # must not raise
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Part B (PC / Windows) of the 2026-07-24 arkiv health-hardening handoff — **F3 / AC2 root cause**, the second of the two Windows failures. Companion to #269.

## What actually happens

`search_media` imports `vectordb` lazily, inside the tool body. Inside the stdio server that import runs while the transport is already up — and on Windows the process then **deadlocks permanently**. The server never answers again; only the client's timeout ends the session. That is the ">180s, whole suite blocked" symptom from the audit.

The trigger is not MCP, and not arkiv. Reproduced with neither in the picture — a thread parked in a blocking read on a **stdin pipe**, which is exactly `mcp.server.stdio`'s steady state (anyio's `AsyncFile` iteration keeps a worker thread in `readline()` on stdin):

| process state | `import numpy` |
|---|---|
| plain | 0.11s |
| 2 idle threads (blocked on `queue.get`) | 0.09s |
| **1 thread blocked on a stdin pipe read** | **deadlock — never returns** |

An import audit hook inside the wedged server shows the import reaching `numpy._core._multiarray_umath` (the OpenBLAS-linked extension) and stopping there.

Narrowing, all inside the same running FastMCP server:

- **numpy-specific, not "any native import"** — `lzma`, `sqlite3`, `PIL.Image` all load in <20ms.
- **not the event loop** — `to_thread` deadlocks identically; `sleep(5)` and a 222KB plain file read inside a *sync* tool both return normally.
- **not `open_code`/AV hooking** — `open` 0.016s vs `open_code` 0.000s on the same numpy source file.
- **not the SDK version.**

## SDK × OS matrix (the AC2 deliverable)

Same machine, same suite, three isolated venvs:

| mcp | result |
|---|---|
| 1.2.1 | 1 failed, 3 passed, 93.41s |
| 1.27.0 | 1 failed, 3 passed, 93.93s |
| 1.28.1 | 1 failed, 3 passed, 94.01s |

Identical. `requirements.txt` therefore stays `mcp>=1.2` — pinning or upgrading would not have fixed this, and the handoff's Red Line forbids touching it without matrix evidence.

(The handoff's harness hypothesis — that the SDK shields cleanup with `CancelScope(shield=True)` so `fail_after` can't interrupt — does not hold: there is no `shield` anywhere in the SDK, and the bound fires correctly every time.)

## Fix

Import `vectordb` on the main thread in `main()`, before `mcp.run()` spawns the stdin reader, so the DLLs load while nothing is parked on the pipe. The lazy import in `search_media_impl` is untouched: non-server callers and the boot-without-chromadb path behave exactly as before, and the prewarm swallows `ImportError` for the same reason. Bonus: the first `search_media` is now fast instead of paying import cost mid-session.

Why macOS CI never saw it: this is a Windows-only interaction, and CI installs no chromadb, so `import vectordb` fails fast and the SQL-degraded path never touches numpy.

## Stage label

`_run_bounded_mcp` set `stage = "cleanup"` in a `finally` — which also runs while the `fail_after` cancellation unwinds through that frame. So a hang *during the call* was always reported as `cleanup`, which is what sent two rounds of investigation at the teardown path. The label now advances only once `body` returns.

## Evidence (Windows 11, Python 3.12.10)

```
before:                          1 failed (timed out, stage: cleanup), 3 passed  93.93s
label fix alone (deadlock kept): 1 failed (timed out, stage: call),    3 passed  91.25s
after:                           6 passed in 10.24s   (end_to_end 90.03s -> 5.82s)
pytest -k mcp:                   53 passed
```

Two regression tests added: the prewarm must run **before** `mcp.run()` (the ordering *is* the fix, and a refactor that drops it would stay green on macOS), and it must stay silent with no vector backend installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)