### PR TITLE
ci(windows): run the MCP stdio suite on the Windows leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,28 @@ jobs:
     # run would red for a platform reason, not a real one. conftest.py fakes the
     # heavy backends (incl. mlx_whisper) via sys.modules, so the guard suite runs
     # with just the lean FastAPI deps. Full-suite Windows 0-fail is tracked as
-    # separate evidence in the 2026-07-24 arkiv-health-hardening handoff; the MCP
-    # stdio hang (F3) is deferred to that handoff's SDK version x OS matrix rather
-    # than imported into CI as a known-red.
+    # separate evidence in the 2026-07-24 arkiv-health-hardening handoff.
+    #
+    # F3 (2026-07-28, handoff Part B): the Windows MCP stdio hang is RESOLVED —
+    # root cause was `search_media`'s lazy `import vectordb` (→ chromadb → numpy)
+    # running after the stdio transport had already parked a worker thread in a
+    # blocking readline() on the stdin pipe; on that box the numpy import then
+    # wedges inside the bundled OpenBLAS DLL and never returns. Fixed by importing
+    # it in main() before mcp.run() (mcp_server._prewarm_vectordb).
+    #
+    # That hang is NOT reproducible on hosted runners — measured 2026-07-28 on
+    # windows-latest / ubuntu-latest / macos-latest: a thread blocked on a stdin
+    # pipe plus `import numpy` (2.5.1) completes in 0.6s on all three, while the
+    # same probe deadlocks on the Win11 dev box with both numpy 2.4.3 and 2.5.1.
+    # It is environment-specific, not version-driven. So installing chromadb here
+    # to exercise the real path would cost ~120s of install (82 packages, ~360MB)
+    # and guard NOTHING — deliberately not done.
+    #
+    # What this leg CAN hold is the ordering invariant that IS the fix: the
+    # prewarm-before-run tests in test_mcp_e2e.py run everywhere, and running the
+    # file here also gives the MCP stdio surface a Windows leg (subprocess spawn,
+    # JSON-RPC framing, teardown) for ~4.5s and zero extra dependencies — mcp and
+    # numpy are already installed above.
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.12
@@ -102,9 +121,9 @@ jobs:
             "fastapi>=0.100.0" "uvicorn>=0.20.0" "pydantic>=2.0,<3" \
             "pillow>=9.0" "requests>=2.28" "xxhash>=2.0.0" "nanoid>=2.0.0" \
             "psutil>=5.9" "whisper-guard>=0.3" numpy mcp
-      - name: Run Windows correctness tests (offload deny-policy contract)
+      - name: Run Windows correctness tests (offload deny-policy + MCP stdio)
         shell: bash
-        run: pytest tests/test_hardening_round4.py -q
+        run: pytest tests/test_hardening_round4.py tests/test_mcp_e2e.py -q
 
   coverage:
     name: coverage


### PR DESCRIPTION
Follow-up to #271. Closes the CI coverage question raised in the Part B report — with a measurement rather than a guess.

## What changes

`test-windows` already installs `mcp` and `numpy`, but only ran `tests/test_hardening_round4.py`. It now also runs `tests/test_mcp_e2e.py`.

That buys two things: the MCP stdio surface (subprocess spawn, JSON-RPC framing, teardown) gets a Windows leg, and the prewarm-ordering tests added in #271 run on Windows instead of only on the macOS 3.12 leg. Since that ordering *is* the F3 fix, it is precisely what a regression would break.

Verified under a venv built from this job's exact install list — no chromadb, as on the runner:

```
pytest tests/test_hardening_round4.py tests/test_mcp_e2e.py -q
→ 50 passed in 7.42s      (mcp 1.28.1, numpy 2.5.1, Python 3.12, Windows 11)
```

~4.5s added, no new dependencies.

## What is deliberately NOT done, and why

Installing chromadb here so the leg exercises the real deadlock path would guard nothing, because **hosted runners do not have the hazard**. Measured 2026-07-28 with a throwaway probe on all three runner families — a thread blocked on a stdin pipe read plus `import numpy`:

| runner | numpy | result |
|---|---|---|
| windows-latest | 2.5.1 | completed in 0.6s |
| ubuntu-latest | 2.5.1 | completed in 0.6s |
| macos-latest | 2.5.1 | completed in 0.7s |
| Win11 dev box | 2.4.3 | **deadlock** |
| Win11 dev box | 2.5.1 | **deadlock** |

So it is environment-specific, not numpy-version-driven. On the dev box the wedge is inside numpy's bundled `libscipy_openblas64_*.dll`; `OPENBLAS_NUM_THREADS=1`, `OMP_NUM_THREADS=1` and `OPENBLAS_MAIN_FREE=1` make no difference.

Cost of adding chromadb anyway, measured cold on Windows: **122s, 82 packages, ~360MB**. `test-windows` currently runs 76s while the slowest job (`docker-build`) is 135s, so that would make this leg the new critical path and add roughly a minute of wall clock to every PR — in exchange for a guard that cannot fire.

The job comment now records that measurement, so the question does not get re-opened from first principles later. It also refreshes the stale sentence that still described F3 as deferred to the handoff matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)