### PR TITLE
fix(embed): content-based freshness — vision-only writes no longer silently unindexed

### DIFF
--- a/db.py
+++ b/db.py
@@ -252,6 +252,15 @@ def init_db():
             # explicitly, so the column default only labels legacy NULL-hash rows.
             ("hash_algo", "TEXT DEFAULT 'xxh3'"),
             ("hash_verified_at", "TEXT"),
+            # Vector-index content-freshness (fix: "向量索引靜默過期"). embed_hash =
+            # sha256 of the exact text embedded at last index (vectordb.content_hash,
+            # over build_doc_text: filename+transcript+frame descriptions/tags), so
+            # embed.py re-embeds a row whose DESCRIPTION changed even though its
+            # media_id is already in Chroma. embedded_at = ISO ts of that embed.
+            # NULL on legacy rows = "unverified" (never rendered as up-to-date), same
+            # spirit as the hash_verified_at label above.
+            ("embed_hash", "TEXT"),
+            ("embedded_at", "TEXT"),
             ("thumbnail_path", "TEXT"),
             ("rating", "TEXT"),
             ("rating_note", "TEXT"),
@@ -586,6 +595,23 @@ def repoint_media_path(media_id: int, new_abs_path: str, _conn=None) -> None:
 
     def _do(c):
         c.execute("UPDATE media SET path=? WHERE id=?", (new_stored, media_id))
+    if _conn is not None:
+        _do(_conn)
+    else:
+        with get_conn() as conn:
+            _do(conn)
+
+
+def set_embed_state(media_id: int, embed_hash: str, embedded_at: str, _conn=None) -> None:
+    """Record what was embedded for this media so embed.py can detect a STALE index
+    by CONTENT, not just by presence (fix: 向量索引靜默過期). Written only by the
+    embed path after a successful upsert — deliberately kept OUT of _ALLOWED_COLS so
+    a re-ingest/refresh can't clobber it (same discipline as in_point/canonical_tags)."""
+    def _do(c):
+        c.execute(
+            "UPDATE media SET embed_hash=?, embedded_at=? WHERE id=?",
+            (embed_hash, embedded_at, media_id),
+        )
     if _conn is not None:
         _do(_conn)
     else:

--- a/embed.py
+++ b/embed.py
@@ -11,10 +11,16 @@ Usage:
 from __future__ import annotations
 import argparse
 import sys
-from typing import Dict, List
+from datetime import datetime, timezone
+from typing import Dict, List, Tuple
 
 import db
 import vectordb as vdb
+
+
+def _now_iso() -> str:
+    """UTC ISO timestamp for media.embedded_at (matches processed_at style)."""
+    return datetime.now(timezone.utc).isoformat()
 
 
 # audit H12: after this many consecutive per-record failures, assume a systemic
@@ -63,6 +69,32 @@ def get_indexed_media_ids(col) -> set[str]:
     return {cid.split("_", 1)[0] for cid in ids}
 
 
+def get_content_signatures() -> Dict[str, Tuple[str, str]]:
+    """{str(media_id): (stored_embed_hash, current_content_hash)} for every media.
+
+    current_content_hash = vectordb.content_hash over the row's CURRENT source text
+    (build_doc_text). Comparing it to the stored media.embed_hash is how run_embed
+    detects a row whose description/transcript changed AFTER it was embedded — the
+    "向量索引靜默過期" bug — without depending on the caller passing force_ids.
+
+    Pulls ONLY the columns build_doc_text needs (filename, transcript, frame_tags) +
+    embed_hash — deliberately NOT the heavy words_json/segments_json (audit M25: don't
+    load the whole library's heavy columns just to diff freshness)."""
+    sigs: Dict[str, Tuple[str, str]] = {}
+    with db.get_conn() as conn:
+        rows = conn.execute(
+            "SELECT id, filename, transcript, frame_tags, embed_hash FROM media"
+        ).fetchall()
+    for r in rows:
+        rec = {
+            "filename": r["filename"],
+            "transcript": r["transcript"],
+            "frame_tags": r["frame_tags"],
+        }
+        sigs[str(r["id"])] = (r["embed_hash"], vdb.content_hash(rec))
+    return sigs
+
+
 def run_embed(rebuild: bool = False, force_ids=None, prune: bool = True) -> dict:
     """Embed pending records. Returns stats {"ok": n, "errors": n, "aborted": bool}
     so the CLI can map failures to exit codes (audit H12) without sys.exit()-ing
@@ -95,18 +127,54 @@ def run_embed(rebuild: bool = False, force_ids=None, prune: bool = True) -> dict
         if orphans:
             print(f"Pruned {len(orphans)} orphaned media id(s) from index.")
 
-    # Re-embed anything not yet indexed PLUS any caller-forced ids (e.g. records
-    # re-processed by `ingest --refresh`, which are already indexed but stale).
-    to_process_ids = [
-        mid for mid in all_ids
-        if str(mid) not in indexed_ids or str(mid) in force_ids
-    ]
+    # Freshness by CONTENT, not just presence (fix: 向量索引靜默過期). The old test
+    # "not indexed OR forced" skipped any already-indexed row whose description was
+    # written AFTER it was embedded (the only writer, `--vision-only`, never passed
+    # force_ids) → stale forever, silently. Now compare each row's current source-text
+    # hash to the one stamped at last embed (media.embed_hash via get_content_signatures).
+    signatures = {} if rebuild else get_content_signatures()
+    new_ids, stale_ids, unverified_ids, forced, unchanged = [], [], [], [], 0
+    to_process_ids: List = []
+    for mid in all_ids:
+        smid = str(mid)
+        if rebuild:
+            to_process_ids.append(mid)
+            continue
+        stored, current = signatures.get(smid, (None, None))
+        if smid not in indexed_ids:
+            new_ids.append(mid)                 # never embedded
+        elif smid in force_ids:
+            forced.append(mid)                  # caller forced (e.g. --refresh)
+        elif stored is None:
+            unverified_ids.append(mid)          # legacy row w/o embed_hash → can't verify → re-embed
+        elif stored != current:
+            stale_ids.append(mid)               # description/transcript changed after embed
+        else:
+            unchanged += 1                      # content-verified identical → skip
+            continue
+        to_process_ids.append(mid)
 
-    print(f"Total records: {len(all_ids)} | Already indexed: {len(indexed_ids)} | To process: {len(to_process_ids)}")
+    # ③ report so "0" that means "checked, nothing stale" is distinguishable from
+    # "0" that means "never looked". stale + unverified = staleness this run caught.
+    stale_detected = len(stale_ids) + len(unverified_ids)
+    print(
+        f"Total: {len(all_ids)} | indexed: {len(indexed_ids)} | new: {len(new_ids)} | "
+        f"stale: {len(stale_ids)} | unverified: {len(unverified_ids)} | forced: {len(forced)} | "
+        f"content-unchanged: {unchanged} → to embed: {len(to_process_ids)} "
+        f"(stale detected: {stale_detected})"
+    )
+    if unverified_ids:
+        print(f"⚠ {len(unverified_ids)} media without embed_hash (legacy/unverified) — "
+              f"freshness NOT confirmable, re-embedding to be safe (not treated as up-to-date).")
 
     if not to_process_ids:
-        print("Index is up to date.")
-        return {"ok": 0, "errors": 0, "aborted": False}
+        # Only claim up-to-date when we actually compared content this run.
+        if rebuild:
+            print("Nothing to embed.")
+        else:
+            print(f"Index is up to date (content-verified {unchanged}/{len(all_ids)}).")
+        return {"ok": 0, "errors": 0, "aborted": False,
+                "new": 0, "stale": 0, "unverified": 0, "forced": 0, "stale_detected": 0}
 
     # audit M25: full rows fetched only for the work set.
     to_process = get_records_by_ids(to_process_ids)
@@ -120,6 +188,14 @@ def run_embed(rebuild: bool = False, force_ids=None, prune: bool = True) -> dict
         print(f"[{i}/{len(to_process)}] {rec['filename']}", end="", flush=True)
         try:
             n = vdb.upsert_record(col, rec)
+            # Stamp what we just embedded so a later run can tell this row is fresh
+            # (content-verified) vs stale — the crux of the fix. Same text upsert
+            # indexed (build_doc_text). Best-effort: a failed stamp only costs a
+            # redundant re-embed next run, never a missed staleness.
+            try:
+                db.set_embed_state(rec["id"], vdb.content_hash(rec), _now_iso())
+            except Exception as se:
+                print(f" [warn: embed_hash stamp failed: {se}]", end="")
             total_chunks += n
             ok += 1
             consecutive = 0
@@ -146,7 +222,10 @@ def run_embed(rebuild: bool = False, force_ids=None, prune: bool = True) -> dict
     status = "Done." if not errors else f"Done with {errors} error(s) ({ok} ok)."
     print(f"\n{status} {total_chunks} total chunks in collection '{vdb.COLLECTION_NAME}'.")
     print(f"ChromaDB path: {vdb.CHROMA_PATH}")
-    return {"ok": ok, "errors": errors, "aborted": aborted}
+    return {"ok": ok, "errors": errors, "aborted": aborted,
+            "new": len(new_ids), "stale": len(stale_ids),
+            "unverified": len(unverified_ids), "forced": len(forced),
+            "stale_detected": stale_detected}
 
 
 def run_search(query: str):

--- a/ingest.py
+++ b/ingest.py
@@ -993,7 +993,7 @@ def _run_vision_only(args):
 
     if not rows:
         print("All frames already have vision descriptions. Nothing to do.")
-        return
+        return (False, set())
 
     # Group by media
     from collections import defaultdict
@@ -1012,6 +1012,7 @@ def _run_vision_only(args):
     ok, halted = 0, False
     total_failed, consecutive_failed = 0, 0
     failed_files = []  # (fname, failed_count, frame_count) for the end-of-run report
+    written_ids = set()  # media that got ≥1 non-empty description this run → re-embed (fix: 向量索引靜默過期)
     for vi, (mid, frames_list) in enumerate(media_frames.items(), 1):
         fname = frames_list[0]["filename"]
         frame_paths = [db.resolve_path(f["thumbnail_path"]) for f in frames_list]
@@ -1067,6 +1068,12 @@ def _run_vision_only(args):
                     (max(scores), mid),
                 )
 
+        # This media's embedded source text changed → mark for re-embed. ① of the
+        # 向量索引靜默過期 fix: vision-only is the writer, so it must hand the caller
+        # the ids to re-embed (embed's content-hash is the backstop for other paths).
+        if any((vr.get("description") or "").strip() for vr in frame_results):
+            written_ids.add(mid)
+
         v_elapsed = _time.time() - v_start
         n_failed = len(still_failed_idx)
         if n_failed:
@@ -1103,7 +1110,7 @@ def _run_vision_only(args):
     if not halted:
         suffix = f", {len(failed_files)} with skipped frames." if failed_files else "."
         print(f"\nVision-only done. {ok} file(s) fully patched{suffix}")
-    return halted
+    return (halted, written_ids)
 
 
 def _regenerate_proxies():
@@ -1684,7 +1691,19 @@ def main():
 
     # ── Vision-only mode: patch missing vision descriptions ──────────────
     if args.vision_only:
-        halted = _run_vision_only(args)
+        halted, written_ids = _run_vision_only(args)
+        # ① 向量索引靜默過期 fix: vision-only is the ONLY writer of descriptions, so it
+        # must re-embed what it wrote — previously it returned here (line ~2180's embed
+        # was unreachable), leaving the index frozen while descriptions kept changing.
+        # Re-embed even on halt: committed work must not stay unsearchable. force_ids is
+        # the explicit signal; embed's content-hash also catches it (belt + suspenders).
+        if written_ids and not getattr(args, "no_embed", False):
+            import embed
+            try:
+                embed.run_embed(force_ids=written_ids)
+            except Exception as e:
+                print(f"[embed] ⚠ vector index build failed: {e}")
+                print("[embed]   run manually: py -3.12 embed.py")
         if halted:
             sys.exit(1)  # halt mid-patch must not report success to cron/watch
         return

--- a/tests/test_embed_content_freshness.py
+++ b/tests/test_embed_content_freshness.py
@@ -1,0 +1,133 @@
+"""Regression tests for the "向量索引靜默過期" bug.
+
+An already-indexed media whose vision description / transcript changed AFTER it was
+embedded used to be skipped forever (embed.py only checked "media_id present in
+Chroma OR in force_ids"). vision-only — the sole writer of descriptions — never
+passed force_ids, so the whole G-corpus index froze on 07-22 while descriptions
+kept being written through 07-29, and semantic search silently missed them.
+
+These tests pin the fix: freshness is decided by CONTENT (media.embed_hash vs the
+current build_doc_text hash), and a legacy row with no hash is reported as
+"unverified" and re-embedded (never rendered up-to-date). Chroma/Ollama are mocked
+so the freshness DECISION is tested without a live embedding backend.
+"""
+import importlib
+import json
+
+import pytest
+
+import embed
+import vectordb as vdb
+
+
+@pytest.fixture
+def dbmod(tmp_db):
+    """tmp_db points config.DB_PATH at a temp file; init the schema (adds the new
+    embed_hash/embedded_at columns) and hand back the db module."""
+    d = importlib.import_module("db")
+    d.init_db()
+    return d
+
+
+def _add_media(d, mid, frame_tags_list, *, transcript=None, embed_hash=None):
+    """Insert a media row with a known frame_tags blob and (optionally) a stored
+    embed_hash, simulating "was embedded with this content"."""
+    ft = json.dumps(frame_tags_list, ensure_ascii=False)
+    with d.get_conn() as c:
+        c.execute(
+            "INSERT INTO media (id, path, filename, ext, transcript, frame_tags, embed_hash) "
+            "VALUES (?,?,?,?,?,?,?)",
+            (mid, f"media/{mid}.mp4", f"{mid}.mp4", ".mp4", transcript, ft, embed_hash),
+        )
+
+
+def _hash_of(mid, frame_tags_list, transcript=None):
+    rec = {"filename": f"{mid}.mp4", "transcript": transcript,
+           "frame_tags": json.dumps(frame_tags_list, ensure_ascii=False)}
+    return vdb.content_hash(rec)
+
+
+@pytest.fixture
+def mock_backend(monkeypatch):
+    """Mock the Chroma/Ollama boundary; record which media ids get (re)embedded.
+    `indexed` is the set of media_ids Chroma already holds (as strings)."""
+    state = {"processed": [], "indexed": set()}
+
+    monkeypatch.setattr(embed.vdb, "get_collection", lambda reset=False: object())
+    monkeypatch.setattr(embed, "get_indexed_media_ids", lambda col: set(state["indexed"]))
+    monkeypatch.setattr(embed.vdb, "delete_media", lambda col, mid: None)
+
+    def fake_upsert(col, rec):
+        state["processed"].append(rec["id"])   # no Ollama call — just record
+        state["indexed"].add(str(rec["id"]))
+        return 1
+    monkeypatch.setattr(embed.vdb, "upsert_record", fake_upsert)
+    return state
+
+
+# ── AC-5: description change on an already-indexed row is detected + re-embedded ──
+def test_content_change_detected_as_stale(dbmod, mock_backend):
+    old = [{"description": "a man holding a cable", "tags": ["cable"]}]
+    _add_media(dbmod, 1, old, embed_hash=_hash_of(1, old))
+    mock_backend["indexed"] = {"1"}                     # already in Chroma, hash matches
+
+    # vision rewrites the frame description (what vision-only does)
+    new = [{"description": "a Furutech FP-209 spade, macro", "tags": ["spade", "furutech"]}]
+    with dbmod.get_conn() as c:
+        c.execute("UPDATE media SET frame_tags=? WHERE id=1",
+                  (json.dumps(new, ensure_ascii=False),))
+
+    res = embed.run_embed()
+    assert mock_backend["processed"] == [1]             # re-embedded exactly the changed row
+    assert res["stale"] == 1 and res["stale_detected"] == 1
+    # and the stamp is refreshed so it won't re-embed next time
+    with dbmod.get_conn() as c:
+        assert c.execute("SELECT embed_hash FROM media WHERE id=1").fetchone()[0] == _hash_of(1, new)
+
+
+# ── AC-3: unchanged content is content-verified and skipped (not a full re-embed) ──
+def test_unchanged_content_skipped(dbmod, mock_backend):
+    ft = [{"description": "a drone shot over a valley", "tags": ["drone"]}]
+    _add_media(dbmod, 1, ft, embed_hash=_hash_of(1, ft))
+    mock_backend["indexed"] = {"1"}
+
+    res = embed.run_embed()
+    assert mock_backend["processed"] == []              # nothing re-embedded
+    assert res["stale"] == 0 and res["new"] == 0 and res["stale_detected"] == 0
+
+
+# ── ③: legacy row with no embed_hash is "unverified" and re-embedded, not up-to-date ──
+def test_legacy_unverified_reembedded(dbmod, mock_backend):
+    ft = [{"description": "kitchen b-roll", "tags": ["kitchen"]}]
+    _add_media(dbmod, 1, ft, embed_hash=None)           # legacy: indexed but never hashed
+    mock_backend["indexed"] = {"1"}
+
+    res = embed.run_embed()
+    assert mock_backend["processed"] == [1]
+    assert res["unverified"] == 1 and res["stale_detected"] == 1
+    # after re-embed it becomes verified → next run skips it
+    res2 = embed.run_embed()
+    assert mock_backend["processed"] == [1]             # unchanged from the first run
+    assert res2["unverified"] == 0 and res2["stale"] == 0
+
+
+# ── never-indexed row is "new" (baseline: existence check still works) ──
+def test_new_media_embedded(dbmod, mock_backend):
+    ft = [{"description": "sunset timelapse", "tags": ["sunset"]}]
+    _add_media(dbmod, 1, ft, embed_hash=None)
+    mock_backend["indexed"] = set()                     # not in Chroma yet
+
+    res = embed.run_embed()
+    assert mock_backend["processed"] == [1]
+    assert res["new"] == 1 and res["stale"] == 0 and res["unverified"] == 0
+
+
+# ── force_ids (── --refresh path) still forces a re-embed of an unchanged, indexed row ──
+def test_force_ids_still_honored(dbmod, mock_backend):
+    ft = [{"description": "unchanged", "tags": ["x"]}]
+    _add_media(dbmod, 1, ft, embed_hash=_hash_of(1, ft))
+    mock_backend["indexed"] = {"1"}
+
+    res = embed.run_embed(force_ids={1})
+    assert mock_backend["processed"] == [1]
+    assert res["forced"] == 1

--- a/tests/test_vision_tolerance.py
+++ b/tests/test_vision_tolerance.py
@@ -141,15 +141,17 @@ def _desc_count(db, mid):
 def test_default_halts_on_persistent_failure(vision_db):
     ing, db, make = vision_db
     mid = make(["ok_0.jpg", "PFAIL_1.jpg", "ok_2.jpg"])
-    halted = ing._run_vision_only(_args())          # default zero-tolerance
+    halted, _ = ing._run_vision_only(_args())       # default zero-tolerance
     assert halted is True
 
 
 def test_skip_failed_completes_and_leaves_failures_empty(vision_db):
     ing, db, make = vision_db
     mid = make(["ok_0.jpg", "PFAIL_1.jpg", "ok_2.jpg", "PFAIL_3.jpg"])
-    halted = ing._run_vision_only(_args(skip_failed=True))
+    halted, written_ids = ing._run_vision_only(_args(skip_failed=True))
     assert halted is False                          # never halts on frame failures
+    # ① fix: the media that got real descriptions is handed back for re-embed.
+    assert mid in written_ids
     done, empty = _desc_count(db, mid)
     assert done == 2                                # the two ok frames described
     assert empty == 2                               # the two PFAIL frames left empty → resumable
@@ -172,5 +174,5 @@ def test_max_failures_tolerates_then_halts(vision_db):
     ing, db, make = vision_db
     # 3 persistent failures across one file; max_failures=2 → exceeded → halt.
     mid = make(["PFAIL_0.jpg", "PFAIL_1.jpg", "PFAIL_2.jpg"])
-    halted = ing._run_vision_only(_args(max_failures=2))
+    halted, _ = ing._run_vision_only(_args(max_failures=2))
     assert halted is True

--- a/vectordb.py
+++ b/vectordb.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 """
 Vector DB module — ChromaDB + Ollama bge-m3 (multilingual, default)
 """
+import hashlib
 import json
 import logging
 import os
@@ -293,6 +294,16 @@ def build_doc_text(record: dict) -> str:
             if chunks:
                 parts.append(" ".join(chunks))
     return " ".join(parts)
+
+
+def content_hash(record: dict) -> str:
+    """sha256 of the exact source text embed would index for this record — i.e.
+    build_doc_text(record), which folds in filename + transcript + every frame
+    description/tags. Stored on media.embed_hash after a successful embed so
+    embed.py can tell a row whose DESCRIPTION changed (stale) from one that's
+    genuinely unchanged (skip), instead of only checking whether the media_id
+    exists in Chroma (fix: 向量索引靜默過期)."""
+    return hashlib.sha256(build_doc_text(record).encode("utf-8")).hexdigest()
 
 
 def delete_media(col, media_id) -> None:


### PR DESCRIPTION
## Problem
G-corpus vector index froze on 07-22 while vision descriptions were written through 07-29 → semantic search silently missed ~1/3 of visual content, no error. Root cause (verified on real data): (1) `--vision-only` returns before ingest's end-of-run embed, and the overnight scheduler runs exactly `--vision-only`; (2) `embed.py` freshness only checked presence/force_ids, never content, so a re-described row stayed stale forever.

## Fix (defense-in-depth)
- **① vision-only → re-embed** (`ingest.py`): `_run_vision_only` returns `(halted, written_ids)`; caller runs `embed.run_embed(force_ids=written_ids)` (unless `--no-embed`), even on halt.
- **② content-based freshness** (`embed.py` + `vectordb.content_hash` + `db.py` schema): new `media.embed_hash` = sha256 of `build_doc_text` at last embed, compared to current → re-embed changed rows regardless of force_ids. `embedded_at` stamped. Legacy rows (no hash) = "unverified" → re-embedded, never rendered up-to-date.
- **③ observability**: `run_embed` reports new/stale/unverified/forced/unchanged so "0=checked" ≠ "0=never looked".

## Acceptance (real测試 output)
- **AC-1**: on a copy of the real G corpus — OLD existence-only `To process: 0` vs NEW content-based `stale detected: 1506`.
- **AC-2**: cleared one frame's description → `ingest.py --vision-only` → chunk `1_f0` seq_id 1→1534, created_at `2026-07-20`→`2026-07-30`, document → new qwen3-vl text (chroma-verified, not log).
- **AC-3**: after hashes stamped, unchanged content → 0 re-embed (idempotent; the AC-2 run re-embedded 1/1506, 1505 skipped).
- **AC-4**: existing suite green locally (81 targeted); `--refresh`/`--no-embed`/`--rebuild` semantics unchanged.
- **AC-5**: new `tests/test_embed_content_freshness.py` pins content-change→re-embed (the core regression).

Red lines honored: no `--refresh`, no full-ingest re-run, real corpus untouched (all verification on a temp copy).