### PR TITLE
fix(deps): cap mcp<2 — 2.0.0 dropped mcp.server.fastmcp, breaking CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
             "pillow>=9.0" "requests>=2.28" "xxhash>=2.0.0" "nanoid>=2.0.0" \
             "psutil>=5.9" "whisper-guard>=0.3" numpy mlx-whisper \
             "opencc; python_version >= '3.10'" \
-            "mcp>=1.2; python_version >= '3.10'"
+            "mcp>=1.2,<2; python_version >= '3.10'"
 
       - name: Run tests
         run: pytest -q
@@ -120,7 +120,7 @@ jobs:
           pip install \
             "fastapi>=0.100.0" "uvicorn>=0.20.0" "pydantic>=2.0,<3" \
             "pillow>=9.0" "requests>=2.28" "xxhash>=2.0.0" "nanoid>=2.0.0" \
-            "psutil>=5.9" "whisper-guard>=0.3" numpy mcp
+            "psutil>=5.9" "whisper-guard>=0.3" numpy "mcp<2"
       - name: Run Windows correctness tests (offload deny-policy + MCP stdio)
         shell: bash
         run: pytest tests/test_hardening_round4.py tests/test_mcp_e2e.py -q
@@ -151,7 +151,7 @@ jobs:
             "fastapi>=0.100.0" "uvicorn>=0.20.0" "pydantic>=2.0,<3" \
             "pillow>=9.0" "requests>=2.28" "xxhash>=2.0.0" "nanoid>=2.0.0" \
             "psutil>=5.9" "whisper-guard>=0.3" numpy mlx-whisper \
-            "opencc; python_version >= '3.10'" "mcp>=1.2"
+            "opencc; python_version >= '3.10'" "mcp>=1.2,<2"
       - name: Coverage
         run: pytest -q -m "not subprocess_stdio" --cov=. --cov-config=pyproject.toml --cov-report=term:skip-covered --cov-fail-under=55
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,12 @@ mlx-whisper>=0.4;platform_system=="Darwin"
 # arkiv's search/metadata to MCP clients (Claude, OpenClaw). The HTTP API and
 # CLI work without it. Gated on Python 3.10+ — the MCP SDK requires it, and arkiv
 # still supports 3.9 (NAS), where an unconditional entry would break pip install.
-mcp>=1.2; python_version >= "3.10"
+# Capped <2: mcp 2.0.0 (2026-07-28) restructured the SDK and dropped the
+# `mcp.server.fastmcp` import path mcp_server.py uses, so a fresh `mcp>=1.2` install
+# now pulls 2.0.0 → `ModuleNotFoundError: mcp.server.fastmcp` → test_mcp_server
+# collection error → CI red on every PR. Stay on the 1.x line (has fastmcp) until
+# mcp_server.py is ported to the 2.x API.
+mcp>=1.2,<2; python_version >= "3.10"
 
 # ── Shared pgvector backend (向量庫整併) — install manually if needed ──────
 # Only needed when ARKIV_VECTOR_BACKEND=pg (route vectors to the shared NAS


### PR DESCRIPTION
## Problem
`mcp` 2.0.0 (2026-07-28) restructured the SDK and removed the `mcp.server.fastmcp` import path `mcp_server.py:28` uses. `requirements.txt` had unpinned `mcp>=1.2`, so fresh installs now resolve to 2.0.0 → `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` at `test_mcp_server` collection → pytest exit 2 → **test(3.12)/test-windows/coverage red on every PR** (3.9 unaffected — mcp gated out). main last went green 07-28 09:48, before 2.0.0 (13:45).

## Fix
Cap `mcp>=1.2,<2` (1.x still ships fastmcp) until `mcp_server.py` is ported to the 2.x API. Unblocks CI repo-wide.

Not opinionated on the 2.x port — that's a separate follow-up.