### PR TITLE
docs(readme): 對外化第一屏 + 公益方案（PR-1 半小時版）

### DIFF
--- a/PUBLIC-INTEREST.md
+++ b/PUBLIC-INTEREST.md
@@ -1,0 +1,95 @@
+# arkiv 公益方案 / Public-Interest Program
+
+> 繁體中文在上、English below.
+
+---
+
+## 這是什麼
+
+arkiv 軟體本身非商業用途免費，用它產出的成品（影片、時間軸、匯出檔）永遠可商用。
+
+但依 [PolyForm Noncommercial 授權](LICENSE)，當你對 **arkiv 軟體本身的使用** 帶有商業性質時（例如你的專案有政府補助、院線／平台發行、或機構營收），嚴格說會落入「商業使用」，需要另談商業授權。
+
+**公益方案**就是為這種情況設的：只要你做的是有公共價值的影像工作，這份商業授權我們**免費提供**。
+
+素材的知識層——「拍過的東西找得回來、可重複使用」——不該只有大製作用得起。
+
+## 誰適合申請（例示，非窮舉）
+
+- **公共議題紀錄片**：環境、勞動、人權、公共衛生、文化保存等題材。
+- **非營利／公益團體的影像**：NGO、社福、教育、公共倡議組織自製或委製的影片。
+- **地方記憶與檔案保存**：口述歷史、地方誌、消失中的產業與聚落、社區影像資料庫。
+- **公共教育與公共媒體**：學校、圖書館、博物館、公共電視性質的內容。
+
+> 這是**起點清單**，不是資格表。沒列到但你覺得有公共價值的，一樣歡迎來談——逐案人工審。
+
+## 什麼不在這個方案裡
+
+- 純商業廣告、品牌行銷、企業形象片（走一般商業授權）。
+- 把 arkiv（或其 fork）當產品／服務**販售、架站、重新包裝**——這在任何情況都不允許，授權正文已明訂。
+- 「有社會意義」的空泛主張但實質是商業專案——我們保留逐案判斷、婉拒的權利。
+
+## 怎麼申請
+
+1. 開一個 [GitHub Issue](https://github.com/vulture-s/arkiv/issues)，標題加上 `[public-interest]`；或 IG 私訊 [@vulture.s](https://www.instagram.com/vulture.s/)。
+2. 簡述你的專案：**做什麼、給誰看、由誰製作、有無商業成分**。不用寫長，三五句講清楚即可。
+3. 我們逐案人工看，通常幾天內回覆。
+
+### 申請範例
+
+> 主旨：`[public-interest] 濁水溪出海口濕地紀錄片`
+>
+> 我們是三人獨立團隊，正在拍一部關於濁水溪出海口濕地與周邊漁村的紀錄片，預計投國內外影展、之後在公共電視與線上平台免費播出。有一筆國藝會補助。素材約 200 小時、大量無對白空景，想用 arkiv 建語義索引來管理與檢索。因為帶補助與發行，想循公益方案申請商業授權。
+
+## 逐案裁量聲明
+
+公益方案是我們在授權正文之上、**自願提供**的政策，走 README / policy 層，不是授權正文的法律義務。我們**逐案人工審**，保留核准或婉拒的裁量權，也保留隨時調整方案內容的權利。核准後若專案性質有重大改變（例如轉為純商業發行），請再來談。
+
+這樣設計是刻意的：不做自動資格表，是為了避免「人人都能自稱有社會價值」而讓方案失去意義。我們寧可一封一封讀。
+
+---
+
+# Public-Interest Program (English)
+
+## What this is
+
+arkiv itself is free for noncommercial use, and whatever you produce with it (videos, timelines, exports) is always yours to use commercially.
+
+But under the [PolyForm Noncommercial license](LICENSE), when your **use of arkiv itself** is commercial in nature (e.g. your project has government grants, theatrical / platform distribution, or institutional revenue), that strictly counts as "commercial use" and would need a separate commercial license.
+
+The **Public-Interest Program** exists for exactly that case: if the work you're doing serves the public interest, we grant that commercial license **for free**.
+
+The knowledge layer over footage — being able to find and reuse what you already shot — shouldn't be something only big productions can afford.
+
+## Who can apply (examples, not exhaustive)
+
+- **Public-issue documentaries**: environment, labor, human rights, public health, cultural preservation, and the like.
+- **Nonprofit / public-good visual work**: films made by or for NGOs, social-service, educational, or public-advocacy organizations.
+- **Local memory and archival preservation**: oral history, local history, vanishing industries and communities, community media archives.
+- **Public education and public media**: content for schools, libraries, museums, and public-broadcasting-style outlets.
+
+> This is a **starting list, not a checklist**. If your work isn't listed but you believe it serves the public interest, reach out anyway — every request is reviewed by a human.
+
+## What this program does *not* cover
+
+- Pure commercial advertising, brand marketing, or corporate promos (use a standard commercial license).
+- Selling, hosting, or repackaging arkiv (or a fork) as a product or service — never permitted, per the license text itself.
+- Vague "social value" claims over what is really a commercial project — we reserve the right to review case by case and decline.
+
+## How to apply
+
+1. Open a [GitHub Issue](https://github.com/vulture-s/arkiv/issues) with `[public-interest]` in the title, or DM [@vulture.s](https://www.instagram.com/vulture.s/) on Instagram.
+2. Briefly describe your project: **what it is, who it's for, who's making it, and whether it has commercial elements.** A few sentences is enough.
+3. We review each request by hand, usually within a few days.
+
+### Sample request
+
+> Subject: `[public-interest] Wetland documentary at the Zhuoshui River estuary`
+>
+> We're a three-person independent team making a documentary about the wetlands and fishing villages at the Zhuoshui River estuary. We plan to submit to festivals and then stream it free on public TV and online. We have one national arts-council grant. About 200 hours of footage, much of it dialogue-free scenery — we'd like to use arkiv to build a semantic index for managing and retrieving it. Because there's a grant and distribution involved, we're applying for a commercial license through the public-interest program.
+
+## Case-by-case discretion
+
+The public-interest program is a policy we offer **voluntarily** on top of the license text — it lives at the README / policy level and is not a legal obligation of the license itself. We review **every request by hand**, reserve discretion to approve or decline, and may adjust the program over time. If a project's nature changes substantially after approval (e.g. it becomes a purely commercial release), please come talk to us again.
+
+This is deliberate: we don't publish an automatic eligibility checklist, because a checklist invites everyone to self-declare "social value" and hollows the program out. We'd rather read requests one at a time.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,24 @@ Designed for solo DITs and small crews who own their data: local-first, self-hos
 
 ---
 
-## Architecture
+## Why arkiv
+
+- **Too much footage, can't find the shot** → search in plain language ("all dusk establishing shots from May"), in Chinese / Japanese / English — it searches what's *in* the frame and the transcript, not filenames.
+- **AI editing tools only understand footage with someone talking** → arkiv runs vision analysis + transcription on every clip, so B-roll and dialogue-free footage stay searchable and manageable.
+- **Your library has to feed any downstream edit** → manual, automated, or script-driven: native Resolve plugin, EDL / FCPXML export, API / MCP interface.
+
+> **License in one line:** arkiv itself is free for any noncommercial use (source-available); the videos, timelines and exports you make with it are **100% yours to use commercially**.
+>
+> **Proven at scale:** fully indexed a **1,506-clip real production library** (1,161 of them dialogue-free B-roll) on a single RTX 4070.
+
+## Screenshots
+
+![ARKIV UI](screenshot.jpg)
+
+<details>
+<summary>System architecture & data flow (for contributors / fork authors)</summary>
+
+### Architecture
 
 ```
 ┌─────────────┐    ┌──────────────┐    ┌─────────────┐
@@ -45,11 +62,9 @@ Designed for solo DITs and small crews who own their data: local-first, self-hos
   └─────────┘  └──────────────┘
 ```
 
-→ **Full pipeline (4 stages, storage layout, exit codes, maintenance modes)**: [docs/pipeline.md](docs/pipeline.md)
+→ **Full pipeline (4 stages, storage layout, exit codes, maintenance modes)**: [docs/pipeline.md](docs/pipeline.md) · architecture overview [ARCHITECTURE.md](ARCHITECTURE.md)
 
-## Screenshots
-
-![ARKIV UI](screenshot.jpg)
+</details>
 
 ## Features
 
@@ -410,7 +425,6 @@ SKIP items are **optional dependencies** — they do not affect functionality. A
 
 | Platform | Health Check | Smoke Test | Date |
 |----------|-------------|------------|------|
-| macOS M2 Max | TBD | TBD | 2026-05-22 |
 | Windows 11 (RTX 4070) | 19/19 PASS, 0 FAIL, 0 SKIP | 9/9 PASS | 2026-05-22 |
 | Linux (Docker) | 14/17 PASS, 0 FAIL, 3 SKIP | 9/9 PASS | 2026-05-22 |
 
@@ -419,3 +433,24 @@ SKIP items are **optional dependencies** — they do not affect functionality. A
 PolyForm Noncommercial License 1.0.0, with a Commercial Output Exception — see [LICENSE](LICENSE).
 
 Videos, timelines and exports you produce with arkiv are yours and may be used commercially. Using arkiv itself is free for any noncommercial purpose; selling, hosting, or repackaging arkiv (or a fork) as a commercial product or service is not permitted.
+
+## Public-Interest Program
+
+arkiv is free for noncommercial use, and what you make with it is always yours to use commercially (see the license above). On top of that, we want to go one step further.
+
+If your project has commercial elements (government grants, theatrical / platform distribution, institutional revenue), strictly speaking your use of arkiv *itself* becomes "commercial use" and would need a separate commercial license — but **if the work you're doing serves the public interest, we grant that license for free**:
+
+- Public-issue documentaries
+- Nonprofit / public-good visual work
+- Local memory, oral history, and archival preservation
+- Public education and public media
+
+The knowledge layer over footage shouldn't be something only big productions can afford.
+
+**How to apply:** open a [GitHub Issue](https://github.com/vulture-s/arkiv/issues) with `[public-interest]` in the title, or DM [@vulture.s](https://www.instagram.com/vulture.s/) on Instagram, with a short description of your project. Reviewed case by case — no automatic eligibility checklist. See [PUBLIC-INTEREST.md](PUBLIC-INTEREST.md) for examples, a sample request, and the case-by-case discretion statement.
+
+## Contact & Follow
+
+- Dev log and demos: Threads / Instagram [@vulture.s](https://www.instagram.com/vulture.s/)
+- Bug reports and feature requests: [GitHub Issues](https://github.com/vulture-s/arkiv/issues)
+- Commercial partnership / deployment help: DM on IG, or open an Issue with `[biz]` in the title

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -14,7 +14,24 @@ arkiv 介於素材硬碟與 DaVinci Resolve 之間：自動 ingest footage、附
 
 ---
 
-## 架構
+## 為什麼需要 arkiv
+
+- **素材太多，找不到那顆鏡頭** → 用自然語言搜（「五月所有黃昏空景」），中日英都行，搜的是畫面內容和逐字稿，不是檔名。
+- **AI 剪輯工具只看得懂「有人在講話」的素材** → arkiv 對每支 clip 做視覺分析 + 轉錄，大量 B-roll、無語音空景一樣可搜可管。
+- **素材庫要能餵給下游任何剪法** → 手動剪、自動剪、腳本剪都接得上：Resolve 原生 plugin、EDL / FCPXML 匯出、API / MCP 介面。
+
+> **授權一句話**：arkiv 軟體本身非商業用途免費（source-available），**用它產出的影片、時間軸、匯出檔 100% 可商用**。
+>
+> **實戰驗證**：已在 **1,506 支真實產品拍攝素材**（其中 1,161 支無對白 B-roll）、單張 RTX 4070 上完整索引跑通。
+
+## 截圖
+
+![ARKIV UI](screenshot.jpg)
+
+<details>
+<summary>系統架構與資料流（給 contributor / fork 作者）</summary>
+
+### 架構
 
 ```
 ┌─────────────┐    ┌──────────────┐    ┌─────────────┐
@@ -45,11 +62,9 @@ arkiv 介於素材硬碟與 DaVinci Resolve 之間：自動 ingest footage、附
   └─────────┘  └──────────────┘
 ```
 
-→ **完整 pipeline（4 階段、儲存路徑、exit code、maintenance modes）**：[docs/pipeline.zh-TW.md](docs/pipeline.zh-TW.md)
+→ **完整 pipeline（4 階段、儲存路徑、exit code、maintenance modes）**：[docs/pipeline.zh-TW.md](docs/pipeline.zh-TW.md) · 架構總覽 [ARCHITECTURE.md](ARCHITECTURE.md)
 
-## 截圖
-
-![ARKIV UI](screenshot.jpg)
+</details>
 
 ## 功能特色
 
@@ -149,6 +164,23 @@ curl -X POST http://localhost:8501/api/chat -H "Authorization: Bearer $ARKIV_TOK
 用 `GET /api/chat/history/{conversation_id}` 讀回歷史、`GET /api/chat/conversations` 列出對話（都需要 `chat_read`）。
 
 ## 快速開始
+
+### 下載應用程式（macOS, Apple Silicon）
+
+不想碰 Python 環境的最快路徑。`.dmg` 已打包 Python 後端與 ML 套件（torch、mlx-whisper、chromadb…），可略過下面的 venv/pip。但你**仍需 FFmpeg 與 Ollama**（負責抽幀、嵌入、視覺）：
+
+```bash
+brew install ffmpeg ollama
+ollama pull bge-m3 && ollama pull qwen3-vl:8b && ollama pull qwen2.5:14b
+```
+
+到 [最新 release](https://github.com/vulture-s/arkiv/releases/latest) 下載 **`arkiv_<version>_aarch64.dmg`**，打開後把 **arkiv** 拖進「應用程式」。首次啟動因未簽名會被 macOS Gatekeeper 擋 —— **右鍵 → 打開** 一次即可（或執行 `xattr -dr com.apple.quarantine /Applications/arkiv.app`），之後正常開啟。
+
+> Intel Mac / Windows 目前沒有預建 app（bundle 內是 aarch64 Python + mlx-whisper）。請改用下面的原始碼安裝。
+
+---
+
+以下皆為**從原始碼**安裝與執行 —— 開發用，或跑在 Linux / Windows。
 
 ### 前置需求
 
@@ -389,7 +421,6 @@ SKIP 項目是**選用的相依套件** — 不影響功能。通過的結果是
 
 | 平台 | 環境健檢 | 冒煙測試 | 日期 |
 |------|----------|----------|------|
-| macOS M2 Max | TBD | TBD | 2026-05-22 |
 | Windows 11 (RTX 4070) | 19/19 PASS, 0 FAIL, 0 SKIP | 9/9 PASS | 2026-05-22 |
 | Linux (Docker) | 14/17 PASS, 0 FAIL, 3 SKIP | 9/9 PASS | 2026-05-22 |
 
@@ -398,3 +429,24 @@ SKIP 項目是**選用的相依套件** — 不影響功能。通過的結果是
 PolyForm Noncommercial License 1.0.0，附 Commercial Output Exception — 見 [LICENSE](LICENSE)。
 
 你用 arkiv 剪出的影片、時間軸、匯出檔都是你的，可商用；arkiv 軟體本身任何非商業用途皆免費，但**不得**把 arkiv（或其 fork）當商業產品/服務販售、架站或重新包裝。
+
+## 公益方案
+
+arkiv 軟體非商業用途免費，用它產出的成品永遠可商用（見上方授權段）。在這之上，我們想再往前一步。
+
+如果你的專案帶有商業成分（政府補助、院線／平台發行、機構營收），對 arkiv 軟體本身的使用嚴格說會落入「商業使用」、需要另談商業授權 —— 但**只要你做的是有公共價值的影像工作**，這份商業授權我們**免費提供**：
+
+- 公共議題紀錄片
+- 非營利／公益團體的影像
+- 地方記憶、口述歷史、檔案保存
+- 公共教育與公共媒體
+
+素材的知識層，不該只有大製作用得起。
+
+**申請方式**：開一個 [GitHub Issue](https://github.com/vulture-s/arkiv/issues) 標題加上 `[public-interest]`，或 IG 私訊 [@vulture.s](https://www.instagram.com/vulture.s/)，簡述你的專案。逐案人工審，不做自動資格表。資格例示、申請範例與逐案裁量說明見 [PUBLIC-INTEREST.md](PUBLIC-INTEREST.md)。
+
+## 聯絡與追蹤
+
+- 開發實錄與 demo：Threads / Instagram [@vulture.s](https://www.instagram.com/vulture.s/)
+- 問題回報與功能許願：[GitHub Issues](https://github.com/vulture-s/arkiv/issues)
+- 商業合作／導入諮詢：IG 私訊，或開 Issue 標題加 `[biz]`


### PR DESCRIPTION
## 為什麼

Threads 討論串已公開貼出 repo 連結，導流受眾＝剪輯師 / DIT / 製作決策者（**非開發者**）。README 現在就是 landing page，但第一屏是 ASCII 架構圖 + `.py` → 剪輯師 3 秒關掉。這支是「半小時版」：把第一屏從 dev-first 翻成 user-first，並接住這波流量。**不刪任何技術內容**（架構圖收 `<details>`，留 `ARCHITECTURE.md` 連結）。

## 改了什麼（EN / zh-TW 逐段對齊）

1. **「為什麼需要 arkiv / Why arkiv」30 秒看懂段** — 三痛點→解法 + 授權一句 + **壓測證據**：1,506 支真實產品拍攝庫（1,161 支無對白 B-roll）、單張 RTX 4070 完整索引。
2. **截圖上移**到架構之前；架構 ASCII 收進 `<details>`（第一屏不再是開發者視角）。
3. **zh-TW 補「下載應用程式（macOS）」段** — 對齊 EN（原本中文受眾看不到最低門檻入口）。
4. **公益方案 / Public-Interest Program**（新增）— 綁 PolyForm-NC 既有商業授權線：做公共價值影像工作（公共議題紀錄片 / 非營利 / 地方記憶檔案保存 / 公共教育），即使帶商業成分（補助 / 發行 / 機構營收），商業授權免費提供；逐案人工審。
5. **聯絡與追蹤 / Contact**（新增）— Threads/IG @vulture.s + Issues。
6. **移除 smoke-test `TBD` 行**（macOS M2 Max，觀感未完成）。
7. **新增 `PUBLIC-INTEREST.md`**（雙語：資格例示、申請範例、逐案裁量聲明）。

## 為何開 draft — 需要 Hevin 過目

- **公益方案措辭**：把「帶商業成分的公共價值專案」框成「需商業授權但免費提供」，這是決定 C 的框架，但公開頁的法律語感想請你先看過。
- **`PUBLIC-INTEREST.md` 資格例示**：目前是起點清單（4 類），你若要增刪或改語氣，這是最終定案點。
- IG 連結用 `@vulture.s`；repo About 欄的 IG 連結要你在 settings 補（我沒權限）。

## 範圍外（PR-2 follow-up）

功能牆重組、API 段移 docs、Resolve 段獨立、EN/zh-TW 既有 model-name 漂移（EN `qwen2.5vl:7b` vs zh `qwen3-vl:8b`）與 v0.3.x 版本號過期——都留給完整版，避免這支 PR 過大。

## 驗證

- [ ] GitHub 手機版渲染（`<details>` 收合正常）
- [ ] EN / zh-TW 逐段對齊（heading 行號對稱：Why→Screenshots→details→Features）
- [ ] 連結可點（Releases / Issues / IG / ARCHITECTURE.md / PUBLIC-INTEREST.md）
- 純 docs、無 code

🤖 Generated with [Claude Code](https://claude.com/claude-code)