### PR TITLE
fix(vision): 繁化 frame 描述 + 截斷 JSON 判失敗（G 壓測審計 Fix 1+3）

### DIFF
--- a/db.py
+++ b/db.py
@@ -821,6 +821,61 @@ def iter_zh_transcript_archive(_conn=None):
         return [dict(r) for r in conn.execute(sql).fetchall()]
 
 
+# ── Vision-description backfill (retraditionalize frames.description +
+# media.frame_tags — the vision write-path historically never routed through
+# zh_convert, so qwen3-vl's Simplified output was stored raw). No lang column on
+# frames; the caller gates each description with classify_zh (language-agnostic:
+# non-zh text classifies "traditional" and is skipped). ─────
+
+def iter_frames_with_description(_conn=None):
+    """All frame rows carrying a non-empty description, for the vision retraditionalize
+    backfill. Returns id/media_id/description. Pass _conn to read inside the caller's
+    transaction."""
+    sql = ("SELECT id, media_id, description FROM frames "
+           "WHERE description IS NOT NULL AND description != ''")
+    if _conn is not None:
+        return [dict(r) for r in _conn.execute(sql).fetchall()]
+    with get_conn() as conn:
+        return [dict(r) for r in conn.execute(sql).fetchall()]
+
+
+def update_frame_description(frame_id, description, _conn=None):
+    """Overwrite ONLY a frame's description (vision retraditionalize backfill). Tags /
+    quality fields are untouched. Pass _conn to join an open transaction."""
+    sql = "UPDATE frames SET description=? WHERE id=?"
+    params = (description, frame_id)
+    if _conn is not None:
+        _conn.execute(sql, params)
+    else:
+        with get_conn() as conn:
+            conn.execute(sql, params)
+
+
+def iter_frame_tags_media(_conn=None):
+    """All media rows carrying a non-empty frame_tags blob (the per-clip JSON rollup of
+    frame descriptions/tags that the embed doc reads), for the vision backfill. Returns
+    id/frame_tags."""
+    sql = ("SELECT id, frame_tags FROM media "
+           "WHERE frame_tags IS NOT NULL AND frame_tags != ''")
+    if _conn is not None:
+        return [dict(r) for r in _conn.execute(sql).fetchall()]
+    with get_conn() as conn:
+        return [dict(r) for r in conn.execute(sql).fetchall()]
+
+
+def update_media_frame_tags(media_id, frame_tags_json, _conn=None):
+    """Overwrite ONLY a media row's frame_tags JSON blob (vision retraditionalize
+    backfill; the caller passes an already-converted, re-serialized blob). Pass _conn to
+    join an open transaction."""
+    sql = "UPDATE media SET frame_tags=? WHERE id=?"
+    params = (frame_tags_json, media_id)
+    if _conn is not None:
+        _conn.execute(sql, params)
+    else:
+        with get_conn() as conn:
+            conn.execute(sql, params)
+
+
 def set_canonical_tags(media_id: int, tags: list) -> None:
     """Store the LLM-canonicalized tag list (JSON) for a media. Separate from the
     raw vision tags — never touches frame_tags / the tags table."""

--- a/retraditionalize.py
+++ b/retraditionalize.py
@@ -1,10 +1,15 @@
 """Phase 9.8b BACKFILL — retro-convert existing Simplified zh transcripts to Taiwan
 Traditional so the pre-9.8b NAS 5yr+ backlog stops missing a 記憶體 query on a
 內存-indexed clip. The 9.8b write-path (transcribe.py → zh_convert) only converts NEW
-transcribes; every row transcribed before it stayed Simplified.
+transcribes; every row transcribed before it stayed Simplified. It ALSO converts
+vision text — frames.description and the media.frame_tags rollup — which the vision
+write-path (vision.py) historically never routed through zh_convert at all, so
+qwen3-vl's Simplified descriptions were stored raw (audit 2026-07-30: 175 frames /
+159 clips).
 
-Run via `python ingest.py --retraditionalize [--dry-run]`, then `python embed.py
---rebuild` to re-index the semantic store on the now-Traditional text.
+Run via `python ingest.py --retraditionalize [--dry-run]`, then `python embed.py`
+to re-index the semantic store on the now-Traditional text (incremental content-diff
+re-embeds exactly the changed rows).
 
 SAFETY (the reason this is gated, learned 2026-07-18): running whole-row s2twp over
 the library CORRUPTS already-Traditional text. opencc's Simplified→Traditional phrase
@@ -58,6 +63,23 @@ def convert_row(transcript, lang, segments_json, words_json, converter):
     return new_t, new_sj, new_wj, changed
 
 
+def convert_description(desc):
+    """Convert one free-text vision/frame description. Gated on classify_zh with the
+    SAME safety as transcripts: genuine Simplified → s2twp idioms (to_taiwan), mixed →
+    char-safe (to_traditional_charwise, no phrase layer), already-Traditional/empty →
+    unchanged (never fed to the phrase layer, so valid Traditional can't be corrupted;
+    non-zh English descriptions classify "traditional" → skipped). Returns
+    (new_desc, changed)."""
+    cls = zh_convert.classify_zh(desc)
+    if cls == "simplified":
+        new = zh_convert.to_taiwan(desc)
+    elif cls == "mixed":
+        new = zh_convert.to_traditional_charwise(desc)
+    else:
+        return desc, False
+    return new, (new != desc)
+
+
 # classification → (converter, count-bucket). "traditional"/"empty" aren't here: they
 # are skipped, never converted.
 _CONVERTERS = {
@@ -75,6 +97,10 @@ def _new_counts():
         "media_skip_empty": 0,
         "archive_scanned": 0,
         "archive_converted": 0,
+        "frames_scanned": 0,              # vision: per-frame descriptions
+        "frames_converted": 0,
+        "frame_tags_media_scanned": 0,    # vision: media.frame_tags JSON rollup blobs
+        "frame_tags_media_converted": 0,
     }
 
 
@@ -124,6 +150,41 @@ def backfill(dry_run=False):
                         row["media_id"], row["lang"], new_t, new_sj, new_wj, _conn=conn
                     )
 
+        # Vision: frames.description (per-frame) — the vision write-path historically
+        # never routed through zh_convert, so qwen3-vl's Simplified output was stored raw.
+        for row in db.iter_frames_with_description(_conn=conn):
+            counts["frames_scanned"] += 1
+            new_desc, changed = convert_description(row["description"])
+            if changed:
+                counts["frames_converted"] += 1
+                if not dry_run:
+                    db.update_frame_description(row["id"], new_desc, _conn=conn)
+
+        # Vision: media.frame_tags rollup blob (the per-clip JSON the embed doc reads).
+        # Convert each frame's description inside the blob and re-serialize; a malformed
+        # blob is skipped (never aborts the backfill), mirroring convert_row's guard.
+        for row in db.iter_frame_tags_media(_conn=conn):
+            counts["frame_tags_media_scanned"] += 1
+            try:
+                tags_list = json.loads(row["frame_tags"])
+            except (ValueError, TypeError):
+                continue
+            if not isinstance(tags_list, list):
+                continue
+            changed_any = False
+            for frame in tags_list:
+                if isinstance(frame, dict) and frame.get("description"):
+                    nd, ch = convert_description(frame["description"])
+                    if ch:
+                        frame["description"] = nd
+                        changed_any = True
+            if changed_any:
+                counts["frame_tags_media_converted"] += 1
+                if not dry_run:
+                    db.update_media_frame_tags(
+                        row["id"], json.dumps(tags_list, ensure_ascii=False), _conn=conn
+                    )
+
         if dry_run:
             # No write helpers were called, so nothing is pending; roll back anyway to
             # make "this transaction changes nothing" explicit and defensive.
@@ -143,5 +204,9 @@ def format_summary(counts, dry_run=False):
         f"         skipped {counts['media_skip_traditional']} already-Traditional, "
         f"{counts['media_skip_empty']} empty\n"
         f"  archive: {counts['archive_scanned']} zh scanned, {verb} {counts['archive_converted']}\n"
-        + ("" if dry_run else "  → run `python embed.py --rebuild` to re-index the semantic store.")
+        f"  vision: {counts['frames_scanned']} frame descriptions scanned, {verb} "
+        f"{counts['frames_converted']}; {counts['frame_tags_media_scanned']} frame_tags blobs "
+        f"scanned, {verb} {counts['frame_tags_media_converted']}\n"
+        + ("" if dry_run else "  → run `python embed.py` to re-index the semantic store "
+                              "(incremental content-diff picks up the changed rows).")
     )

--- a/tests/test_retraditionalize_vision.py
+++ b/tests/test_retraditionalize_vision.py
@@ -1,0 +1,125 @@
+"""Vision retraditionalize backfill — retro-convert Simplified qwen3-vl frame
+descriptions (frames.description + media.frame_tags) to Taiwan Traditional. The vision
+write-path (vision.py) historically never routed through zh_convert, so descriptions were
+stored raw Simplified (audit 2026-07-30: 175 frames / 159 clips). Gates on classify_zh
+with the SAME safety as the transcript backfill: already-Traditional descriptions must
+never be corrupted by the s2twp phrase layer; non-zh (English) descriptions are skipped."""
+import importlib
+import json
+
+import pytest
+
+zh = importlib.import_module("zh_convert")
+db = importlib.import_module("db")
+retrad = importlib.import_module("retraditionalize")
+
+_HAVE_OPENCC = zh._converter("s2t") is not None
+_skip_no_opencc = pytest.mark.skipif(not _HAVE_OPENCC, reason="opencc not installed")
+
+_SIMP_DESC = "一只手正在整理黑色的电缆线，这些电缆插在一台白色设备上"   # genuine Simplified
+_TRAD_DESC = "這個音樂類型的設備系統只是測試"                        # already-Traditional (s2twp bait)
+_MIXED_DESC = "这是繁體字混合的畫面"                                # mixed (simp 这 + trad-only 體/畫)
+_EN_DESC = "a hand organizing black cables on a white device"       # non-zh
+
+
+def _insert_media(conn, mid, frame_tags=None):
+    conn.execute(
+        "INSERT INTO media (id, path, filename, ext, frame_tags) VALUES (?,?,?,?,?)",
+        (mid, "/tmp/clip_{0}.mp4".format(mid), "clip_{0}.mp4".format(mid), ".mp4",
+         json.dumps(frame_tags, ensure_ascii=False) if frame_tags is not None else None),
+    )
+
+
+def _insert_frame(conn, fid, mid, idx, description):
+    conn.execute(
+        "INSERT INTO frames (id, media_id, frame_index, timestamp_s, description) "
+        "VALUES (?,?,?,?,?)",
+        (fid, mid, idx, float(idx), description),
+    )
+
+
+def _frame_desc(fid):
+    with db.get_conn() as conn:
+        return conn.execute("SELECT description FROM frames WHERE id=?", (fid,)).fetchone()[0]
+
+
+def _seed(tmp_db):
+    # media 1's frame_tags rollup blob mixes a Simplified frame + an already-Traditional
+    # frame — the blob writer must convert the first and leave the second byte-identical.
+    ft_blob = [
+        {"description": _SIMP_DESC, "tags": ["电缆"]},
+        {"description": _TRAD_DESC, "tags": []},
+    ]
+    with db.get_conn() as conn:
+        _insert_media(conn, 1, frame_tags=ft_blob)
+        _insert_media(conn, 2)
+        _insert_media(conn, 3)
+        _insert_media(conn, 4)
+        _insert_frame(conn, 101, 1, 0, _SIMP_DESC)    # simplified → convert
+        _insert_frame(conn, 102, 2, 0, _TRAD_DESC)    # already-Traditional → untouched
+        _insert_frame(conn, 103, 3, 0, _MIXED_DESC)   # mixed → char-safe
+        _insert_frame(conn, 104, 4, 0, _EN_DESC)      # english → skipped
+
+
+@_skip_no_opencc
+def test_simplified_frame_description_converted(tmp_db):
+    _seed(tmp_db)
+    counts = retrad.backfill()
+    assert counts["frames_converted"] == 2               # id 101 (simplified) + 103 (mixed)
+    f101 = _frame_desc(101)
+    assert "電纜" in f101                                 # s2twp: 电缆→電纜 (设备→裝置, 台→臺)
+    assert zh.classify_zh(f101) == "traditional"          # no Simplified residue at all
+    assert "设备" not in f101 and "电缆" not in f101
+
+
+@_skip_no_opencc
+def test_already_traditional_frame_never_corrupted(tmp_db):
+    _seed(tmp_db)
+    retrad.backfill()
+    assert _frame_desc(102) == _TRAD_DESC                # byte-for-byte unchanged
+    for corruption in ("型別", "裝置", "係統", "隻是"):
+        assert corruption not in _frame_desc(102)
+
+
+@_skip_no_opencc
+def test_mixed_frame_char_safe_no_idioms(tmp_db):
+    _seed(tmp_db)
+    retrad.backfill()
+    assert _frame_desc(103) == "這是繁體字混合的畫面"     # 这→這 only, rest byte-identical
+
+
+@_skip_no_opencc
+def test_english_frame_description_skipped(tmp_db):
+    _seed(tmp_db)
+    retrad.backfill()
+    assert _frame_desc(104) == _EN_DESC                  # non-zh never converted
+
+
+@_skip_no_opencc
+def test_frame_tags_blob_converted(tmp_db):
+    _seed(tmp_db)
+    counts = retrad.backfill()
+    assert counts["frame_tags_media_converted"] == 1
+    blob = json.loads(db.get_record_by_id(1)["frame_tags"])
+    assert zh.classify_zh(blob[0]["description"]) == "traditional"  # Simplified frame converted
+    assert "電纜" in blob[0]["description"]
+    assert blob[1]["description"] == _TRAD_DESC          # Traditional frame in blob untouched
+
+
+@_skip_no_opencc
+def test_dry_run_writes_nothing(tmp_db):
+    _seed(tmp_db)
+    counts = retrad.backfill(dry_run=True)
+    assert counts["frames_converted"] == 2               # reports what WOULD convert
+    assert _frame_desc(101) == _SIMP_DESC                # but nothing written
+
+
+@_skip_no_opencc
+def test_idempotent_second_run_is_noop(tmp_db):
+    _seed(tmp_db)
+    retrad.backfill()
+    snap = {i: _frame_desc(i) for i in (101, 103)}
+    counts2 = retrad.backfill()
+    assert counts2["frames_converted"] == 0 and counts2["frame_tags_media_converted"] == 0
+    for i in (101, 103):
+        assert _frame_desc(i) == snap[i]

--- a/tests/test_vision_zh_and_jsonfail.py
+++ b/tests/test_vision_zh_and_jsonfail.py
@@ -1,0 +1,76 @@
+"""vision.py write-path quality (audit 2026-07-30):
+  Fix 1 — qwen3-vl ignores the "繁體中文" prompt and emits Simplified; the write-path
+          never routed descriptions through zh_convert, so they were stored raw. Now every
+          description goes through zh_convert.to_taiwan (s2twp), mirroring transcribe.py.
+  Fix 3 — a truncated/garbled JSON reply (a bare "{") fell into the free-text fallback and
+          was stored as description="{" with no error → passed downstream failure-detection.
+          Now malformed-JSON / degenerate output is flagged as a failure instead of stored.
+"""
+import importlib
+
+import pytest
+
+vision = importlib.import_module("vision")
+zh = importlib.import_module("zh_convert")
+
+_HAVE_OPENCC = zh._converter("s2t") is not None
+_skip_no_opencc = pytest.mark.skipif(not _HAVE_OPENCC, reason="opencc not installed")
+
+
+# ── Fix 1: descriptions converted to Taiwan Traditional ───────────────────────
+@_skip_no_opencc
+def test_normalize_result_converts_description_to_traditional():
+    r = vision._normalize_result({"description": "一台白色设备，黑色电缆", "tags": ["设备"]})
+    assert "電纜" in r["description"]                     # 电缆→電纜 (设备→裝置, 台→臺 via s2twp)
+    assert zh.classify_zh(r["description"]) == "traditional"   # no Simplified residue
+    assert "设备" not in r["description"] and "电缆" not in r["description"]
+    assert not r.get("error")
+
+
+@_skip_no_opencc
+def test_describe_one_json_success_converted(monkeypatch):
+    monkeypatch.setattr(vision, "_call_vision", lambda *a, **k: '{"description": "黑色电缆", "tags": []}')
+    r = vision._describe_one("/tmp/x.jpg")
+    assert not r.get("error")
+    assert "電纜" in r["description"] and "电缆" not in r["description"]
+
+
+@_skip_no_opencc
+def test_describe_one_plain_text_fallback_converted(monkeypatch):
+    # genuine free-text (non-JSON) reply is kept AND converted, not flagged failed
+    monkeypatch.setattr(vision, "_call_vision", lambda *a, **k: "一台设备在桌上")
+    r = vision._describe_one("/tmp/x.jpg")
+    assert not r.get("error")
+    assert zh.classify_zh(r["description"]) == "traditional" and "设备" not in r["description"]
+
+
+# ── Fix 3: malformed / degenerate JSON output is flagged as a failure ─────────
+def test_normalize_result_non_dict_is_flagged_failure():
+    # a double-encoded JSON string parses to a str/list, not a dict — a parse failure
+    # masquerading as success; must be flagged, not have .get() blow up or store garbage.
+    r = vision._normalize_result(["not", "a", "dict"])
+    assert r.get("error")
+    assert not r.get("description")
+
+
+def test_describe_one_bare_brace_flagged_failure(monkeypatch):
+    # the exact audit symptom: qwen3-vl returns a truncated "{" → must be a failure,
+    # never description="{".
+    monkeypatch.setattr(vision, "_call_vision", lambda *a, **k: "{")
+    r = vision._describe_one("/tmp/x.jpg")
+    assert r.get("error")
+    assert r.get("description", "") == ""
+
+
+def test_describe_one_truncated_json_flagged_failure(monkeypatch):
+    monkeypatch.setattr(vision, "_call_vision", lambda *a, **k: '{"description": "一個人')
+    r = vision._describe_one("/tmp/x.jpg")
+    assert r.get("error")
+    assert "{" not in (r.get("description") or "")
+
+
+def test_describe_one_light_bare_brace_flagged_failure(monkeypatch):
+    # the light path shares the bug; empty description → downstream marks it failed
+    monkeypatch.setattr(vision, "_call_vision", lambda *a, **k: "{")
+    r = vision._describe_one_light("/tmp/x.jpg")
+    assert r.get("description", "") == ""

--- a/vision.py
+++ b/vision.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional
 import requests
 
 import config
+import zh_convert
 from llm import vision
 
 OLLAMA_URL = f"{config.OLLAMA_URL}/api/generate"
@@ -211,9 +212,25 @@ def describe_frames(frame_paths: List[str], model: Optional[str] = None) -> List
     return results
 
 
+def _is_degenerate_desc(d: str) -> bool:
+    """A 'description' that is really a broken-JSON fragment ('{', '}', '{}', '[',
+    ']') or empty — a parse failure, not a real description (audit: 23 frames stored
+    a bare '{' when qwen3-vl returned truncated JSON)."""
+    return (d or "").strip() in ("", "{", "}", "{}", "[", "]")
+
+
 def _normalize_result(parsed: Dict) -> Dict:
     result = _empty_result()
-    result["description"] = parsed.get("description", "")
+    # A non-object payload (double-encoded string / bare list) is a parse failure
+    # masquerading as success — flag it so the frame is marked failed, not stored.
+    if not isinstance(parsed, dict):
+        result["error"] = "vision output JSON was not an object"
+        return result
+    # qwen3-vl ignores the "繁體中文" prompt and often emits Simplified — route the
+    # description through zh_convert (s2twp), mirroring transcribe.py's write-path,
+    # so frame descriptions honor the Traditional-Chinese contract (audit: 175 frames
+    # / 159 clips had Simplified vision text because this path never converted).
+    result["description"] = zh_convert.to_taiwan(parsed.get("description", ""))
     # Sanitize at the source: drop empty / pure-punctuation tags (e.g. the bare
     # "}" the JSON-fallback parser leaks) so they never enter the DB. Read-side
     # filtering (tag_quality.is_noise) also screens them, this just keeps storage clean.
@@ -268,12 +285,20 @@ def _describe_one(img_path, max_retries=2, model=None):
     except json.JSONDecodeError:
         pass
 
-    # Fallback: free-text parse
+    # Fallback: model returned plain text, not JSON. But if it returned MALFORMED
+    # JSON (starts with { / [ yet failed to parse — e.g. a truncated "{"), the
+    # free-text parse would store the raw fragment as a description; flag it as a
+    # failure instead so the frame is marked failed (→ [skipped]/retry) and never
+    # pollutes the index.
     lines = [ln.strip() for ln in raw.splitlines() if ln.strip() and not ln.strip().startswith("```")]
     description = lines[0] if lines else ""
+    if raw.lstrip().startswith(("{", "[")) or _is_degenerate_desc(description):
+        result = _empty_result()
+        result["error"] = "vision output not parseable as JSON (truncated/garbled)"
+        return result
     tags = [t.strip() for t in lines[-1].split(",")] if len(lines) > 1 else []
     result = _empty_result()
-    result["description"] = description
+    result["description"] = zh_convert.to_taiwan(description)
     result["tags"] = tags
     return result
 
@@ -287,16 +312,21 @@ def _describe_one_light(img_path, max_retries=2, model=None):
         return _empty_result()
     try:
         parsed = json.loads(raw)
+        if not isinstance(parsed, dict):
+            return _empty_result()  # non-object payload → empty desc → flagged failed
         result = _empty_result()
-        result["description"] = parsed.get("description", "")
+        result["description"] = zh_convert.to_taiwan(parsed.get("description", ""))
         result["tags"] = parsed.get("tags", []) or []
         for field in _LIGHT_FIELDS:
             result[field] = parsed.get(field)
         return result
     except json.JSONDecodeError:
         lines = [ln.strip() for ln in raw.splitlines() if ln.strip() and not ln.strip().startswith("```")]
+        description = lines[0] if lines else ""
+        if raw.lstrip().startswith(("{", "[")) or _is_degenerate_desc(description):
+            return _empty_result()  # broken-JSON fragment → empty desc → flagged failed
         result = _empty_result()
-        result["description"] = lines[0] if lines else ""
+        result["description"] = zh_convert.to_taiwan(description)
         result["tags"] = [t.strip() for t in lines[-1].split(",")] if len(lines) > 1 else []
         return result
 


### PR DESCRIPTION
2026-07-30 品質審計(1506 支 G 庫)抓到 vision 兩問題,同在 `vision.py`。

## Fix 1 — Vision 描述簡體(175 幀 / 159 支)
`vision.py` 寫描述完全不走 `zh_convert`(transcript 有走 `transcribe.py:261`)。qwen3-vl 無視「繁體中文」prompt 吐簡體 → 原封存,違反繁體契約。
- **write-path**:`_normalize_result` + 兩處 `_describe_one*` fallback 對 `description` 套 `zh_convert.to_taiwan()`(s2twp;單句無時間碼、比照 `convert_result`)。所有 3 個 DB writer + `frames_to_json` 都繼承。
- **backfill**:擴 `retraditionalize`(同一 `--retraditionalize` flag)掃 `frames.description` + `media.frame_tags` blob。新 `db` helpers(`iter_frames_with_description`/`update_frame_description`/`iter_frame_tags_media`/`update_media_frame_tags`)。gate `classify_zh`——已繁/英文跳過不腐化、simplified→s2twp、mixed→charwise。

## Fix 3 — 截斷 JSON `{` 當描述存(23 幀)
`_describe_one` 的 `except JSONDecodeError: pass` → free-text fallback 存 `lines[0]="{"`、無 `error` key → `ingest.py:916` 判成功、污染索引。
- fallback 偵測「raw 以 `{`/`[` 開頭但解析失敗」或退化片段(`{`/`}`/空)→ 設 error/空描述判失敗(→ `[skipped]`/retry)。`_normalize_result` 收到非 dict(雙重編碼 JSON)也判失敗。

## 測試
`test_retraditionalize_vision.py`(frames + frame_tags backfill:already-Traditional-never-corrupted / mixed char-safe / 英文跳過 / dry-run / idempotent)+ `test_vision_zh_and_jsonfail.py`(繁化 + bare-`{` 判失敗)。本地 **122 passed / 0 fail**(vision/embed/retrad/frames 子集)。

## 備註
- 草稿:等 review。**E: 語料 backfill(159 支)在 merge 後才跑**(先備份 DB → `--retraditionalize` → `embed.py` 增量)。
- 關聯 issue #279:vision 是「health 查不到的靜默存壞值」的第二條路徑;此 PR 修 write-path + backfill,issue #279 的 health-gate 另排。
- s2twp 把 `设备`→`裝置`、`台`→`臺`(Taiwan 慣用/標準),非 bug。

🤖 Generated with [Claude Code](https://claude.com/claude-code)