### PR TITLE
fix(integrity): 蓋 hash_verified_at（G 壓測審計 Fix 5）

### DIFF
--- a/db.py
+++ b/db.py
@@ -619,6 +619,24 @@ def set_embed_state(media_id: int, embed_hash: str, embedded_at: str, _conn=None
             _do(conn)
 
 
+def set_hash_verified(media_id: int, verified_at: str, _conn=None) -> None:
+    """Stamp when a media row's file_hash was confirmed against the file's bytes (audit
+    2026-07-30: hash_verified_at was declared + allow-listed but had NO writer → NULL for
+    every row). The ingest write-path sets it inline via the record upsert (hash_verified_at
+    IS in _ALLOWED_COLS); this is the targeted writer for a one-off integrity backfill or a
+    future re-verify pass. Mirrors set_embed_state."""
+    def _do(c):
+        c.execute(
+            "UPDATE media SET hash_verified_at=? WHERE id=?",
+            (verified_at, media_id),
+        )
+    if _conn is not None:
+        _do(_conn)
+    else:
+        with get_conn() as conn:
+            _do(conn)
+
+
 _ALLOWED_COLS = {
     "path", "filename", "ext", "duration_s", "size_mb", "width", "height",
     "fps", "has_audio", "transcript", "lang", "frame_tags", "thumbnail_path",

--- a/ingest.py
+++ b/ingest.py
@@ -768,6 +768,12 @@ def process_file(path: Path, skip_vision: bool, existing: Optional[Dict] = None,
     if fhash:
         record["file_hash"] = fhash
         record["hash_algo"] = "xxh3"
+        # Stamp when the content hash was confirmed against the file's bytes (audit
+        # 2026-07-30: this column was declared + allow-listed but had NO writer, so it
+        # stayed NULL for every row). The hash was just (re)computed/confirmed from the
+        # real file this ingest; on --refresh this re-reads and re-verifies. hash_verified_at
+        # is in _ALLOWED_COLS, so the record upsert persists it.
+        record["hash_verified_at"] = datetime.now(timezone.utc).isoformat()
 
     # Audio transcription (skip on refresh — reuse existing)
     if meta["has_audio"] and not existing:

--- a/tests/test_hash_verified_at.py
+++ b/tests/test_hash_verified_at.py
@@ -1,0 +1,33 @@
+"""hash_verified_at writer (audit 2026-07-30): the column was declared (db.py:254) and
+allow-listed (_ALLOWED_COLS) but had NO writer anywhere in the codebase → NULL for all
+1506 rows. Ingest now stamps it inline via the record upsert; db.set_hash_verified is the
+targeted writer for a one-off integrity backfill / future re-verify pass."""
+import importlib
+from datetime import datetime, timezone
+
+db = importlib.import_module("db")
+
+
+def test_set_hash_verified_writes_timestamp(tmp_db):
+    with db.get_conn() as conn:
+        conn.execute(
+            "INSERT INTO media (id, path, filename, ext, file_hash, hash_algo) "
+            "VALUES (1, '/tmp/c1.mp4', 'c1.mp4', '.mp4', 'abc', 'xxh3')"
+        )
+    assert db.get_record_by_id(1)["hash_verified_at"] is None   # unwritten to start
+    ts = datetime.now(timezone.utc).isoformat()
+    db.set_hash_verified(1, ts)
+    assert db.get_record_by_id(1)["hash_verified_at"] == ts
+
+
+def test_upsert_persists_hash_verified_at(tmp_db):
+    # the ingest write-path sets record["hash_verified_at"]; since it's in _ALLOWED_COLS
+    # the upsert must persist it (previously nothing ever set it).
+    ts = datetime.now(timezone.utc).isoformat()
+    db.upsert({"path": "/tmp/c2.mp4", "filename": "c2.mp4", "ext": ".mp4",
+               "file_hash": "def", "hash_algo": "xxh3", "hash_verified_at": ts})
+    with db.get_conn() as conn:
+        row = conn.execute(
+            "SELECT hash_verified_at FROM media WHERE path=?", ("/tmp/c2.mp4",)
+        ).fetchone()
+    assert row[0] == ts


### PR DESCRIPTION
審計:`media.hash_verified_at` 全 1506 支 NULL。

**根因(實查)**:欄位 declared(`db.py:254`)+ 在 `_ALLOWED_COLS`,但**全 repo 零 assignment**。`file_hash`(xxh3)有寫、`hash_verified_at` 沒同步蓋;`mhl.py verify` 與 DB 脫鉤不蓋。

**修**:
- `ingest.py`:確認 `file_hash` 後 `record["hash_verified_at"]=datetime.now(UTC)`。該欄在 `_ALLOWED_COLS`,record upsert 直接寫。`--refresh` 重讀重 hash = 真 re-verify。
- `db.set_hash_verified`(mirror `set_embed_state`):一次性 backfill / 未來 re-verify pass 的 targeted writer。

**測試**:`test_hash_verified_at.py`(set_hash_verified + upsert 持久化)。本地 9 passed。

草稿:E: 既有 1506 支的一次性 backfill 在 merge 後跑(先備份)。語意=「hash 確認於此 ingest」;真正的獨立 re-verify pass(重讀比對)另排。

🤖 Generated with [Claude Code](https://claude.com/claude-code)