### PR TITLE
fix(metadata): FX30 鏡頭 + iPhone 16 Pro 廠牌抽取（G 壓測審計 Fix 2）

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -415,6 +415,14 @@ def exiftool_extract(path: str, fps: Optional[float] = None) -> dict:
         # call so sidecar-less clips still populate camera_make/model. Non-Sony
         # files simply don't have these tags → d.get() returns None → no effect.
         "-DeviceManufacturer", "-DeviceModelName", "-LensZoomModelName",
+        # audit 2026-07-30: FX30 XAVC-S .mp4 puts the lens in the NRT XML block as
+        # LensModelName (not the composite LensModel the standard tag maps to) → 548
+        # FX30 clips had NULL lens_model; and iPhone 16 Pro ProRes leaves standard
+        # Make blank, putting the maker in AppleProappsManufacturer → 88 clips had
+        # NULL camera_make. (FX30 iso/shutter/aperture/focal are genuinely absent from
+        # the file — the NRT AcquisitionRecord carries gamma/timecode but no exposure
+        # triad — so those stay NULL by source, not by this mapping.)
+        "-LensModelName", "-AppleProappsManufacturer",
         "-GPSLatitude", "-GPSLongitude",
         "-ColorSpace",
         "-ISO",
@@ -513,9 +521,10 @@ def exiftool_extract(path: str, fps: Optional[float] = None) -> dict:
         # issue #115: fall back to embedded-XML device identity when the
         # standard EXIF Make/Model are blank (Sony XAVC without an M01.XML
         # sidecar). Standard tags still win when present.
-        "camera_make": d.get("Make") or d.get("DeviceManufacturer"),
+        "camera_make": d.get("Make") or d.get("DeviceManufacturer") or d.get("AppleProappsManufacturer"),
         "camera_model": d.get("Model") or d.get("DeviceModelName"),
-        "lens_model": d.get("LensModel") or d.get("Blackmagic-designCameraLensType") or d.get("LensZoomModelName"),
+        "lens_model": (d.get("LensModel") or d.get("Blackmagic-designCameraLensType")
+                       or d.get("LensZoomModelName") or d.get("LensModelName")),
         "gps_lat": d.get("GPSLatitude"),
         "gps_lon": d.get("GPSLongitude"),
         "color_space": str(d.get("ColorSpace")) if d.get("ColorSpace") else None,

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -119,6 +119,79 @@ def test_exiftool_camera_prefers_standard_over_embedded_xml(monkeypatch):
     assert result["lens_model"] == "E 17-70mm F2.8 B070"
 
 
+# audit 2026-07-30: FX30 XAVC-S .mp4 lens is in the NRT XML as LensModelName
+
+def test_exiftool_fx30_lens_from_lensmodelname(monkeypatch):
+    """FX30 XAVC-S .mp4 leaves the composite LensModel blank and carries the lens in the
+    embedded NRT XML as LensModelName → 548 FX30 clips had NULL lens_model until this
+    fallback (make/model already came from DeviceManufacturer/DeviceModelName)."""
+    import sys, os, json
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    import ingest
+    fake_stdout = json.dumps([{
+        "SourceFile": "FX30.5173.MP4",
+        "DeviceManufacturer": "Sony",
+        "DeviceModelName": "ILME-FX30",
+        "LensModelName": "E 17-70mm F2.8 B070",   # NRT lens; composite LensModel absent
+    }])
+
+    class _FakeProc:
+        returncode = 0
+        stdout = fake_stdout
+        stderr = ""
+
+    monkeypatch.setattr(ingest.subprocess, "run", lambda *a, **kw: _FakeProc())
+    result = ingest.exiftool_extract("FX30.5173.MP4")
+    assert result["camera_make"] == "Sony"
+    assert result["camera_model"] == "ILME-FX30"
+    assert result["lens_model"] == "E 17-70mm F2.8 B070"
+
+
+# audit 2026-07-30: iPhone 16 Pro ProRes make is in AppleProappsManufacturer
+
+def test_exiftool_iphone_make_from_appleproapps(monkeypatch):
+    """iPhone 16 Pro ProRes leaves standard Make blank and puts the maker in
+    AppleProappsManufacturer → 88 clips had NULL camera_make until this fallback (Model
+    already populated camera_model)."""
+    import sys, os, json
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    import ingest
+    fake_stdout = json.dumps([{
+        "SourceFile": "A001_05161434_C075.mov",
+        "Model": "Apple iPhone 16 Pro 48mm",
+        "AppleProappsManufacturer": "Apple Inc.",   # standard Make absent
+    }])
+
+    class _FakeProc:
+        returncode = 0
+        stdout = fake_stdout
+        stderr = ""
+
+    monkeypatch.setattr(ingest.subprocess, "run", lambda *a, **kw: _FakeProc())
+    result = ingest.exiftool_extract("A001_05161434_C075.mov")
+    assert result["camera_make"] == "Apple Inc."
+    assert result["camera_model"] == "Apple iPhone 16 Pro 48mm"
+
+
+def test_exiftool_standard_make_wins_over_appleproapps(monkeypatch):
+    """A standard EXIF Make (older iPhones) still wins over the AppleProapps fallback."""
+    import sys, os, json
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    import ingest
+    fake_stdout = json.dumps([{
+        "SourceFile": "IMG.mov", "Make": "Apple", "Model": "iPhone 11",
+        "AppleProappsManufacturer": "Apple Inc.",
+    }])
+
+    class _FakeProc:
+        returncode = 0
+        stdout = fake_stdout
+        stderr = ""
+
+    monkeypatch.setattr(ingest.subprocess, "run", lambda *a, **kw: _FakeProc())
+    assert ingest.exiftool_extract("IMG.mov")["camera_make"] == "Apple"
+
+
 # B10b2: Blackmagic Cam app (iOS) per-vendor lens tag
 
 def test_exiftool_lens_falls_back_to_bmd_camera_lens_type(monkeypatch):


### PR DESCRIPTION
審計報「相機 metadata split-brain」。**對真檔跑 exiftool 實測後,初判被推翻**——多數缺欄是**來源資料本身就沒有**,不是 code bug。本 PR 只修兩個確實可抽卻沒抽的缺口。

## 可修(本 PR)
- **FX30 `.mp4` 鏡頭(548 支 NULL)**:鏡頭在 NRT XML 的 `LensModelName`,現有 map 只讀 composite `LensModel`(FX30 沒填)。加 `-LensModelName` + fallback。實測 → `E 17-70mm F2.8 B070`。
- **iPhone 16 Pro `.mov` 廠牌(88 支 NULL)**:標準 `Make` 空、廠牌在 `AppleProappsManufacturer`。加該 tag + fallback。實測 → `Apple Inc.`(`camera_model` 早已由 `Model` 抽到)。

## 非本 PR 能修(來源限制,已寫進 code 註解)
- **FX30 iso/快門/光圈/焦距**:NRT `AcquisitionRecord` 只帶 gamma(`s-log3-cine`)+ LTC timecode,**沒有曝光三元組**。exiftool `-a` 全掃也無。→ 這幾欄 NULL 是相機沒寫,mapping 補不出來。
- **全庫 shutter/focal ~0%**:主因同上(FX30 是主力機)+ 舊 iPhone 不吐 ISO。非 bug。
- **FX30 timecode**:LTC 在 `LtcChangeTableLtcChangeValue`(packed),轉 HH:MM:SS:FF 非平凡 → 留後續。

## 測試
`test_ingest.py` +3(FX30 `LensModelName` / iPhone `AppleProappsManufacturer` make / 標準 Make 仍優先)。本地 27 passed。

草稿:E: metadata 重抽 backfill 在 merge 後跑(先備份)。**取捨判斷**:原以為是可完全修復的 split-brain,實測後縮成兩個抽取補丁 + 一份「哪些欄天生沒有」的誠實結論——這比硬湊不存在的欄更正確。

🤖 Generated with [Claude Code](https://claude.com/claude-code)