### PR TITLE
feat(ui): 批次重轉錄語言選擇器 + 誠實化「自動偵測」（Fix 4 / A2）

### DIFF
--- a/frontend/src/routes/IngestSetup.svelte
+++ b/frontend/src/routes/IngestSetup.svelte
@@ -158,12 +158,12 @@
           </div>
           <div class="optrow">
             <select class="ak-input sel" bind:value={language} title="force transcription language">
-              <option value="">Auto-detect</option>
+              <option value="">系統預設（中文 zh）</option>
               {#each (engines?.languages ?? []) as l}
                 <option value={l.code}>{l.label} · {l.code}</option>
               {/each}
             </select>
-            <div class="optlabel"><span>Language</span><Mono dim style="font-size:10px;">強制語言（留 Auto = 自動偵測 / 預設提示）</Mono></div>
+            <div class="optlabel"><span>Language</span><Mono dim style="font-size:10px;">強制語言（留白＝系統預設，目前為中文 zh；非中文素材請選對應語言，無自動偵測）</Mono></div>
           </div>
         </div>
 

--- a/frontend/src/routes/SettingsLive.svelte
+++ b/frontend/src/routes/SettingsLive.svelte
@@ -256,6 +256,10 @@
   // the whole project so new hotwords take effect. Poll status while running.
   let retr = null // {total, done, failed, current, running, backup}
   let retrTimer = null
+  // Batch retranscribe language — sent EXPLICITLY. The pipeline forces zh when no
+  // language is given (transcribe.py coerces None→zh), so "auto-detect" isn't real;
+  // the picker makes the language a deliberate choice, default zh.
+  let retrLang = 'zh'
   async function pollRetr() {
     try {
       retr = await api.retranscribeAllStatus()
@@ -267,7 +271,7 @@
     if (retr && retr.running) return
     vocabMsg = ''
     try {
-      const r = await api.retranscribeAll(true)
+      const r = await api.retranscribeAll(true, retrLang || 'zh')
       if (!r.queued) { vocabMsg = r.message || '沒有可重轉錄的素材'; return }
       retr = { total: r.queued, done: 0, failed: 0, current: null, running: true, backup: null }
       pollRetr()
@@ -426,6 +430,11 @@
               <div class="fsdesc">重跑整庫 Whisper，讓新加的 hotword 生效——<b>慢、耗資源</b>，只在某詞被聽成完全不同的東西、批次校正救不回時才用。重轉前自動備份，可還原。</div>
             </div>
             <div class="vctl">
+              <select class="ak-input" bind:value={retrLang} disabled={retr && retr.running} title="批次重轉錄語言（強制指定，非自動偵測）" style="max-width:170px;">
+                {#each (engines?.languages ?? [{ code: 'zh', label: '中文' }, { code: 'en', label: 'English' }]) as l}
+                  <option value={l.code}>{l.label} · {l.code}</option>
+                {/each}
+              </select>
               <button class="ak-btn" on:click={runRetranscribeAll} disabled={retr && retr.running}>{retr && retr.running ? '重轉錄中…' : '批次重轉錄'}</button>
               {#if retr}
                 <Mono dim style="font-size:11px;">{retr.done}/{retr.total} 完成{retr.failed ? ` · ${retr.failed} 失敗` : ''}{retr.running ? '…' : ' · 完成'}</Mono>
@@ -454,7 +463,7 @@
                     <span class="chip">auto-detect</span>
                   </div>
                 </div>
-                <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Current default</Mono><Mono style="font-size:12px;color:var(--ink);">preset {engines.default_mode} · 語言自動偵測</Mono></div>
+                <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Current default</Mono><Mono style="font-size:12px;color:var(--ink);">preset {engines.default_mode} · 語言預設 {engines.default_language || '中文 zh'}</Mono></div>
               </div>
             {:else}
               <span class="pend">engines endpoint unreachable</span>


### PR DESCRIPTION
壓測發現 12 支英文片被誤標 `zh` + 89 支非-zh 有聲片空稿。根因:pipeline 對 `language=None` **強制 zh**(`transcribe.py` coerce None→`DEFAULT_LANGUAGE=zh`),**沒有真自動偵測**。但 ingest UI 給了個 `Auto-detect` 選項(value=`''`)→ 送空值 → 後端強制 zh → 整個 G 庫就是這樣全被當 zh 轉的。

**route A(明確指定語言、不動 zh-first 預設、零回歸)＋ UI:**

1. **批次重轉錄加語言選擇器**(`SettingsLive.svelte`):ingest / 單片 retranscribe 早有選單,只有批次 retranscribe-all 沒有。加 `<select>`(options ← `engines.languages`,fallback zh/en)→ `api.retranscribeAll(true, lang)`。純 UI,`RetranscribeAllRequest.language` + `api.js` 早已支援。
2. **誠實化「自動偵測」謊言**:`IngestSetup` 的 `<option value="">Auto-detect</option>` → 「系統預設(中文 zh)」,說明加「無自動偵測」;`SettingsLive` 的「語言自動偵測」→ 實際預設語言。防止 user 以為留白會偵測、結果全被當 zh 的重演。

## 為何不做真自動偵測
真 auto-detect = 放開 `transcribe.py:230` 的 coercion(route B),對短/口音的台灣 zh 片有誤判回歸風險。你選 A2 = 保留 zh-first 明確指定。若日後要真 auto-detect,另開 route B/C。

## 驗證
`npm run build` ✓ built。純前端、無 API 變更、無 code behavior 變更。

草稿等 review。配套的資料修(重轉錄 12 誤標 + 89 空稿非-zh 片)是另一個 E: backfill,GPU 空出後跑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)