### PR TITLE
fix(zh): opencc 缺席不再靜默 — health WARN + 轉換警告 + dry-run 不謊報 0（closes #279）

### DIFF
--- a/health.py
+++ b/health.py
@@ -22,6 +22,7 @@ from config import FFMPEG_PATH, FFPROBE_PATH
 PASS = 0
 FAIL = 0
 SKIP = 0
+WARN_COUNT = 0
 
 
 class HealthStatus(str, Enum):
@@ -44,6 +45,49 @@ def check(name: str, ok: bool, detail: str = "", required: bool = True):
     else:
         SKIP += 1
         print(f"  \033[33m[SKIP]\033[0m {name} {detail} (optional)")
+
+
+def warn(name: str, detail: str = ""):
+    """Loud non-fatal finding. Distinct from SKIP: SKIP means "optional and absent,
+    nothing is wrong"; WARN means "absent AND it is silently degrading your data"
+    (issue #279). Counted separately so it can't be read as a clean optional skip."""
+    global WARN_COUNT
+    WARN_COUNT += 1
+    print(f"  \033[33m[WARN]\033[0m {name} {detail}")
+
+
+def _zh_media_count() -> int:
+    """How many zh rows this library actually has (-1 if the DB can't be read).
+    Decides whether a missing opencc is harmless or actively corrupting data."""
+    try:
+        import db
+        with db.get_conn() as conn:
+            return conn.execute(
+                "SELECT COUNT(*) FROM media WHERE lang LIKE 'zh%' "
+                "AND transcript IS NOT NULL AND transcript != ''"
+            ).fetchone()[0]
+    except Exception:  # noqa: BLE001 — no DB yet / older schema → can't judge
+        return -1
+
+
+def _check_opencc():
+    try:
+        import zh_convert
+        available = zh_convert.opencc_available()
+    except Exception:  # noqa: BLE001
+        available = False
+    if available:
+        check("opencc", True, "(zh transcripts stored as Taiwan Traditional)")
+        return
+    n = _zh_media_count()
+    if n > 0:
+        warn("opencc", f"NOT installed — {n} zh transcript(s) in this library are stored "
+                       "EXACTLY as the model produced them (Simplified stays Simplified), "
+                       "and `--retraditionalize --dry-run` cannot detect it either. "
+                       "Fix: pip install \"opencc>=1.1\" && python ingest.py --retraditionalize")
+    else:
+        check("opencc", False, "(not installed — needed only for Chinese transcripts)",
+              required=False)
 
 
 def detect_platform() -> str:
@@ -272,6 +316,15 @@ def main():
     else:
         check("exiftool", exiftool_ok, detail, required=False)
 
+    # ── opencc (zh→Traditional conversion) ──────────────────────────────
+    # issue #279: opencc was absent from this table entirely, so a library whose zh
+    # conversion was silently OFF still健檢-ed all green — the exact blind spot that
+    # let 81 Simplified transcripts through. Treated as optional ONLY when there is no
+    # zh content to convert; with zh media present a missing opencc is a real defect
+    # in the stored data, so it WARNs loudly instead of a quiet SKIP.
+    print("\n-- Chinese conversion (opencc) --")
+    _check_opencc()
+
     # ── Whisper ─────────────────────────────────────────────────────────
     print("\n-- Whisper --")
     has_mlx = False
@@ -412,11 +465,17 @@ def main():
 
     # ── Summary ─────────────────────────────────────────────────────────
     total = PASS + FAIL + SKIP
-    print(f"\n═══ Result: {PASS}/{total} PASS, {FAIL} FAIL, {SKIP} SKIP ═══")
+    warn_part = f", {WARN_COUNT} WARN" if WARN_COUNT else ""
+    print(f"\n═══ Result: {PASS}/{total} PASS, {FAIL} FAIL, {SKIP} SKIP{warn_part} ═══")
     if FAIL == 0:
         print("\033[32m    Ready to run! → uvicorn server:app --host 0.0.0.0 --port 8501\033[0m")
     else:
         print("\033[31m    Fix the failures above before running.\033[0m")
+    if WARN_COUNT:
+        # A WARN never fails the run (it isn't a broken environment), but it must not
+        # vanish under a green "0 FAIL" either — that green is what hid issue #279.
+        print("\033[33m    {0} warning(s) above: the environment runs, but something is "
+              "silently degrading your data.\033[0m".format(WARN_COUNT))
     print()
     return 0 if FAIL == 0 else 1
 

--- a/retraditionalize.py
+++ b/retraditionalize.py
@@ -101,6 +101,10 @@ def _new_counts():
         "frames_converted": 0,
         "frame_tags_media_scanned": 0,    # vision: media.frame_tags JSON rollup blobs
         "frame_tags_media_converted": 0,
+        # issue #279: without opencc every classify_zh degrades to identity, so EVERY
+        # row reads "traditional" and the run reports 0 — a self-blinding tool that
+        # answers "is anything Simplified?" with "no" precisely when it cannot tell.
+        "opencc_missing": False,
     }
 
 
@@ -111,6 +115,10 @@ def backfill(dry_run=False):
     the same counts, so `--dry-run` previews exactly what a real run would touch.
     Returns a counts dict."""
     counts = _new_counts()
+    # Check FIRST: a run without opencc converts nothing and, worse, reports "0 to
+    # convert" as though the library were clean (issue #279). Scan anyway so the
+    # scanned-counts stay honest, but flag the run as unable to detect.
+    counts["opencc_missing"] = not zh_convert.opencc_available()
     with db.get_conn() as conn:
         for row in db.iter_zh_media(_conn=conn):
             counts["media_scanned"] += 1
@@ -196,6 +204,19 @@ def format_summary(counts, dry_run=False):
     """Human-readable one-block summary for the CLI."""
     head = "Retraditionalize (Phase 9.8b backfill)" + (" — DRY RUN (no writes)" if dry_run else "")
     verb = "would convert" if dry_run else "converted"
+    if counts.get("opencc_missing"):
+        # issue #279: never let a 0 that means "couldn't look" read like a 0 that means
+        # "nothing to convert". Lead with the blocker instead of a clean-looking table.
+        return (
+            f"{head}\n"
+            "  ⚠ opencc is NOT installed — this run could not detect OR convert anything.\n"
+            "    Every row was read as already-Traditional because the detector itself\n"
+            "    degrades to identity without opencc, so the zero counts below mean\n"
+            "    \"could not check\", NOT \"library is clean\".\n"
+            "    Fix: pip install \"opencc>=1.1\"   then re-run this command.\n"
+            f"  (scanned: {counts['media_scanned']} zh media, {counts['archive_scanned']} archive, "
+            f"{counts['frames_scanned']} frame descriptions)"
+        )
     return (
         f"{head}\n"
         f"  media: {counts['media_scanned']} zh scanned, {verb} "

--- a/tests/test_opencc_gate.py
+++ b/tests/test_opencc_gate.py
@@ -1,0 +1,91 @@
+"""issue #279 — a missing opencc used to be SILENT at three layers, so a 1506-clip
+library was transcribed with zh→Traditional conversion secretly off and every check
+stayed green (audit 2026-07-30: 81 Simplified rows stored, health all-PASS,
+`--retraditionalize --dry-run` reporting "0 to convert").
+
+The degrade-to-identity behaviour is kept (a missing wheel must never break a
+transcribe) — these tests pin that it is no longer silent:
+  1. zh_convert warns once when asked to convert CJK with no converter
+  2. the backfill flags the run instead of reporting a clean-looking 0
+  3. health.py WARNs (not a quiet SKIP) when the library has zh media
+"""
+import importlib
+
+import pytest
+
+zh = importlib.import_module("zh_convert")
+retrad = importlib.import_module("retraditionalize")
+health = importlib.import_module("health")
+
+
+@pytest.fixture
+def no_opencc(monkeypatch):
+    """Simulate opencc being absent: every converter build returns None."""
+    monkeypatch.setattr(zh, "_converter", lambda config: None)
+    monkeypatch.setattr(zh, "_warned_no_converter", False)
+    return monkeypatch
+
+
+# ── 1. zh_convert: identity degrade is loud (once) ───────────────────────────
+def test_convert_warns_once_on_cjk_without_converter(no_opencc, capsys):
+    assert zh.to_taiwan("这是软件") == "这是软件"      # still degrades, never raises
+    zh.to_taiwan("这是视频")                            # second call
+    err = capsys.readouterr().err
+    assert "opencc is not installed" in err
+    assert err.count("opencc is not installed") == 1   # warn ONCE, not per clip
+
+
+def test_no_warning_for_latin_text(no_opencc, capsys):
+    zh.to_taiwan("this is english narration")
+    assert "opencc" not in capsys.readouterr().err     # would fire on every en clip
+
+
+def test_opencc_available_reports_false(no_opencc):
+    assert zh.opencc_available() is False
+
+
+# ── 2. backfill: a 0 that means "couldn't look" says so ──────────────────────
+def test_backfill_flags_missing_opencc(no_opencc, tmp_db):
+    counts = retrad.backfill(dry_run=True)
+    assert counts["opencc_missing"] is True
+
+
+def test_summary_leads_with_blocker_not_clean_zeros(no_opencc):
+    counts = retrad._new_counts()
+    counts["opencc_missing"] = True
+    out = retrad.format_summary(counts, dry_run=True)
+    assert "opencc is NOT installed" in out
+    assert "could not check" in out                    # explicitly not "library is clean"
+
+
+def test_summary_normal_when_opencc_present():
+    counts = retrad._new_counts()          # opencc_missing defaults False
+    out = retrad.format_summary(counts, dry_run=True)
+    assert "opencc is NOT installed" not in out
+    assert "zh scanned" in out
+
+
+# ── 3. health: WARN when the library actually has zh content ─────────────────
+def test_health_warns_when_zh_media_present(monkeypatch, capsys):
+    monkeypatch.setattr(zh, "opencc_available", lambda: False)
+    monkeypatch.setattr(health, "_zh_media_count", lambda: 81)
+    monkeypatch.setattr(health, "WARN_COUNT", 0)
+    health._check_opencc()
+    out = capsys.readouterr().out
+    assert "[WARN]" in out and "81 zh transcript" in out
+    assert "[SKIP]" not in out                          # must NOT read as benign
+    assert health.WARN_COUNT == 1
+
+
+def test_health_skips_when_no_zh_content(monkeypatch, capsys):
+    monkeypatch.setattr(zh, "opencc_available", lambda: False)
+    monkeypatch.setattr(health, "_zh_media_count", lambda: 0)
+    health._check_opencc()
+    out = capsys.readouterr().out
+    assert "[SKIP]" in out and "[WARN]" not in out      # genuinely optional here
+
+
+def test_health_passes_when_opencc_present(monkeypatch, capsys):
+    monkeypatch.setattr(zh, "opencc_available", lambda: True)
+    health._check_opencc()
+    assert "[PASS]" in capsys.readouterr().out

--- a/zh_convert.py
+++ b/zh_convert.py
@@ -23,6 +23,38 @@ backfill of the stored transcript/segments/words columns + re-embed is a documen
 follow-up (roadmap Phase 9.8b), not silent.
 """
 import functools
+import sys
+
+# issue #279: degrade-to-identity kept a missing opencc SILENT — a whole 1506-clip
+# library was transcribed with the conversion secretly off (audit 2026-07-30: 81 zh
+# rows stored Simplified, health check green the whole time). The degrade stays (a
+# missing wheel must never break a transcribe) but it is no longer silent: the first
+# time we are asked to convert CJK text without a converter, say so once.
+_warned_no_converter = False
+
+
+def opencc_available() -> bool:
+    """True when a real opencc converter can be built. Public so health.py / the
+    backfill can report the conversion path as OFF instead of silently no-op-ing."""
+    return _converter("s2t") is not None
+
+
+def _has_cjk(text) -> bool:
+    return any("一" <= ch <= "鿿" for ch in (text or ""))
+
+
+def _warn_identity_once():
+    global _warned_no_converter
+    if _warned_no_converter:
+        return
+    _warned_no_converter = True
+    print(
+        "\n[WARN] opencc is not installed — Chinese text is being stored EXACTLY as the "
+        "model produced it (Simplified stays Simplified). Install it with "
+        "`pip install \"opencc>=1.1\"`, then run `python ingest.py --retraditionalize` "
+        "to convert what was already stored.",
+        file=sys.stderr, flush=True,
+    )
 
 
 @functools.lru_cache(maxsize=4)
@@ -39,6 +71,11 @@ def _convert(config, text):
         return text
     conv = _converter(config)
     if conv is None:
+        # Only meaningful for CJK: warning on Latin text would fire on every English
+        # clip. Probe configs (t2s/s2tw used by classify_zh) go through here too, so a
+        # single warning covers detection AND conversion going dark.
+        if _has_cjk(text):
+            _warn_identity_once()
         return text
     try:
         return conv.convert(text)


### PR DESCRIPTION
07-30 壓測抓到的結構性缺口:整個 1506 支語料在「zh→繁轉換其實沒開」的狀態下跑完,而**三道檢查全綠**。degrade-to-identity 本身是對的(缺 wheel 不該打斷 transcribe),錯的是它**完全無聲**。本 PR 保留降級、拿掉沉默。

## 三層各自的修法
| 層 | 原本 | 現在 |
|---|---|---|
| `zh_convert` | 缺 opencc → 靜默 identity,零訊息 | 被要求轉 **CJK** 但無 converter → **每 process 警告一次**(附安裝 + backfill 指令);拉丁文字不警告(否則每支英文片都噴)。新增 `opencc_available()` |
| `retraditionalize --dry-run` | `classify_zh` 同樣降級 → 全判 traditional → 報「would convert 0」＝**偵測工具在它要偵測的故障下自我瞎掉** | counts 帶 `opencc_missing`;summary 缺 opencc 時**先講 blocker**,明說「這些 0 代表『查不到』不是『語料乾淨』」 |
| `health.py` | 相依表**根本沒列 opencc** → 轉換沒開也全綠 | 新增檢查,**不是靜默 SKIP**:庫裡有 zh 素材 → `[WARN]` + 筆數(新計數器,列進 summary,**不破壞 0-FAIL 契約**);沒 zh 素材才算單純 optional SKIP |

## 為什麼 WARN 而不是 SKIP / FAIL
- `SKIP` 的語意是「optional 且缺席,沒事」——那正是把這個 bug 藏了幾週的訊號。
- `FAIL` 會打壞既有「0 FAIL 才算過」的 smoke-test 契約,而環境其實跑得動。
- 所以引入第三態 `WARN`＝**環境能跑,但有東西正在無聲地劣化你的資料**。

這是 **presence≠correctness 的第二次修正**(第一次是 embed freshness #275:檢查 chunk 在不在、不檢查內容 hash)。

## 驗證
- `test_opencc_gate.py` 9 例:警告只發一次 / 拉丁不發 / backfill 旗標 / summary 先講 blocker / health 的 WARN·SKIP·PASS 三態。
- regression **176 passed, 0 fail**(zh/retrad/vision/health/ingest 子集)。
- 實跑 `health.py`(本機 opencc 已裝)→ 新區塊顯示 `[PASS] opencc`。

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)