### PR TITLE
docs(readme): PR-2 完整版 — 功能牆重組 / API 移 docs / Resolve 獨立 / 修兩處漂移

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,30 @@ Designed for solo DITs and small crews who own their data: local-first, self-hos
 
 ## Features
 
+**Find footage**
+- Semantic search (Chinese / English / Japanese) — searches what's *in* the frame and the transcript, not filenames
+- Library Chat: compilation search, refine the previous result, find similar shots, analytics — with conversation memory
+- Ratings (GOOD / NG / Review) plus auto and manual tags with autocomplete
+
+**AI metadata**
+- Whisper large-v3-turbo transcription + a **4-layer anti-hallucination guard** (VAD silence filter → no_speech threshold → blank/repeat filter → LLM correction)
+- Frame vision analysis with brand/object recognition; 360 footage (Insta360 / GoPro Max) reprojected before indexing
+- Chinese transcripts stored as Taiwan Traditional (plus a batch converter for an existing library)
+- Full camera metadata: EXIF + Sony XAVC sidecar, so FX-series footage keeps its identity
+
+**On-set DIT**
+- Card offload: parallel multi-destination copy + per-file hash verify + resumable, and it **never deletes the source card**
+- ASC MHL v2 hash manifests (interop-verified against the ASC reference implementation)
+- Camera report CSV, auto-offload on card insert, browser DIT console (`/dit`)
+
+**Into the edit**
+- DaVinci Resolve plugin: search, import with clip color, add frame markers
+- Export SRT / VTT / TXT / EDL (DF/NDF) / FCPXML 1.8, plus metadata CSV straight into Resolve
+- Web UI, CLI and API all work on the same library
+
+<details>
+<summary>Full feature list (including advanced options)</summary>
+
 - **Semantic search** — query in natural language (Chinese/English/Japanese)
 - **Chat RAG over your video library** — 5-intent assistant for compilation searches, refinement, similarity, analytics, and general questions with persisted conversation memory
 - **AI transcription** — Whisper large-v3-turbo + Silero VAD + LLM polish (Apple Silicon MLX / NVIDIA CUDA)
@@ -81,8 +105,8 @@ Designed for solo DITs and small crews who own their data: local-first, self-hos
 - **DaVinci Resolve metadata CSV** — `/api/export/metadata-csv` endpoint exports clip metadata (Camera/Lens/ISO/Shutter/Aperture/GPS/CreateDate) ready for Resolve's `File → Import Metadata from CSV`. Plugin auto-prompts after import
 - **ExifTool integration** — auto-extracts 12 fields per clip (Make/Model/LensModel/GPS/ColorSpace/ISO/Shutter/Aperture/FocalLength/CreateDate). Sidecar-aware for Sony XAVC `.XML`, iPhone Keys group, Blackmagic Cam app per-vendor lens tags. Auto-detects exiftool binary on Windows (winget/scoop/chocolatey/Program Files)
 - **EDL reel name** — uses ExifTool ReelName with safe fallback to filename stem (8-char CMX3600 compat, control-char sanitized)
-- **HEVC/ProRes browser proxy** — auto-builds H.264 proxy on demand for browser playback (Phase 7.7g)
-- **Tauri native app** — desktop app with native file/folder dialogs (Windows panic hook surfaces Rust crashes to stderr)
+- **HEVC/ProRes browser proxy** — auto-builds H.264 proxy on demand for browser playback
+- **Tauri native app** — desktop app with native file/folder dialogs
 - **DaVinci Resolve plugin** — search, import with clip color, add frame markers
 - **ASC MHL v2 hash manifests** — `mhl.py create` / `verify` CLI emits real `urn:ASC:MHL:v2.0` with `xxh3` / `md5` / `sha1` / `sha256` / `c4`, directory + structure root hashes, chained `ascmhl_chain.xml`. Interop-verified with ASC reference impl 1.2 — drop-in for Silverstack / MediaVerify / Hedge / YoYotta workflows
 - **Multi-destination offload** — `offload.py --src <SD> --dst <A> --dst <B>` does chunked parallel copy + per-file hash verify + 3× retry on mismatch + atomic rename + sidecar-aware (XAVC / ARRI / RED / iPhone Live Photo). Resumable JSON state file — kill mid-copy and pending files pick up exactly where they stopped. Emits per-dst MHL v2
@@ -90,78 +114,29 @@ Designed for solo DITs and small crews who own their data: local-first, self-hos
 - **DIT Offload UI (`/dit`)** — browser control panel for card→backup offload: preview the destination layout, run with **live per-file progress streaming**, multi-destination + `xxh3` verify + ASC MHL v2. Never deletes the source card
 - **Offload organize policy** — `offload.py --organize "{date}/{camera}/{reel}"` files footage into a date/camera/reel tree (tokens: `{date}/{camera}/{reel}/{stem}/{ext}`, fs-safe, path-traversal guarded) — or leave it empty to mirror the source structure
 - **Card-watcher** — `offload.py --watch` auto-offloads on card insert (detects DCIM / media volumes), with re-insert / mount-flicker guard so a wobbling card never re-copies
-- **360 reprojection** — dual-fisheye `.insv` / `.360` clips are reprojected to **equirectangular** before vision tagging (FFmpeg `v360`), so on-frame text and events the raw fisheye hides become searchable (Phase 8.3b)
+- **360 reprojection** — dual-fisheye `.insv` / `.360` clips are reprojected to **equirectangular** before vision tagging (FFmpeg `v360`), so on-frame text and events the raw fisheye hides become searchable
 - **Vision failure tolerance** — `ingest.py --max-failures N` / `--skip-failed` tolerate flaky per-frame vision on long unattended runs; failed frames are left empty for a later `--vision-only` resume (a whole-Ollama outage still halts fast)
 
-## API Authentication
+</details>
 
-All `/api/*` endpoints require a Bearer token with the correct scope. Scope-based tokens let you split a fleet by machine role: read-only review stations can use `videos_read` or `media_read`, ingest machines can use `ingest_write`, and admin machines can manage tokens.
+## DaVinci Resolve integration
 
-First-time bootstrap:
+arkiv isn't just another asset manager sitting beside your NLE — it runs inside it:
 
-```bash
-export ARKIV_ADMIN_BOOTSTRAP_TOKEN=$(openssl rand -base64 32)
-python server.py
-```
+- **Resolve plugin** (`resolve_plugin/`): search your arkiv library from within Resolve, import results **with clip color** onto the timeline, and drop frame markers — without leaving the NLE.
+- **Ratings carry through**: GOOD / NG / Review become Resolve clip colors.
+- **Metadata CSV**: `/api/export/metadata-csv` emits exactly the columns Resolve's `File → Import Metadata from CSV` expects (Camera/Lens/ISO/Shutter/Aperture/GPS/CreateDate); the plugin prompts for it after import.
+- **Timeline interchange**: EDL (drop-frame / non-drop timecode) and FCPXML 1.8, compatible with both FCPX and DaVinci.
 
-On first startup, the server seeds a single `admin` token from that env var. Use it once to create per-machine tokens, then unset it and revoke the bootstrap token.
+> On macOS, Resolve needs the official python.org Python 3.10 Framework (see Prerequisites below).
 
-Create and manage tokens directly with the CLI:
+## API / MCP
 
-```bash
-python arkiv_token.py create --name "PC-dev" --scopes videos_read,videos_write --ip-allowlist 127.0.0.1/32,100.64.0.0/10 --expires-in 90
-python arkiv_token.py list
-python arkiv_token.py show <token-id>
-python arkiv_token.py revoke <token-id>
-```
+Everything arkiv does is available over a REST API (`/api/*`, scope-based Bearer tokens)
+and a read-only MCP server — the Web UI is just one client. Script it, wire it into an
+automation, or let Claude/OpenClaw query your library.
 
-Use the token in requests:
-
-```bash
-curl -H "Authorization: Bearer <token>" http://localhost:8501/api/media
-```
-
-Available scopes: `videos_read`, `videos_write`, `media_read`, `collections_read`, `collections_write`, `projects_read`, `projects_write`, `ingest_write`, `chat_read`, `chat_write`, `admin`
-
-### Chat API — RAG over your video library
-
-Ask natural-language questions about your archive. The classifier routes each prompt to one of five handlers:
-
-| Intent | Example | What it does |
-|--------|---------|--------------|
-| `compilation` | "Give me all sunset shots from May" | Semantic search → ranked scene list |
-| `refinement` | "Only the indoor ones" | Filters the *previous* result, in-conversation |
-| `similarity` | "Similar to scene 42" | Vector nearest-neighbours to a reference clip |
-| `analytics` | "How many hours did I shoot this month?" | Aggregate query over the library |
-| `general` | "What can you help me with?" | Plain LLM chat, no search |
-
-Conversation history (last 10 messages) is threaded into each follow-up, so `refinement` acts on what the previous turn returned.
-
-**Model requirement:** chat uses `ARKIV_CHAT_MODEL` (default `qwen2.5:14b`) for *both* intent classification and answers — a single `ollama pull qwen2.5:14b` covers it. Only set `ARKIV_INTENT_MODEL` to a smaller model (e.g. `qwen2.5:7b-instruct`) if that model is actually installed on the Ollama host. If the model is missing, `/api/chat` returns a clear "run ollama pull …" message instead of a 500.
-
-**Prerequisite — ingest + index first:** chat queries your *indexed* library, not a standalone chatbot. Ingest media (Step 1) and build the index with `python embed.py` (Step 2) before chatting. `compilation` / `refinement` / `similarity` need the vector index; `analytics` needs ingested media only; `general` is the only intent that works on an empty library. On an empty/unindexed library chat does not error — it just returns "0 results".
-
-```bash
-# Create a conversation
-curl -X POST http://localhost:8501/api/chat \
-  -H "Authorization: Bearer $ARKIV_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "Give me all sunset shots"}'
-# → {"conversation_id":"…", "assistant_text":"…", "scene_ids":[…], "intent":"compilation", "tokens_used":…, "latency_ms":…}
-
-# Continue the same conversation — refinement acts on the prior result
-curl -X POST http://localhost:8501/api/chat \
-  -H "Authorization: Bearer $ARKIV_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "Only indoor ones", "conversation_id": "abc123"}'
-
-# Scope a conversation to specific projects
-curl -X POST http://localhost:8501/api/chat -H "Authorization: Bearer $ARKIV_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "wide establishing shots", "project_scope": ["client-acme"]}'
-```
-
-Read history with `GET /api/chat/history/{conversation_id}` and list conversations with `GET /api/chat/conversations` (both need `chat_read`).
+→ **[API auth, token scopes, and the library Chat (RAG) endpoint: docs/api.md](docs/api.md)**
 
 ## Quick Start
 
@@ -247,15 +222,18 @@ docker compose up -d
 
 > Models are pulled automatically inside the Ollama container on first run (may take a few minutes).
 
-### Upgrading from v0.3.0 → v0.3.1
+<details>
+<summary>Upgrading from an old version (v0.3.0 → v0.3.1 storage layout migration)</summary>
 
-v0.3.1 changes the default storage layout (artifacts now live in `BASE_DIR/.arkiv/` — see Phase 8.0c). One-shot migration:
+v0.3.1 changed the default storage layout (artifacts now live in `BASE_DIR/.arkiv/`). Only needed when upgrading from before that:
 
 ```bash
 cd ~/.arkiv && git pull && python ingest.py --migrate-storage
 ```
 
-Full SOP (backup, rollback, per-project layout): [docs/pipeline.md#upgrading-from-v030](docs/pipeline.md#upgrading-from-v030) · [CHANGELOG v0.3.1](CHANGELOG.md)
+Full SOP (backup, rollback, per-project layout): [docs/pipeline.md](docs/pipeline.md) · [CHANGELOG](CHANGELOG.md)
+
+</details>
 
 ### Option A: Web UI — browse, search, rate, and tag in the browser
 
@@ -322,6 +300,9 @@ Invoke-RestMethod "http://localhost:8501/api/media?q=keyword&limit=5"
 
 ## Configuration
 
+<details>
+<summary>All environment variables (`.env`) — defaults just work; open this to tune</summary>
+
 Copy `.env.example` to `.env` and customize:
 
 | Variable | Default | Description |
@@ -331,7 +312,7 @@ Copy `.env.example` to `.env` and customize:
 | `ARKIV_THUMBNAILS_DIR` | `./thumbnails` | Thumbnail output dir |
 | `ARKIV_OLLAMA_URL` | `http://localhost:11434` | Ollama API endpoint |
 | `ARKIV_EMBED_MODEL` | `bge-m3` | Embedding model — **do not change after indexing** (see note below) |
-| `ARKIV_VISION_MODEL` | `qwen2.5vl:7b` | Vision model for frame descriptions |
+| `ARKIV_VISION_MODEL` | `qwen2.5vl:7b` | Vision model for frame descriptions. **2.5-VL is the deliberate default over qwen3-vl:8b**: Qwen3-VL's vision path is ~10× slower under Ollama (measured ~60s/frame vs ~8s/frame) — 30h vs 3.5h across 2000 frames, at comparable tag quality. Set `ARKIV_OLLAMA_VISION_MODEL=qwen3-vl:8b` for the higher ceiling |
 | `ARKIV_CHAT_MODEL` | `qwen2.5:14b` | Chat model — answers and (by default) intent classification |
 | `ARKIV_INTENT_MODEL` | *(= `ARKIV_CHAT_MODEL`)* | Optional faster model for intent classification only; must be installed |
 | `ARKIV_WHISPER_MODEL` | `mlx-community/whisper-large-v3-turbo` (macOS) / `large-v3-turbo` (other) | Whisper model |
@@ -347,6 +328,7 @@ Copy `.env.example` to `.env` and customize:
 >
 > **Hardware floor for chat:** `qwen2.5:14b` needs ~9 GB and runs alongside the embedding model. Plan for ~12–16 GB free RAM/VRAM on the Ollama host. On tighter machines, set `ARKIV_CHAT_MODEL=qwen2.5:7b` (~4.7 GB) for a lighter default.
 
+</details>
 
 ## Tech Stack
 
@@ -421,12 +403,16 @@ SKIP items are **optional dependencies** — they do not affect functionality. A
 | Apple Silicon | — | Required | — | |
 | fastapi + uvicorn | Required | Required | Required | |
 
-### Latest Results (v0.3.0)
+### Latest Results
 
 | Platform | Health Check | Smoke Test | Date |
 |----------|-------------|------------|------|
 | Windows 11 (RTX 4070) | 19/19 PASS, 0 FAIL, 0 SKIP | 9/9 PASS | 2026-05-22 |
 | Linux (Docker) | 14/17 PASS, 0 FAIL, 3 SKIP | 9/9 PASS | 2026-05-22 |
+
+## For developers
+
+[ARCHITECTURE.md](ARCHITECTURE.md) (architecture overview) · [docs/api.md](docs/api.md) (API + Chat) · [docs/pipeline.md](docs/pipeline.md) (full pipeline) · [CONTRIBUTING.md](CONTRIBUTING.md) · [CHANGELOG.md](CHANGELOG.md)
 
 ## License
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -58,7 +58,7 @@ arkiv 介於素材硬碟與 DaVinci Resolve 之間：自動 ingest footage、附
   階段 2：視覺分析（卸載 LLM 後釋放 VRAM）
   ┌─────────┐  ┌──────────────┐
   │frames.py│→ │  vision.py   │
-  │（擷取幀）│  │(qwen3-vl:8b) │
+  │（擷取幀）│  │(qwen2.5vl:7b) │
   └─────────┘  └──────────────┘
 ```
 
@@ -66,13 +66,37 @@ arkiv 介於素材硬碟與 DaVinci Resolve 之間：自動 ingest footage、附
 
 </details>
 
-## 功能特色
+## 功能總覽
+
+**找素材**
+- 語義搜尋（中／英／日）——搜的是畫面內容 + 逐字稿，不是檔名
+- 素材庫 Chat：搜清單、對上一輪結果續篩、找相似鏡頭、統計問答（帶對話記憶）
+- 評級（GOOD / NG / 待審）+ 自動與手動標籤，附自動補全
+
+**AI 標註**
+- Whisper large-v3-turbo 轉錄 + **四層反幻覺防護**（VAD 靜音過濾 → no_speech 門檻 → 空白/重複過濾 → LLM 校正）
+- 幀視覺分析（含品牌／物件辨識）；360 素材（Insta360 / GoPro Max）自動重投影後索引
+- 中文逐字稿存檔即轉台灣繁體（含既有素材的批次轉換工具）
+- 相機 metadata 全吃：EXIF + Sony XAVC sidecar，FX 系列機型不會掉
+
+**DIT 現場**
+- 記憶卡轉存：多目的地平行 copy + 逐檔 hash 驗證 + 可斷點續傳，**絕不刪來源卡**
+- ASC MHL v2 雜湊清單（已與 ASC 官方 reference impl 互通驗證）
+- 攝影日報 CSV、插卡自動轉存監看、瀏覽器 DIT 控制台（`/dit`）
+
+**進剪輯**
+- DaVinci Resolve plugin：站內搜尋、帶 clip color 匯入、加 frame marker
+- 匯出 SRT / VTT / TXT / EDL（DF/NDF）/ FCPXML 1.8、metadata CSV 直餵 Resolve
+- 全部功能同時有 Web UI、CLI 與 API，共用同一個庫
+
+<details>
+<summary>完整功能清單（含進階選項）</summary>
 
 - **語義搜尋** — 用自然語言查詢（中文／英文／日文）
 - **素材庫 Chat RAG** — 5-intent 助手支援素材清單搜尋、延伸篩選、相似鏡頭、統計與一般問答，並保留對話記憶
 - **AI 轉錄** — Whisper large-v3-turbo + Silero VAD + LLM 潤稿（Apple Silicon MLX / NVIDIA CUDA）
 - **四層反幻覺防護** — VAD 靜音過濾 → no_speech 門檻 → 空白/重複過濾 → LLM 校正
-- **幀分析** — qwen3-vl:8b 視覺描述，含品牌/物件辨識
+- **幀分析** — qwen2.5vl:7b 視覺描述，含品牌/物件辨識
 - **兩階段管線** — 先轉錄、卸載 LLM、再視覺分析（避免 12GB 顯卡 VRAM 衝突）
 - **評級系統** — GOOD / NG / 待審，含備註 + Resolve 片段上色
 - **標籤系統** — 自動（AI）+ 手動標籤，附自動補全
@@ -81,8 +105,8 @@ arkiv 介於素材硬碟與 DaVinci Resolve 之間：自動 ingest footage、附
 - **DaVinci Resolve 詮釋資料 CSV 匯出** — `/api/export/metadata-csv` 端點輸出片段詮釋資料（Camera／Lens／ISO／Shutter／Aperture／GPS／CreateDate），可直接餵 Resolve 的「檔案 → 從 CSV 匯入詮釋資料」。外掛匯入後自動提示
 - **ExifTool 整合** — 每支片段自動擷取 12 個欄位（Make／Model／LensModel／GPS／ColorSpace／ISO／Shutter／Aperture／FocalLength／CreateDate）。支援 sidecar：Sony XAVC `.XML`、iPhone Keys group、Blackmagic Cam app 廠商專屬鏡頭標籤。Windows 自動偵測 exiftool 二進位位置（winget／scoop／chocolatey／Program Files）
 - **EDL reel 名** — 採 ExifTool ReelName，缺失時 fallback 到檔名 stem（8 字元 CMX3600 規格相容、控制字元已過濾）
-- **HEVC／ProRes 瀏覽器代理** — 瀏覽器播放時依需求自動產生 H.264 代理（Phase 7.7g）
-- **Tauri 原生應用** — 桌面應用程式，支援原生檔案/資料夾對話框（Windows panic hook 將 Rust crash 寫到 stderr）
+- **HEVC／ProRes 瀏覽器代理** — 瀏覽器播放時依需求自動產生 H.264 代理
+- **Tauri 原生應用** — 桌面應用程式，支援原生檔案/資料夾對話框
 - **DaVinci Resolve 外掛** — 搜尋、匯入（含片段顏色）、新增幀標記
 - **ASC MHL v2 雜湊清單** — `mhl.py create` / `verify` CLI 產出真正的 `urn:ASC:MHL:v2.0` 格式，支援 `xxh3` / `md5` / `sha1` / `sha256` / `c4`，含 directory + structure root hash、鏈式 `ascmhl_chain.xml`。已跟 ASC 官方 reference impl 1.2 互通驗證 — 可直接接 Silverstack / MediaVerify / Hedge / YoYotta 工作流
 - **多目的地 offload** — `offload.py --src <SD> --dst <A> --dst <B>` chunked 平行 copy + 每檔 hash 驗證 + mismatch 3× retry + atomic rename + sidecar 感知（XAVC / ARRI / RED / iPhone Live Photo）。可恢復的 JSON state file — copy 一半 kill 掉，pending 檔案下次接著跑。每個 dst 結尾 emit MHL v2
@@ -90,78 +114,28 @@ arkiv 介於素材硬碟與 DaVinci Resolve 之間：自動 ingest footage、附
 - **DIT 轉存 UI（`/dit`）** — 瀏覽器控制台做記憶卡→備份轉存：預覽目的端排版、執行時**即時逐檔進度串流**、多目的地 + `xxh3` 校驗 + ASC MHL v2。**絕不刪來源卡**
 - **轉存歸檔規則** — `offload.py --organize "{date}/{camera}/{reel}"` 把素材歸進 日期/攝影機/Reel 樹狀（token：`{date}/{camera}/{reel}/{stem}/{ext}`，檔名安全、防路徑逃逸）；留空則鏡射原結構
 - **記憶卡監看** — `offload.py --watch` 插卡自動轉存（偵測 DCIM / 媒體卷宗），含重插 / 掛載抖動防護，晃動的卡不會重複複製
-- **360 重投影** — 雙魚眼 `.insv` / `.360` 在 vision tagging 前重投影成**等距柱狀（equirectangular）**（FFmpeg `v360`），讓原始魚眼藏住的畫面文字與事件變得可搜尋（Phase 8.3b）
+- **360 重投影** — 雙魚眼 `.insv` / `.360` 在 vision tagging 前重投影成**等距柱狀（equirectangular）**（FFmpeg `v360`），讓原始魚眼藏住的畫面文字與事件變得可搜尋
 - **Vision 失敗容錯** — `ingest.py --max-failures N` / `--skip-failed` 容忍長時間無人值守時的零星幀 vision 失敗；失敗幀留空，之後可用 `--vision-only` 續跑（整個 Ollama 掛掉仍會快速停止）
 
-## API 驗證
+</details>
 
-所有 `/api/*` 端點都需要帶有正確 scope 的 Bearer token。這種以 scope 為基礎的 token 可以把整個機器群組拆開管理：只讀審片機可用 `videos_read` 或 `media_read`，匯入機可用 `ingest_write`，管理機可用 `admin`。
+## DaVinci Resolve 整合
 
-第一次啟動時先做 bootstrap：
+arkiv 不只是「另一個素材管理器」——它直接活在你的 NLE 裡：
 
-```bash
-export ARKIV_ADMIN_BOOTSTRAP_TOKEN=$(openssl rand -base64 32)
-python server.py
-```
+- **Resolve plugin**（`resolve_plugin/`）：在 Resolve 內搜尋 arkiv 素材庫、把結果**帶 clip color 匯入**時間軸、對片段加 frame marker，全程不離開 NLE。
+- **評級直通**：arkiv 的 GOOD / NG / 待審會變成 Resolve 的片段顏色。
+- **metadata CSV**：`/api/export/metadata-csv` 產出可直接餵 Resolve「檔案 → 從 CSV 匯入詮釋資料」的欄位（Camera／Lens／ISO／Shutter／Aperture／GPS／CreateDate），plugin 匯入後會自動提示。
+- **時間軸交換**：EDL（DF/NDF 時間碼）與 FCPXML 1.8 匯出，FCPX 與 DaVinci 皆相容。
 
-第一次啟動時，server 會用這個 env var 建立一組 `admin` token。先用它建立各機器專用 token，之後再移除該 env 並撤銷 bootstrap token。
+> macOS 上 Resolve 需要 python.org 官方 Python 3.10 Framework（見下方前置需求）。
 
-直接用 CLI 建立與管理 token：
+## API / MCP
 
-```bash
-python arkiv_token.py create --name "PC-dev" --scopes videos_read,videos_write --ip-allowlist 127.0.0.1/32,100.64.0.0/10 --expires-in 90
-python arkiv_token.py list
-python arkiv_token.py show <token-id>
-python arkiv_token.py revoke <token-id>
-```
+arkiv 的功能全部有 REST API（`/api/*`，scope-based Bearer token）與 read-only MCP server，
+Web UI 只是其中一個使用者 —— 你可以用腳本、自動化流程、或接 Claude／OpenClaw 來查素材庫。
 
-在請求中使用 token：
-
-```bash
-curl -H "Authorization: Bearer <token>" http://localhost:8501/api/media
-```
-
-可用 scopes：`videos_read`、`videos_write`、`media_read`、`collections_read`、`collections_write`、`projects_read`、`projects_write`、`ingest_write`、`chat_read`、`chat_write`、`admin`
-
-### Chat API — 素材庫 RAG 問答
-
-你可以用自然語言詢問素材庫。分類器會把每個 prompt 交給五個 handler 其中之一：
-
-| Intent | 範例 | 做什麼 |
-|--------|------|--------|
-| `compilation` | 「給我五月所有黃昏鏡頭」 | 語意搜尋 → 排序後的 scene 清單 |
-| `refinement` | 「只要室內的」 | 在對話中對*上一輪結果*再篩選 |
-| `similarity` | 「找跟 scene 42 類似的」 | 對參考鏡頭做向量最近鄰 |
-| `analytics` | 「這個月總共拍了幾小時？」 | 對素材庫做統計查詢 |
-| `general` | 「你能幫我做什麼？」 | 純 LLM 問答，不查庫 |
-
-對話歷史（最近 10 則）會帶入每次後續回應，所以 `refinement` 是對上一輪傳回的結果做篩選。
-
-**模型需求**：chat 用 `ARKIV_CHAT_MODEL`（預設 `qwen2.5:14b`）同時處理*意圖分類與回答* —— 一個 `ollama pull qwen2.5:14b` 就夠。只有當較小模型（例如 `qwen2.5:7b-instruct`）確實已裝在 Ollama 主機上時，才設 `ARKIV_INTENT_MODEL`。模型缺失時 `/api/chat` 會回清楚的「請 ollama pull …」訊息而非 500。
-
-**前置條件 —— 先 ingest + 建索引**：chat 查的是*已建索引*的素材庫，不是獨立聊天機器人。先 ingest 素材（Step 1）+ 跑 `python embed.py` 建索引（Step 2）再用 chat。`compilation` / `refinement` / `similarity` 需要向量索引；`analytics` 只要 ingest 過；`general` 是唯一空庫也能用的 intent。空庫 / 未建索引時 chat 不會報錯，只會回「找到 0 個」。
-
-```bash
-# 建立對話
-curl -X POST http://localhost:8501/api/chat \
-  -H "Authorization: Bearer $ARKIV_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "給我所有黃昏鏡頭"}'
-# → {"conversation_id":"…", "assistant_text":"…", "scene_ids":[…], "intent":"compilation", …}
-
-# 延續同一個對話 —— refinement 會對上一輪結果操作
-curl -X POST http://localhost:8501/api/chat \
-  -H "Authorization: Bearer $ARKIV_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "只要室內的", "conversation_id": "abc123"}'
-
-# 把對話限定在特定 project
-curl -X POST http://localhost:8501/api/chat -H "Authorization: Bearer $ARKIV_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "寬景鏡頭", "project_scope": ["client-acme"]}'
-```
-
-用 `GET /api/chat/history/{conversation_id}` 讀回歷史、`GET /api/chat/conversations` 列出對話（都需要 `chat_read`）。
+→ **[API 驗證、token scopes、素材庫 Chat（RAG）問答完整說明：docs/api.zh-TW.md](docs/api.zh-TW.md)**
 
 ## 快速開始
 
@@ -171,7 +145,7 @@ curl -X POST http://localhost:8501/api/chat -H "Authorization: Bearer $ARKIV_TOK
 
 ```bash
 brew install ffmpeg ollama
-ollama pull bge-m3 && ollama pull qwen3-vl:8b && ollama pull qwen2.5:14b
+ollama pull bge-m3 && ollama pull qwen2.5vl:7b && ollama pull qwen2.5:14b
 ```
 
 到 [最新 release](https://github.com/vulture-s/arkiv/releases/latest) 下載 **`arkiv_<version>_aarch64.dmg`**，打開後把 **arkiv** 拖進「應用程式」。首次啟動因未簽名會被 macOS Gatekeeper 擋 —— **右鍵 → 打開** 一次即可（或執行 `xattr -dr com.apple.quarantine /Applications/arkiv.app`），之後正常開啟。
@@ -201,7 +175,7 @@ cd arkiv
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 pip install mlx-whisper          # Apple Silicon (Metal GPU)
-ollama pull bge-m3 && ollama pull qwen3-vl:8b && ollama pull qwen2.5:14b
+ollama pull bge-m3 && ollama pull qwen2.5vl:7b && ollama pull qwen2.5:14b
 python health.py
 ```
 
@@ -215,7 +189,7 @@ python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 pip install faster-whisper torch  # NVIDIA CUDA GPU
 # pip install faster-whisper      # CPU 後備
-ollama pull bge-m3 && ollama pull qwen3-vl:8b && ollama pull qwen2.5:14b
+ollama pull bge-m3 && ollama pull qwen2.5vl:7b && ollama pull qwen2.5:14b
 python health.py
 ```
 
@@ -230,7 +204,7 @@ python -m venv .venv
 pip install -r requirements.txt
 pip install faster-whisper torch  # NVIDIA CUDA GPU
 # pip install faster-whisper      # CPU 後備
-ollama pull bge-m3; ollama pull qwen3-vl:8b; ollama pull qwen2.5:14b
+ollama pull bge-m3; ollama pull qwen2.5vl:7b; ollama pull qwen2.5:14b
 $env:PYTHONUTF8=1; python health.py
 ```
 
@@ -245,15 +219,18 @@ docker compose up -d
 
 > 模型會在 Ollama container 首次啟動時自動下載（可能需要幾分鐘）。
 
-### 從 v0.3.0 升級到 v0.3.1
+<details>
+<summary>從舊版升級（v0.3.0 → v0.3.1 的儲存 layout 遷移）</summary>
 
-v0.3.1 改了預設儲存 layout（產出檔案落 `BASE_DIR/.arkiv/` — 見 Phase 8.0c）。一鍵 migration：
+v0.3.1 改了預設儲存 layout（產出檔案落 `BASE_DIR/.arkiv/`）。從那之前的版本升級才需要這步：
 
 ```bash
 cd ~/.arkiv && git pull && python ingest.py --migrate-storage
 ```
 
-完整 SOP（backup、rollback、per-project layout）：[docs/pipeline.zh-TW.md#v030--v031-升級](docs/pipeline.zh-TW.md#v030--v031-升級) · [CHANGELOG v0.3.1](CHANGELOG.md)
+完整 SOP（backup、rollback、per-project layout）：[docs/pipeline.zh-TW.md](docs/pipeline.zh-TW.md) · [CHANGELOG](CHANGELOG.md)
+
+</details>
 
 ### 方式 A：Web UI — 在瀏覽器中瀏覽、搜尋、評級、標記
 
@@ -319,6 +296,9 @@ Invoke-RestMethod "http://localhost:8501/api/media?q=關鍵字&limit=5"
 
 ## 設定
 
+<details>
+<summary>環境變數全表（`.env`）—— 預設值就能跑，要調再看</summary>
+
 複製 `.env.example` 為 `.env` 並自訂：
 
 | 變數 | 預設值 | 說明 |
@@ -328,7 +308,7 @@ Invoke-RestMethod "http://localhost:8501/api/media?q=關鍵字&limit=5"
 | `ARKIV_THUMBNAILS_DIR` | `./thumbnails` | 縮圖輸出目錄 |
 | `ARKIV_OLLAMA_URL` | `http://localhost:11434` | Ollama API 端點 |
 | `ARKIV_EMBED_MODEL` | `bge-m3` | 嵌入模型 —— **建索引後請勿更換**（見下方說明） |
-| `ARKIV_VISION_MODEL` | `qwen3-vl:8b` | 視覺模型（幀描述） |
+| `ARKIV_VISION_MODEL` | `qwen2.5vl:7b` | 視覺模型（幀描述）。**預設刻意用 2.5-VL 而非 qwen3-vl:8b**：Qwen3-VL 在 Ollama 下的視覺路徑約慢 10×（實測 ~60s/幀 vs ~8s/幀），2000 幀就是 30 小時 vs 3.5 小時、標註品質相當。要更高上限可設 `ARKIV_OLLAMA_VISION_MODEL=qwen3-vl:8b` |
 | `ARKIV_CHAT_MODEL` | `qwen2.5:14b` | Chat 模型 —— 回答與（預設）意圖分類 |
 | `ARKIV_INTENT_MODEL` | *(= `ARKIV_CHAT_MODEL`)* | 選用的較快意圖分類模型；必須已安裝 |
 | `ARKIV_WHISPER_MODEL` | `mlx-community/whisper-large-v3-turbo` (macOS) / `large-v3-turbo` (其他) | Whisper 模型 |
@@ -344,6 +324,8 @@ Invoke-RestMethod "http://localhost:8501/api/media?q=關鍵字&limit=5"
 >
 > **Chat 硬體門檻：** `qwen2.5:14b` 約需 9 GB，且與嵌入模型同時運行，請在 Ollama 主機預留約 12–16 GB 可用 RAM/VRAM。記憶體較緊的機器可設 `ARKIV_CHAT_MODEL=qwen2.5:7b`（約 4.7 GB）當較輕的預設。
 
+</details>
+
 ## 技術架構
 
 | 層級 | 技術 |
@@ -355,7 +337,7 @@ Invoke-RestMethod "http://localhost:8501/api/media?q=關鍵字&limit=5"
 | 轉錄 | mlx-whisper / faster-whisper (large-v3-turbo) |
 | VAD | Silero VAD（Whisper 前的靜音過濾） |
 | LLM 潤稿 + Chat | Ollama qwen2.5:14b（轉錄潤稿 + 5-intent chat RAG） |
-| 視覺 | Ollama qwen3-vl:8b（品牌/物件辨識） |
+| 視覺 | Ollama qwen2.5vl:7b（品牌/物件辨識） |
 | 媒體 | FFmpeg（探測、縮圖、幀擷取） |
 | 詮釋資料 | ExifTool（12 欄位、sidecar-aware、跨平台自動偵測） |
 | 匯出 | SRT、VTT、TXT、EDL（DF/NDF）、FCPXML 1.8 |
@@ -408,7 +390,7 @@ SKIP 項目是**選用的相依套件** — 不影響功能。通過的結果是
 | FFmpeg / ffprobe | 必要 | 必要 | 必要 | |
 | Ollama server | 必要 | 必要 | 必要 | |
 | bge-m3 | 必要 | 必要 | 必要 | |
-| qwen3-vl:8b | 選用 | 選用 | 選用 | 幀描述用 |
+| qwen2.5vl:7b | 選用 | 選用 | 選用 | 幀描述用 |
 | qwen2.5:14b | 選用 | 選用 | 選用 | 轉錄潤稿 + chat（`/api/chat` 必需） |
 | ExifTool | 選用 | 選用 | 選用 | 豐富詮釋資料 |
 | faster-whisper | 必要 | 選用 | 必要 | CUDA/CPU whisper |
@@ -417,12 +399,16 @@ SKIP 項目是**選用的相依套件** — 不影響功能。通過的結果是
 | Apple Silicon | — | 必要 | — | |
 | fastapi + uvicorn | 必要 | 必要 | 必要 | |
 
-### 最新結果 (v0.3.0)
+### 最新結果
 
 | 平台 | 環境健檢 | 冒煙測試 | 日期 |
 |------|----------|----------|------|
 | Windows 11 (RTX 4070) | 19/19 PASS, 0 FAIL, 0 SKIP | 9/9 PASS | 2026-05-22 |
 | Linux (Docker) | 14/17 PASS, 0 FAIL, 3 SKIP | 9/9 PASS | 2026-05-22 |
+
+## 開發者資訊
+
+[ARCHITECTURE.md](ARCHITECTURE.md)（架構總覽） · [docs/api.zh-TW.md](docs/api.zh-TW.md)（API + Chat） · [docs/pipeline.zh-TW.md](docs/pipeline.zh-TW.md)（完整 pipeline） · [CONTRIBUTING.md](CONTRIBUTING.md) · [CHANGELOG.md](CHANGELOG.md)
 
 ## 授權
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,76 @@
+# arkiv API — Authentication & Chat
+
+> Day-2 material: get arkiv running and ingest some footage first (see the [README](../README.md)), then come back for the API.
+> 繁體中文: [docs/api.zh-TW.md](api.zh-TW.md)
+
+---
+
+## API Authentication
+
+All `/api/*` endpoints require a Bearer token with the correct scope. Scope-based tokens let you split a fleet by machine role: read-only review stations can use `videos_read` or `media_read`, ingest machines can use `ingest_write`, and admin machines can manage tokens.
+
+First-time bootstrap:
+
+```bash
+export ARKIV_ADMIN_BOOTSTRAP_TOKEN=$(openssl rand -base64 32)
+python server.py
+```
+
+On first startup, the server seeds a single `admin` token from that env var. Use it once to create per-machine tokens, then unset it and revoke the bootstrap token.
+
+Create and manage tokens directly with the CLI:
+
+```bash
+python arkiv_token.py create --name "PC-dev" --scopes videos_read,videos_write --ip-allowlist 127.0.0.1/32,100.64.0.0/10 --expires-in 90
+python arkiv_token.py list
+python arkiv_token.py show <token-id>
+python arkiv_token.py revoke <token-id>
+```
+
+Use the token in requests:
+
+```bash
+curl -H "Authorization: Bearer <token>" http://localhost:8501/api/media
+```
+
+Available scopes: `videos_read`, `videos_write`, `media_read`, `collections_read`, `collections_write`, `projects_read`, `projects_write`, `ingest_write`, `chat_read`, `chat_write`, `admin`
+
+### Chat API — RAG over your video library
+
+Ask natural-language questions about your archive. The classifier routes each prompt to one of five handlers:
+
+| Intent | Example | What it does |
+|--------|---------|--------------|
+| `compilation` | "Give me all sunset shots from May" | Semantic search → ranked scene list |
+| `refinement` | "Only the indoor ones" | Filters the *previous* result, in-conversation |
+| `similarity` | "Similar to scene 42" | Vector nearest-neighbours to a reference clip |
+| `analytics` | "How many hours did I shoot this month?" | Aggregate query over the library |
+| `general` | "What can you help me with?" | Plain LLM chat, no search |
+
+Conversation history (last 10 messages) is threaded into each follow-up, so `refinement` acts on what the previous turn returned.
+
+**Model requirement:** chat uses `ARKIV_CHAT_MODEL` (default `qwen2.5:14b`) for *both* intent classification and answers — a single `ollama pull qwen2.5:14b` covers it. Only set `ARKIV_INTENT_MODEL` to a smaller model (e.g. `qwen2.5:7b-instruct`) if that model is actually installed on the Ollama host. If the model is missing, `/api/chat` returns a clear "run ollama pull …" message instead of a 500.
+
+**Prerequisite — ingest + index first:** chat queries your *indexed* library, not a standalone chatbot. Ingest media (Step 1) and build the index with `python embed.py` (Step 2) before chatting. `compilation` / `refinement` / `similarity` need the vector index; `analytics` needs ingested media only; `general` is the only intent that works on an empty library. On an empty/unindexed library chat does not error — it just returns "0 results".
+
+```bash
+# Create a conversation
+curl -X POST http://localhost:8501/api/chat \
+  -H "Authorization: Bearer $ARKIV_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Give me all sunset shots"}'
+# → {"conversation_id":"…", "assistant_text":"…", "scene_ids":[…], "intent":"compilation", "tokens_used":…, "latency_ms":…}
+
+# Continue the same conversation — refinement acts on the prior result
+curl -X POST http://localhost:8501/api/chat \
+  -H "Authorization: Bearer $ARKIV_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Only indoor ones", "conversation_id": "abc123"}'
+
+# Scope a conversation to specific projects
+curl -X POST http://localhost:8501/api/chat -H "Authorization: Bearer $ARKIV_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "wide establishing shots", "project_scope": ["client-acme"]}'
+```
+
+Read history with `GET /api/chat/history/{conversation_id}` and list conversations with `GET /api/chat/conversations` (both need `chat_read`).

--- a/docs/api.zh-TW.md
+++ b/docs/api.zh-TW.md
@@ -1,0 +1,76 @@
+# arkiv API — 驗證與 Chat（繁體中文）
+
+> 這頁是 day-2 內容：先看 [README](../README.zh-TW.md) 把 arkiv 跑起來、匯入素材，再回來接 API。
+> English: [docs/api.md](api.md)
+
+---
+
+## API 驗證
+
+所有 `/api/*` 端點都需要帶有正確 scope 的 Bearer token。這種以 scope 為基礎的 token 可以把整個機器群組拆開管理：只讀審片機可用 `videos_read` 或 `media_read`，匯入機可用 `ingest_write`，管理機可用 `admin`。
+
+第一次啟動時先做 bootstrap：
+
+```bash
+export ARKIV_ADMIN_BOOTSTRAP_TOKEN=$(openssl rand -base64 32)
+python server.py
+```
+
+第一次啟動時，server 會用這個 env var 建立一組 `admin` token。先用它建立各機器專用 token，之後再移除該 env 並撤銷 bootstrap token。
+
+直接用 CLI 建立與管理 token：
+
+```bash
+python arkiv_token.py create --name "PC-dev" --scopes videos_read,videos_write --ip-allowlist 127.0.0.1/32,100.64.0.0/10 --expires-in 90
+python arkiv_token.py list
+python arkiv_token.py show <token-id>
+python arkiv_token.py revoke <token-id>
+```
+
+在請求中使用 token：
+
+```bash
+curl -H "Authorization: Bearer <token>" http://localhost:8501/api/media
+```
+
+可用 scopes：`videos_read`、`videos_write`、`media_read`、`collections_read`、`collections_write`、`projects_read`、`projects_write`、`ingest_write`、`chat_read`、`chat_write`、`admin`
+
+### Chat API — 素材庫 RAG 問答
+
+你可以用自然語言詢問素材庫。分類器會把每個 prompt 交給五個 handler 其中之一：
+
+| Intent | 範例 | 做什麼 |
+|--------|------|--------|
+| `compilation` | 「給我五月所有黃昏鏡頭」 | 語意搜尋 → 排序後的 scene 清單 |
+| `refinement` | 「只要室內的」 | 在對話中對*上一輪結果*再篩選 |
+| `similarity` | 「找跟 scene 42 類似的」 | 對參考鏡頭做向量最近鄰 |
+| `analytics` | 「這個月總共拍了幾小時？」 | 對素材庫做統計查詢 |
+| `general` | 「你能幫我做什麼？」 | 純 LLM 問答，不查庫 |
+
+對話歷史（最近 10 則）會帶入每次後續回應，所以 `refinement` 是對上一輪傳回的結果做篩選。
+
+**模型需求**：chat 用 `ARKIV_CHAT_MODEL`（預設 `qwen2.5:14b`）同時處理*意圖分類與回答* —— 一個 `ollama pull qwen2.5:14b` 就夠。只有當較小模型（例如 `qwen2.5:7b-instruct`）確實已裝在 Ollama 主機上時，才設 `ARKIV_INTENT_MODEL`。模型缺失時 `/api/chat` 會回清楚的「請 ollama pull …」訊息而非 500。
+
+**前置條件 —— 先 ingest + 建索引**：chat 查的是*已建索引*的素材庫，不是獨立聊天機器人。先 ingest 素材（Step 1）+ 跑 `python embed.py` 建索引（Step 2）再用 chat。`compilation` / `refinement` / `similarity` 需要向量索引；`analytics` 只要 ingest 過；`general` 是唯一空庫也能用的 intent。空庫 / 未建索引時 chat 不會報錯，只會回「找到 0 個」。
+
+```bash
+# 建立對話
+curl -X POST http://localhost:8501/api/chat \
+  -H "Authorization: Bearer $ARKIV_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "給我所有黃昏鏡頭"}'
+# → {"conversation_id":"…", "assistant_text":"…", "scene_ids":[…], "intent":"compilation", …}
+
+# 延續同一個對話 —— refinement 會對上一輪結果操作
+curl -X POST http://localhost:8501/api/chat \
+  -H "Authorization: Bearer $ARKIV_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "只要室內的", "conversation_id": "abc123"}'
+
+# 把對話限定在特定 project
+curl -X POST http://localhost:8501/api/chat -H "Authorization: Bearer $ARKIV_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "寬景鏡頭", "project_scope": ["client-acme"]}'
+```
+
+用 `GET /api/chat/history/{conversation_id}` 讀回歷史、`GET /api/chat/conversations` 列出對話（都需要 `chat_read`）。


### PR DESCRIPTION
接 PR-1（#278 已接住 Threads 流量）。處理剩下的結構問題 + 兩個 EN/zh 不一致。

**可見長度各減 84 行**（EN 388→304、zh 384→300），而且同時**新增**了 Resolve 段 —— 縮的是噪音不是內容。

## 結構
- **功能牆重組**：25+ 條平鋪 bullet → 四群組（找素材／AI 標註／DIT 現場／進剪輯）各 3-4 條，完整 24 條收 `<details>`。刪掉對外無意義的內部噪音（`Phase 7.7g`、「Windows panic hook 將 Rust crash 寫到 stderr」這類）。
- **API 移 docs**：`API 驗證` + `Chat API` 兩大段（token scopes / curl / 5-intent 表）本來擋在「快速開始」**前面** ＝ day-2 內容擋住 day-1 入口 → 移到新建 `docs/api.md` + `docs/api.zh-TW.md`，README 留 4 行 + 連結。
- **Resolve 整合獨立成段**：差異化賣點原本埋在功能牆裡，現在單獨露出。
- **`.env` 全表收 `<details>`** ＋ **開發者資訊連結列**（ARCHITECTURE / api / pipeline / CONTRIBUTING / CHANGELOG）。

## 兩處漂移
- **版號過期**：v0.3.0→v0.3.1 遷移已是三個大版之前（現行 **v0.11.0**）→ 收 `<details>` 並標明「只有從那之前升級才需要」；smoke 結果表拿掉 `(v0.3.0)`。
- **model 名漂移 —— 結果是 zh 錯、EN 對**：zh 寫 `qwen3-vl:8b`、EN 寫 `qwen2.5vl:7b`。查 `config.py:135`：**2.5-VL 是刻意的預設** —— Qwen3-VL 在 Ollama 下視覺路徑慢約 10×（實測 ~60s/幀 vs ~8s/幀；2000 幀＝30h vs 3.5h，標註品質相當）。zh 全部改回 `qwen2.5vl:7b`，並在**兩版**的設定表寫清楚「為何不是 qwen3-vl」+ override 方式 —— 這正是我們自己壓測時踩過的混淆點（當時用 env override 跑 qwen3-vl:8b）。

## 驗證
- EN / zh 章節順序與行號**逐段對齊**（Why→Screenshots→Features→Resolve→API→Quick Start→Config→Tech→FAQ→Smoke→Developers→License→Public-Interest→Contact）
- `<details>` 5/5 平衡（兩版）
- 所有本地 `.md` 連結可解析（含新建兩個 docs）
- API 的 3 個 curl 範例完整搬到 docs、未遺失

純文件、無 code。

🤖 Generated with [Claude Code](https://claude.com/claude-code)