### PR TITLE
docs(contributing): fix stale MIT claim, add inbound contributor terms

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## What this changes
+
+<!-- One or two sentences. What does this PR do, and why? -->
+
+## How it was tested
+
+<!-- e.g. `pytest -q` locally, ingested a file and searched, checked the UI at 1440px.
+     Screenshots welcome for anything visual. -->
+
+## Checklist
+
+- [ ] I've read the [contributor terms](../CONTRIBUTING.md#contributor-terms) and my
+      contribution is offered under them (my own work to submit, licensed under the project's
+      license, and relicensable by the maintainer).
+- [ ] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-messages).
+- [ ] `pytest -q` passes locally (or: why it doesn't apply).
+
+<!-- New here? Everything above is a guide, not a gate — open the PR and we'll work it out
+     together. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,4 +176,29 @@ health.py      — Environment health check
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+arkiv is licensed under the **PolyForm Noncommercial License 1.0.0**, with a **Commercial
+Output Exception** — see [LICENSE](LICENSE). In short: arkiv itself is source-available and
+free for noncommercial use, while whatever you *make* with it (videos, timelines,
+EDL/FCPXML/OTIO exports) is yours to use commercially.
+
+### Contributor terms
+
+By submitting a contribution — a pull request, a patch, or code posted in an issue — you
+confirm that:
+
+1. **It's yours to submit.** You wrote it, or you otherwise have the right to contribute it,
+   and you are not knowingly including code owned by someone else under incompatible terms.
+   Using an AI assistant to write or package your change is fine; the same condition applies
+   to what it produced for you.
+2. **It ships under the project's license.** Your contribution is licensed to the project and
+   its users under the same terms as arkiv itself (PolyForm NC 1.0.0 + Commercial Output
+   Exception).
+3. **The maintainer may relicense it.** You grant Hevin Yeh — the copyright holder named in
+   [LICENSE](LICENSE) — a perpetual, worldwide, irrevocable, royalty-free right to license
+   your contribution under different terms, including proprietary ones. This is what lets
+   arkiv's licensing evolve (for example, if a component is later offered commercially)
+   without having to track down every past contributor for permission.
+
+You keep the copyright to what you wrote — point 3 is a license you grant, not a transfer of
+ownership. Merged contributions are credited in the repository's contributor list; if you'd
+like to be credited under a different name than your Git identity, just say so in the PR.


### PR DESCRIPTION
## Why

`CONTRIBUTING.md` still ended with:

> By contributing, you agree that your contributions will be licensed under the MIT License.

That line predates #225, which relicensed arkiv to **PolyForm Noncommercial 1.0.0 + Commercial Output Exception**. Anyone submitting a PR on the strength of it would have been handed terms the project doesn't ship under — and the repo had no inbound license grant at all.

That matters more than usual right now: the project expects its first outside contribution shortly, and a source-available project that may later offer a paid or closed component cannot afford to accumulate contributions whose copyright is unencumbered by a relicensing grant. Handling it at contributor #1 costs a paragraph; handling it at #30 means chasing 30 people.

## What changed

**`CONTRIBUTING.md` § License** — states the real license, then three contributor terms:

1. **Right to submit** — your own work, no knowingly-incompatible third-party code. AI-assisted changes explicitly fine (this is a Claude-Code-heavy ecosystem; leaving it ambiguous would chill exactly the contributions we want).
2. **Same license as the project** — contributions ship under PolyForm NC + Commercial Output Exception.
3. **Relicensing grant** — a perpetual, irrevocable, royalty-free right for the copyright holder to license the contribution under other terms, including proprietary ones.

Contributors keep their copyright; #3 is a license grant, not an assignment. Merged contributions are credited, and contributors can pick the credited name.

**`.github/PULL_REQUEST_TEMPLATE.md`** (new) — puts the acknowledgement at the point of submission rather than relying on people finding CONTRIBUTING. Kept short, and closes with a note that the checklist is a guide rather than a gate, so it doesn't scare off first-timers.

## Not in scope (but noticed)

Two other stale spots in `CONTRIBUTING.md`, from before the Svelte cutover (#78):

- **Code Style** says the frontend is "vanilla JS + Tailwind CSS (no build step)" — it's Svelte with a build step.
- **Project Structure** lists `index.html — Tailwind frontend (single file)`, which was deleted in Phase 3.

Both would actively mislead a frontend contributor. Left out to keep this PR to one concern; worth a follow-up before the first UI contribution lands.
