### PR TITLE
docs: refresh frontend guidance, clear remaining MIT claims

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-arkiv 是 local-first 開源 media asset manager — ingest 拍攝素材，做 transcoding probe / Whisper 轉錄 / Vision tagging / metadata extraction，存 SQLite + ChromaDB，並提供**語意搜尋 + 自然語言 chat（RAG）+ NLE/DIT 導出**。四條入口：Svelte SPA（Tauri WebView / 瀏覽器）、REST API、CLI、read-only MCP server。MIT license，0 雲端，0 phone-home。
+arkiv 是 local-first、source-available 的 media asset manager — ingest 拍攝素材，做 transcoding probe / Whisper 轉錄 / Vision tagging / metadata extraction，存 SQLite + ChromaDB，並提供**語意搜尋 + 自然語言 chat（RAG）+ NLE/DIT 導出**。四條入口：Svelte SPA（Tauri WebView / 瀏覽器）、REST API、CLI、read-only MCP server。PolyForm Noncommercial 1.0.0 + Commercial Output Exception（見 [LICENSE](LICENSE)），0 雲端，0 phone-home。
 
 設計取捨：
 - **Local-first** — 全部運算本機（FFmpeg / Whisper / Ollama），檔案不離開使用者磁碟

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ Thanks for your interest in contributing! arkiv is a local-first media asset man
 - Python 3.9+
 - FFmpeg 6.0+
 - [Ollama](https://ollama.com/) with `nomic-embed-text` model
+- Node 20+ (the UI is a Svelte SPA that `server.py` serves as a built bundle)
 - Git
 
 ### Getting Started
@@ -28,6 +29,9 @@ pip install faster-whisper torch  # NVIDIA GPU
 ollama pull nomic-embed-text
 ollama pull qwen3-vl:8b
 
+# Build the UI (server.py serves frontend/dist at /)
+cd frontend && npm ci && npm run build && cd ..
+
 # Verify environment
 python health.py
 ```
@@ -37,6 +41,18 @@ python health.py
 ```bash
 uvicorn server:app --host 0.0.0.0 --port 8501 --reload
 ```
+
+Open <http://127.0.0.1:8501> — `server.py` serves the built SPA from `frontend/dist`. Without
+a build, `/` only shows a "run npm run build" hint.
+
+Working on the UI? Run Vite's dev server alongside the backend for hot reload:
+
+```bash
+cd frontend && npm run dev   # http://127.0.0.1:5173
+```
+
+It proxies `/api`, `/thumbnails` and `/ws` to the backend on :8501, so keep both running.
+Rebuild with `npm run build` before checking the production path at :8501.
 
 ### Git hooks
 
@@ -86,9 +102,13 @@ chore: update requirements.txt
 ## Code Style
 
 - Python: follow existing patterns in the codebase
-- Frontend: vanilla JS + Tailwind CSS (no build step)
 - Keep modules small and focused — each `.py` file has a single responsibility
 - Use `config.py` for all configurable values (never hardcode paths/URLs)
+- Frontend: Svelte 4 + Vite 5 (`frontend/`). No CSS framework — styling goes through the
+  design tokens in `frontend/src/app.css` (CSS custom properties); don't introduce Tailwind
+  or another framework without discussing it first. Fonts are self-hosted via `@fontsource`.
+- Before pushing frontend changes, run `npm run check` (svelte-check with
+  `--fail-on-warnings`) — CI blocks on it, and the baseline is currently zero warnings
 
 ## Testing & Coverage
 
@@ -161,18 +181,26 @@ Rollback = the prior tag's artifact; delete the GitHub Release (and tag) if a re
 
 ## Project Structure
 
+[`ARCHITECTURE.md`](ARCHITECTURE.md) is the authoritative map — every backend module, the
+frontend routes, and how data flows between them. The list below is just orientation for a
+first change:
+
 ```
-server.py      — FastAPI REST API (the main entry point)
-index.html     — Tailwind frontend (single file)
-config.py      — Centralized configuration
-db.py          — SQLite data layer
-vectordb.py    — ChromaDB + Ollama embeddings
-ingest.py      — Media file processing pipeline
-transcribe.py  — Whisper transcription + anti-hallucination guard
-frames.py      — FFmpeg frame extraction
-vision.py      — Ollama vision analysis (JSON output)
-health.py      — Environment health check
+server.py         — FastAPI app: ~70 REST endpoints, and serves the built SPA
+config.py         — Centralized configuration
+db.py             — SQLite data layer
+vectordb.py       — ChromaDB + Ollama embeddings
+ingest.py         — Media pipeline: probe → thumbnail → transcribe → vision → embed
+transcribe.py     — Whisper transcription + anti-hallucination guard
+frames.py         — FFmpeg frame extraction (incl. 360/dual-fisheye)
+vision.py         — Ollama vision analysis (JSON output)
+health.py         — Environment health check
+frontend/src/     — Svelte SPA: routes/ (screens), lib/ (shared), app.css (design tokens)
+docs/             — API reference, pipeline notes, ADRs
 ```
+
+Backend modules sit flat at the repo root (~37 of them). The ones above are the files you're
+most likely to touch first, not the full set.
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,4 +66,6 @@ python health.py   # all required checks should PASS
 
 ---
 
-*MIT licensed. Self-hosted, no cloud, no telemetry.*
+*Source-available under the [PolyForm Noncommercial License 1.0.0](../LICENSE) with a
+Commercial Output Exception — arkiv is free for noncommercial use, and what you make with it
+is yours to use commercially. Self-hosted, no cloud, no telemetry.*


### PR DESCRIPTION
Follow-up to #286, which deliberately left these out of scope.

## The frontend guidance was two cutovers out of date

`CONTRIBUTING.md` § Code Style said:

> Frontend: vanilla JS + Tailwind CSS (no build step)

Wrong on all three counts. It's **Svelte 4 + Vite 5** (`frontend/`), there **is** a build step, and there is **no Tailwind anywhere in the project** — styling goes through the design tokens in `frontend/src/app.css`, with fonts self-hosted via `@fontsource`. § Project Structure still listed `index.html — Tailwind frontend (single file)`, deleted in Phase 3 of the Svelte cutover (#78).

Anyone arriving to make a UI change would have gone looking for a file that isn't there, then tried to add Tailwind.

**What changed:**

- **Prerequisites** — Node 20+ added.
- **Getting Started** — `npm ci && npm run build`. Without it `/` only serves a "run npm run build" hint, which reads like a broken install.
- **Running** — both paths documented: the built SPA at `:8501`, and `npm run dev` on `:5173` proxying `/api`, `/thumbnails` and `/ws` to the backend (so both processes need to be up).
- **Code Style** — the real stack, an explicit "no CSS framework, discuss before introducing one", and `npm run check` (`svelte-check --fail-on-warnings`) flagged as the blocking CI gate with a zero-warning baseline.
- **Project Structure** — defers to [`ARCHITECTURE.md`](ARCHITECTURE.md) as the authoritative map and keeps only an orientation subset. The old list rotted because it tried to be complete; this one says outright that it isn't.

## Two more MIT leftovers

Same defect as #286 — the #225 relicense didn't reach every doc:

- `ARCHITECTURE.md` (written *for* contributors and fork authors) called arkiv "local-first 開源 … MIT license".
- `docs/index.md` closed with "*MIT licensed.*"

Both now state PolyForm Noncommercial 1.0.0 + Commercial Output Exception, and say source-available rather than open source.

A repo-wide sweep finds no other MIT claim in arkiv's own files (remaining hits are third-party packages' own licenses under `.venv/`).

## Deliberately not touched

`frontend/src/routes/Edge.svelte:141` still reads "MIT licensed", but it's mounted at `/_design/edge` as a frozen design mock. Changing it would break the freeze convention; worth catching whenever those mocks are next revised.
