### PR TITLE
fix(federation): pg 模式下 federated 搜尋靜默退化成關鍵字查詢

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### Fixed
+- **Federated search silently stopped being search under the pg backend.** With
+  `ARKIV_VECTOR_BACKEND=pg` the vectors live in the shared pgvector store keyed by
+  `project_name`, and no project has a `.arkiv/chroma_db` directory. Federation
+  opened that directory anyway. Two things then went wrong in sequence, neither of
+  which produced an error: `health.project_health` treated the missing directory as
+  `CHROMA_MISSING`, so **every** project failed preflight and was reported as a
+  project error; and where a project did get past that, `_query_chroma` found
+  nothing and the code fell through to `_sql_like_search` — so a semantic query
+  came back as a keyword `LIKE`, ranked by nothing, with a plausible-looking result
+  set and no marker saying the search had changed kind. The pg path now queries the
+  shared store scoped to the project (`PgCollection.query` already accepted a
+  `project_name` filter, and `vectordb._query_collection` already built it — the
+  wiring was the only thing missing), and the chroma preflight applies only under
+  the chroma backend. As a side effect the pg path opens no external project
+  directory at all, so the untrusted-collection concern documented on
+  `_query_chroma` does not arise there.
+
 ### Added
 - **Sony `.mxf` footage now indexes (DIT wrapper ④).** FX6 / FX9 / Venice cards are `.mxf`, and pointing a `--dir` scan at one produced zero indexed clips — the extension sat in `ingest._PRO_UNSUPPORTED_EXT` next to `.braw` / `.r3d` / `.ari`, and the skip notice told the user pro formats "aren't indexable (ffmpeg has no decoder without vendor SDKs)". That grouping was over-broad: those three are proprietary RAW **codecs** with genuinely no ffmpeg decoder, whereas MXF is a **container**, and ffmpeg decodes what Sony wraps inside it. `.mxf` moves to `mediatypes.VIDEO_EXT`, which propagates to `ingest.SUPPORTED`, db.py's SQL video filter, the watcher, and the query builder through the shared set rather than by hand. Verified before landing across the whole chain ingest depends on — `probe()`, thumbnail, frame extraction, and the 16 kHz mono audio decode whisper consumes — on two samples: `samples.ffmpeg.org/MXF/C0023S01.mxf` (Sony 2006, MPEG-4 part 2, 352×288, `start_tc 01:43:48:21` read from format-level tags) and a synthesised XAVC-Intra file (H.264 High 4:2:2 all-I, 1920×1080, `start_tc 01:00:00:00`); every stage green on both. An MXF whose inner codec ffmpeg *cannot* decode degrades exactly as any unreadable file does — `probe()` returns `None`, the clip is skipped with `[ffprobe failed]` — so admitting the container adds no new failure mode. `.m2ts` deliberately stays in the pro-unsupported set: it is also a container, but frame extraction failed on the sample tested, so it needs its own measurement instead of being swept along. Three documents had recorded this feature as shipped since June (ADR 0001's status line, its Decision ④ entry claiming "Shipped (v0.8.1)", and the roadmap); the ADR now carries a correction noting it was never true.
 

--- a/federation.py
+++ b/federation.py
@@ -192,12 +192,22 @@ def _query_chroma(project: ProjectMeta, query_embeddings, limit: int) -> List[Di
     except Exception as exc:
         import vectordb
         vectordb._reraise_dim_error(exc)  # dim mismatch -> EmbeddingDimensionMismatch
+    return _hits_from_raw(raw, limit)
+
+
+def _hits_from_raw(raw: Dict[str, Any], limit: int) -> List[Dict[str, Any]]:
+    """Flatten a Chroma-shaped query result into federation hits.
+
+    Shared by both vector backends: ``PgCollection.query`` deliberately returns
+    Chroma's nested ``[[...]]`` shape, so one parser serves both.
+    """
     documents = raw.get("documents", [[]])[0] if raw.get("documents") else []
     metadatas = raw.get("metadatas", [[]])[0] if raw.get("metadatas") else []
     distances = raw.get("distances", [[]])[0] if raw.get("distances") else []
     seen = set()
     hits = []
     for index, (document, meta, distance) in enumerate(zip(documents, metadatas, distances)):
+        meta = meta or {}
         media_id = meta.get("media_id")
         if media_id in seen:
             continue
@@ -216,6 +226,37 @@ def _query_chroma(project: ProjectMeta, query_embeddings, limit: int) -> List[Di
         if len(hits) >= limit:
             break
     return hits
+
+
+def _query_pg(project: ProjectMeta, query_embeddings, limit: int) -> List[Dict[str, Any]]:
+    """Federated vector search against the shared pgvector store.
+
+    In pg mode an external project has no ``.arkiv/chroma_db`` to open — its
+    vectors live in the shared store, tagged with ``project_name``. Querying
+    that store scoped to this project is the semantic search the chroma path
+    provides; without it federation fell through to ``_sql_like_search`` and
+    quietly downgraded every federated query to a keyword LIKE.
+
+    A side benefit: nothing here opens an external project's directory, so the
+    untrusted-collection concern documented on ``_query_chroma`` does not arise.
+    """
+    import vectordb
+
+    col = vectordb.get_collection()
+    raw = vectordb._query_collection(
+        col,
+        [query_embeddings],
+        max(limit * 3, limit),
+        project_scope=[project.name],
+    )
+    return _hits_from_raw(raw, limit)
+
+
+def _query_vectors(project: ProjectMeta, query_embeddings, limit: int) -> List[Dict[str, Any]]:
+    """Query whichever backend actually holds this project's vectors."""
+    if getattr(config, "VECTOR_BACKEND", "chroma") == "pg":
+        return _query_pg(project, query_embeddings, limit)
+    return _query_chroma(project, query_embeddings, limit)
 
 
 def _sql_like_search(conn: sqlite3.Connection, project: ProjectMeta, query: str, limit: int) -> List[Dict[str, Any]]:
@@ -296,7 +337,7 @@ def query_single_project(
             try:
                 if q_embed is None:
                     q_embed = embed_query(query)
-                chroma_hits = _query_chroma(project, q_embed, limit)
+                chroma_hits = _query_vectors(project, q_embed, limit)
                 if chroma_hits:
                     for hit in chroma_hits:
                         row = _fetch_media_row(conn, hit["media_id"])

--- a/health.py
+++ b/health.py
@@ -135,9 +135,17 @@ def project_health(project):
     if not db_path.exists():
         return HealthStatus.DB_MISSING
 
-    chroma_path = project_path / ".arkiv" / "chroma_db"
-    if not chroma_path.is_dir():
-        return HealthStatus.CHROMA_MISSING
+    # A per-project chroma directory is only evidence of an index under the
+    # chroma backend. In pg mode the vectors live in the shared pgvector store
+    # keyed by project_name, and no project has a chroma_db dir — requiring one
+    # failed every project at preflight, which federation then reported as a
+    # project error and degraded to keyword search.
+    import config
+
+    if getattr(config, "VECTOR_BACKEND", "chroma") != "pg":
+        chroma_path = project_path / ".arkiv" / "chroma_db"
+        if not chroma_path.is_dir():
+            return HealthStatus.CHROMA_MISSING
 
     if not _check_mount(project_path):
         return HealthStatus.NAS_UNMOUNTED

--- a/tests/test_federation_pg.py
+++ b/tests/test_federation_pg.py
@@ -1,0 +1,173 @@
+"""Federated search must stay semantic under the pgvector backend.
+
+In pg mode an external project has no ``.arkiv/chroma_db`` to open — its vectors
+live in the shared store, tagged by ``project_name``. Federation opened that
+directory anyway, got nothing, and fell through to ``_sql_like_search``: every
+federated query silently degraded from vector search to a keyword LIKE, with no
+error and no marker in the response.
+"""
+
+import importlib
+import sqlite3
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _make_project(tmp_path, name, with_chroma=False, media_count=50):
+    """A project on disk. ``with_chroma=False`` is the pg-mode shape: a real
+    database, no chroma directory anywhere."""
+    root = tmp_path / name
+    db_dir = root / ".arkiv"
+    db_dir.mkdir(parents=True, exist_ok=True)
+    if with_chroma:
+        (db_dir / "chroma_db").mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_dir / "project.db"))
+    conn.execute(
+        "CREATE TABLE media (id INTEGER PRIMARY KEY, path TEXT, filename TEXT, "
+        "duration_s REAL, rating TEXT, lang TEXT, ext TEXT, transcript TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE tags (id INTEGER PRIMARY KEY, media_id INTEGER, name TEXT, "
+        "source TEXT DEFAULT 'manual')"
+    )
+    for idx in range(1, media_count + 1):
+        conn.execute(
+            "INSERT INTO media (id, path, filename, duration_s, rating, lang, ext, transcript) "
+            "VALUES (?,?,?,?,?,?,?,?)",
+            (idx, "clips/%d.mp4" % idx, "%s_%d.mp4" % (name, idx), float(idx),
+             "good", "en", ".mp4", "project %s row %d query token" % (name, idx)),
+        )
+    conn.commit()
+    conn.close()
+    return root
+
+
+def _fake_vectordb(recorder):
+    """A stand-in for the shared pg collection that records its scope filter."""
+    def _query_collection(col, query_embeddings, n_results, project_scope=None):
+        recorder.append({"scope": project_scope, "n": n_results})
+        name = (project_scope or ["?"])[0]
+        return {
+            "documents": [["%s semantic hit" % name, "%s second hit" % name]],
+            "metadatas": [[
+                {"media_id": "7", "filename": "%s_7.mp4" % name, "path": "clips/7.mp4",
+                 "duration_s": 7.0, "lang": "en", "chunk_type": "transcript", "chunk_idx": 0},
+                {"media_id": "8", "filename": "%s_8.mp4" % name, "path": "clips/8.mp4",
+                 "duration_s": 8.0, "lang": "en", "chunk_type": "transcript", "chunk_idx": 1},
+            ]],
+            "distances": [[0.05, 0.30]],
+        }
+
+    return types.SimpleNamespace(
+        get_collection=lambda: object(),
+        _query_collection=_query_collection,
+        embed=lambda q: [0.42],
+    )
+
+
+def _exploding_chromadb():
+    """Any attempt to open a chroma directory in pg mode is a bug."""
+    def _boom(path):
+        raise AssertionError("pg mode must not open a chroma dir: %s" % path)
+    return types.SimpleNamespace(PersistentClient=_boom)
+
+
+@pytest.fixture
+def fed():
+    return importlib.import_module("federation")
+
+
+def test_pg_mode_queries_the_shared_store_scoped_to_the_project(fed, tmp_path, monkeypatch):
+    project = importlib.import_module("projects").ProjectMeta(
+        name="alpha", path=_make_project(tmp_path, "alpha"))
+    calls = []
+    monkeypatch.setattr(fed.config, "VECTOR_BACKEND", "pg")
+    monkeypatch.setitem(__import__("sys").modules, "vectordb", _fake_vectordb(calls))
+
+    hits = fed._query_vectors(project, [0.42], limit=5)
+
+    assert calls[0]["scope"] == ["alpha"]          # scoped, not the whole store
+    assert calls[0]["n"] >= 5
+    assert [h["media_id"] for h in hits] == ["7", "8"]
+    assert hits[0]["excerpt"] == "alpha semantic hit"
+    assert hits[0]["score"] == pytest.approx(0.95)
+
+
+def test_pg_mode_never_opens_a_chroma_directory(fed, tmp_path, monkeypatch):
+    project = importlib.import_module("projects").ProjectMeta(
+        name="alpha", path=_make_project(tmp_path, "alpha"))
+    monkeypatch.setattr(fed.config, "VECTOR_BACKEND", "pg")
+    monkeypatch.setattr(fed, "chromadb", _exploding_chromadb())
+    monkeypatch.setitem(__import__("sys").modules, "vectordb", _fake_vectordb([]))
+
+    hits = fed._query_vectors(project, [0.42], limit=3)
+    assert hits  # would have raised AssertionError inside _exploding_chromadb
+
+
+def test_chroma_mode_is_unchanged(fed, tmp_path, monkeypatch):
+    """The default backend must keep its existing path — this is additive."""
+    project = importlib.import_module("projects").ProjectMeta(
+        name="alpha", path=_make_project(tmp_path, "alpha", with_chroma=True))
+    seen = {}
+
+    class _Col:
+        def query(self, query_embeddings, n_results, include):
+            seen["include"] = include
+            return {"documents": [["chroma hit"]],
+                    "metadatas": [[{"media_id": "1", "filename": "a.mp4", "path": "clips/1.mp4"}]],
+                    "distances": [[0.1]]}
+
+    class _Client:
+        def __init__(self, path):
+            seen["path"] = path
+
+        def get_collection(self, name):
+            return _Col()
+
+    monkeypatch.setattr(fed.config, "VECTOR_BACKEND", "chroma")
+    monkeypatch.setattr(fed, "chromadb", types.SimpleNamespace(PersistentClient=_Client))
+
+    hits = fed._query_vectors(project, [0.42], limit=3)
+
+    assert "chroma_db" in seen["path"]
+    assert hits[0]["excerpt"] == "chroma hit"
+
+
+def test_pg_mode_end_to_end_stays_semantic_without_any_chroma_dir(fed, tmp_path, monkeypatch):
+    """The defect in one assertion: no chroma dirs anywhere, and the federated
+    result is still vector hits rather than a keyword-LIKE degradation."""
+    project_mod = importlib.import_module("projects")
+    projects = [
+        project_mod.ProjectMeta(name=name, path=_make_project(tmp_path, name))
+        for name in ("alpha", "beta")
+    ]
+    for p in projects:
+        assert not (p.path / ".arkiv" / "chroma_db").exists()
+
+    calls = []
+    monkeypatch.setattr(fed.config, "VECTOR_BACKEND", "pg")
+    monkeypatch.setattr(fed.config, "discover_projects", lambda: projects)
+    monkeypatch.setattr(fed, "embed_query", lambda q: [0.42])
+    monkeypatch.setattr(fed, "chromadb", _exploding_chromadb())
+    monkeypatch.setitem(__import__("sys").modules, "vectordb", _fake_vectordb(calls))
+    fed._neg_clear()
+
+    payload = fed.search_all_projects("query token", limit=6, per_project_limit=2, timeout=5.0)
+
+    assert payload["projects_failed"] == 0
+    assert {c["scope"][0] for c in calls} == {"alpha", "beta"}
+    excerpts = {item["excerpt"] for item in payload["items"]}
+    assert "alpha semantic hit" in excerpts
+    assert "beta semantic hit" in excerpts
+    # A SQL-LIKE degradation would have produced transcript rows instead.
+    assert not any("row" in e and "query token" in e for e in excerpts)
+
+
+def test_hits_from_raw_tolerates_empty_and_null_metadata(fed):
+    assert fed._hits_from_raw({}, 5) == []
+    raw = {"documents": [["d"]], "metadatas": [[None]], "distances": [[0.2]]}
+    hits = fed._hits_from_raw(raw, 5)
+    assert hits[0]["media_id"] == "None"
+    assert hits[0]["score"] == pytest.approx(0.8)


### PR DESCRIPTION
`ARKIV_VECTOR_BACKEND=pg` 時向量存在共用 pgvector store、以 `project_name` 標記，**沒有任何 project 有 `.arkiv/chroma_db` 目錄**。但 federation 還是去開那個目錄。

接著兩件事依序出錯，而且兩件都不會報錯：

1. `health.project_health` 把「沒有 chroma 目錄」判成 `CHROMA_MISSING`，於是**每一個** project 都在 preflight 就失敗、被當成 project error
2. 就算有 project 過了那關，`_query_chroma` 什麼也找不到，程式落到 `_sql_like_search` —— 語意查詢變成關鍵字 `LIKE`，排序失去意義，但回傳的結果集看起來很合理，**沒有任何標記說明搜尋的種類已經被換掉了**

這是最難查的那種壞法：它不是壞掉，是換了一件事做，然後不告訴你。

## 修法

其實沒有新東西要發明 —— `PgCollection.query` 本來就吃 `where={"project_name": {"$in": [...]}}`，`vectordb._scope_where` / `_query_collection` 也早就會組這個 filter。**缺的只有接線。**

- `federation._query_vectors` 依 `config.VECTOR_BACKEND` 路由：pg 走共用 store 並 scope 到該 project，chroma 維持原路徑不動
- 兩條路徑共用 `_hits_from_raw`（`PgCollection.query` 刻意回傳 Chroma 的巢狀 `[[...]]` 形狀，所以一個 parser 就夠）
- chroma preflight 只在 chroma backend 下套用

副作用是好的：pg 路徑完全不開啟外部 project 的目錄，所以 `_query_chroma` 上面記載的「外部 collection 不可信」（ChromaToast / chroma#6717）那個顧慮在這條路上不存在。

## 驗證

- 全套 **1127 passed / 35 skipped**
- 新增 6 個測試。其中 end-to-end 那個刻意讓任何開啟 chroma 目錄的行為直接 `AssertionError`，並斷言結果不是 SQL LIKE 會產生的 transcript 列
- **第 ① 層是被這個測試抓出來的** —— 原本只打算修第 ② 層，測試跑出 `project preflight failed: chroma_missing` 才發現前面還有一關

🤖 Generated with [Claude Code](https://claude.com/claude-code)