### PR TITLE
fix(collections): 7 blockers from the Codex audit of #292

### DIFF
--- a/collection_defs.py
+++ b/collection_defs.py
@@ -490,9 +490,14 @@ def validate_candidate(
     carries no information. The floor is the other half — a 2-clip collection
     costs a permanent sidebar row and saves nobody any scrolling.
     """
-    if not (MIN_DERIVED_TAGS <= len(col.tags) <= MAX_DERIVED_TAGS):
+    # Count what the scorer counts: distinct CONCEPTS after alias folding, not tag
+    # strings. Derived candidates come from an already-folded vocabulary so the two
+    # agree there, but reading len(col.tags) would let a hand-edited or
+    # re-validated collection be gated on a number the engine does not use.
+    k = len({smart_collections.fold_tag(t) for t in col.tags})
+    if not (MIN_DERIVED_TAGS <= k <= MAX_DERIVED_TAGS):
         return None, "k={0} outside [{1},{2}]".format(
-            len(col.tags), MIN_DERIVED_TAGS, MAX_DERIVED_TAGS)
+            k, MIN_DERIVED_TAGS, MAX_DERIVED_TAGS)
 
     members = set(candidate_members(col, records))
     library = len([r for r in records if r.get("id") is not None])
@@ -544,7 +549,15 @@ def merge_proposal(
     Hysteresis is the point — an ingest that temporarily pushes a collection
     below the floor should not delete a definition that the next ingest restores.
     """
-    by_key = {e.get("key"): dict(e) for e in existing if isinstance(e, dict) and e.get("key")}
+    # FIRST wins on a duplicate key, matching the loader (`_read_file` keeps the
+    # first and skips the rest). A dict comprehension here kept the LAST, so
+    # merely re-running derivation over a file with a duplicated key silently
+    # swapped which definition was effective — a rename, which this function
+    # exists to prevent.
+    by_key: Dict[Any, Dict[str, Any]] = {}
+    for e in existing:
+        if isinstance(e, dict) and e.get("key") and e["key"] not in by_key:
+            by_key[e["key"]] = dict(e)
     fresh_keys = {c["key"] for c in candidates}
 
     for key, entry in by_key.items():

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -313,7 +313,15 @@
   // filter already handles. Clicking the active pool toggles back to all.
   function onPoolClick(label) {
     activeCamera = null
-    if (label === 'All media') { activeRating = null; activeFilter = 'all'; return }
+    if (label === 'All media') {
+      activeRating = null
+      activeFilter = 'all'
+      // "All media" has to actually leave a collection. Clearing only the rating
+      // filters left the grid showing the collection subset with its sidebar row
+      // still highlighted, while the user had just asked for the whole library.
+      if (activeCollection || query) { query = ''; load() }
+      return
+    }
     const map = { 'Needs review': 'rev', 'Rated good': 'good', 'N·G': 'ng', 'Unrated': 'none' }
     const target = map[label]
     if (target === undefined) return

--- a/ingest.py
+++ b/ingest.py
@@ -1641,6 +1641,34 @@ def _run_propose_aliases(args):
     print("Review/edit that file, then: python ingest.py --apply-aliases")
 
 
+def _atomic_write_json(path, payload):
+    """Write JSON via a temp file + os.replace, so the target is never truncated.
+
+    `Path.write_text` opens with O_TRUNC: a disk-full, a kill, or an encoding
+    error partway through leaves a half-written file where a valid configuration
+    used to be. os.replace is atomic within a filesystem, so a reader sees either
+    the old file or the new one.
+    """
+    import json as _json
+    import os as _os
+    import tempfile as _tempfile
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = _tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
+    try:
+        with _os.fdopen(fd, "w", encoding="utf-8") as fh:
+            _json.dump(payload, fh, ensure_ascii=False, indent=2)
+            fh.flush()
+            _os.fsync(fh.fileno())
+        _os.replace(tmp, str(path))
+    except BaseException:
+        try:
+            _os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
 _THEME_JUDGE_PROMPT = (
     "以下是一組經常一起出現在同一支影片裡的標籤。請判斷它們是否構成一個「可以拿來瀏覽素材的主題」，"
     "如果是，取一個簡短的中文名稱（不超過 12 字），並從清單裡挑出真正屬於這個主題的標籤。"
@@ -1739,14 +1767,48 @@ def _run_propose_collections(args):
     """
     import json as _json
 
+    def _write_proposal(candidates):
+        """Merge candidates over whatever is live and write the proposal file."""
+        existing, existing_disable = [], []
+        src = config.COLLECTIONS_PATH
+        if src.exists():
+            try:
+                prev = _json.loads(src.read_text(encoding="utf-8"))
+            except (ValueError, OSError):
+                prev = None
+            if isinstance(prev, dict):
+                raw_prev = prev.get("collections")
+                if isinstance(raw_prev, list):
+                    existing = [e for e in raw_prev if isinstance(e, dict)]
+                raw_disable = prev.get("disable")
+                if isinstance(raw_disable, list):
+                    existing_disable = [k for k in raw_disable if isinstance(k, str)]
+        merged = collection_defs.merge_proposal(existing, candidates)
+        payload = {"version": collection_defs.FORMAT_VERSION, "collections": merged}
+        if existing_disable:
+            payload["disable"] = existing_disable
+        _atomic_write_json(config.COLLECTIONS_PROPOSED_PATH, payload)
+        return merged
+
     min_freq = getattr(args, "collection_min_tag_count", 3) or 3
     min_members = getattr(args, "collection_min_members", 4) or 4
     max_share = getattr(args, "collection_max_share", 0.35) or 0.35
     dry_run = bool(getattr(args, "collection_dry_run", False))
 
+    # An early return used to leave a previous proposal file sitting on disk, so a
+    # later --apply-collections could activate definitions derived from a library
+    # state that no longer exists. Every exit path from here on writes the
+    # proposal, even when it is empty — "this derivation found nothing" is a
+    # result, and it must overwrite the one that found something.
+    def _bail(message):
+        print(message)
+        _write_proposal([])
+        print("Wrote an empty proposal → {0} (any earlier proposal is now superseded)."
+              .format(config.COLLECTIONS_PROPOSED_PATH))
+
     records = collection_defs.classification_records()
     if not records:
-        print("Library is empty — nothing to derive.")
+        _bail("Library is empty — nothing to derive.")
         return
 
     vocab, docs, rejected = collection_defs.derivable_vocabulary(records, min_freq)
@@ -1754,7 +1816,7 @@ def _run_propose_collections(args):
     if rejected:
         print("  pruned: " + "  ".join("{0}={1}".format(k, v) for k, v in sorted(rejected.items())))
     if len(vocab) < collection_defs.MIN_DERIVED_TAGS:
-        print("Too few derivable tags — nothing to propose.")
+        _bail("Too few derivable tags — nothing to propose.")
         return
 
     clusters = collection_defs.cooccurrence_clusters(vocab, docs)
@@ -1785,22 +1847,9 @@ def _run_propose_collections(args):
         print("    {0:<20} KEPT  members={1} share={2:.0%}  {3}".format(
             title[:20], stats["members_at_build"], stats["share"], "、".join(tags)))
 
-    # Re-running must never silently rename or drop a collection already in use.
-    existing = []
-    src = config.COLLECTIONS_PATH
-    if src.exists():
-        try:
-            prev = _json.loads(src.read_text(encoding="utf-8"))
-            if isinstance(prev, dict):
-                existing = [e for e in (prev.get("collections") or []) if isinstance(e, dict)]
-        except (ValueError, OSError):
-            existing = []
-    merged = collection_defs.merge_proposal(existing, candidates)
-
-    payload = {"version": collection_defs.FORMAT_VERSION, "collections": merged}
-    config.COLLECTIONS_PROPOSED_PATH.parent.mkdir(parents=True, exist_ok=True)
-    config.COLLECTIONS_PROPOSED_PATH.write_text(
-        _json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    # Re-running must never silently rename or drop a collection already in use,
+    # and must carry `disable` through — see _write_proposal.
+    merged = _write_proposal(candidates)
 
     fresh = len([c for c in merged if c.get("key") in {x["key"] for x in candidates}])
     stale = len([c for c in merged if c.get("stale")])
@@ -1839,21 +1888,39 @@ def _run_apply_collections(args):
         print("Proposal malformed (top level is {0}, expected an object) — not applying."
               .format(type(data).__name__))
         sys.exit(1)
+    if data.get("version") != collection_defs.FORMAT_VERSION:
+        # The loader treats an unknown version as absent; apply must not quietly
+        # downgrade a future-format proposal by rewriting it as v1.
+        print("Proposal is version {0!r}, expected {1} — not applying."
+              .format(data.get("version"), collection_defs.FORMAT_VERSION))
+        sys.exit(1)
 
     raw_entries = data.get("collections")
-    raw_entries = raw_entries if isinstance(raw_entries, list) else []
-    clean, dropped = [], 0
-    for entry in raw_entries:
+    if not isinstance(raw_entries, list):
+        print("Proposal malformed (`collections` is {0}, expected a list) — not applying."
+              .format(type(raw_entries).__name__))
+        sys.exit(1)
+
+    clean, invalid = [], []
+    for idx, entry in enumerate(raw_entries):
         # Reuse the loader's validator: it already treats this file as untrusted,
         # so apply and load can never disagree about what a valid entry is.
         if collection_defs._entry_to_collection(entry) is None:
-            dropped += 1
+            key = entry.get("key") if isinstance(entry, dict) else None
+            invalid.append("#{0}{1}".format(idx, " ({0})".format(key) if key else ""))
             continue
         clean.append({k: v for k, v in entry.items() if k != "stale"})
 
+    if invalid:
+        # All-or-nothing. Dropping the bad entries and exiting 0 would report
+        # success for a partial application of a file the human reviewed as a
+        # whole — the reviewer approved a set, not a subset.
+        print("Proposal has {0} invalid entr{1} ({2}) — not applying.".format(
+            len(invalid), "y" if len(invalid) == 1 else "ies", ", ".join(invalid)))
+        print("Fix or remove them and re-run; nothing was written.")
+        sys.exit(1)
     if not clean:
-        print("Proposal contains no valid collections ({0} entries dropped) — not applying."
-              .format(dropped))
+        print("Proposal contains no collections — not applying.")
         sys.exit(1)
 
     disable = [k for k in (data.get("disable") or [])
@@ -1861,14 +1928,10 @@ def _run_apply_collections(args):
     payload = {"version": collection_defs.FORMAT_VERSION, "collections": clean}
     if disable:
         payload["disable"] = disable
-    config.COLLECTIONS_PATH.parent.mkdir(parents=True, exist_ok=True)
-    config.COLLECTIONS_PATH.write_text(
-        _json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    _atomic_write_json(config.COLLECTIONS_PATH, payload)
     collection_defs._CACHE["mtime"] = None  # take effect without a restart
 
-    print("Applied {0} collection(s){1} → {2}".format(
-        len(clean), " ({0} dropped as invalid)".format(dropped) if dropped else "",
-        config.COLLECTIONS_PATH))
+    print("Applied {0} collection(s) → {1}".format(len(clean), config.COLLECTIONS_PATH))
     print("Sidebar picks them up on next /api/collections (file auto-reloads on change).")
 
 

--- a/smart_collections.py
+++ b/smart_collections.py
@@ -167,16 +167,23 @@ def media_signal(media: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _booster_applies(b: Booster, sig: Dict[str, Any]) -> bool:
+    # Booster tag fields fold through the same normaliser as Collection.tags and
+    # Collection.exclude_tags. Missed on the first pass: sig["tags"] is folded, so
+    # a booster written `any_tags=["吧檯"]` silently never fired once the clip's
+    # 吧檯 became 吧台 — the third side of a comparison that was supposed to have
+    # two. No shipped collection uses boosters and the file format deliberately
+    # cannot express them, so nothing in production was affected; left unfixed it
+    # would have been a trap for whoever added the first one.
     tags = sig["tags"]
     if b.min_duration is not None and sig["duration_s"] < b.min_duration:
         return False
     if b.has_audio is not None and sig["has_audio"] != b.has_audio:
         return False
-    if b.all_tags and not all(t in tags for t in b.all_tags):
+    if b.all_tags and not all(fold_tag(t) in tags for t in b.all_tags):
         return False
-    if b.any_tags and not any(t in tags for t in b.any_tags):
+    if b.any_tags and not any(fold_tag(t) in tags for t in b.any_tags):
         return False
-    if b.no_tags and any(t in tags for t in b.no_tags):
+    if b.no_tags and any(fold_tag(t) in tags for t in b.no_tags):
         return False
     if b.content_types and not (set(b.content_types) & sig["content_types"]):
         return False
@@ -217,14 +224,23 @@ def score_collection(
 
     # Base signal: fraction of the collection's vocabulary the item hits, but
     # rewarded by absolute overlap too (so a 1-of-8 hit isn't as strong as 4-of-8).
-    if not col.tags:
+    #
+    # Count CONCEPTS, not spellings. Folding is what makes this necessary: a
+    # collection listing ["黑膠唱片", "黑膠唱盤", "唱針", "唱片架"] with 黑膠唱盤
+    # aliased to 黑膠唱片 has three concepts written as four tags, and counting
+    # per-tag gave a clip carrying only 黑膠唱片 two hits out of a denominator of
+    # four — 0.583, a member on ONE concept. That silently broke the guarantee the
+    # whole 4..14 band exists to provide, using the very folding introduced to make
+    # membership work. Dedupe both sides of the ratio so k is the concept count.
+    folded_col_tags = {fold_tag(t) for t in col.tags}
+    if not folded_col_tags:
         base = 0.0
     else:
-        hits = sum(1 for t in col.tags if fold_tag(t) in sig["tags"])
+        hits = len(folded_col_tags & sig["tags"])
         if hits == 0:
             base = 0.0
         else:
-            coverage = hits / len(col.tags)  # 0..1
+            coverage = hits / len(folded_col_tags)  # 0..1
             # saturating reward for raw hits: 1 hit→0.5, 2→0.67, 3→0.75, 4→0.8...
             depth = hits / (hits + 1)
             base = col.tag_weight * (0.5 * coverage + 0.5 * depth)

--- a/tests/test_collection_derive.py
+++ b/tests/test_collection_derive.py
@@ -222,3 +222,66 @@ def test_a_stale_collection_recovers_on_a_later_run():
     existing = [{"key": "topic_a", "title": "甲", "tags": ["a", "b", "c", "d"], "stale": True}]
     out = cd.merge_proposal(existing, [{"key": "topic_a", "title": "甲", "tags": ["a", "b", "c", "d"]}])
     assert "stale" not in out[0]
+
+
+# ───────────────── regressions from the 2026-08-10 Codex audit ─────────────────
+
+def _with_alias_map(tmp_path, monkeypatch, groups):
+    import json
+    import config
+    import tag_aliases
+    amap = tmp_path / "tag_aliases.json"
+    amap.write_text(json.dumps({"version": 1, "groups": groups}, ensure_ascii=False),
+                    encoding="utf-8")
+    monkeypatch.setattr(config, "TAG_ALIASES_PATH", amap)
+    tag_aliases._CACHE["mtime"] = None
+    return tag_aliases
+
+
+def test_two_spellings_of_one_concept_are_one_hit_not_two(tmp_path, monkeypatch):
+    """BLOCKER. A collection listing both spellings of one concept gave a clip
+    carrying only that concept TWO hits against a denominator of four — 0.583, a
+    member on a single concept, which is exactly what the 4..14 band exists to
+    prevent. Both sides of the ratio now count folded concepts, so a duplicate
+    spelling changes nothing."""
+    aliases = _with_alias_map(tmp_path, monkeypatch,
+                              [{"pref": "黑膠唱片", "alts": ["黑膠唱盤"]}])
+    clip = {"duration_s": 3, "has_audio": 1, "tags": ["黑膠唱片"]}
+    with_dup = sc.Collection(key="topic_x", title="t", category="topic",
+                             tags=("黑膠唱片", "黑膠唱盤", "唱針", "唱片架"))
+    without = sc.Collection(key="topic_y", title="t", category="topic",
+                            tags=("黑膠唱片", "唱針", "唱片架"))
+    assert sc.score_collection(clip, with_dup) == sc.score_collection(clip, without)
+    aliases._CACHE["mtime"] = None
+
+
+def test_booster_tag_conditions_fold_like_everything_else():
+    """CONCERN. sig["tags"] is folded, so an unfolded booster condition silently
+    never fires (any_tags/all_tags) or always fires (no_tags)."""
+    sig = sc.media_signal({"duration_s": 3, "has_audio": 1, "tags": ["吧檯"]})
+    assert sig["tags"] == {"吧台"}
+    assert sc._booster_applies(sc.Booster(boost=0.1, any_tags=["吧檯"]), sig)
+    assert sc._booster_applies(sc.Booster(boost=0.1, all_tags=["吧檯"]), sig)
+    assert not sc._booster_applies(sc.Booster(boost=0.1, no_tags=["吧檯"]), sig)
+
+
+def test_merge_proposal_keeps_the_first_duplicate_like_the_loader():
+    """BLOCKER. A dict comprehension kept the LAST duplicate while the loader keeps
+    the first, so re-running derivation silently swapped which definition was
+    effective — a rename, from the function whose whole job is preventing them."""
+    existing = [
+        {"key": "topic_dup", "title": "原名", "tags": ["a", "b", "c", "d"]},
+        {"key": "topic_dup", "title": "新名", "tags": ["e", "f", "g", "h"]},
+    ]
+    assert [e["title"] for e in cd.merge_proposal(existing, [])] == ["原名"]
+
+
+def test_validate_candidate_counts_concepts_not_tag_strings(tmp_path, monkeypatch):
+    """The k-band gate must measure what the scorer measures."""
+    aliases = _with_alias_map(tmp_path, monkeypatch,
+                              [{"pref": "甲", "alts": ["甲2", "甲3"]}])
+    col = sc.Collection(key="topic_z", title="t", category="topic",
+                        tags=("甲", "甲2", "甲3", "乙", "丙"))  # 5 strings, 3 concepts
+    stats, why = cd.validate_candidate(col, _three_topic_library())
+    assert stats is None and "k=3" in why
+    aliases._CACHE["mtime"] = None


### PR DESCRIPTION
fix(collections): 7 blockers from the Codex audit of #292

Read-only Codex audit of the merged change set. It returned 8 blockers, 3
concerns and 1 nit; every finding below was reproduced by hand before being
fixed. The worst one broke the guarantee the whole feature was designed around.

BLOCKER — two spellings of one concept counted as two independent hits.
smart_collections.py scored each of col.tags separately after folding, but never
deduplicated the folded results while keeping the original tag count as the
denominator. A hand-written 4-tag collection listing 黑膠唱片 and 黑膠唱盤 (one
aliased to the other) gave a clip carrying only 黑膠唱片 a score of 0.583 — a
member on ONE concept, from a collection whose 4-tag size is supposed to demand
two. The 4..14 band exists precisely to make that impossible, and the alias
folding introduced to make membership work is what broke it. Both sides of the
ratio now count folded concepts. collection_defs.validate_candidate likewise
gates on the concept count rather than len(col.tags), so the gate measures what
the scorer measures.

BLOCKER — --propose-collections crashed on a file the loader accepts.
`{"version":1,"collections":42}` is fail-soft in collection_defs but reached a
list comprehension in ingest.py and died with TypeError. Every field of the live
file is now type-checked at that call site too.

BLOCKER — --apply-collections reported success for a partial application. Invalid
entries were dropped, the valid ones written, exit 0. A reviewer approves a set,
not whatever subset survives validation; it is now all-or-nothing, names the
offending entries, and writes nothing.

BLOCKER — the active collections.json was replaced non-atomically. write_text
opens O_TRUNC, so a disk-full or a kill mid-write leaves a half-written file
where a valid configuration used to be. Now temp file + fsync + os.replace.

BLOCKER — propose/apply silently re-enabled a disabled built-in. The proposal
payload rebuilt only the collections list, so a `disable` the project had set was
dropped on the round trip. Carried through now.

BLOCKER — merge_proposal kept the LAST duplicate key while the loader keeps the
first. Re-running derivation over a file with a duplicated key silently swapped
which definition was effective — a rename, from the function whose entire purpose
is preventing renames.

BLOCKER — an empty derivation left the previous proposal on disk, so a later
--apply-collections could activate definitions derived from a library state that
no longer exists. Every exit path now writes the proposal; "this run found
nothing" is a result that must supersede the run that found something.

BLOCKER — "All media" did not leave a collection view. It cleared the rating
filters only, so the grid kept showing the collection subset with its sidebar row
still highlighted while the user had just asked for the whole library.

CONCERN — booster tag conditions were not folded (found independently before the
audit report arrived, and confirmed by it). sig["tags"] is folded, so
any_tags/all_tags silently never fired and no_tags always did. Latent only: no
shipped collection uses boosters and the file format cannot express them.

CONCERN — apply ignored the proposal's format version, so a v2 file would be
read as v1 and rewritten as v1. It now refuses, matching the loader's treatment
of an unknown version as absent.

NOT FIXED, recorded deliberately:
- CONCERN: the async race the audit found in the frontend — selecting a
  collection while a search is in flight can leave the highlight disagreeing with
  the grid. A real bug, but the fix is a request-generation guard across all
  three grid-loading paths, which is a change to shared loading machinery that
  should not ride along inside an audit-fix commit. Follow-up.
- CONCERN: the CLI/Svelte branches have no automated coverage. Four of the
  blockers above were exercised by hand against a copy of the real library. Real
  gap; a proper CLI harness is its own piece of work.
- NIT: _run_apply_collections ignores `args`, kept for handler-shape consistency
  with the adjacent maintenance commands.

Verified by hand, not only by the new tests: propose no longer dies on the
malformed live file; a proposal with one bad entry exits 1 and writes nothing;
`disable: ["b_roll"]` survives a propose round trip with a hand-written
custom_ entry untouched.

Local: 1254 passed, 7 skipped. svelte-check 39 files, 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)