### PR TITLE
fix(frontend): the grid stopped showing the view the user asked for last

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,13 @@ jobs:
       - name: svelte-check (gate at zero warnings)
         working-directory: frontend
         run: npm run check
+      - name: frontend unit tests (node:test, no runner dependency)
+        working-directory: frontend
+        # The Codex audit of #292 recorded that the Svelte side had NO automated
+        # coverage — four of its blockers were only reproducible by hand. node:test is
+        # built into the Node already installed above, so this closes part of that gap
+        # without adding a devDependency or a new required check.
+        run: npm run test
       - name: bundle budget (eager chunks)
         working-directory: frontend
         run: |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-check --fail-on-warnings"
+    "check": "svelte-check --fail-on-warnings",
+    "test": "node --test tests/*.test.mjs"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^3.1.2",

--- a/frontend/scripts/audit/verify-collection-race.mjs
+++ b/frontend/scripts/audit/verify-collection-race.mjs
@@ -1,0 +1,107 @@
+// Deterministic repro for the load race the Codex audit of #292 found: picking a Smart
+// Collection while a search is still in flight left the sidebar highlighting the
+// collection and the grid repainting with the search results a moment later.
+//
+// Unlike the other verify-* scripts this one ASSERTS and exits non-zero, because a race
+// is not something you can eyeball off a screenshot. The interleaving is forced rather
+// than raced for: request interception holds the /api/media?q= response open while the
+// collection click goes through, so the "slow response lands last" ordering happens
+// every run instead of on an unlucky one.
+//
+// Needs a backend + `npm run dev`. Point it at a library where a collection's membership
+// differs from the whole library (otherwise both outcomes look identical):
+//   node verify-collection-race.mjs http://localhost:5173/ a_roll
+import puppeteer from 'puppeteer-core'
+
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+const dev = process.argv[2] || 'http://localhost:5173/'
+const collectionKey = process.argv[3] || 'a_roll'
+const HOLD_MS = 3000
+
+const fail = []
+const b = await puppeteer.launch({ executablePath: CHROME, headless: true, args: ['--no-sandbox'] })
+const p = await b.newPage()
+const errs = []
+p.on('console', (m) => { if (m.type() === 'error' && !/Failed to load resource/.test(m.text())) errs.push(m.text()) })
+p.on('pageerror', (e) => errs.push(String(e)))
+
+await p.goto(dev + '#/main-live', { waitUntil: 'networkidle0', timeout: 30000 })
+await new Promise((r) => setTimeout(r, 1800))
+
+// Read the collection's expected membership straight from the API the sidebar renders,
+// so the assertion compares against the server's answer rather than a hardcoded count.
+const target = await p.evaluate(async (key) => {
+  const r = await fetch('/api/collections')
+  const d = await r.json()
+  const c = (d.collections || []).find((x) => x.key === key)
+  return c ? { title: c.title, count: c.count, names: (c.items || []).map((i) => i.filename) } : null
+}, collectionKey)
+if (!target) { console.error(`collection ${collectionKey} not present — nothing to test`); await b.close(); process.exit(2) }
+
+const libraryCount = await p.evaluate(() => document.querySelectorAll('.card').length)
+if (libraryCount <= target.count) {
+  console.error(`library (${libraryCount}) must be larger than the collection (${target.count}) or the race is unobservable`)
+  await b.close(); process.exit(2)
+}
+
+// Hold the search response open. Everything else passes through untouched.
+await p.setRequestInterception(true)
+let heldSearch = 0
+p.on('request', (req) => {
+  const u = req.url()
+  if (/\/api\/media\?/.test(u) && /[?&]q=/.test(u)) {
+    heldSearch++
+    setTimeout(() => { try { req.continue() } catch { /* page gone */ } }, HOLD_MS)
+    return
+  }
+  try { req.continue() } catch { /* page gone */ }
+})
+
+// Fire a search, then pick the collection while the response is still held.
+await p.evaluate(() => {
+  const box = document.querySelector('input.livesearch')
+  if (!box) throw new Error('search input not found')
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set
+  setter.call(box, '唱片')
+  box.dispatchEvent(new Event('input', { bubbles: true }))
+  box.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+})
+await new Promise((r) => setTimeout(r, 300))
+
+const clicked = await p.evaluate((title) => {
+  const row = [...document.querySelectorAll('.collrow')].find((r) => r.textContent.includes(title))
+  if (!row) return false
+  row.click()
+  return true
+}, target.title)
+if (!clicked) { console.error(`sidebar row for ${target.title} not found`); await b.close(); process.exit(2) }
+
+// The collection is synchronous, so the grid is already correct here. The bug shows up
+// only once the held search response finally lands.
+const beforeLanding = await p.evaluate(() => ({
+  cards: document.querySelectorAll('.card').length,
+  highlighted: !!document.querySelector('.collrow.activecoll'),
+}))
+await new Promise((r) => setTimeout(r, HOLD_MS + 1500))
+
+const after = await p.evaluate(() => ({
+  cards: document.querySelectorAll('.card').length,
+  names: [...document.querySelectorAll('.name')].map((n) => n.textContent.trim()),
+  highlighted: [...document.querySelectorAll('.collrow.activecoll')].map((r) => r.textContent.replace(/\s+/g, ' ').trim()),
+}))
+
+if (heldSearch === 0) fail.push('no search request was intercepted — the interleaving never happened, so a pass here means nothing')
+if (beforeLanding.cards !== target.count) fail.push(`right after the click the grid showed ${beforeLanding.cards} cards, expected ${target.count}`)
+if (after.cards !== target.count) fail.push(`after the held search landed the grid showed ${after.cards} cards, expected the collection's ${target.count}`)
+if (after.highlighted.length !== 1) fail.push(`expected exactly one highlighted collection row, saw ${after.highlighted.length}`)
+const missing = target.names.filter((n) => !after.names.includes(n))
+if (missing.length) fail.push(`collection members missing from the grid: ${missing.join(', ')}`)
+if (errs.length) fail.push(`console errors: ${errs.join(' | ')}`)
+
+console.log(JSON.stringify({
+  collection: collectionKey, title: target.title, expected: target.count,
+  libraryCount, heldSearch, beforeLanding, after, fail,
+}, null, 2))
+await b.close()
+if (fail.length) { console.error(`\nFAIL (${fail.length})\n` + fail.map((f) => '  - ' + f).join('\n')); process.exit(1) }
+console.log('\nPASS — the superseded search did not repaint the collection view')

--- a/frontend/src/lib/viewGen.js
+++ b/frontend/src/lib/viewGen.js
@@ -1,0 +1,38 @@
+// A monotonic generation counter for "which view is the grid supposed to be showing".
+//
+// MainLive has four independent writers to the same grid state (items/total/
+// moreParams/selectedId/state): load(), runSearch(), loadIds() and the synchronous
+// onCollectionClick(). Three of them await the network before writing, so the write
+// that lands last wins — which is not the same as the view the user asked for last.
+// Clicking a collection while a search is in flight left the sidebar highlighting the
+// collection while the grid repainted with the search results a moment later.
+//
+// The fix is a token: a path that replaces the view calls begin() and carries its token
+// across every await, and applies its results only while that token is still current.
+// A path that EXTENDS the current view (loadMore) reads current instead of calling
+// begin(), so its append is dropped if the view changed underneath it rather than
+// stapling the old view's rows onto the new one.
+export function createViewGen() {
+  let gen = 0
+  return {
+    // Claim the grid for a new view. Everything in flight is now stale.
+    begin() {
+      return ++gen
+    },
+    // Read the current token WITHOUT claiming — for work that extends the current view.
+    get current() {
+      return gen
+    },
+    isCurrent(token) {
+      return token === gen
+    },
+    // Run `fn` only if `token` still owns the grid; report whether it did. Returning a
+    // boolean (rather than just skipping) lets callers keep `finally` bookkeeping —
+    // resetting a spinner is correct even for a superseded request.
+    apply(token, fn) {
+      if (token !== gen) return false
+      fn()
+      return true
+    },
+  }
+}

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -17,11 +17,18 @@
   import Eyebrow from '../lib/Eyebrow.svelte'
   import { resolvedTheme } from '../lib/prefs.js'
   import { pushToast } from '../lib/toast.js'
+  import { createViewGen } from '../lib/viewGen.js'
 
   $: theme = $resolvedTheme
   let state = 'loading' // loading | ok | error
   let err = ''
   let items = []
+  // Four paths replace the grid (load / runSearch / loadIds / picking a collection) and
+  // three of them await the network first, so the response that lands last used to win
+  // regardless of what the user asked for last — picking a collection while a search was
+  // in flight left the sidebar highlighting the collection and the grid showing the
+  // search. Each of them now carries a generation token across its awaits.
+  const viewGen = createViewGen()
   // R5-20 (#37): the grid used to cap at 500 with no indicator — clips 501+ were
   // unreachable from browse. `total` is the server-side pool count; `moreParams`
   // holds the request to re-issue with an incrementing offset (null = fully
@@ -247,30 +254,41 @@
     // Clearing here rather than in each caller keeps the highlight honest on
     // every path back out (search cleared, pool picked, initial mount).
     activeCollection = null
+    const gen = viewGen.begin()
     state = 'loading'
     readyState = 'checking'
-    readyState = await checkReady()
+    const ready = await checkReady()
+    // Guard every await, not only the last one: a readyState write from a superseded
+    // load is as capable of contradicting the view on screen as an items write.
+    if (!viewGen.isCurrent(gen)) return
+    readyState = ready
     if (readyState === 'unreachable') { state = 'ok'; return } // panel renders via readyState
     try {
       const [s, m, t, c, si] = await Promise.all([
         api.getStats(), api.getMedia({ limit: PAGE }), api.getTags(), api.getCollections(),
         api.sampleStatus().catch(() => null), // non-fatal: chip just stays hidden
       ])
-      stats = s
-      sampleInfo = si
-      items = (m.items || []).map(toCard)
-      total = m.total ?? items.length
-      moreParams = { limit: PAGE }
-      liveTags = (t || []).map((x) => ({ name: x.name, count: x.count }))
-      liveCollections = (c?.collections || []).map((col) => ({
-        key: col.key, title: col.title, count: col.count,
-        items: col.items || [], // full member items (id/filename/thumb/duration_s/score)
-      }))
-      if (items.length && selectedId == null) selectedId = items[0].id
-      state = 'ok'
+      viewGen.apply(gen, () => {
+        stats = s
+        sampleInfo = si
+        items = (m.items || []).map(toCard)
+        total = m.total ?? items.length
+        moreParams = { limit: PAGE }
+        liveTags = (t || []).map((x) => ({ name: x.name, count: x.count }))
+        liveCollections = (c?.collections || []).map((col) => ({
+          key: col.key, title: col.title, count: col.count,
+          items: col.items || [], // full member items (id/filename/thumb/duration_s/score)
+        }))
+        if (items.length && selectedId == null) selectedId = items[0].id
+        state = 'ok'
+      })
     } catch (e) {
-      state = 'error'
-      err = e.message + (e.body ? ' · ' + JSON.stringify(e.body) : '')
+      // The error banner is a claim about the view on screen, so a request nobody is
+      // waiting for must not raise one.
+      viewGen.apply(gen, () => {
+        state = 'error'
+        err = e.message + (e.body ? ' · ' + JSON.stringify(e.body) : '')
+      })
     }
   }
 
@@ -280,16 +298,24 @@
   // double-inserting a row. Silent failure was the B11 anti-pattern — surface it.
   async function loadMore() {
     if (!moreParams || loadingMore || items.length >= total) return
+    // Paging EXTENDS the current view rather than replacing it, so it reads the
+    // generation instead of claiming a new one — but it still has to check on the way
+    // back, or a page of the old view gets stapled onto whatever replaced it.
+    const gen = viewGen.current
     loadingMore = true
     try {
       const r = await api.getMedia({ ...moreParams, offset: items.length })
-      const seen = new Set(items.map((x) => x.id))
-      const more = (r.items || []).map(toCard).filter((x) => !seen.has(x.id))
-      items = [...items, ...more]
-      total = r.total ?? total
+      viewGen.apply(gen, () => {
+        const seen = new Set(items.map((x) => x.id))
+        const more = (r.items || []).map(toCard).filter((x) => !seen.has(x.id))
+        items = [...items, ...more]
+        total = r.total ?? total
+      })
     } catch (e) {
-      pushToast(`載入更多失敗: ${e.message}`, 'error')
+      if (viewGen.isCurrent(gen)) pushToast(`載入更多失敗: ${e.message}`, 'error')
     } finally {
+      // Outside the guard on purpose: the spinner belongs to this component, not to
+      // the view, and leaving it stuck true would disable the button for good.
       loadingMore = false
     }
   }
@@ -348,6 +374,10 @@
     }
     query = ''
     activeCamera = null
+    // This writer is synchronous — the members are already in hand from
+    // /api/collections — so without claiming a generation it would be the one path a
+    // slow in-flight search could still overwrite a moment later.
+    viewGen.begin()
     activeCollection = col.key
     items = (col.items || []).map((it) => ({
       id: it.id,
@@ -367,6 +397,11 @@
     total = items.length
     moreParams = null
     selectedId = items.length ? items[0].id : null
+    // This path has its data in hand, so it owns `state` too. Previously it inherited
+    // whatever the in-flight request had left behind, which was invisible only because
+    // that request would later set 'ok' itself — now that a superseded response is
+    // correctly suppressed, not claiming 'ok' here leaves the grid stuck on "loading…".
+    state = 'ok'
   }
 
   // D — live sidebar derived data.
@@ -395,20 +430,27 @@
     // Leaving the collection view: clear the highlight too, or the sidebar keeps
     // claiming a collection is active while the grid shows search results.
     activeCollection = null
+    const gen = viewGen.begin()
     state = 'loading'
     try {
       // Same-DB search via /api/media?q= → {items, total, search:true}.
       // NOT /api/search/all — that's cross-project federation over the
       // ~/.arkiv-projects.json registry, which is empty here → 0 results.
       const r = await api.getMedia({ q: query, limit: PAGE })
-      items = (r.items || []).map(toCard)
-      total = r.total ?? items.length
-      moreParams = { q: query, limit: PAGE }
-      selectedId = items.length ? items[0].id : null
-      state = 'ok'
+      // Also fixes two searches in a row resolving out of order: the slower first
+      // query used to repaint the grid while the box already read the second one.
+      viewGen.apply(gen, () => {
+        items = (r.items || []).map(toCard)
+        total = r.total ?? items.length
+        moreParams = { q: query, limit: PAGE }
+        selectedId = items.length ? items[0].id : null
+        state = 'ok'
+      })
     } catch (e) {
-      state = 'error'
-      err = e.message
+      viewGen.apply(gen, () => {
+        state = 'error'
+        err = e.message
+      })
     }
   }
 
@@ -430,6 +472,7 @@
   // Chat deep-link: #/main-live?ids=2,5,9 shows exactly that relevant subset
   // (not the full library) via the backend's ?ids= filter.
   async function loadIds(ids) {
+    const gen = viewGen.begin()
     state = 'loading'
     try {
       // Load the sidebar data (stats/tags/collections) too — otherwise the
@@ -438,29 +481,38 @@
       const [s, m, t, c] = await Promise.all([
         api.getStats(), api.getMedia({ ids, limit: PAGE }), api.getTags(), api.getCollections(),
       ])
-      stats = s
-      items = (m.items || []).map(toCard)
-      // A deep-link ?ids= subset is exactly the returned rows — no further pages.
-      total = items.length
-      moreParams = null
-      liveTags = (t || []).map((x) => ({ name: x.name, count: x.count }))
-      liveCollections = (c?.collections || []).map((col) => ({
-        key: col.key, title: col.title, count: col.count, items: col.items || [],
-      }))
-      selectedId = items.length ? items[0].id : null
-      state = 'ok'
+      viewGen.apply(gen, () => {
+        stats = s
+        items = (m.items || []).map(toCard)
+        // A deep-link ?ids= subset is exactly the returned rows — no further pages.
+        total = items.length
+        moreParams = null
+        liveTags = (t || []).map((x) => ({ name: x.name, count: x.count }))
+        liveCollections = (c?.collections || []).map((col) => ({
+          key: col.key, title: col.title, count: col.count, items: col.items || [],
+        }))
+        selectedId = items.length ? items[0].id : null
+        state = 'ok'
+      })
     } catch (e) {
-      state = 'error'
-      err = e.message
+      viewGen.apply(gen, () => {
+        state = 'error'
+        err = e.message
+      })
     }
   }
   async function selectFromParam() {
     const sel = readSelParam()
     if (sel == null) return
     if (items.find((m) => m.id === sel)) { selectedId = sel; return }
+    // Prepending into whatever view is current: if the user moved on while the detail
+    // fetch was in flight, this would splice an unrelated clip into the new grid.
+    const gen = viewGen.current
     try {
       const d = await api.getMediaDetail(sel)
-      if (d && d.id != null) { items = [toCard(d), ...items]; selectedId = sel }
+      if (d && d.id != null) {
+        viewGen.apply(gen, () => { items = [toCard(d), ...items]; selectedId = sel })
+      }
     } catch (e) { /* unknown id → keep default selection */ }
   }
   // Engine languages for the retranscribe picker — non-fatal (mock fallback in UI).

--- a/frontend/tests/viewGen.test.mjs
+++ b/frontend/tests/viewGen.test.mjs
@@ -1,0 +1,117 @@
+// node --test. No test runner dependency: Node 20 ships node:test, and CI already
+// installs Node 20 for the frontend build job.
+//
+// These do NOT assert that a counter counts — that would be a tautology dressed as a
+// test. Each case replays one of the interleavings that actually reaches MainLive's
+// grid state, with the awaits resolved by hand so the ordering is deterministic
+// instead of timing-dependent.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createViewGen } from '../src/lib/viewGen.js'
+
+// A stand-in for the shared grid state the four writers fight over.
+function grid() {
+  return { view: 'initial', items: [] }
+}
+
+test('a search that lands after the user picked a collection does not repaint the grid', () => {
+  const g = createViewGen()
+  const state = grid()
+
+  // runSearch() starts and awaits /api/media?q=
+  const searchToken = g.begin()
+
+  // ...the user clicks a Smart Collection, which writes synchronously.
+  const collectionToken = g.begin()
+  g.apply(collectionToken, () => {
+    state.view = 'collection'
+    state.items = ['c1', 'c2']
+  })
+
+  // ...and only now does the search response arrive.
+  const applied = g.apply(searchToken, () => {
+    state.view = 'search'
+    state.items = ['s1']
+  })
+
+  assert.equal(applied, false, 'the superseded search must not write')
+  assert.equal(state.view, 'collection')
+  assert.deepEqual(state.items, ['c1', 'c2'])
+})
+
+test('a collection picked while load() is in flight survives load() resolving', () => {
+  const g = createViewGen()
+  const state = grid()
+
+  // load() clears activeCollection and awaits checkReady() + Promise.all([...]).
+  const loadToken = g.begin()
+
+  const collectionToken = g.begin()
+  g.apply(collectionToken, () => {
+    state.view = 'collection'
+  })
+
+  // load()'s two await points both have to be guarded, not just the last one: the
+  // readyState write is as capable of contradicting the new view as the items write.
+  assert.equal(g.isCurrent(loadToken), false, 'guard after checkReady()')
+  assert.equal(g.apply(loadToken, () => { state.view = 'library' }), false)
+  assert.equal(state.view, 'collection')
+})
+
+test('out-of-order search responses leave the newest query showing', () => {
+  const g = createViewGen()
+  const state = grid()
+
+  const slow = g.begin() // 黑膠
+  const fast = g.begin() // 唱針
+
+  // The second request resolves first (smaller result set, warm cache — ordinary).
+  assert.equal(g.apply(fast, () => { state.items = ['唱針結果'] }), true)
+  // The first one finally lands. Before the guard this repainted the grid with the
+  // previous query's results while the search box still read 唱針.
+  assert.equal(g.apply(slow, () => { state.items = ['黑膠結果'] }), false)
+
+  assert.deepEqual(state.items, ['唱針結果'])
+})
+
+test('a failing stale request does not blow away the view that replaced it', () => {
+  const g = createViewGen()
+  const state = grid()
+
+  const searchToken = g.begin()
+  const collectionToken = g.begin()
+  g.apply(collectionToken, () => { state.view = 'collection' })
+
+  // The catch block needs the same guard as the success path. An error banner from a
+  // request nobody is waiting for is a false report about the view on screen.
+  assert.equal(g.apply(searchToken, () => { state.view = 'error' }), false)
+  assert.equal(state.view, 'collection')
+})
+
+test('loadMore extends the current view and is dropped when the view changed', () => {
+  const g = createViewGen()
+  const state = grid()
+
+  const viewToken = g.begin()
+  g.apply(viewToken, () => { state.items = ['a', 'b'] })
+
+  // loadMore() reads `current` rather than calling begin() — paging is not a new view,
+  // so it must not invalidate anything.
+  const pageToken = g.current
+  assert.equal(pageToken, viewToken, 'paging must not claim a new generation')
+  assert.equal(g.apply(pageToken, () => { state.items = [...state.items, 'c'] }), true)
+  assert.deepEqual(state.items, ['a', 'b', 'c'])
+
+  // Now page again, but the user switches view before the page lands.
+  const stalePage = g.current
+  g.begin()
+  assert.equal(g.apply(stalePage, () => { state.items = [...state.items, 'd'] }), false)
+  assert.deepEqual(state.items, ['a', 'b', 'c'], 'old-view rows must not append to a new view')
+})
+
+test('a token stays valid across awaits when nothing else claims the grid', async () => {
+  const g = createViewGen()
+  const token = g.begin()
+  await new Promise((r) => setTimeout(r, 1))
+  assert.equal(g.isCurrent(token), true, 'the uncontended case must still write')
+})


### PR DESCRIPTION
fix(frontend): the grid stopped showing the view the user asked for last

Follow-up the Codex audit of #292 flagged and #293 deliberately left alone: the
fix touches shared loading machinery, which had no business riding inside an
audit-fix commit.

MainLive has four writers to the same grid state — load(), runSearch(),
loadIds() and the synchronous collection click — and three of them await the
network before writing. The response that landed last won, which is not the same
thing as the view the user asked for last. Picking a Smart Collection while a
search was in flight left the sidebar highlighting the collection and the grid
repainting with the search results a second later. Two searches in a row hit the
same way: the slower first query repainted the grid while the box already read
the second one.

Each replacing path now claims a generation token and carries it across every
await; loadMore and selectFromParam read the current token instead of claiming
one, because extending a view must not invalidate it, but must still be dropped
if the view changed underneath. Both await points in load() are guarded, not
just the last: a readyState write from a superseded load contradicts the screen
as readily as an items write. The catch blocks are guarded too — an error banner
raised by a request nobody is waiting for is a false report about what is
on screen.

One regression the guard introduced, caught by the browser repro rather than by
reading: picking a collection mid-search left the grid stuck on "loading…"
forever. The collection path had never set state itself — it silently inherited
the 'ok' that the in-flight request would set moments later. Now that a
superseded response is correctly suppressed, that inheritance was gone. It has
its data in hand synchronously, so it owns state too.

Coverage, against the audit's standing concern that the Svelte side has none:

- frontend/tests/viewGen.test.mjs, run by node:test. No new devDependency — Node
  20 ships the runner and CI already installs it for the frontend job, so this
  is a step in the existing frontend-build job rather than a new required check.
  The cases replay the actual interleavings with the awaits resolved by hand,
  not "does a counter count". Mutation-checked: dropping the guard inside
  apply() reds 5 of 6; pinning isCurrent to true reds 1.
- frontend/scripts/audit/verify-collection-race.mjs asserts and exits non-zero,
  unlike its print-and-eyeball neighbours, because a race is not something a
  screenshot shows. Request interception holds the search response open so the
  ordering is forced every run instead of raced for. Against pre-fix MainLive it
  reports the bug exactly: grid 43 cards (the search), sidebar highlighting
  "A-roll · 主軸 3". Local-only — it needs Chrome and a live backend.

Verified against a snapshot of the real 62-clip library (isolated root, original
untouched): normal browsing still goes 62 → 43 on search → 3 in the collection →
62 on toggle-off, zero console errors. Full suite 1254 passed, 7 skipped.
svelte-check 39 files, 0 errors, 0 warnings. Eager bundle 407 kB JS / 493 kB CSS,
both inside the CI budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)