### PR TITLE
feat(packaging): assemble the backend on Windows, and spawn it correctly there (W1/W3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,11 @@ build/
 .DS_Store
 .venv/
 venv/
+# Windows packaging venv — a CPU-only-torch tree built solely to feed
+# assemble-backend-win.ps1. Kept separate from .venv because a dev box with an
+# NVIDIA card resolves torch to the +cuXXX build (4.2 GB vs ~250 MB), which
+# would land whole in the installer.
+.venv-pack/
 *.db-journal
 pages/
 src-tauri/target/

--- a/src-tauri/assemble-backend-win.ps1
+++ b/src-tauri/assemble-backend-win.ps1
@@ -1,4 +1,4 @@
-# Assemble the self-contained backend bundle for the arkiv desktop app — Windows.
+# Assemble the self-contained backend bundle for the arkiv desktop app -- Windows.
 #
 # Windows counterpart of assemble-backend.sh. Same shape, same output contract:
 # produces src-tauri\backend\{python,site-packages,src}, which tauri.conf.json
@@ -17,8 +17,8 @@
 #   1. The venv layout is `Lib\site-packages`, not `lib/python3.12/site-packages`.
 #   2. The source venv defaults to .venv-pack, NOT .venv. On a dev box with an
 #      NVIDIA card `pip install -r requirements.txt` resolves silero-vad's torch
-#      to the +cuXXX build — 4.2 GB against ~250 MB for the CPU wheel, measured
-#      on the Win11/RTX 4070 box on 2026-08-12 — and all of it would land in the
+#      to the +cuXXX build -- 4.2 GB against ~250 MB for the CPU wheel, measured
+#      on the Win11/RTX 4070 box on 2026-08-12 -- and all of it would land in the
 #      installer. torch here only backs silero VAD (transcribe.py:14-15);
 #      transcription itself runs on ctranslate2, so the CPU build costs nothing
 #      a user would feel. Build .venv-pack with:
@@ -26,11 +26,19 @@
 #        .venv-pack\Scripts\pip install --index-url https://download.pytorch.org/whl/cpu torch torchaudio
 #        .venv-pack\Scripts\pip install -r requirements.txt
 #      Override with $env:ARKIV_PACKAGING_VENV to point somewhere else.
-#   3. Copies go through robocopy rather than rsync — it is native on every
+#   3. Copies go through robocopy rather than rsync -- it is native on every
 #      Windows box and on the windows-latest runner, so the script has no
 #      Git-Bash/MSYS dependency.
 #
 # The staging dir is git-ignored (it is ~1 GB); this script rebuilds it.
+#
+# KEEP THIS FILE PURE ASCII. Windows PowerShell 5.1 reads a BOM-less file as the
+# machine's ANSI codepage, not UTF-8, so a non-ASCII byte sequence is re-split
+# under e.g. Big5 (cp950) or cp1252. When the re-split swallows a quote the whole
+# script dies at PARSE time with errors pointing at unrelated lines -- and it
+# does so only on machines with that codepage, which is the worst possible way to
+# find out. An ellipsis next to a quote cost a debugging round here on
+# 2026-08-12. Use `--` and `->` rather than the typographic characters.
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
@@ -41,7 +49,7 @@ $BACKEND = Join-Path $HERE 'backend'
 
 $PY_VERSION = '3.12.13'
 $PBS_TAG    = '20260623'
-# NOTE the %2B — the asset name contains a literal '+' which must stay encoded in the URL.
+# NOTE the %2B -- the asset name contains a literal '+' which must stay encoded in the URL.
 $PBS_URL    = "https://github.com/astral-sh/python-build-standalone/releases/download/$PBS_TAG/cpython-$PY_VERSION%2B$PBS_TAG-x86_64-pc-windows-msvc-install_only.tar.gz"
 
 $PACK_VENV = if ($env:ARKIV_PACKAGING_VENV) { $env:ARKIV_PACKAGING_VENV } else { Join-Path $REPO '.venv-pack' }
@@ -49,7 +57,7 @@ $VENV_SP   = Join-Path $PACK_VENV 'Lib\site-packages'
 
 # robocopy signals detail through its exit code: 0-7 are success (1 = files were
 # copied, 2 = extra files in dest, 4 = mismatched files), 8+ are real failures.
-# Treating it like a normal command would fail the script on a successful copy —
+# Treating it like a normal command would fail the script on a successful copy --
 # and, worse, leave $LASTEXITCODE non-zero for whatever reads it next (CI does).
 function Invoke-Robocopy {
     param([string]$Source, [string]$Dest, [string[]]$ExtraArgs)
@@ -64,7 +72,7 @@ function Invoke-Robocopy {
 
 # Resolve curl/tar from System32 by ABSOLUTE path rather than trusting PATH.
 # Git for Windows ships MSYS twins of both in `Git\usr\bin`, and when this script
-# is launched from a Git Bash shell those come first — at which point GNU tar
+# is launched from a Git Bash shell those come first -- at which point GNU tar
 # reads the `C:\...` destination as a remote `host:path` and dies with
 # "Cannot connect to C: resolve failed" (observed 2026-08-12 on the Win11 box).
 # Windows' own tar is bsdtar, which handles both drive paths and .tar.gz natively.
@@ -72,7 +80,7 @@ function Get-SystemTool {
     param([string]$Name)
     $p = Join-Path $env:SystemRoot "System32\$Name"
     if (-not (Test-Path $p)) {
-        throw "$p not found — this script needs the Windows-native $Name (Windows 10 1803+), not an MSYS/Git twin."
+        throw "$p not found -- this script needs the Windows-native $Name (Windows 10 1803+), not an MSYS/Git twin."
     }
     return $p
 }
@@ -90,7 +98,7 @@ if (-not (Test-Path $VENV_SP)) {
     Write-Error @"
 $VENV_SP not found.
 
-Build the packaging venv first (CPU-only torch — see the header of this script for why):
+Build the packaging venv first (CPU-only torch -- see the header of this script for why):
   py -3.12 -m venv .venv-pack
   .venv-pack\Scripts\pip install --index-url https://download.pytorch.org/whl/cpu torch torchaudio
   .venv-pack\Scripts\pip install -r requirements.txt
@@ -112,7 +120,7 @@ $TMP = Join-Path ([System.IO.Path]::GetTempPath()) ("arkiv-pbs-" + [System.Guid]
 New-Item -ItemType Directory -Force -Path $TMP | Out-Null
 try {
     $tarball = Join-Path $TMP 'pbs.tar.gz'
-    # curl.exe / tar.exe (System32, see Get-SystemTool) — not the PowerShell
+    # curl.exe / tar.exe (System32, see Get-SystemTool) -- not the PowerShell
     # aliases, which resolve to Invoke-WebRequest / nothing.
     & (Get-SystemTool 'curl.exe') -fsSL $PBS_URL -o $tarball
     if ($LASTEXITCODE -ne 0) { throw "curl failed (exit $LASTEXITCODE) fetching $PBS_URL" }
@@ -149,9 +157,9 @@ Write-Host "[assemble] arkiv source (runtime .py + routers + built SPA; no tests
 # box's local data and have no business in a shipped bundle. Less obviously,
 # `temp\` is what made this copy fail on 2026-08-12: the offload tests leave
 # `temp\arkiv-offload-*` dirs behind with ACLs the current user can no longer
-# enumerate, and 20 of them turned into robocopy's "directories failed" count →
+# enumerate, and 20 of them turned into robocopy's "directories failed" count ->
 # exit 9. A CI runner checks out clean and never sees them, so this only ever
-# bites a real workstation — the one machine that also does the release build.
+# bites a real workstation -- the one machine that also does the release build.
 Invoke-Robocopy -Source $REPO -Dest (Join-Path $BACKEND 'src') -ExtraArgs @(
     '/XD',
     (Join-Path $REPO '.git'),
@@ -174,7 +182,7 @@ Invoke-Robocopy -Source $REPO -Dest (Join-Path $BACKEND 'src') -ExtraArgs @(
 )
 
 if (-not (Test-Path (Join-Path $BACKEND 'src\frontend\dist\index.html'))) {
-    Write-Warning "frontend\dist\index.html missing — run 'cd frontend; npm run build' first,"
+    Write-Warning "frontend\dist\index.html missing -- run 'cd frontend; npm run build' first,"
     Write-Warning "      or the packaged app will serve the fallback page."
 }
 

--- a/src-tauri/assemble-backend-win.ps1
+++ b/src-tauri/assemble-backend-win.ps1
@@ -1,0 +1,187 @@
+# Assemble the self-contained backend bundle for the arkiv desktop app — Windows.
+#
+# Windows counterpart of assemble-backend.sh. Same shape, same output contract:
+# produces src-tauri\backend\{python,site-packages,src}, which tauri.conf.json
+# bundles as an app resource. Run this ONCE before `cargo tauri build` (and again
+# whenever the deps or the SPA change).
+#
+# The backend is python-build-standalone (a portable, self-contained CPython) +
+# an already-built site-packages + the arkiv Python source + the built SPA. It is
+# deliberately NOT PyInstaller, for the reason recorded in the .sh: the spike
+# (2026-07-17) showed the native-heavy tree imports and boots cleanly under a
+# stock portable interpreter, sidestepping the hidden-import/DLL whack-a-mole
+# PyInstaller would demand for this dep set.
+#
+# Three things differ from the .sh beyond path separators:
+#
+#   1. The venv layout is `Lib\site-packages`, not `lib/python3.12/site-packages`.
+#   2. The source venv defaults to .venv-pack, NOT .venv. On a dev box with an
+#      NVIDIA card `pip install -r requirements.txt` resolves silero-vad's torch
+#      to the +cuXXX build — 4.2 GB against ~250 MB for the CPU wheel, measured
+#      on the Win11/RTX 4070 box on 2026-08-12 — and all of it would land in the
+#      installer. torch here only backs silero VAD (transcribe.py:14-15);
+#      transcription itself runs on ctranslate2, so the CPU build costs nothing
+#      a user would feel. Build .venv-pack with:
+#        py -3.12 -m venv .venv-pack
+#        .venv-pack\Scripts\pip install --index-url https://download.pytorch.org/whl/cpu torch torchaudio
+#        .venv-pack\Scripts\pip install -r requirements.txt
+#      Override with $env:ARKIV_PACKAGING_VENV to point somewhere else.
+#   3. Copies go through robocopy rather than rsync — it is native on every
+#      Windows box and on the windows-latest runner, so the script has no
+#      Git-Bash/MSYS dependency.
+#
+# The staging dir is git-ignored (it is ~1 GB); this script rebuilds it.
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$HERE    = Split-Path -Parent $MyInvocation.MyCommand.Path   # src-tauri\
+$REPO    = Split-Path -Parent $HERE                          # repo root
+$BACKEND = Join-Path $HERE 'backend'
+
+$PY_VERSION = '3.12.13'
+$PBS_TAG    = '20260623'
+# NOTE the %2B — the asset name contains a literal '+' which must stay encoded in the URL.
+$PBS_URL    = "https://github.com/astral-sh/python-build-standalone/releases/download/$PBS_TAG/cpython-$PY_VERSION%2B$PBS_TAG-x86_64-pc-windows-msvc-install_only.tar.gz"
+
+$PACK_VENV = if ($env:ARKIV_PACKAGING_VENV) { $env:ARKIV_PACKAGING_VENV } else { Join-Path $REPO '.venv-pack' }
+$VENV_SP   = Join-Path $PACK_VENV 'Lib\site-packages'
+
+# robocopy signals detail through its exit code: 0-7 are success (1 = files were
+# copied, 2 = extra files in dest, 4 = mismatched files), 8+ are real failures.
+# Treating it like a normal command would fail the script on a successful copy —
+# and, worse, leave $LASTEXITCODE non-zero for whatever reads it next (CI does).
+function Invoke-Robocopy {
+    param([string]$Source, [string]$Dest, [string[]]$ExtraArgs)
+    $argv = @($Source, $Dest, '/E', '/NFL', '/NDL', '/NJH', '/NJS', '/NP', '/R:2', '/W:1') + $ExtraArgs
+    & (Get-SystemTool 'robocopy.exe') @argv | Out-Null
+    $rc = $LASTEXITCODE
+    if ($rc -ge 8) {
+        throw "robocopy failed (exit $rc) copying '$Source' -> '$Dest'"
+    }
+    $global:LASTEXITCODE = 0
+}
+
+# Resolve curl/tar from System32 by ABSOLUTE path rather than trusting PATH.
+# Git for Windows ships MSYS twins of both in `Git\usr\bin`, and when this script
+# is launched from a Git Bash shell those come first — at which point GNU tar
+# reads the `C:\...` destination as a remote `host:path` and dies with
+# "Cannot connect to C: resolve failed" (observed 2026-08-12 on the Win11 box).
+# Windows' own tar is bsdtar, which handles both drive paths and .tar.gz natively.
+function Get-SystemTool {
+    param([string]$Name)
+    $p = Join-Path $env:SystemRoot "System32\$Name"
+    if (-not (Test-Path $p)) {
+        throw "$p not found — this script needs the Windows-native $Name (Windows 10 1803+), not an MSYS/Git twin."
+    }
+    return $p
+}
+
+function Get-DirSizeMB {
+    param([string]$Path)
+    if (-not (Test-Path $Path)) { return 0 }
+    $bytes = (Get-ChildItem -LiteralPath $Path -Recurse -File -Force -ErrorAction SilentlyContinue |
+              Measure-Object -Property Length -Sum).Sum
+    if (-not $bytes) { return 0 }
+    return [math]::Round($bytes / 1MB)
+}
+
+if (-not (Test-Path $VENV_SP)) {
+    Write-Error @"
+$VENV_SP not found.
+
+Build the packaging venv first (CPU-only torch — see the header of this script for why):
+  py -3.12 -m venv .venv-pack
+  .venv-pack\Scripts\pip install --index-url https://download.pytorch.org/whl/cpu torch torchaudio
+  .venv-pack\Scripts\pip install -r requirements.txt
+
+Or point `$env:ARKIV_PACKAGING_VENV` at an existing CPU-only venv.
+"@
+    exit 1
+}
+
+Write-Host "[assemble] clean staging: $BACKEND (preserving tracked .gitkeep)"
+foreach ($d in 'python', 'site-packages', 'src') {
+    $p = Join-Path $BACKEND $d
+    if (Test-Path $p) { Remove-Item -LiteralPath $p -Recurse -Force }
+}
+New-Item -ItemType Directory -Force -Path (Join-Path $BACKEND 'src') | Out-Null
+
+Write-Host "[assemble] portable python $PY_VERSION (python-build-standalone $PBS_TAG)"
+$TMP = Join-Path ([System.IO.Path]::GetTempPath()) ("arkiv-pbs-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $TMP | Out-Null
+try {
+    $tarball = Join-Path $TMP 'pbs.tar.gz'
+    # curl.exe / tar.exe (System32, see Get-SystemTool) — not the PowerShell
+    # aliases, which resolve to Invoke-WebRequest / nothing.
+    & (Get-SystemTool 'curl.exe') -fsSL $PBS_URL -o $tarball
+    if ($LASTEXITCODE -ne 0) { throw "curl failed (exit $LASTEXITCODE) fetching $PBS_URL" }
+    & (Get-SystemTool 'tar.exe') -xzf $tarball -C $TMP          # extracts .\python\
+    if ($LASTEXITCODE -ne 0) { throw "tar failed (exit $LASTEXITCODE) extracting $tarball" }
+    Move-Item -LiteralPath (Join-Path $TMP 'python') -Destination (Join-Path $BACKEND 'python')
+} finally {
+    Remove-Item -LiteralPath $TMP -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+$pyExe = Join-Path $BACKEND 'python\python.exe'
+if (-not (Test-Path $pyExe)) { throw "expected $pyExe after extracting the PBS tarball" }
+
+Write-Host "[assemble] site-packages from $PACK_VENV (trim caches + chromadb transitives arkiv never imports at runtime)"
+# arkiv embeds via ollama, not chromadb's built-in onnx/k8s embedding paths, so
+# kubernetes\ and onnxruntime\ (~155 MB) are dead weight in the bundle. Drop
+# bytecode caches too. If a future feature needs them, remove the excludes.
+Invoke-Robocopy -Source $VENV_SP -Dest (Join-Path $BACKEND 'site-packages') -ExtraArgs @(
+    '/XD', '__pycache__', 'kubernetes', 'onnxruntime',
+    '/XF', '*.pyc'
+)
+
+Write-Host "[assemble] arkiv source (runtime .py + routers + built SPA; no tests/docs/venv)"
+# The server imports many top-level modules + the routers package, and serves the
+# SPA from .\frontend\dist relative to its cwd. Copy generously (repo minus the
+# heavy/irrelevant dirs) so no runtime import is missed.
+#
+# Bare names in /XD match a directory of that name at ANY depth; everything the
+# repo also has a legitimate copy of is passed path-scoped instead, since `src`
+# and `dist` name dirs we need to keep (frontend\dist is the SPA).
+#
+# The gitignored runtime-scratch dirs (temp\, thumbnails\, proxies\, waveforms\,
+# .arkiv\, chroma_db\) are excluded for two reasons. Obviously they are a dev
+# box's local data and have no business in a shipped bundle. Less obviously,
+# `temp\` is what made this copy fail on 2026-08-12: the offload tests leave
+# `temp\arkiv-offload-*` dirs behind with ACLs the current user can no longer
+# enumerate, and 20 of them turned into robocopy's "directories failed" count →
+# exit 9. A CI runner checks out clean and never sees them, so this only ever
+# bites a real workstation — the one machine that also does the release build.
+Invoke-Robocopy -Source $REPO -Dest (Join-Path $BACKEND 'src') -ExtraArgs @(
+    '/XD',
+    (Join-Path $REPO '.git'),
+    (Join-Path $REPO '.venv'),
+    (Join-Path $REPO '.venv-pack'),
+    (Join-Path $REPO 'src-tauri'),
+    (Join-Path $REPO 'tests'),
+    (Join-Path $REPO 'docs'),
+    (Join-Path $REPO 'frontend\node_modules'),
+    (Join-Path $REPO 'frontend\src'),
+    (Join-Path $REPO '.arkiv'),
+    (Join-Path $REPO 'chroma_db'),
+    (Join-Path $REPO 'temp'),
+    (Join-Path $REPO 'thumbnails'),
+    (Join-Path $REPO 'proxies'),
+    (Join-Path $REPO 'waveforms'),
+    (Join-Path $REPO '.tmp-camera-report-tests'),
+    'node_modules', '__pycache__', '.pytest_cache', '.ruff_cache',
+    '/XF', '*.pyc'
+)
+
+if (-not (Test-Path (Join-Path $BACKEND 'src\frontend\dist\index.html'))) {
+    Write-Warning "frontend\dist\index.html missing — run 'cd frontend; npm run build' first,"
+    Write-Warning "      or the packaged app will serve the fallback page."
+}
+
+Write-Host "[assemble] done:"
+foreach ($d in '', 'python', 'site-packages', 'src') {
+    $p = if ($d) { Join-Path $BACKEND $d } else { $BACKEND }
+    "{0,8} MB  {1}" -f (Get-DirSizeMB $p), $p | Write-Host
+}
+Write-Host "[assemble] next:  cargo tauri build   (from src-tauri\)"
+exit 0

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -60,10 +60,22 @@ fn resolve_backend(app: &tauri::App) -> Result<(String, String, String), String>
         .resource_dir()
         .map_err(|e| format!("resource_dir: {e}"))?;
     let backend = res.join("backend");
-    let python = backend.join("python").join("bin").join("python3");
+    // python-build-standalone lays the interpreter out differently per platform:
+    // `python/bin/python3` on Unix, `python\python.exe` on Windows (there is no
+    // bin/ there at all). Same tarball family, different shape.
+    let python = if cfg!(windows) {
+        backend.join("python").join("python.exe")
+    } else {
+        backend.join("python").join("bin").join("python3")
+    };
     let site = backend.join("site-packages");
     let src = backend.join("src");
-    let pythonpath = format!("{}:{}", site.display(), src.display());
+    // join_paths, not format!("{}:{}") — the PYTHONPATH separator is ';' on
+    // Windows and ':' elsewhere, and std already knows which.
+    let pythonpath = std::env::join_paths([&site, &src])
+        .map_err(|e| format!("join_paths(PYTHONPATH): {e}"))?
+        .to_string_lossy()
+        .into_owned();
     Ok((
         python.to_string_lossy().into_owned(),
         pythonpath,
@@ -151,6 +163,16 @@ fn main() {
             .env("ARKIV_PROJECT_ROOT", &proj_root)
             .env("ARKIV_PORT", port.to_string())
             .env("ARKIV_TRUST_LOOPBACK", "1");
+            // `windows_subsystem = "windows"` (top of this file) only silences OUR
+            // console. Spawning python.exe from a GUI process still allocates a new
+            // one, so without this flag every launch parks a black console window
+            // next to the app for the life of the backend.
+            #[cfg(windows)]
+            {
+                use std::os::windows::process::CommandExt;
+                const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+                cmd.creation_flags(CREATE_NO_WINDOW);
+            }
             if let Some(out) = stdout_cfg {
                 cmd.stdout(out);
             }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,6 +31,11 @@
     "macOS": {
       "minimumSystemVersion": "12.0",
       "entitlements": "entitlements.plist"
+    },
+    "windows": {
+      "webviewInstallMode": {
+        "type": "downloadBootstrapper"
+      }
     }
   },
   "plugins": {}


### PR DESCRIPTION
W1 + W3 of the [Windows installer plan](https://github.com/vulture-s/arkiv), plus a step the plan did not have.

## What this does

- **`src-tauri/assemble-backend-win.ps1`** — Windows twin of `assemble-backend.sh`. Same output contract (`backend/{python,site-packages,src}`), same reasoning carried over in the comments.
- **`src-tauri/src/main.rs`** — the desktop shell was never portable. `resolve_backend()` hardcoded `backend/python/bin/python3` and joined PYTHONPATH with `:`. A Windows bundle would have built cleanly and then failed to spawn anything on first launch — precisely what a CI "did it build?" dry-run cannot catch. Also sets `CREATE_NO_WINDOW`, without which a GUI launch parks a black console window next to the app for the life of the backend.
- **`src-tauri/tauri.conf.json`** — `bundle.windows.webviewInstallMode`.

## Two findings that change the plan's numbers

**torch is 4.2 GB here, not the ~200 MB the plan assumed.** On a box with an NVIDIA card, `pip install -r requirements.txt` resolves silero-vad's torch to the `+cuXXX` build, and all of it would land in the installer. So the script sources from `.venv-pack` (CPU wheel, 524 MB), not `.venv`. torch only backs silero VAD (`transcribe.py:14-15`) — transcription runs on ctranslate2 — so this costs nothing a user would feel.

**`temp\arkiv-offload-*` breaks the copy on a real workstation.** The offload tests leave those dirs behind with ACLs the current user can no longer enumerate; 20 of them turn into robocopy's "directories failed" count. A CI runner checks out clean and never sees it, so it only bites the machine that also does the release build. The src copy now excludes the gitignored runtime-scratch dirs.

## Windows-specific traps handled

- robocopy reports success as exit **0-7**; treating it like a normal command fails the script on a successful copy and leaves `$LASTEXITCODE` dirty for CI.
- `curl`/`tar` are resolved from **System32 by absolute path**. Launched from Git Bash, `tar` otherwise hits Git's MSYS twin, which reads the `C:\...` destination as a remote `host:path` and dies with `Cannot connect to C: resolve failed`.

## Verified (Win11 / i7-13700)

- `cargo check --locked` green.
- Script produces `backend/{python 142 MB, site-packages 850 MB, src 22 MB}` = **1014 MB**, comparable to the macOS bundle.
- Bundled 3.12.13 interpreter imports `chromadb 1.5.9`, `faster_whisper`, `silero_vad`, `torch 2.13.0+cpu`, `av`, `opencc`, `fastapi`, `uvicorn`, `PIL`, `soundfile`, `xxhash`, `psutil`, `watchdog`.
- `onnxruntime` confirmed trimmed, chromadb still imports.
- `frontend/dist/index.html` lands in `backend/src`; no scratch dir leaks in.

`cargo tauri build` is running as this goes up; the resulting installer gets installed and launched before the release leg (W2) lands.

## Deliberately not in this PR

`assemble-backend.sh` has the same scratch-dir gap. Left alone rather than perturbing the verified macOS release path — tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
