### PR TITLE
docs(changelog): cut v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## v0.12.0 - 2026-08-12
+
+**arkiv runs on Windows without a Python setup.** v0.11.0 shipped the first installer but only
+for macOS Apple Silicon; the README told everyone else to build from source. This release adds
+the second platform end to end — a Windows backend assembler, a `windows-latest` release leg,
+and the desktop shell fixes that a Windows bundle turns out to need — so a tag now publishes an
+`.exe` and an `.msi` alongside the `.dmg`. Both platforms remain unsigned. Also lands a month of
+Smart Collections, shoot-year faceting and storage-migration work.
+
 ### Added
 - **arkiv ships a Windows installer (#308, #309, #310).** v0.11.0 was macOS-arm-only: `assemble-backend.sh` bundled an `aarch64-apple-darwin` Python and `release.yml` had one leg. Windows now has the same path — `assemble-backend-win.ps1` builds `backend/{python,site-packages,src}` from a python-build-standalone `x86_64-pc-windows-msvc` interpreter, and a `release-windows` job produces an unsigned `arkiv_<version>_x64-setup.exe` (226 MB) plus an `.msi` (341 MB) for admin/GPO deployment. Unsigned means SmartScreen shows "Windows protected your PC" once, the same shape as the macOS right-click → Open step; `docs/quickstart-windows.md` walks through it. The 2026-07-28 plan scoped this as "fork the shell script"; three things it did not anticipate mattered more than the fork.
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arkiv"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arkiv"
-version = "0.11.0"
+version = "0.12.0"
 description = "arkiv — Local Media Asset Manager"
 authors = ["Hevin Yeh"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui-org/nicegui/main/tauri/src-tauri/tauri.conf.json",
   "productName": "arkiv",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "identifier": "com.hevin.arkiv",
   "build": {
     "devUrl": "http://localhost:8501",


### PR DESCRIPTION
Cuts the release. Version stamped in `tauri.conf.json`, `Cargo.toml` and the `Cargo.lock` root entry — that last one is what drifted to 0.2.0 across the whole v0.2→v0.10 tag history, so every built DMG embedded the wrong version.

0.11.0 → **0.12.0** rather than a patch: this adds a supported platform, and the README plus the CONTRIBUTING artifact matrix both changed to say so.

After merge, an annotated `v0.12.0` tag triggers `release.yml`: the macOS leg builds and publishes the `.dmg`, then `release-windows` attaches the `.exe` and `.msi` to the same Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)