### PR TITLE
docs: finish the model-name correction #202 started

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 ## 專案 Context
 arkiv 是影片素材管理工具（Tauri + Python backend），功能包含：
 - Whisper 語音轉錄 + 4 層防幻覺 Guard
-- Vision 分析（qwen3-vl）
+- Vision 分析（qwen2.5-vl）
 - ChromaDB 語義搜尋
 - DaVinci Resolve / FCPX 插件整合
 - SRT/VTT/EDL/FCPXML export

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Fixed
+- **Docker ran a different embedding model from every other install (#312).** `docker-compose.yml` set `ARKIV_EMBED_MODEL=nomic-embed-text` and `ARKIV_VISION_MODEL=qwen3-vl:8b`. Those do not *document* the defaults — they **override** them, so a Docker user got an English-centric embedder in a project whose headline feature is CJK semantic search, plus the vision model `config.py` documents at length as ~10x slower (~60s/frame against ~8s/frame; ~30h against ~3.5h over 2000 frames, at comparable tag quality). Both now track `config.py` (`bge-m3` / `qwen2.5vl:7b`), with a comment saying they must keep tracking it, because the divergence was invisible: nothing compared the compose file to the defaults it silently shadowed.
+
+  **Migration for existing Docker libraries.** The vision change needs nothing — frame descriptions are regenerated per frame and nothing is keyed on the model. The embedding change does: `bge-m3` is 1024-dimensional against `nomic-embed-text`'s 768, so an index built under the old value cannot accept new vectors. Rebuild it once after pulling:
+
+  ```bash
+  docker exec arkiv-arkiv-1 python embed.py --rebuild
+  ```
+
+  This drops and rebuilds the ChromaDB index from the SQLite rows. Media, transcripts, frame descriptions and tags are untouched — only the vectors are recomputed. To stay on the old model instead, set `ARKIV_EMBED_MODEL=nomic-embed-text` in your own compose override.
+- **Six files still named the pre-#202 model pair (#312).** #202 corrected the README, `.env.example` and `docs/install.md` when the defaults moved to `bge-m3` / `qwen2.5vl:7b`, and recorded why it mattered: a README-follower pulled a 10x slower vision model that `health.py` then reported MISSING. That sweep missed `CONTRIBUTING.md`, `docs/index.md`, `docs/pipeline.md` and its `.zh-TW` twin, `docs/faq.md` and `AGENTS.md`, so the same trap stayed live for anyone starting from any of them. CONTRIBUTING's pull block also listed only two of the three models `health.py` checks. Historical records (`CHANGELOG.md`, the handover and acceptance docs) are left as written — they describe what the defaults were at the time.
+
 ## v0.12.0 - 2026-08-12
 
 **arkiv runs on Windows without a Python setup.** v0.11.0 shipped the first installer but only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thanks for your interest in contributing! arkiv is a local-first media asset man
 
 - Python 3.9+
 - FFmpeg 6.0+
-- [Ollama](https://ollama.com/) with `nomic-embed-text` model
+- [Ollama](https://ollama.com/) with the three default models (see below)
 - Node 20+ (the UI is a Svelte SPA that `server.py` serves as a built bundle)
 - Git
 
@@ -25,9 +25,10 @@ pip install -r requirements.txt
 pip install mlx-whisper          # macOS Apple Silicon
 pip install faster-whisper torch  # NVIDIA GPU
 
-# Ollama models
-ollama pull nomic-embed-text
-ollama pull qwen3-vl:8b
+# Ollama models — these are the config.py defaults health.py checks for
+ollama pull bge-m3          # embeddings
+ollama pull qwen2.5vl:7b    # vision
+ollama pull qwen2.5:14b     # chat / transcript polish
 
 # Build the UI (server.py serves frontend/dist at /)
 cd frontend && npm ci && npm run build && cd ..

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - ARKIV_THUMBNAILS_DIR=/app/thumbnails
       - ARKIV_OLLAMA_URL=http://ollama:11434
       - ARKIV_EMBED_MODEL=nomic-embed-text
-      - ARKIV_VISION_MODEL=qwen3-vl:8b
+      - ARKIV_VISION_MODEL=qwen2.5vl:7b
       - ARKIV_WHISPER_MODEL=large-v3-turbo
       - ARKIV_HOST=0.0.0.0
       - ARKIV_PORT=8501

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,10 @@ services:
       - ARKIV_CHROMA_PATH=/app/chroma_db
       - ARKIV_THUMBNAILS_DIR=/app/thumbnails
       - ARKIV_OLLAMA_URL=http://ollama:11434
-      - ARKIV_EMBED_MODEL=nomic-embed-text
+      # Both of these must track the config.py defaults. Pinned here only so the
+      # compose file is self-describing — if you change one, change config.py too,
+      # or Docker silently diverges from every other install (it did, for months).
+      - ARKIV_EMBED_MODEL=bge-m3
       - ARKIV_VISION_MODEL=qwen2.5vl:7b
       - ARKIV_WHISPER_MODEL=large-v3-turbo
       - ARKIV_HOST=0.0.0.0

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,7 +24,7 @@ Cross-project query is on the roadmap (W2). Current release uses per-project `me
 
 **Q: Do I need a GPU?**
 
-No. arkiv runs CPU-only with `faster-whisper` (no torch). A GPU speeds up transcription 3-5x. Vision descriptions (`qwen3-vl:8b`) can be skipped with `--skip-vision` if GPU is unavailable.
+No. arkiv runs CPU-only with `faster-whisper` (no torch). A GPU speeds up transcription 3-5x. Vision descriptions (`qwen2.5vl:7b`) can be skipped with `--skip-vision` if GPU is unavailable.
 
 ## DaVinci Resolve plugin
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,8 +29,8 @@ pip install mlx-whisper          # Apple Silicon
 **Step 3 — Pull Ollama models**
 
 ```bash
-ollama pull nomic-embed-text     # required
-ollama pull qwen3-vl:8b          # optional: vision tags
+ollama pull bge-m3               # required
+ollama pull qwen2.5vl:7b         # optional: vision tags
 ollama pull qwen2.5:14b          # optional: transcript polish
 ```
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -22,9 +22,9 @@ invocation; embedding runs out-of-band via `embed.py`.
 |-------|--------------|--------------|
 | 0. Preflight | Storage path health check (since v0.3.1) | — |
 | 1. Phase 1 | Probe + transcribe + thumbnail + frames | FFmpeg + ExifTool + Whisper |
-| 2. Phase 2 | Vision descriptions (skippable) | qwen3-vl:8b + minicpm-v fallback |
+| 2. Phase 2 | Vision descriptions (skippable) | qwen2.5vl:7b + minicpm-v fallback |
 | 3. Phase 3 | Browser proxy generation | FFmpeg (HEVC/ProRes → H.264) |
-| 4. Embedding | Semantic search index | Ollama nomic-embed-text → ChromaDB |
+| 4. Embedding | Semantic search index | Ollama bge-m3 → ChromaDB |
 
 ---
 
@@ -96,9 +96,9 @@ Skippable with `--skip-vision`. Runs after Phase 1 because vision and LLM
 polish (Phase 1) can't coexist on 12 GB GPUs.
 
 1. **Unload** `qwen2.5:14b` (free VRAM)
-2. **Warm up** `qwen3-vl:8b`
+2. **Warm up** `qwen2.5vl:7b`
 3. Per file:
-   - Primary describe = `qwen3-vl:8b`
+   - Primary describe = `qwen2.5vl:7b`
    - Fallback for failed frames = `minicpm-v:latest`
    - Scoring: `focus_score / exposure / stability / audio_quality / atmosphere / energy / edit_position / edit_reason / editability_score`
 4. **Halt-on-3-consecutive-fail** (since v0.3.1): break loop and print resume hint instead of burning through every file writing the same error.
@@ -132,7 +132,7 @@ python embed.py --rebuild   # drop and rebuild
 python embed.py --search "drone footage aerial"   # quick CLI test
 ```
 
-Reads `media.transcript` → chunks → Ollama `nomic-embed-text` →
+Reads `media.transcript` → chunks → Ollama `bge-m3` →
 `CHROMA_PATH/` collection `media_assets` (768-dim).
 
 ---

--- a/docs/pipeline.zh-TW.md
+++ b/docs/pipeline.zh-TW.md
@@ -21,9 +21,9 @@ arkiv ingest 是 4 階段 pipeline，把原始素材變成可搜尋、可匯入 
 |------|--------|------------|
 | 0. Preflight | 儲存路徑健康檢查（v0.3.1 新增） | — |
 | 1. Phase 1 | Probe + 轉錄 + thumbnail + frames | FFmpeg + ExifTool + Whisper |
-| 2. Phase 2 | Vision 描述（可 skip） | qwen3-vl:8b + minicpm-v fallback |
+| 2. Phase 2 | Vision 描述（可 skip） | qwen2.5vl:7b + minicpm-v fallback |
 | 3. Phase 3 | 瀏覽器 proxy 生成 | FFmpeg（HEVC/ProRes → H.264） |
-| 4. Embedding | 語意搜尋索引 | Ollama nomic-embed-text → ChromaDB |
+| 4. Embedding | 語意搜尋索引 | Ollama bge-m3 → ChromaDB |
 
 ---
 
@@ -94,9 +94,9 @@ per file：
 polish 不能共存。
 
 1. **Unload** `qwen2.5:14b`（釋放 VRAM）
-2. **Warm up** `qwen3-vl:8b`
+2. **Warm up** `qwen2.5vl:7b`
 3. per file：
-   - 主模型 = `qwen3-vl:8b`
+   - 主模型 = `qwen2.5vl:7b`
    - 失敗 frame 的 fallback = `minicpm-v:latest`
    - Scoring：`focus_score / exposure / stability / audio_quality / atmosphere / energy / edit_position / edit_reason / editability_score`
 4. **連續 3 fail 就 halt**（v0.3.1 新增）— 不要在每個 file 都寫同一個 error，break + 印 resume 指令
@@ -129,7 +129,7 @@ python embed.py --rebuild   # 砍掉重建
 python embed.py --search "drone footage aerial"   # CLI 快速測試
 ```
 
-讀 `media.transcript` → chunk → Ollama `nomic-embed-text` →
+讀 `media.transcript` → chunk → Ollama `bge-m3` →
 `CHROMA_PATH/` collection `media_assets`（768-dim）。
 
 ---


### PR DESCRIPTION
docs: finish the model-name correction #202 started

#202 fixed the README, `.env.example` and `docs/install.md` when the defaults
moved to `bge-m3` / `qwen2.5vl:7b`, and recorded why: a README-follower was
pulling a 10x slower vision model that `health.py` then flagged as MISSING. Six
more files were never swept and still name the old pair, so the same trap is
still live for anyone who starts from CONTRIBUTING, `docs/index.md` or the
pipeline docs.

Corrected: `CONTRIBUTING.md` (prereq line + the pull block, which listed only
two of the three models `health.py` actually checks), `docs/index.md`,
`docs/pipeline.md` + `.zh-TW`, `docs/faq.md`, `AGENTS.md`.

`docker-compose.yml` is the one that is not a docs fix. It sets
`ARKIV_VISION_MODEL=qwen3-vl:8b`, which does not describe the default -- it
OVERRIDES it, for every Docker user, to the model `config.py` documents at
length as ~10x slower (~60s/frame vs ~8s/frame; ~30h vs ~3.5h over 2000 frames,
at comparable tag quality). Changed to the real default. No data impact: frame
descriptions are regenerated per frame, nothing is keyed on the model.

`ARKIV_EMBED_MODEL=nomic-embed-text` on the line above had the same shape and is
also fixed, on the owner's call (2026-08-12). It is the sharper of the two: an
English-centric embedder for every Docker user, in a project whose headline
feature is CJK semantic search. It does carry a migration cost -- bge-m3 is
1024-dimensional against nomic-embed-text's 768, so an index built under the old
value cannot accept new vectors -- so CHANGELOG carries the one-command rebuild
(`embed.py --rebuild`, vectors only; media, transcripts, descriptions and tags
are untouched) and how to stay on the old model deliberately.

Both model lines now carry a comment saying they must track `config.py`. The
divergence lasted months because nothing compared the compose file against the
defaults it was silently shadowing.

Left alone: `CHANGELOG.md`, `docs/llm-router-handover.md` and
`docs/phase-11.5-acceptance.md` record what the defaults were at the time --
they are history, not instructions. `README.md`, `README.zh-TW.md`,
`.env.example` and both quickstarts already name `qwen3-vl:8b` correctly, as the
documented higher-quality/slower override.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
