### PR TITLE
feat(ui): make Esc work, and make refusals say what is missing

### DIFF
--- a/frontend/src/routes/ChatLive.svelte
+++ b/frontend/src/routes/ChatLive.svelte
@@ -4,6 +4,7 @@
      inline. Requires chat_write scope (token-free on loopback). -->
 <script>
   import { onMount, onDestroy, tick } from 'svelte'
+  import { push } from 'svelte-spa-router'
   import { VERSION } from '../lib/version.js'
   import * as api from '../lib/api.js'
   import ArkivLogo from '../lib/ArkivLogo.svelte'
@@ -180,9 +181,25 @@
     }
   }
 
-  // Global Esc → interrupt the current chat task (works anywhere in the view).
+  // Global Esc. Same rule the ingest and offload dialogs use: if something is
+  // running, interrupt it; otherwise leave the screen. Previously Esc did the
+  // first half only, so on an idle chat the key silently did nothing while the
+  // same key closed every other screen.
+  //
+  // "Leave" here means this view's own exit — the "← 返回素材庫" link, i.e.
+  // /main-live — not home, the way the dialogs' Esc matches their own
+  // ESC · CANCEL button rather than a hardcoded destination.
+  //
+  // No confirm on the busy branch, unlike offload's: a chat turn is seconds and
+  // is already abortable by a visible button, so asking would cost more than the
+  // interruption does. Offload guards because a stray key there can drop a
+  // 30-minute card copy.
   function onGlobalKey(e) {
-    if (e.key === 'Escape' && busy) { e.preventDefault(); abort() }
+    if (e.key !== 'Escape') return
+    if (e.metaKey || e.ctrlKey || e.altKey) return
+    e.preventDefault()
+    if (busy) { abort(); return }
+    push('/main-live')
   }
 
   onMount(() => {
@@ -199,7 +216,11 @@
     <Mono dim style="font-size:10px;">{VERSION}</Mono>
     <div class="grow"></div>
     <Mono dim style="font-size:11px;">chat · 5-intent · vector + LLM</Mono>
-    <a class="ak-btn" href="#/main-live">← 返回素材庫</a>
+    <!-- Same affordance the ingest and offload dialogs use, so Esc looks the same
+         everywhere it works. The label is dynamic because Esc genuinely does two
+         different things here: a static "返回素材庫" would be a lie mid-answer,
+         when the key aborts instead of navigating. -->
+    <button class="esc" on:click={() => (busy ? abort() : push('/main-live'))}>ESC · {busy ? '中斷回覆' : '返回素材庫'}</button>
   </div>
 
   <div class="body">
@@ -290,15 +311,12 @@
   .artboard { width: 100%; max-width: 1920px; height: 100vh; height: 100dvh; background: var(--bg); color: var(--ink); display: grid; grid-template-rows: 52px 1fr; overflow: hidden; margin: 0 auto; }
   .grow { flex: 1; }
   .topbar { display: flex; align-items: center; border-bottom: 1px solid var(--rule); padding: 0 16px; gap: 16px; }
-  /* Match the global button.ak-btn look for the back-link <a> (global rule is
-     element-qualified to <button>, so an <a class="ak-btn"> is otherwise unstyled). */
-  .topbar a.ak-btn {
-    font-family: var(--ak-mono); font-size: var(--fs-tiny); text-transform: uppercase;
-    letter-spacing: var(--tr-uppercase); color: var(--ink); background: transparent;
-    border: 1px solid var(--rule-hi); padding: 6px 10px; line-height: 1;
-    text-decoration: none; cursor: pointer; white-space: nowrap;
-  }
-  .topbar a.ak-btn:hover { background: var(--surface-2); border-color: var(--ink); }
+  /* Verbatim from the ingest/offload dialogs, minus their `margin-left: auto` —
+     this topbar already pushes with .grow. Keeping the two in sync matters more
+     than saving the duplication: Esc is one gesture and should not look like
+     two different controls depending on which screen you are on. */
+  .esc { font-family: var(--ak-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--quiet); background: none; border: none; cursor: pointer; white-space: nowrap; }
+  .esc:hover { color: var(--ink); }
   .body { display: grid; grid-template-columns: 240px 1fr; min-height: 0; }
   .convs { border-right: 1px solid var(--rule); display: flex; flex-direction: column; min-height: 0; }
   .convhead { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 14px 16px; border-bottom: 1px solid var(--rule); }

--- a/frontend/src/routes/IngestSetup.svelte
+++ b/frontend/src/routes/IngestSetup.svelte
@@ -42,6 +42,21 @@
 
   $: gb = manifest ? (manifest.total_size_mb / 1024).toFixed(1) : null
 
+  // The header button has read "ESC · CANCEL" since this screen shipped, but the
+  // key was never wired. Same fix as Offload's, minus its running-copy guard:
+  // nothing here runs long enough to be worth interrupting with a confirm — Scan
+  // is a single request, and the actual ingest happens on /ingest-live.
+  //
+  // No skip-when-focused-in-an-input guard on purpose: that belongs to printable
+  // shortcuts (Inspector's onKey), not to Escape, which should close the dialog
+  // from inside the path field too.
+  function onKey(e) {
+    if (e.key !== 'Escape') return
+    if (e.metaKey || e.ctrlKey || e.altKey) return
+    e.preventDefault()
+    push('/')
+  }
+
   // Native folder chooser, same contract as Offload's: desktop shell only, and a
   // cancel leaves the field alone rather than clearing a path someone typed.
   const canBrowse = canPickFolder()
@@ -55,7 +70,14 @@
   }
 
   async function scan() {
-    if (!path.trim()) { err = '請先填來源資料夾路徑'; return }
+    // Same rule as Offload's: a missing required path shouts, because pressing
+    // the action with a blank field is the likeliest way to hit it and a line of
+    // inline text is easy to miss. `err` stays for operation failures below, so
+    // validation and runtime errors do not compete for the same slot.
+    if (!path.trim()) {
+      pushToast('請先填來源資料夾路徑（Source · folder）', 'error')
+      return
+    }
     err = ''; notice = ''; scanning = true; manifest = null
     try {
       const d = await api.scanMedia(path.trim())
@@ -65,7 +87,18 @@
   }
 
   async function start() {
-    if (!path.trim()) { err = '需要來源資料夾'; return }
+    // Same shape as Offload's doRun: collect every unmet prerequisite and name
+    // them in one message. "Scan first" and "that folder had nothing in it" are
+    // different problems with the same symptom (total === 0), so they get
+    // different sentences — manifest is null only before a scan has run.
+    const missing = []
+    if (!path.trim()) missing.push('來源資料夾路徑（Source · folder）')
+    if (manifest === null) missing.push('先按 Scan 掃描來源資料夾')
+    else if (total === 0) missing.push('可匯入的媒體檔（這個資料夾掃到 0 個）')
+    if (missing.length) {
+      pushToast(`無法開始匯入 — 缺少：${missing.join('、')}`, 'error')
+      return
+    }
     err = ''; starting = true
     try {
       const body = { ...opts }
@@ -113,6 +146,8 @@
     ['no_embed', 'Skip index rebuild', '匯入後不自動重建向量索引'],
   ]
 </script>
+
+<svelte:window on:keydown={onKey} />
 
 <div class="artboard" data-theme={$resolvedTheme}>
   <div class="topbar">
@@ -227,7 +262,10 @@
       {#if err}<Mono style="font-size:11px;color:var(--cyan);">{err}</Mono>{:else if notice}<Mono dim style="font-size:11px;">{notice}</Mono>{/if}
       <div class="grow"></div>
       <button class="ak-btn" on:click={() => push('/')}>Cancel</button>
-      <button class="ak-btn ak-btn--primary" on:click={start} disabled={starting || total === 0}>{starting ? 'starting…' : 'Start ingest →'}</button>
+      <!-- Disabled only while a start is actually in flight; every other refusal
+           is a toast naming what is missing, same as Offload's Run. -->
+      <button class="ak-btn ak-btn--primary" on:click={start} disabled={starting}
+              title={total > 0 ? `開始匯入 ${total} 個檔案` : '開始匯入'}>{starting ? 'starting…' : 'Start ingest →'}</button>
     </div>
   </div>
 </div>

--- a/frontend/src/routes/Offload.svelte
+++ b/frontend/src/routes/Offload.svelte
@@ -54,7 +54,13 @@
   // Run is armed after a Preview; also re-armed after a Stop so the user can
   // Resume directly — the backend keeps a per-source state file and picks up from
   // the last verified file (R5-17 #19), no re-Preview needed.
-  $: canRun = (phase === 'preview' || (phase === 'done' && stopped)) && liveDsts.length > 0
+  // The human gate (Preview must precede Run, plan §DIT rule 1) is unchanged as
+  // a RULE — what changed is how it refuses. It used to be folded into the
+  // button's `disabled` along with the destination check, so a user with a blank
+  // form got one greyed-out button and no way to tell which of the two things it
+  // wanted. Now the button is pressable whenever a run isn't already going, and
+  // every refusal names its reason.
+  $: previewed = phase === 'preview' || (phase === 'done' && stopped)
   $: pct = pTotal ? Math.min(100, Math.round((pDone / pTotal) * 100)) : 0
   $: anyFailed = summary ? Object.values(summary).some((s) => s.failed_files > 0) || doneCode !== 0 : false
   const base = (p) => String(p).split(/[\\/]/).pop()
@@ -88,8 +94,28 @@
     if (p) dsts[i] = p
   }
 
+  // Required-path guards. These toast rather than only setting `err`, because a
+  // line of inline text is easy to miss and the failure it reports is the one a
+  // user is most likely to hit: pressing the action with a field still blank.
+  // `err` stays the channel for operation failures (a copy that broke), so the
+  // two do not compete: validation shouts, runtime errors stay on the page.
+  //
+  // A toast, not a native alert(): a modal blocks the whole webview, and in a
+  // Tauri window a blocked webview stops responding to everything else.
+  // Collects EVERY unmet prerequisite, not just the first. Reporting them one at
+  // a time turns the form into a guessing game: you fill the source, press
+  // again, and only then find out a destination was blank too.
+  function blockers({ needDst, needPreview }) {
+    const missing = []
+    if (!src.trim()) missing.push('來源路徑（Source）')
+    if (needDst && liveDsts.length === 0) missing.push('至少一個目的地路徑（Destinations）')
+    if (needPreview && !previewed) missing.push('先按 Preview 讀取來源檔案清單')
+    return missing
+  }
+
   async function doPreview() {
-    if (!src.trim()) { err = '請先填來源路徑'; return }
+    const missing = blockers({ needDst: false, needPreview: false })
+    if (missing.length) { pushToast(`無法預覽 — 缺少：${missing.join('、')}`, 'error'); return }
     err = ''; phase = 'previewing'; preview = null
     try {
       preview = await api.offloadPreview({
@@ -103,7 +129,9 @@
   }
 
   async function doRun() {
-    if (!canRun) return
+    if (phase === 'running') return
+    const missing = blockers({ needDst: true, needPreview: true })
+    if (missing.length) { pushToast(`無法開始複製 — 缺少：${missing.join('、')}`, 'error'); return }
     err = ''; phase = 'running'; stopped = false
     curDst = ''; pTotal = 0; pDone = 0; pFailed = 0; recent = []; summary = null; doneCode = null
     abortCtl = new AbortController()
@@ -165,12 +193,43 @@
   // Navigating away mid-copy must also stop the server-side copy, not orphan it.
   onDestroy(() => { if (abortCtl) abortCtl.abort() })
 
+  // The header button has read "ESC · CANCEL" since this screen shipped, but the
+  // key itself was never wired — the label advertised a shortcut that did not
+  // exist. It now does the same thing the button does.
+  //
+  // Note this deliberately does NOT skip when focus is in an input, the way
+  // Inspector's onKey does. That guard is there because its shortcuts are
+  // printable letters; Escape is not, and closing a dialog from inside its own
+  // text field is exactly what the key is for.
+  //
+  // The one divergence from the button: while a copy is running, Escape asks
+  // first, reusing Stop's confirm. Clicking the button has to be aimed at;
+  // a key does not, and this dialog is the one place in the app where a stray
+  // keystroke can interrupt a 30-minute card copy. Answering no leaves the
+  // transfer running rather than closing the screen.
+  // One function behind both the key and the button that is named after it.
+  // They were briefly allowed to diverge — the key confirmed before stopping a
+  // running copy while the button still navigated away silently — which is worse
+  // than either behaviour alone: a control labelled ESC has to do what ESC does.
+  function escAction() {
+    if (phase === 'running') { stopRun(); return }
+    push('/')
+  }
+  function onKey(e) {
+    if (e.key !== 'Escape') return
+    if (e.metaKey || e.ctrlKey || e.altKey) return
+    e.preventDefault()
+    escAction()
+  }
+
   // 2-phase handoff — ingest the first destination we just offloaded.
   function ingestNext() {
     const target = (summary && Object.keys(summary)[0]) || liveDsts[0]
     if (target) push(`/ingest-setup?src=${encodeURIComponent(target)}`)
   }
 </script>
+
+<svelte:window on:keydown={onKey} />
 
 <div class="artboard" data-theme={$resolvedTheme}>
   <div class="topbar">
@@ -184,7 +243,7 @@
     <div class="dhead">
       <Eyebrow>DIT · card → backup</Eyebrow>
       <div class="ak-display title">Offload{preview ? ` · ${preview.count} files` : ''}</div>
-      <button class="esc" on:click={() => push('/')}>ESC · CANCEL</button>
+      <button class="esc" on:click={escAction}>ESC · {phase === 'running' ? '停止複製' : 'CANCEL'}</button>
     </div>
 
     <div class="body">
@@ -298,7 +357,10 @@
       {:else}
         <button class="ak-btn" on:click={() => push('/')}>{phase === 'done' ? 'Done' : 'Cancel'}</button>
       {/if}
-      <button class="ak-btn ak-btn--primary" on:click={doRun} disabled={!canRun}>{phase === 'running' ? 'copying…' : (stopped && phase === 'done' ? 'Resume →' : 'Run offload →')}</button>
+      <!-- Disabled only while a copy is actually in flight. Every other refusal
+           is a toast naming what is missing, so the button is never mutely dead. -->
+      <button class="ak-btn ak-btn--primary" on:click={doRun} disabled={phase === 'running'}
+              title="開始複製到所有目的地">{phase === 'running' ? 'copying…' : (stopped && phase === 'done' ? 'Resume →' : 'Run offload →')}</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
feat(ui): make Esc work, and make refusals say what is missing

Three related things, all the same shape: a control that looked like it did
something and then did not.

**Esc was never wired.** The ingest and offload dialog headers have read
"ESC · CANCEL" since those screens shipped, but no keydown handler existed --
the label advertised a shortcut that was never implemented. It now does what
the button does, on both screens.

Deliberately no skip-when-focus-is-in-an-input guard, unlike Inspector's onKey.
That guard belongs to printable shortcuts (pressing `i` in a text field should
type an i, not set an IN point); Escape is not printable, and closing a dialog
from inside its own path field is precisely what the key is for.

Chat had the rule half-implemented: Esc aborted a running answer but did
nothing when idle, so the same key that closed every other screen was silently
inert there. Esc is now one rule app-wide -- **if something is running,
interrupt it; otherwise leave the screen** -- with each screen's "leave" being
its own documented exit rather than a hardcoded one. The dialogs go where their
ESC · CANCEL button goes; Chat goes where its back link goes (/main-live).
Hardcoding a single destination would have made Chat's Esc land somewhere its
own back button does not.

Offload confirms before interrupting; Chat does not. A chat turn is seconds and
already has a visible abort button, so asking would cost more than the
interruption. Offload guards because a stray keystroke there can drop a
30-minute card copy.

**Refusals were mute.** Run offload was disabled unless a preview existed AND a
destination was filled, so a user with a blank form got one greyed-out button
and no way to tell which of the two it wanted; Start ingest was disabled until a
scan succeeded, with the same silence. Both are now pressable whenever an
operation is not already in flight, and every refusal is a toast that names
**every** unmet prerequisite at once -- reporting them one at a time turns the
form into a guessing game, where you fill the source, press again, and only then
learn the destination was blank too.

The human gate is unchanged as a rule: Preview still has to precede Run (plan
§DIT rule 1). What changed is that it now explains itself instead of presenting
a dead button. Ingest additionally separates "you have not scanned yet" from
"that folder contained nothing", which are different problems with the same
symptom (total === 0).

Toasts rather than native alert(): a modal blocks the whole webview, and in a
Tauri window a blocked webview stops responding to everything. Validation
toasts; `err` stays the channel for operation failures, so the two do not
compete for the same slot.

**Esc's UI is now one control.** Chat's bordered "← 返回素材庫" link becomes the
same borderless mono affordance the dialogs use, so the gesture does not look
like two different controls depending on the screen. Labels are dynamic where
the behaviour is: Chat reads 返回素材庫 / 中斷回覆, offload CANCEL / 停止複製.
That also closes a divergence introduced earlier in this branch -- offload's Esc
KEY confirmed before stopping a copy while its ESC-labelled BUTTON still
navigated away silently. Both now call one function; a control named after a key
has to do what the key does.

svelte-check --fail-on-warnings clean (39 files). Every path exercised on Win11
against the installed desktop app.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
