### PR TITLE
feat(site): 給非工程師的產品頁，取代「GitHub Releases 是唯一的門」

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 **Source-available AI metadata layer for DIT workflows — Resolve-native, CJK-first.**
 
 > 🌐 **English** | [繁體中文](README.zh-TW.md)
+>
+> 📦 **Just want the app?** → **[https://vulture-s.github.io/arkiv/](https://vulture-s.github.io/arkiv/)** — download, what it does, and the licence in one page.
+> Free for any purpose, commercial work included.
 
 arkiv sits between your media drive and DaVinci Resolve: it ingests your footage, attaches AI-generated metadata (transcript, vision tags, atmosphere, energy, edit position), and surfaces clips via semantic search in any language — Chinese, Japanese, or English. The Resolve plugin lets you search, import with clip color, and drop frame markers without leaving the NLE.
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -7,6 +7,9 @@
 **DIT 工作流的 source-available AI 素材標註層 — Resolve 原生、CJK 優先。**
 
 > 🌐 [English](README.md) | **繁體中文**
+>
+> 📦 **只想拿到 app？** → **[https://vulture-s.github.io/arkiv/](https://vulture-s.github.io/arkiv/)** —— 下載、它在做什麼、授權，一頁講完。
+> 免費，任何用途皆可，包含商業工作。
 
 arkiv 介於素材硬碟與 DaVinci Resolve 之間：自動 ingest footage、附上 AI 標註（逐字稿、視覺標籤、氛圍、能量、剪輯位置），並用任何語言（中文、日文、英文）的語義搜尋找回 clip。Resolve plugin 讓你搜尋、帶 clip color 匯入、加 frame marker，不用離開 NLE。
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,325 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>arkiv — 拍過的東西，找得回來</title>
+<meta name="description" content="本機優先的 AI 素材索引層。自動轉錄、看懂畫面，用中文問句找到那顆鏡頭。Resolve 原生、零雲端、免費且商用不受限。">
+<meta property="og:title" content="arkiv — 拍過的東西，找得回來">
+<meta property="og:description" content="本機優先的 AI 素材索引層。免費、商用不受限、原始碼公開。">
+<meta property="og:type" content="website">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Noto+Sans+TC:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+:root{
+  --ak-display:'Archivo Black','Inter',sans-serif;
+  --ak-sans:'Inter','Noto Sans TC',system-ui,sans-serif;
+  --ak-mono:'JetBrains Mono',ui-monospace,monospace;
+  --bg:#0a0a0c; --surface:#111114; --surface-2:#17171a;
+  --rule:#26262a; --rule-hi:#3a3a3f;
+  --ink:#f3f2ee; --ink-2:#b6b5b0; --quiet:#6a6a6d;
+  --invert:#f3f2ee; --invert-ink:#0a0a0c; --cyan:#18b6dc;
+}
+*{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{
+  background:var(--bg); color:var(--ink);
+  font-family:var(--ak-sans); font-feature-settings:'ss01','cv11','tnum';
+  line-height:1.7; -webkit-font-smoothing:antialiased;
+}
+.wrap{max-width:960px;margin:0 auto;padding:0 24px}
+section{padding:72px 0;border-bottom:1px solid var(--rule)}
+section:last-of-type{border-bottom:0}
+h2{font-size:clamp(20px,3.2vw,26px);font-weight:600;letter-spacing:-.01em;margin-bottom:28px}
+h3{font-size:16px;font-weight:600;margin-bottom:8px}
+p{color:var(--ink-2)}
+a{color:var(--cyan)}
+.mono{font-family:var(--ak-mono)}
+
+/* hero */
+.hero{padding:96px 0 80px;border-bottom:1px solid var(--rule)}
+.eyebrow{font-family:var(--ak-mono);font-size:11px;letter-spacing:.22em;text-transform:uppercase;color:var(--quiet);margin-bottom:20px}
+.wordmark{font-family:var(--ak-display);font-size:clamp(52px,11vw,92px);line-height:.92;letter-spacing:-.03em}
+.wordmark .dot{color:var(--cyan)}
+.lede{font-size:clamp(22px,4vw,34px);font-weight:600;letter-spacing:-.02em;color:var(--ink);margin:28px 0 16px;line-height:1.3}
+.sub{font-size:clamp(15px,2.2vw,17px);max-width:62ch}
+.badges{display:flex;flex-wrap:wrap;gap:10px;margin-top:28px}
+.badge{font-family:var(--ak-mono);font-size:12px;color:var(--ink-2);border:1px solid var(--rule-hi);border-radius:999px;padding:5px 13px}
+.badge b{color:var(--cyan);font-weight:500}
+
+/* buttons */
+.dl{display:flex;flex-wrap:wrap;gap:12px;margin-top:36px}
+.btn{
+  display:inline-flex;flex-direction:column;gap:2px;
+  background:var(--invert);color:var(--invert-ink);
+  text-decoration:none;border-radius:10px;padding:13px 22px;
+  font-weight:600;font-size:15px;transition:transform .12s ease,opacity .12s ease;
+}
+.btn:hover{transform:translateY(-1px);opacity:.9}
+.btn small{font-weight:400;font-size:11.5px;opacity:.62;font-family:var(--ak-mono)}
+.btn.ghost{background:transparent;color:var(--ink);border:1px solid var(--rule-hi)}
+.dl-note{margin-top:14px;font-size:13px;color:var(--quiet)}
+
+/* license — the wedge */
+.lic{background:var(--surface);border:1px solid var(--rule);border-radius:14px;padding:32px}
+.lic ul{list-style:none;display:grid;gap:20px}
+.lic li{display:grid;grid-template-columns:26px 1fr;gap:14px;align-items:start}
+.lic .mk{font-family:var(--ak-mono);font-size:15px;line-height:1.5}
+.lic .yes{color:var(--cyan)}
+.lic .no{color:#e2686d}
+.lic b{color:var(--ink);font-weight:600}
+.lic .fine{margin-top:24px;padding-top:20px;border-top:1px solid var(--rule);font-size:13.5px;color:var(--quiet)}
+
+/* why */
+.why{display:grid;gap:26px}
+.why .row{display:grid;grid-template-columns:auto 1fr;gap:16px;align-items:start}
+.why .n{font-family:var(--ak-mono);font-size:12px;color:var(--quiet);padding-top:4px}
+.why p{font-size:15px}
+
+/* proof */
+.proof{background:var(--surface-2);border-left:2px solid var(--cyan);padding:24px 26px;border-radius:0 10px 10px 0}
+.proof .big{font-family:var(--ak-mono);font-size:clamp(26px,5vw,34px);color:var(--ink);letter-spacing:-.02em}
+.proof p{font-size:14px;margin-top:8px}
+
+/* tiers */
+table{width:100%;border-collapse:collapse;font-size:15px}
+th,td{text-align:left;padding:14px 12px;border-bottom:1px solid var(--rule)}
+th{font-size:12px;font-family:var(--ak-mono);letter-spacing:.12em;text-transform:uppercase;color:var(--quiet);font-weight:400}
+td:first-child{color:var(--ink-2)}
+td b{color:var(--ink)}
+.soon{display:inline-block;font-family:var(--ak-mono);font-size:11px;color:var(--invert-ink);background:var(--ink-2);border-radius:4px;padding:2px 7px;margin-left:8px;vertical-align:middle}
+.tier-note{margin-top:20px;font-size:14px;color:var(--quiet)}
+
+/* honesty */
+.real{display:grid;gap:14px}
+.real div{display:grid;grid-template-columns:20px 1fr;gap:12px;font-size:14.5px;color:var(--ink-2)}
+.real .m{color:var(--quiet);font-family:var(--ak-mono);font-size:13px}
+
+/* email */
+#signup{display:none}
+#signup form{display:flex;flex-wrap:wrap;gap:10px;margin-top:8px}
+#signup input{
+  flex:1 1 260px;background:var(--surface-2);border:1px solid var(--rule-hi);
+  color:var(--ink);border-radius:10px;padding:13px 16px;font-size:15px;font-family:inherit;
+}
+#signup input:focus{outline:2px solid var(--cyan);outline-offset:1px}
+#signup button{
+  background:var(--invert);color:var(--invert-ink);border:0;border-radius:10px;
+  padding:13px 26px;font-weight:600;font-size:15px;cursor:pointer;font-family:inherit;
+}
+
+footer{padding:48px 0 72px;font-size:14px;color:var(--quiet)}
+footer a{color:var(--ink-2);text-decoration:none;margin-right:20px}
+footer a:hover{color:var(--cyan)}
+.foot-links{margin-bottom:20px}
+
+@media (max-width:600px){
+  section{padding:56px 0}
+  .hero{padding:64px 0 56px}
+  .lic{padding:24px 20px}
+  table{font-size:14px}
+  th,td{padding:12px 8px}
+}
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <div class="wrap">
+    <div class="eyebrow">Media Asset Manager · 本機優先</div>
+    <div class="wordmark">arkiv<span class="dot">.</span></div>
+    <p class="lede">拍過的東西，找得回來。</p>
+    <p class="sub">
+      arkiv 自動幫每一支素材做轉錄、看懂畫面、標記氛圍與剪輯位置，
+      然後讓你用一句中文找到那顆鏡頭 ——「五月所有黃昏空景」。
+      全部在你自己的機器上跑，零雲端、不對外回報。
+    </p>
+
+    <div class="badges">
+      <span class="badge"><b>免費</b>　任何用途</span>
+      <span class="badge"><b>商用不受限</b>　接案／工作室都可以</span>
+      <span class="badge"><b>原始碼公開</b>　source-available</span>
+      <span class="badge">DaVinci Resolve 原生</span>
+      <span class="badge">中／日／英 語意搜尋</span>
+    </div>
+
+    <div class="dl">
+      <a class="btn" href="https://github.com/vulture-s/arkiv/releases/latest">
+        下載 macOS 版<small>Apple Silicon · .dmg</small>
+      </a>
+      <a class="btn" href="https://github.com/vulture-s/arkiv/releases/latest">
+        下載 Windows 版<small>x64 · .exe / .msi</small>
+      </a>
+      <a class="btn ghost" href="https://github.com/vulture-s/arkiv">
+        看原始碼<small>GitHub</small>
+      </a>
+    </div>
+    <p class="dl-note">
+      最新版 <span class="mono">v0.12.1</span>　·　安裝前請先看下方
+      <a href="#real">實際需要什麼</a>　·　English: <a href="https://github.com/vulture-s/arkiv#readme">README</a>
+    </p>
+  </div>
+</header>
+
+<section>
+  <div class="wrap">
+    <h2>授權：一句話講完</h2>
+    <div class="lic">
+      <ul>
+        <li>
+          <span class="mk yes">✓</span>
+          <div>
+            <b>免費使用，任何用途 —— 包含商業工作。</b>
+            <p>接客戶的案子、工作室日常、有補助的製作，全部可以。不需要跟我們談授權，也不需要通知我們。</p>
+          </div>
+        </li>
+        <li>
+          <span class="mk yes">✓</span>
+          <div>
+            <b>你做出來的東西是你的。</b>
+            <p>影片、時間軸、EDL / FCPXML / OTIO 匯出檔、縮圖 —— 授權不對它們加任何限制。</p>
+          </div>
+        </li>
+        <li>
+          <span class="mk no">✕</span>
+          <div>
+            <b>唯一不允許：把 arkiv 做成跟它競爭的產品。</b>
+            <p>fork 成對手素材管理工具、包成索引服務賣給第三方、或重新實作成替代品 —— 即使免費提供也一樣。</p>
+          </div>
+        </li>
+      </ul>
+      <p class="fine">
+        界線在於<b style="color:var(--ink-2)">你的客戶買的是什麼</b>：買你用 arkiv 做出來的成品，是一般的工具使用；
+        買 arkiv 的功能本身（當成產品、服務、函式庫或外掛），才構成競爭。
+        條文為 <a href="https://github.com/vulture-s/arkiv/blob/main/LICENSE">PolyForm Perimeter 1.0.1</a>。
+      </p>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="wrap">
+    <h2>它解決什麼</h2>
+    <div class="why">
+      <div class="row">
+        <span class="n">01</span>
+        <div>
+          <h3>素材太多，找不到那顆鏡頭</h3>
+          <p>用自然語言搜，中日英都行 —— 搜的是<b style="color:var(--ink)">畫面內容和逐字稿</b>，不是檔名。</p>
+        </div>
+      </div>
+      <div class="row">
+        <span class="n">02</span>
+        <div>
+          <h3>AI 剪輯工具只看得懂「有人在講話」的素材</h3>
+          <p>arkiv 對每支 clip 做視覺分析 <b style="color:var(--ink)">加</b> 轉錄，所以大量 B-roll、無對白空景一樣可搜可管。</p>
+        </div>
+      </div>
+      <div class="row">
+        <span class="n">03</span>
+        <div>
+          <h3>素材庫要能餵給下游任何剪法</h3>
+          <p>手動剪、自動剪、腳本剪都接得上：Resolve 原生 plugin、EDL / FCPXML 匯出、REST API 與 MCP 介面。</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="wrap">
+    <h2>不是 demo 專案</h2>
+    <div class="proof">
+      <div class="big">1,506 支</div>
+      <p>
+        真實產品拍攝素材完整索引跑通，其中 <b style="color:var(--ink-2)">1,161 支是無對白 B-roll</b>
+        —— 也就是一般字幕工具完全抓不到的那些。單張 RTX 4070，5,732 幀視覺描述，零缺口。
+      </p>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="wrap">
+    <h2>免費版與 Pro</h2>
+    <table>
+      <thead>
+        <tr><th></th><th>免費</th><th>Pro<span class="soon">尚未開賣</span></th></tr>
+      </thead>
+      <tbody>
+        <tr><td>全部索引與搜尋功能</td><td><b>✓</b></td><td><b>✓</b></td></tr>
+        <tr><td>商業使用</td><td><b>✓</b></td><td><b>✓</b></td></tr>
+        <tr><td>專案數</td><td><b>3 個</b></td><td><b>無限</b></td></tr>
+        <tr><td>跨專案聚合搜尋</td><td>—</td><td><b>✓</b></td></tr>
+        <tr><td>價格</td><td><b>NT$0</b></td><td><b>NT$3,000</b> 一次買斷</td></tr>
+      </tbody>
+    </table>
+    <p class="tier-note">
+      Pro 還沒開賣，購買流程還在建 ——
+      <a href="https://github.com/vulture-s/arkiv/blob/main/docs/pro-addon-license.md">條款先公開</a>，
+      讓你在那之前就能讀。做紀錄片、非營利、檔案保存、公共教育的，
+      <a href="https://github.com/vulture-s/arkiv/blob/main/PUBLIC-INTEREST.md">公益方案</a>免費給。
+      <br><b style="color:var(--ink-2)">現在裝的人不受影響</b>：專案上限只對日後的新安裝生效，既有素材庫永久沿用無限。
+    </p>
+  </div>
+</section>
+
+<section id="real">
+  <div class="wrap">
+    <h2>安裝前先知道</h2>
+    <div class="real">
+      <div><span class="m">01</span><span>安裝檔<b style="color:var(--ink)">包含 Python 後端與 ML 套件</b>，但你<b style="color:var(--ink)">仍需自行安裝 FFmpeg 與 Ollama</b>（抽幀、向量、視覺分析要用）。</span></div>
+      <div><span class="m">02</span><span>macOS 版<b style="color:var(--ink)">僅支援 Apple Silicon</b>，沒有 Intel build。</span></div>
+      <div><span class="m">03</span><span>安裝檔<b style="color:var(--ink)">未經簽章</b>。macOS 首次要「右鍵 → 打開」，Windows 會跳一次 SmartScreen 警告。這是刻意的：簽章憑證每年要錢，那筆錢目前寧可不花。</span></div>
+      <div><span class="m">04</span><span>視覺分析吃 GPU。沒有獨顯也跑得動，但會慢很多。</span></div>
+    </div>
+  </div>
+</section>
+
+<!--
+  ────────────────────────────────────────────────────────────────
+  EMAIL 名單：尚未接上，所以整段預設不顯示（不放壞掉的表單上線）。
+  接法：去 Kit / Buttondown / Google Form 開一個表單，把它的 POST
+  endpoint 貼進下面的 FORM_ENDPOINT，這一段就會自動出現。
+  ────────────────────────────────────────────────────────────────
+-->
+<section id="signup">
+  <div class="wrap">
+    <h2>新版本出來時通知我</h2>
+    <p>不定期、只講實質更新，隨時可退訂。</p>
+    <form id="signup-form" method="post">
+      <input type="email" name="email" placeholder="your@email.com" required aria-label="Email">
+      <button type="submit">訂閱</button>
+    </form>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    <div class="foot-links">
+      <a href="https://github.com/vulture-s/arkiv">GitHub</a>
+      <a href="quickstart.html">安裝說明</a>
+      <a href="faq.html">FAQ</a>
+      <a href="https://github.com/vulture-s/arkiv/blob/main/LICENSE">授權</a>
+      <a href="https://www.instagram.com/vulture.s/">@vulture.s</a>
+    </div>
+    <p>
+      PolyForm Perimeter 1.0.1 · source-available（非 OSI 開源授權，所以我們不寫「open source」）<br>
+      本機優先 · 零雲端 · 不對外回報
+    </p>
+  </div>
+</footer>
+
+<script>
+  // 把這行換成真的表單 endpoint，訂閱區塊就會自動顯示。
+  const FORM_ENDPOINT = "";
+
+  if (FORM_ENDPOINT) {
+    document.getElementById("signup").style.display = "block";
+    document.getElementById("signup-form").action = FORM_ENDPOINT;
+  }
+</script>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,6 +8,7 @@
 <meta property="og:title" content="arkiv — 拍過的東西，找得回來">
 <meta property="og:description" content="本機優先的 AI 素材索引層。免費、商用不受限、原始碼公開。">
 <meta property="og:type" content="website">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 64 64%27%3E%3Crect width=%2764%27 height=%2764%27 rx=%2712%27 fill=%27%230a0a0c%27/%3E%3Ctext x=%2732%27 y=%2744%27 font-family=%27Helvetica,Arial,sans-serif%27 font-size=%2740%27 font-weight=%27900%27 fill=%27%23f3f2ee%27 text-anchor=%27middle%27%3Ea%3C/text%3E%3Ccircle cx=%2750%27 cy=%2744%27 r=%274%27 fill=%27%2318b6dc%27/%3E%3C/svg%3E">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&family=Noto+Sans+TC:wght@400;500;700&display=swap" rel="stylesheet">

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,8 @@
 # arkiv — Quickstart
 
-**Open-source AI metadata layer for DIT workflows — Resolve-native, CJK-first.**
+> ← [回產品頁](index.html)
+
+**Source-available AI metadata layer for DIT workflows — Resolve-native, CJK-first.**
 
 arkiv attaches AI metadata (transcript, vision tags, atmosphere, edit position) to your footage and surfaces clips via natural-language search in Chinese, Japanese, or English.
 

--- a/social-preview.html
+++ b/social-preview.html
@@ -198,7 +198,7 @@
     <div class="wordmark">arkiv<span class="dot">.</span></div>
     <div class="brush"></div>
     <div class="tagline">
-      The <b>open-source</b> media asset manager for filmmakers who <b>own their data</b>.
+      The <b>source-available</b> media asset manager for filmmakers who <b>own their data</b>.
     </div>
   </div>
 


### PR DESCRIPTION
feat(site): 給非工程師的產品頁，取代「GitHub Releases 是唯一的門」

`.dmg` / `.exe` / `.msi` 都齊了，但唯一的下載入口是 GitHub Releases，
而那扇門對剪輯師是敵意的：點進來看到程式碼頁，得自己找到 Releases、
在三個副檔名之間猜、而且沒有一句話說這是什麼。repo 的 homepage 欄位
甚至填的是 Instagram —— 等於根本沒有產品頁。

真正讓這件事現在才做得成的不是產物齊全，是**話術終於能一句話講完**。
在 PolyForm-NC 底下要解釋「軟體非商用免費、但你剪的片可商用、可是你
接案用它嚴格說要另外談授權」——沒有人會讀完。換成 Perimeter（#320）
之後同一件事變成：免費、商用隨便用、你剪出來的東西是你的。那是一個
headline，不是一段免責聲明。

`docs/index.html` —— zh-TW 為主（CJK wedge 與課程漏斗都在台灣；英文
受眾本來就從 GitHub 進來，頁面右上導回 README）。內容依序：一句話價值
主張 → 下載鍵 → **授權三點**（放在第二段，因為它現在是賣點不是小字）
→ 解決什麼 → 1,506 支真實素材的實證 → 免費/Pro 對照 → 安裝前先知道。

三個刻意的決定：

- **下載鍵指向 `/releases/latest` 而非寫死檔名。** 產物名帶版號
  (`arkiv_0.12.1_aarch64.dmg`)，寫死等於每次發版都多一個會爛的地方。
- **email 區塊預設不顯示。** 名單是 SOSTAC §2 算出來的真 binding
  constraint（0 → 需要 2,300–5,800），但表單還沒接 provider ——
  與其上線一個壞掉的表單，不如讓它在 `FORM_ENDPOINT` 填好前不存在。
  填了就自動出現。
- **「安裝前先知道」整段是負面資訊**：仍需 FFmpeg + Ollama、mac 僅
  Apple Silicon、未簽章要多點一次、沒獨顯會慢。上市 campaign 診斷的
  破洞是 Convert 不是 Reach，而 Convert 死在期待落差。

順帶修掉兩處 #225 明文禁用的假宣稱（那次和今天的 sweep 都漏了，因為
grep 的是 `polyform|noncommercial` 不是 `open-source`）：
`social-preview.html` 的 OG 卡（分享時最公開的一面）與
`docs/index.md` 開頭。**PolyForm 不是 OSI 授權，寫 open source 是假的。**

`docs/index.md` → `docs/quickstart.md`（Pages 要用 index 當產品頁；
全 repo 只有 CHANGELOG 的歷史紀錄提到舊路徑，不動）。

Pro 對照表明寫「現在裝的人不受影響：專案上限只對日後新安裝生效」——
Hevin 2026-08-18 拍板 grandfather。實查過 code 目前沒有任何專案上限
gate，等於現在所有使用者都在用 Pro 功能，所以這個承諾必須先寫出來。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
