### PR TITLE
docs(copy): 對外文案統一為半正式商業語體

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -17,17 +17,17 @@ This summary is for convenience and does not modify them.
     timelines, EDL/FCPXML/OTIO exports, thumbnails, and any other output -- are
     yours, with no restriction of any kind arising from this license.
 
-  * The one thing you may not do is provide other people with a product that
-    competes with arkiv. Forking it into a rival asset manager, wrapping it as a
-    hosted indexing service sold to third parties, or reimplementing its
-    functionality as a substitute product are all covered by the Noncompete and
-    Competition sections below -- including when the competing product is given
-    away free of charge.
+  * The sole restriction is that you may not provide others with a product that
+    competes with arkiv. Deriving a rival asset manager from it, offering it to
+    third parties as a hosted indexing service, or reimplementing its
+    functionality as a substitute product all fall under the Noncompete and
+    Competition sections below -- including where the competing product is
+    supplied free of charge.
 
-The line is what your customer is buying. If they are buying a deliverable you
-produced with arkiv, that is ordinary tool use and is permitted. If they are
-buying arkiv's functionality itself -- as a product, a service, a library, or a
-plug-in -- that competes with the software.
+The test is what your customer is purchasing. A deliverable you produced with
+arkiv is ordinary tool use and is permitted. arkiv's functionality itself --
+supplied as a product, a service, a library, or a plug-in -- competes with the
+software.
 
 Separately licensed component: the optional Pro add-on (unlimited projects and
 cross-project aggregation) is NOT covered by this license. It is a closed-source

--- a/PUBLIC-INTEREST.md
+++ b/PUBLIC-INTEREST.md
@@ -10,7 +10,7 @@ arkiv 軟體本身依 [PolyForm Perimeter 授權](LICENSE)**任何用途皆免�
 用它產出的成品永遠是你的。公益工作要用核心，不需要向我們申請任何東西。
 
 要收費的只有一個東西：**Pro 附加元件**（無限專案 + 跨專案聚合，NT$3,000 買斷）。
-免費核心支援 3 個專案，長期經營的紀錄片團隊、地方影像資料庫、口述歷史計畫很快就會超過。
+免費核心支援 3 個專案。長期經營的紀錄片團隊、地方影像資料庫與口述歷史計畫，通常會超出此一額度。
 
 **公益方案就是為這種情況設的：只要你做的是有公共價值的影像工作，這個附加元件我們免費提供，
 且為終身授權。**
@@ -28,8 +28,8 @@ arkiv 軟體本身依 [PolyForm Perimeter 授權](LICENSE)**任何用途皆免�
 
 ## 什麼不在這個方案裡
 
-- 純商業廣告、品牌行銷、企業形象片。這些用 arkiv 完全沒問題（授權本來就允許），
-  只是超過 3 個專案時請正常購買 Pro 附加元件。
+- 純商業廣告、品牌行銷、企業形象片。此類用途使用 arkiv 不受任何限制（授權本即允許），
+  惟專案數超過 3 個時，請循一般管道購買 Pro 附加元件。
 - 把 arkiv（或其 fork）當產品／服務**販售、架站、重新包裝**——這在任何情況都不允許，
   [授權正文](LICENSE)的 Noncompete 與 Competition 兩節已明訂。
 - 「有社會意義」的空泛主張但實質是商業專案——我們保留逐案判斷、婉拒的權利。
@@ -57,8 +57,8 @@ arkiv 軟體本身依 [PolyForm Perimeter 授權](LICENSE)**任何用途皆免�
 也保留隨時調整方案內容的權利。核准後若專案性質有重大改變（例如轉為純商業發行），
 請再來談——不過就算談不成，你原本的授權仍然有效，我們不追回已發出的 grant。
 
-這樣設計是刻意的：不做自動資格表，是為了避免「人人都能自稱有社會價值」而讓方案失去意義。
-我們寧可一封一封讀。
+本方案不設自動資格表，係為避免以自我宣稱取代實質審查、致使方案失去意義。
+每一封申請均由專人閱讀。
 
 ---
 
@@ -96,9 +96,9 @@ shouldn't be something only big productions can afford.
 
 ## What this program does *not* cover
 
-- Pure commercial advertising, brand marketing, or corporate promos. Using arkiv for these is
-  entirely fine — the license already permits it — but past 3 projects, please just buy the
-  Pro add-on.
+- Pure commercial advertising, brand marketing, or corporate promos. Such use of arkiv is
+  entirely unrestricted — the licence already permits it — but beyond 3 projects, please
+  purchase the Pro add-on through the standard channel.
 - Selling, hosting, or repackaging arkiv (or a fork) as a product or service — never
   permitted, per the Noncompete and Competition sections of the [license](LICENSE) itself.
 - Vague "social value" claims over what is really a commercial project — we reserve the right
@@ -133,6 +133,6 @@ program over time. If a project's nature changes substantially after approval (e
 a purely commercial release), please come talk to us again — though even if we can't agree,
 your existing grant stands. We don't claw back grants already issued.
 
-This is deliberate: we don't publish an automatic eligibility checklist, because a checklist
-invites everyone to self-declare "social value" and hollows the program out. We'd rather read
-requests one at a time.
+No automatic eligibility checklist is published, as a checklist invites self-declared "social
+value" to substitute for substantive review and hollows the programme out. Every request is
+read individually.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 > 🌐 **English** | [繁體中文](README.zh-TW.md)
 >
-> 📦 **Just want the app?** → **[https://vulture-s.github.io/arkiv/](https://vulture-s.github.io/arkiv/)** — download, what it does, and the licence in one page.
-> Free for any purpose, commercial work included.
+> 📦 **Looking for the application?** → **[https://vulture-s.github.io/arkiv/](https://vulture-s.github.io/arkiv/)** — downloads, capabilities, and licence terms on a single page.
+> Free for any purpose, commercial use included.
 
 arkiv sits between your media drive and DaVinci Resolve: it ingests your footage, attaches AI-generated metadata (transcript, vision tags, atmosphere, energy, edit position), and surfaces clips via semantic search in any language — Chinese, Japanese, or English. The Resolve plugin lets you search, import with clip color, and drop frame markers without leaving the NLE.
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -8,8 +8,8 @@
 
 > 🌐 [English](README.md) | **繁體中文**
 >
-> 📦 **只想拿到 app？** → **[https://vulture-s.github.io/arkiv/](https://vulture-s.github.io/arkiv/)** —— 下載、它在做什麼、授權，一頁講完。
-> 免費，任何用途皆可，包含商業工作。
+> 📦 **尋找應用程式？** → **[https://vulture-s.github.io/arkiv/](https://vulture-s.github.io/arkiv/)** —— 下載、功能說明與授權條款，單頁完整呈現。
+> 免費，任何用途皆可，包含商業用途。
 
 arkiv 介於素材硬碟與 DaVinci Resolve 之間：自動 ingest footage、附上 AI 標註（逐字稿、視覺標籤、氛圍、能量、剪輯位置），並用任何語言（中文、日文、英文）的語義搜尋找回 clip。Resolve plugin 讓你搜尋、帶 clip color 匯入、加 frame marker，不用離開 NLE。
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -132,14 +132,14 @@ footer a:hover{color:var(--cyan)}
     <div class="wordmark">arkiv<span class="dot">.</span></div>
     <p class="lede">拍過的東西，找得回來。</p>
     <p class="sub">
-      arkiv 自動幫每一支素材做轉錄、看懂畫面、標記氛圍與剪輯位置，
-      然後讓你用一句中文找到那顆鏡頭 ——「五月所有黃昏空景」。
-      全部在你自己的機器上跑，零雲端、不對外回報。
+      arkiv 為每一支素材自動產生逐字稿、視覺描述，並標記氛圍與剪輯位置，
+      使你得以一句中文找到所需鏡頭 ——「五月所有黃昏空景」。
+      全程於本機執行，不依賴雲端服務，不對外傳送資料。
     </p>
 
     <div class="badges">
       <span class="badge"><b>免費</b>　任何用途</span>
-      <span class="badge"><b>商用不受限</b>　接案／工作室都可以</span>
+      <span class="badge"><b>商用不受限</b>　含客戶委製</span>
       <span class="badge"><b>原始碼公開</b>　source-available</span>
       <span class="badge">DaVinci Resolve 原生</span>
       <span class="badge">中／日／英 語意搜尋</span>
@@ -158,41 +158,41 @@ footer a:hover{color:var(--cyan)}
     </div>
     <p class="dl-note">
       最新版 <span class="mono">v0.12.1</span>　·　安裝前請先看下方
-      <a href="#real">實際需要什麼</a>　·　English: <a href="https://github.com/vulture-s/arkiv#readme">README</a>
+      <a href="#real">系統需求</a>　·　English: <a href="https://github.com/vulture-s/arkiv#readme">README</a>
     </p>
   </div>
 </header>
 
 <section>
   <div class="wrap">
-    <h2>授權：一句話講完</h2>
+    <h2>授權條款</h2>
     <div class="lic">
       <ul>
         <li>
           <span class="mk yes">✓</span>
           <div>
-            <b>免費使用，任何用途 —— 包含商業工作。</b>
-            <p>接客戶的案子、工作室日常、有補助的製作，全部可以。不需要跟我們談授權，也不需要通知我們。</p>
+            <b>免費使用，任何用途 —— 包含商業用途。</b>
+            <p>客戶委製、工作室日常作業、受補助之製作，均在授權範圍內。無需另行取得授權，亦無需事前通知。</p>
           </div>
         </li>
         <li>
           <span class="mk yes">✓</span>
           <div>
-            <b>你做出來的東西是你的。</b>
-            <p>影片、時間軸、EDL / FCPXML / OTIO 匯出檔、縮圖 —— 授權不對它們加任何限制。</p>
+            <b>產出物之權利完全歸你所有。</b>
+            <p>影片、時間軸、EDL / FCPXML / OTIO 匯出檔與縮圖，本授權均不加以限制。</p>
           </div>
         </li>
         <li>
           <span class="mk no">✕</span>
           <div>
-            <b>唯一不允許：把 arkiv 做成跟它競爭的產品。</b>
-            <p>fork 成對手素材管理工具、包成索引服務賣給第三方、或重新實作成替代品 —— 即使免費提供也一樣。</p>
+            <b>唯一的限制：不得用於開發與 arkiv 競爭的產品。</b>
+            <p>將其衍生為競爭性素材管理工具、以索引服務形式提供予第三方，或重新實作為替代產品 —— 即使免費提供亦同。</p>
           </div>
         </li>
       </ul>
       <p class="fine">
-        界線在於<b style="color:var(--ink-2)">你的客戶買的是什麼</b>：買你用 arkiv 做出來的成品，是一般的工具使用；
-        買 arkiv 的功能本身（當成產品、服務、函式庫或外掛），才構成競爭。
+        判斷基準在於<b style="color:var(--ink-2)">客戶所購買的標的</b>：購買你以 arkiv 完成的成品，屬一般工具使用；
+        購買 arkiv 的功能本身（無論以產品、服務、函式庫或外掛形式提供），則構成競爭。
         條文為 <a href="https://github.com/vulture-s/arkiv/blob/main/LICENSE">PolyForm Perimeter 1.0.1</a>。
       </p>
     </div>
@@ -201,27 +201,27 @@ footer a:hover{color:var(--cyan)}
 
 <section>
   <div class="wrap">
-    <h2>它解決什麼</h2>
+    <h2>解決的問題</h2>
     <div class="why">
       <div class="row">
         <span class="n">01</span>
         <div>
           <h3>素材太多，找不到那顆鏡頭</h3>
-          <p>用自然語言搜，中日英都行 —— 搜的是<b style="color:var(--ink)">畫面內容和逐字稿</b>，不是檔名。</p>
+          <p>以自然語言檢索，支援中、日、英 —— 比對的是<b style="color:var(--ink)">畫面內容與逐字稿</b>，而非檔名。</p>
         </div>
       </div>
       <div class="row">
         <span class="n">02</span>
         <div>
-          <h3>AI 剪輯工具只看得懂「有人在講話」的素材</h3>
-          <p>arkiv 對每支 clip 做視覺分析 <b style="color:var(--ink)">加</b> 轉錄，所以大量 B-roll、無對白空景一樣可搜可管。</p>
+          <h3>多數 AI 剪輯工具僅能處理有對白的素材</h3>
+          <p>arkiv 對每一支素材同時執行視覺分析<b style="color:var(--ink)">與</b>語音轉錄，因此 B-roll 與無對白空景同樣可檢索、可管理。</p>
         </div>
       </div>
       <div class="row">
         <span class="n">03</span>
         <div>
           <h3>素材庫要能餵給下游任何剪法</h3>
-          <p>手動剪、自動剪、腳本剪都接得上：Resolve 原生 plugin、EDL / FCPXML 匯出、REST API 與 MCP 介面。</p>
+          <p>無論手動剪輯、自動化流程或腳本驅動皆可銜接：Resolve 原生外掛、EDL / FCPXML 匯出、REST API 與 MCP 介面。</p>
         </div>
       </div>
     </div>
@@ -230,12 +230,12 @@ footer a:hover{color:var(--cyan)}
 
 <section>
   <div class="wrap">
-    <h2>不是 demo 專案</h2>
+    <h2>實際運作規模</h2>
     <div class="proof">
       <div class="big">1,506 支</div>
       <p>
-        真實產品拍攝素材完整索引跑通，其中 <b style="color:var(--ink-2)">1,161 支是無對白 B-roll</b>
-        —— 也就是一般字幕工具完全抓不到的那些。單張 RTX 4070，5,732 幀視覺描述，零缺口。
+        真實商業案件素材已完成完整索引，其中 <b style="color:var(--ink-2)">1,161 支為無對白 B-roll</b>。
+        單張 RTX 4070，產出 5,732 幀視覺描述，索引覆蓋率 100%。
       </p>
     </div>
   </div>
@@ -257,23 +257,23 @@ footer a:hover{color:var(--cyan)}
       </tbody>
     </table>
     <p class="tier-note">
-      Pro 還沒開賣，購買流程還在建 ——
+      Pro 尚未開放購買 ——
       <a href="https://github.com/vulture-s/arkiv/blob/main/docs/pro-addon-license.md">條款先公開</a>，
-      讓你在那之前就能讀。做紀錄片、非營利、檔案保存、公共教育的，
-      <a href="https://github.com/vulture-s/arkiv/blob/main/PUBLIC-INTEREST.md">公益方案</a>免費給。
-      <br><b style="color:var(--ink-2)">現在裝的人不受影響</b>：專案上限只對日後的新安裝生效，既有素材庫永久沿用無限。
+      供事前查閱。紀錄片、非營利、檔案保存與公共教育類製作，
+      可循<a href="https://github.com/vulture-s/arkiv/blob/main/PUBLIC-INTEREST.md">公益方案</a>免費申請。
+      <br><b style="color:var(--ink-2)">既有使用者不受影響</b>：專案數上限僅對日後的新安裝生效，現有素材庫永久沿用無限制。
     </p>
   </div>
 </section>
 
 <section id="real">
   <div class="wrap">
-    <h2>安裝前先知道</h2>
+    <h2>系統需求與注意事項</h2>
     <div class="real">
-      <div><span class="m">01</span><span>安裝檔<b style="color:var(--ink)">包含 Python 後端與 ML 套件</b>，但你<b style="color:var(--ink)">仍需自行安裝 FFmpeg 與 Ollama</b>（抽幀、向量、視覺分析要用）。</span></div>
-      <div><span class="m">02</span><span>macOS 版<b style="color:var(--ink)">僅支援 Apple Silicon</b>，沒有 Intel build。</span></div>
-      <div><span class="m">03</span><span>安裝檔<b style="color:var(--ink)">未經簽章</b>。macOS 首次要「右鍵 → 打開」，Windows 會跳一次 SmartScreen 警告。這是刻意的：簽章憑證每年要錢，那筆錢目前寧可不花。</span></div>
-      <div><span class="m">04</span><span>視覺分析吃 GPU。沒有獨顯也跑得動，但會慢很多。</span></div>
+      <div><span class="m">01</span><span>安裝檔<b style="color:var(--ink)">已內含 Python 後端與 ML 套件</b>，惟<b style="color:var(--ink)">仍需自行安裝 FFmpeg 與 Ollama</b>，供抽幀、向量運算與視覺分析使用。</span></div>
+      <div><span class="m">02</span><span>macOS 版<b style="color:var(--ink)">僅支援 Apple Silicon</b>，未提供 Intel 版本。</span></div>
+      <div><span class="m">03</span><span>安裝檔<b style="color:var(--ink)">尚未經數位簽章</b>。macOS 首次開啟請使用「右鍵 → 打開」，Windows 會顯示一次 SmartScreen 提示，後續開啟不再出現。</span></div>
+      <div><span class="m">04</span><span>視覺分析仰賴 GPU 加速。無獨立顯示卡亦可運作，處理時間將顯著增加。</span></div>
     </div>
   </div>
 </section>
@@ -287,8 +287,8 @@ footer a:hover{color:var(--cyan)}
 -->
 <section id="signup">
   <div class="wrap">
-    <h2>新版本出來時通知我</h2>
-    <p>不定期、只講實質更新，隨時可退訂。</p>
+    <h2>訂閱產品更新</h2>
+    <p>僅於重要版本更新時寄送，可隨時取消訂閱。</p>
     <form id="signup-form" method="post">
       <input type="email" name="email" placeholder="your@email.com" required aria-label="Email">
       <button type="submit">訂閱</button>
@@ -306,8 +306,8 @@ footer a:hover{color:var(--cyan)}
       <a href="https://www.instagram.com/vulture.s/">@vulture.s</a>
     </div>
     <p>
-      PolyForm Perimeter 1.0.1 · source-available（非 OSI 開源授權，所以我們不寫「open source」）<br>
-      本機優先 · 零雲端 · 不對外回報
+      PolyForm Perimeter 1.0.1 · source-available（非 OSI 認證之開源授權）<br>
+      本機優先 · 不依賴雲端服務 · 不對外傳送資料
     </p>
   </div>
 </footer>

--- a/docs/pro-addon-license.md
+++ b/docs/pro-addon-license.md
@@ -48,9 +48,9 @@ distributed under the terms on this page.
 The license is granted to **one named individual, or one named organization for
 its internal use**.
 
-There is no seat counter and no activation server. arkiv does not phone home,
-and the add-on does not either — that property is worth more than enforcement,
-so scope is a matter of these terms rather than of code. Concretely:
+There is no seat counter and no activation server. Neither arkiv nor the add-on
+transmits any data externally; scope is therefore defined by these terms rather
+than enforced in software. Specifically:
 
 - **One individual** may use the add-on on the machines they personally work on.
 - **One organization** may use it on the machines of people working for that
@@ -70,18 +70,17 @@ so scope is a matter of these terms rather than of code. Concretely:
 
 **7 days from delivery, no questions asked.** Email the address on the receipt.
 
-That is the statutory period for a distance sale in Taiwan (Consumer Protection
-Act art. 19 para. 1) — given in full rather than claimed away. This add-on
-would in fact qualify for the digital-content exception (Standards for
-Reasonable Exceptions to the Right of Withdrawal in Distance Sales, art. 2
-subparas. 4–5), which permits **no** withdrawal right at all. We are not using
-it.
+This matches the statutory period for a distance sale in Taiwan (Consumer
+Protection Act art. 19 para. 1), **provided in full and not contracted away**.
+Under the Standards for Reasonable Exceptions to the Right of Withdrawal in
+Distance Sales, art. 2 subparas. 4–5, non-tangible digital content is an
+enumerated exception and the add-on could carry no withdrawal right at all;
+we do not rely on that exception.
 
-There is no extra goodwill window on top of the statutory one, and there does
-not need to be: **arkiv itself is already free to use commercially**, so nothing
-here gates access to the product. What you are buying is extra capacity on
-software you could already run and earn with — and you can reach that decision
-on the free core, across three real projects, before paying anything.
+No discretionary window is offered beyond the statutory one. **arkiv itself is
+already free for commercial use**, so nothing here restricts access to the
+product — the add-on provides additional capacity, and the decision can be made
+on the free core across three real projects before any payment.
 
 `[LEGAL REVIEW]` — this policy sits *exactly on* the statutory floor rather
 than above it, so two mechanics become load-bearing and the purchase flow must
@@ -161,8 +160,8 @@ arkiv 本體（ingest、轉錄、視覺標註、語意搜尋、chat、NLE／DIT 
 
 授予**一位具名個人，或一個具名組織供其內部使用**。
 
-沒有席次計數器，也沒有啟用伺服器。arkiv 不對外回報，附加元件也不會——
-這個性質比執法更值錢，所以範圍靠條款約束而不是靠程式。具體而言：
+本附加元件不設席次計數器，亦無啟用伺服器。arkiv 與本附加元件均不對外傳送
+任何資料，授權範圍因此由本條款界定，而非由程式強制。具體而言：
 
 - **個人**：可在自己實際工作的機器上使用。
 - **組織**：可在該組織成員的機器上、為該組織自己的製作使用。
@@ -179,9 +178,9 @@ arkiv 本體（ingest、轉錄、視覺標註、語意搜尋、chat、NLE／DIT 
 
 **自交付起 7 天內，無條件退款。** 來信收據上的信箱即可。
 
-這就是台灣通訊交易的法定解除權期間（消保法第 19 條第 1 項）—— **完整給出，不主張
-排除**。事實上本附加元件符合數位內容的法定例外（通訊交易解除權合理例外情事適用準則
-第 2 條第 4、5 款），依法**可以完全不給解除權**，我們不用那條。
+此為台灣通訊交易之法定解除權期間（消費者保護法第 19 條第 1 項），本附加元件
+**完整提供，不予排除**。依通訊交易解除權合理例外情事適用準則第 2 條第 4、5 款，
+非以有形媒介提供之數位內容屬法定例外，本得不提供解除權；本方案選擇不援用該例外。
 
 法定期間之上不另外加碼，也不需要加碼：**arkiv 本體已經任何用途免費、包含商用**，
 這裡沒有任何東西擋著你使用產品。你買的是**額外容量**，加在一個你早就能跑、能拿來


### PR DESCRIPTION
docs(copy): 對外文案統一為半正式商業語體

Hevin 審閱產品頁後指出，不要寫「這是刻意的：簽章憑證每年要錢，那筆錢
目前寧可不花」這類文字，並要求全部對外文案改為半正式商業用語。

審計後發現那不是單一句子的問題，是同一種病在六個檔案上的變體。分六類：

**① 自曝內部決策與成本**（Hevin 點名的那句）。未簽章的事實與操作方式
使用者需要知道；「憑證每年要錢、那筆錢寧可不花」是我們的預算考量，
對使用者沒有價值，只顯得產品在省錢。改為只陳述事實與後續行為
（「後續開啟不再出現」）。

**② 自我後設評論。** 頁尾原寫「非 OSI 開源授權，所以我們不寫
open source」——那是在解釋自己的用字選擇。改為「非 OSI 認證之開源授權」。
同類：add-on 條款的「這個性質比執法更值錢」、「我們不用那條」，都是把
內部權衡寫進對外文件。

**③ 防禦性框架。** 標題「不是 demo 專案」是在回應沒人提出的指控，
反而先替讀者植入懷疑。改為「實際運作規模」。

**④ 貶低競品。** 「也就是一般字幕工具完全抓不到的那些」——數據本身
已經夠強，加上這句只是把陳述變成攻擊。刪去。

**⑤ 口語與俚語。** 吃 GPU／跑得動／跑通／免費給／還在建／全部可以／
寧可一封一封讀／just buy／we'd rather。

**⑥ 開發者黑話進對外文案。** 零缺口→索引覆蓋率 100%；clip→素材；
fork 成→衍生為；包成…賣給→以…形式提供予。

涵蓋 docs/index.html（26 處）、docs/pro-addon-license.md（4）、
PUBLIC-INTEREST.md（5，中英各半）、LICENSE 白話摘要（2）、
README ×2（各 1），再加一輪語氣一致性收尾（5）。

保留不動：README 環境變數表裡的「預設刻意用 2.5-VL」與英文
"deliberate default"——那是技術文件在說明「這是刻意不是疏漏」並附
實測數據，讀者需要那個資訊，與行銷文案自曝內部權衡不同類。

1440px 重新渲染確認版面未跑掉。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
