### PR TITLE
fix(release): 版本號五處有兩處漂了兩個 minor，補守衛而非再修一次清單

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,9 +162,23 @@ from `main` by tag:
 
 1. Move `## Unreleased` in `CHANGELOG.md` to `## vX.Y.Z - YYYY-MM-DD`; leave a fresh
    `## Unreleased` on top.
-2. Bump the version to `X.Y.Z` in **both** `src-tauri/tauri.conf.json` and
-   `src-tauri/Cargo.toml` so it matches the tag (these historically drifted — stuck at 0.2.0
-   across the whole v0.2→v0.10 tag history, so every built DMG embedded 0.2.0).
+2. Bump the version to `X.Y.Z` in **all five** places, so it matches the tag:
+
+   | File | Field |
+   |---|---|
+   | `src-tauri/tauri.conf.json` | `version` |
+   | `src-tauri/Cargo.toml` | top-level `version` |
+   | `src-tauri/Cargo.lock` | the **root `arkiv` package entry** |
+   | `config.py` | `VERSION` — served by `GET /api/version` and `/api/health` |
+   | `frontend/src/lib/version.js` | `export const VERSION` — rendered in the SPA |
+
+   `tests/test_version_sync.py` fails if any of them disagree, so you cannot cut a
+   release with them out of step. Do not rely on this list alone — it has undershot
+   twice. The first two files were stuck at 0.2.0 across the whole v0.2→v0.10 tag
+   history (every DMG embedded 0.2.0, fixed in #244); the last two were then missed by
+   that fix *and* by #311, and were still reading 0.10.0 at v0.12.1 — the two that are
+   actually **user-visible**, in the app UI and in the version a support request
+   reports. If you add a sixth location, add it to `VERSION_SOURCES` in that test.
 3. Commit (`docs(changelog): cut vX.Y.Z`), then push an **annotated** tag: `git tag -a vX.Y.Z -m …`.
 4. The tag-triggered `release.yml` workflow builds the `.app`/`.dmg` on a macOS-arm runner. It
    **stamps the version from the tag**, so the bundle can't drift from the tag; signs +

--- a/config.py
+++ b/config.py
@@ -10,7 +10,7 @@ BASE_DIR = Path(__file__).parent
 # Backend product version. Keep in sync with the release tag + frontend
 # version.js at release time. Served by GET /api/version and included in
 # GET /api/health so a user/support can identify the build.
-VERSION = "0.10.0"
+VERSION = "0.12.1"
 
 # Codex Round-2 audit (J3): without bounds, ARKIV_PROXIES_DIR=/etc would have
 # arkiv write generated proxy mp4 files into /etc on every HEVC ingest. Same

--- a/frontend/src/lib/version.js
+++ b/frontend/src/lib/version.js
@@ -2,4 +2,4 @@
 // The label had drifted to a stale v0.9.2 across a dozen files while the app
 // shipped v0.10.0, because every route hardcoded its own copy — importing this
 // const keeps the version from going stale per-file again.
-export const VERSION = 'v0.10.0'
+export const VERSION = 'v0.12.1'

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -1,0 +1,95 @@
+"""The product version is written in five files. They must all agree.
+
+Two prior fixes tried to stop this drifting and both undershot. #244 corrected a
+tag history that had run 0.2.0 -> 0.10.0 while `Cargo.lock`'s root entry stayed
+behind; #311 corrected three files at release time and named the `Cargo.lock`
+root entry as the one that had caused the earlier drift. Neither covered
+`config.py` or `frontend/src/lib/version.js`, so by v0.12.1 those two still read
+`0.10.0` — two minor releases behind, and both of them user-visible: the SPA
+renders `version.js` in the UI, and `config.py:VERSION` is what `GET /api/version`
+and `GET /api/health` report to anyone diagnosing a build.
+
+A release checklist that has now failed twice is not a checklist problem. This
+pins the invariant instead: every location that states the version states the
+same one.
+
+Adding a sixth location is fine — add it to VERSION_SOURCES so it is covered
+from the start rather than discovered two releases later.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+SEMVER = r"\d+\.\d+\.\d+"
+
+
+def _tauri_conf() -> str:
+    data = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
+    return data["version"]
+
+
+def _cargo_toml() -> str:
+    text = (ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8")
+    m = re.search(rf'^version\s*=\s*"({SEMVER})"', text, re.M)
+    assert m, "src-tauri/Cargo.toml has no top-level version"
+    return m.group(1)
+
+
+def _cargo_lock_root() -> str:
+    """The root package entry — the exact field #311 identified as the drift source."""
+    text = (ROOT / "src-tauri" / "Cargo.lock").read_text(encoding="utf-8")
+    m = re.search(rf'^name = "arkiv"\nversion = "({SEMVER})"', text, re.M)
+    assert m, "src-tauri/Cargo.lock has no root `arkiv` package entry"
+    return m.group(1)
+
+
+def _config_py() -> str:
+    text = (ROOT / "config.py").read_text(encoding="utf-8")
+    m = re.search(rf'^VERSION\s*=\s*"({SEMVER})"', text, re.M)
+    assert m, "config.py has no VERSION"
+    return m.group(1)
+
+
+def _frontend_version_js() -> str:
+    text = (ROOT / "frontend" / "src" / "lib" / "version.js").read_text(encoding="utf-8")
+    m = re.search(rf"^export const VERSION\s*=\s*'v({SEMVER})'", text, re.M)
+    assert m, "frontend/src/lib/version.js has no exported VERSION"
+    return m.group(1)
+
+
+VERSION_SOURCES = {
+    "src-tauri/tauri.conf.json": _tauri_conf,
+    "src-tauri/Cargo.toml": _cargo_toml,
+    "src-tauri/Cargo.lock (root arkiv entry)": _cargo_lock_root,
+    "config.py:VERSION": _config_py,
+    "frontend/src/lib/version.js": _frontend_version_js,
+}
+
+
+def test_every_version_location_agrees():
+    found = {label: read() for label, read in VERSION_SOURCES.items()}
+    distinct = set(found.values())
+    assert len(distinct) == 1, (
+        "product version disagrees across files:\n"
+        + "\n".join(f"  {label:<42} {value}" for label, value in found.items())
+        + "\n\nBump every entry in VERSION_SOURCES together. The two that drift are "
+          "config.py and frontend/src/lib/version.js, because release tooling only "
+          "touches the three under src-tauri/."
+    )
+
+
+@pytest.mark.parametrize("label", sorted(VERSION_SOURCES))
+def test_each_location_is_parseable(label):
+    """A version that cannot be read is drift waiting to happen.
+
+    Without this, renaming the constant or reformatting the file would make the
+    agreement test above skip that location silently rather than fail.
+    """
+    value = VERSION_SOURCES[label]()
+    assert re.fullmatch(SEMVER, value), f"{label} produced an unparseable version: {value!r}"


### PR DESCRIPTION
fix(release): 版本號五處有兩處漂了兩個 minor，補守衛而非再修一次清單

切 1.0 之前先查版本號，發現 `config.py:VERSION` 與
`frontend/src/lib/version.js` 都還停在 `0.10.0`，而實際發布是 v0.12.1。

**而漂掉的正好是使用者看得到的那兩處**：SPA 在 UI 裡渲染 version.js，
`config.py:VERSION` 則是 `GET /api/version` 與 `/api/health` 回報的值 ——
也就是有人來報問題時，我們拿來判斷他跑哪一版的那個數字。整整兩個 minor
的診斷資訊是錯的。

這不是新問題，是同一個問題的第三次：#244 修過（v0.2→v0.10 整段 tag 史
卡在 0.2.0，每個 DMG 都內嵌 0.2.0），#311 又修過（並點名 `Cargo.lock`
root entry 是元凶）。兩次都只涵蓋 `src-tauri/` 下的檔案。而
`CONTRIBUTING.md` 的發版清單第 2 步寫的是「**both** tauri.conf.json 和
Cargo.toml」——**五處只列兩處**，連 #311 剛修過的 Cargo.lock 都沒補進去。

**一份已經失敗兩次的清單不是清單問題。** 所以這支的主體是
`tests/test_version_sync.py`：把「所有宣告版本的地方都宣告同一個版本」
釘成不變量。

守衛有牙齒 —— 對修正前的樹跑，它精準報出漂移並列出五處實際值：

    src-tauri/tauri.conf.json                  0.12.1
    src-tauri/Cargo.toml                       0.12.1
    src-tauri/Cargo.lock (root arkiv entry)    0.12.1
    config.py:VERSION                          0.10.0
    frontend/src/lib/version.js                0.10.0

附帶的第二支測試斷言每個位置都**讀得出來**：少了它，日後改名常數或重排
版面會讓該位置在主測試裡靜默跳過，而不是紅 —— 那正是「守衛看起來還在、
其實已經不守」的形狀。

三項修正：兩處同步到 0.12.1、CONTRIBUTING 第 2 步改成五處表格並指向本
測試、明寫「加第六處要同時加進 VERSION_SOURCES」。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
