### PR TITLE
feat(licensing): 先種 grandfather 錨點，並停止用現在式描述不存在的限制

### DIFF
--- a/PUBLIC-INTEREST.md
+++ b/PUBLIC-INTEREST.md
@@ -10,12 +10,17 @@ arkiv 軟體本身依 [PolyForm Perimeter 授權](LICENSE)**任何用途皆免�
 用它產出的成品永遠是你的。公益工作要用核心，不需要向我們申請任何東西。
 
 要收費的只有一個東西：**Pro 附加元件**（無限專案 + 跨專案聚合，NT$3,000 買斷）。
-免費核心支援 3 個專案。長期經營的紀錄片團隊、地方影像資料庫與口述歷史計畫，通常會超出此一額度。
+免費核心規劃的額度為 3 個專案（**現行版本尚未實施此限制**，詳見下方說明）。
+長期經營的紀錄片團隊、地方影像資料庫與口述歷史計畫，通常會超出此一額度。
 
 **公益方案就是為這種情況設的：只要你做的是有公共價值的影像工作，這個附加元件我們免費提供，
 且為終身授權。**
 
 素材的知識層——「拍過的東西找得回來、可重複使用」——不該只有大製作用得起。
+
+> **現況說明**：目前已發布的任何 arkiv 版本，都**不限制專案數、也未保留跨專案聚合功能**。
+> 免費額度將自未來某一版起對**新安裝**生效；在該版之前已在使用的素材庫永久不受限制。
+> 因此若你現在就開始用，實際上還不需要這個方案 —— 但先申請、先入列也可以，grant 是終身的。
 
 ## 誰適合申請（例示，非窮舉）
 
@@ -29,7 +34,7 @@ arkiv 軟體本身依 [PolyForm Perimeter 授權](LICENSE)**任何用途皆免�
 ## 什麼不在這個方案裡
 
 - 純商業廣告、品牌行銷、企業形象片。此類用途使用 arkiv 不受任何限制（授權本即允許），
-  惟專案數超過 3 個時，請循一般管道購買 Pro 附加元件。
+  惟日後專案數超過免費額度時，請循一般管道購買 Pro 附加元件。
 - 把 arkiv（或其 fork）當產品／服務**販售、架站、重新包裝**——這在任何情況都不允許，
   [授權正文](LICENSE)的 Noncompete 與 Competition 兩節已明訂。
 - 「有社會意義」的空泛主張但實質是商業專案——我們保留逐案判斷、婉拒的權利。
@@ -48,7 +53,7 @@ arkiv 軟體本身依 [PolyForm Perimeter 授權](LICENSE)**任何用途皆免�
 > 我們是三人獨立團隊，正在拍一部關於濁水溪出海口濕地與周邊漁村的紀錄片，預計投國內外影展、
 > 之後在公共電視與線上平台免費播出。有一筆國藝會補助。素材約 200 小時、大量無對白空景，
 > 想用 arkiv 建語義索引來管理與檢索。另外我們同時在整理過去五年拍的六個相關聚落的素材，
-> 想跨案一起搜，所以會超過免費的 3 個專案 —— 想循公益方案申請 Pro 附加元件。
+> 想跨案一起搜，會超出免費額度 —— 想循公益方案申請 Pro 附加元件。
 
 ## 逐案裁量聲明
 
@@ -71,14 +76,21 @@ arkiv itself is free to use for **any** purpose under the
 with it is always yours. Public-interest work needs no permission from us to use the core.
 
 Only one thing costs money: the **Pro add-on** (unlimited projects and cross-project
-aggregation, NT$3,000 one time). The free core covers 3 projects, which long-running
-documentary teams, community media archives, and oral-history projects outgrow quickly.
+aggregation, NT$3,000 one time). The free tier is planned at 3 projects — **no shipped
+version enforces this yet** — an allowance that long-running documentary teams, community
+media archives, and oral-history projects outgrow quickly.
 
 **The Public-Interest Program exists for exactly that case: if the work you're doing serves
 the public interest, we grant the add-on for free, perpetually.**
 
 The knowledge layer over footage — being able to find and reuse what you already shot —
 shouldn't be something only big productions can afford.
+
+> **Current status**: no released version of arkiv caps projects or withholds cross-project
+> aggregation. The free allowance will apply to **new installations** from a future release
+> onward; libraries already in use before then are permanently unrestricted. If you are
+> starting now you do not yet need this programme — applying early is still fine, as grants
+> are perpetual.
 
 ## Who can apply (examples, not exhaustive)
 
@@ -97,8 +109,8 @@ shouldn't be something only big productions can afford.
 ## What this program does *not* cover
 
 - Pure commercial advertising, brand marketing, or corporate promos. Such use of arkiv is
-  entirely unrestricted — the licence already permits it — but beyond 3 projects, please
-  purchase the Pro add-on through the standard channel.
+  entirely unrestricted — the licence already permits it — but once past the free allowance,
+  please purchase the Pro add-on through the standard channel.
 - Selling, hosting, or repackaging arkiv (or a fork) as a product or service — never
   permitted, per the Noncompete and Competition sections of the [license](LICENSE) itself.
 - Vague "social value" claims over what is really a commercial project — we reserve the right

--- a/db.py
+++ b/db.py
@@ -492,6 +492,48 @@ def init_db():
                 UNIQUE(scope, key)
             )
         """)
+        # ── library provenance ─────────────────────────────────────────────
+        # Written once, on the first init that runs this code, and never
+        # updated. Its only job is to answer a question the paid tier will ask
+        # later: was this library already in use before the free-tier project
+        # cap existed?
+        #
+        # The key is `first_seen_version`, not `created_with_version`, because
+        # that is what it truthfully records. A brand-new library gets stamped
+        # at creation; an existing library upgrading into a build that carries
+        # this code gets stamped on its next init. Both are the earliest
+        # version we can prove the library was in use by, and both answer the
+        # grandfathering question the same way — but only one of them is
+        # literally a creation date, so the key does not claim to be one.
+        #
+        # The cap does not exist yet — every build in the wild today allows
+        # unlimited projects — and the published terms promise that libraries
+        # created before it ships keep that permanently. Keeping that promise
+        # needs evidence recorded NOW: once the cap ships there is no way to
+        # tell, after the fact, whether a two-project library was started under
+        # the old terms or the new ones. Behavioural inference ("already has
+        # more than three") only catches libraries that had already exceeded
+        # the cap, not the ones that would grow into it.
+        #
+        # INSERT OR IGNORE, not upsert: an upgrade must never restamp an old
+        # library with a new version and silently revoke its exemption.
+        #
+        # A library with no row at all predates this stamp, which is strictly
+        # older, so absence reads as exempt. This is a goodwill promise, not
+        # DRM — the row is trivially editable and that is fine; the licence is
+        # enforced by its terms, not by the database.
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS library_meta (
+                key        TEXT PRIMARY KEY,
+                value      TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )
+        """)
+        conn.execute(
+            "INSERT OR IGNORE INTO library_meta (key, value) VALUES ('first_seen_version', ?)",
+            (_config.VERSION,),
+        )
+
         # audit M6: PRAGMA foreign_keys was never enabled before, so orphan
         # child rows accumulated (e.g. scopes of revoked tokens, tags/frames of
         # deleted media). Clear them once here so the now-active enforcement in
@@ -516,6 +558,38 @@ def init_db():
                 "[init_db] foreign_key_check: removed {0} orphan child row(s)"
                 " left from pre-enforcement era (audit M6)".format(removed)
             )
+
+
+
+def get_library_origin():
+    """Earliest version known to have used this library, or None if it predates the stamp.
+
+    Not a creation date. See `first_seen_version` in `init_db`: an upgraded
+    library is stamped on its next init, not retroactively at its real birth.
+    What the value guarantees is an upper bound — the library was in use by
+    this version at the latest — which is exactly what grandfathering needs.
+
+    None is the older case, not an error: libraries created before
+    `library_meta` existed carry no row, and every build that shipped before it
+    allowed unlimited projects. Callers deciding whether the free-tier project
+    cap applies must therefore treat None as exempt — the same as an explicitly
+    pre-cap version. Defaulting the other way would revoke the exemption from
+    exactly the users who have held it longest.
+
+    Missing table is handled rather than raised for the same reason: a
+    read-only or partially-migrated legacy database must not turn a licensing
+    question into a crash.
+    """
+    try:
+        with get_conn() as conn:
+            row = conn.execute(
+                "SELECT value, created_at FROM library_meta WHERE key='first_seen_version'"
+            ).fetchone()
+    except sqlite3.Error:
+        return None
+    if row is None:
+        return None
+    return {"version": row["value"], "created_at": row["created_at"]}
 
 
 def migrate_to_relative():

--- a/docs/index.html
+++ b/docs/index.html
@@ -91,6 +91,7 @@ td:first-child{color:var(--ink-2)}
 td b{color:var(--ink)}
 .soon{display:inline-block;font-family:var(--ak-mono);font-size:11px;color:var(--invert-ink);background:var(--ink-2);border-radius:4px;padding:2px 7px;margin-left:8px;vertical-align:middle}
 .tier-note{margin-top:20px;font-size:14px;color:var(--quiet)}
+.future{font-size:12px;color:var(--quiet);font-family:var(--ak-mono)}
 
 /* honesty */
 .real{display:grid;gap:14px}
@@ -251,17 +252,20 @@ footer a:hover{color:var(--cyan)}
       <tbody>
         <tr><td>全部索引與搜尋功能</td><td><b>✓</b></td><td><b>✓</b></td></tr>
         <tr><td>商業使用</td><td><b>✓</b></td><td><b>✓</b></td></tr>
-        <tr><td>專案數</td><td><b>3 個</b></td><td><b>無限</b></td></tr>
-        <tr><td>跨專案聚合搜尋</td><td>—</td><td><b>✓</b></td></tr>
+        <tr><td>專案數</td><td><b>目前不限</b><br><span class="future">未來版本起，新安裝為 3 個</span></td><td><b>無限</b></td></tr>
+        <tr><td>跨專案聚合搜尋</td><td><b>目前開放</b><br><span class="future">未來版本起，新安裝不含</span></td><td><b>✓</b></td></tr>
         <tr><td>價格</td><td><b>NT$0</b></td><td><b>NT$3,000</b> 一次買斷</td></tr>
       </tbody>
     </table>
     <p class="tier-note">
-      Pro 尚未開放購買 ——
+      <b style="color:var(--ink)">目前版本不設任何限制</b> —— 上表 Pro 欄的兩項功能，現在所有使用者都可使用。
+      免費額度將自未來某一版起對<b style="color:var(--ink)">新安裝</b>生效；
+      <b style="color:var(--ink)">在該版之前已在使用的素材庫，永久保留現有的無限制狀態</b>，這項承諾已寫入軟體：
+      素材庫會在初次建立時記錄版本，作為日後判定的依據。
+      <br>Pro 尚未開放購買 ——
       <a href="https://github.com/vulture-s/arkiv/blob/main/docs/pro-addon-license.md">條款先公開</a>，
       供事前查閱。紀錄片、非營利、檔案保存與公共教育類製作，
       可循<a href="https://github.com/vulture-s/arkiv/blob/main/PUBLIC-INTEREST.md">公益方案</a>免費申請。
-      <br><b style="color:var(--ink-2)">既有使用者不受影響</b>：專案數上限僅對日後的新安裝生效，現有素材庫永久沿用無限制。
     </p>
   </div>
 </section>

--- a/docs/pro-addon-license.md
+++ b/docs/pro-addon-license.md
@@ -28,6 +28,14 @@ things the free core does not provide:
 | Projects | Up to 3 | Unlimited |
 | Cross-project aggregation (search and collections spanning projects) | — | ✅ |
 
+> **Current builds impose neither limit.** No shipped version of arkiv caps
+> projects or withholds cross-project aggregation; the table describes the
+> intended tiers, not today's behaviour. The free allowance will apply to **new
+> installations** from a future release onward. **Libraries already in use
+> before that release keep unlimited projects permanently** — the software
+> records the version a library was first seen under (`library_meta.
+> first_seen_version`) so this can be honoured rather than guessed at.
+
 The add-on is **not** covered by the PolyForm Perimeter License. It is
 distributed under the terms on this page.
 
@@ -142,6 +150,12 @@ arkiv 本體（ingest、轉錄、視覺標註、語意搜尋、chat、NLE／DIT 
 |---|---|---|
 | 專案數 | 最多 3 個 | 無限 |
 | 跨專案聚合（跨專案搜尋與精選集） | — | ✅ |
+
+> **現行版本兩項限制均未實施。** 目前已發布的任何版本都不限制專案數，
+> 亦未保留跨專案聚合功能；上表描述的是規劃中的方案分層，而非現況。
+> 免費額度將自未來某一版起對**新安裝**生效；**在該版之前已在使用的素材庫，
+> 永久保留無限制專案數** —— 軟體會記錄素材庫初次使用時的版本
+> （`library_meta.first_seen_version`），使此一承諾得以查證而非事後推測。
 
 附加元件**不在** PolyForm Perimeter 授權範圍內，依本頁條款授權。
 

--- a/tests/test_library_origin.py
+++ b/tests/test_library_origin.py
@@ -1,0 +1,91 @@
+"""The grandfathering stamp: written once, never restamped, absent means exempt.
+
+Nothing reads this yet. It ships ahead of the feature it serves on purpose —
+the free-tier project cap does not exist in any build in the wild, and the
+published terms promise that libraries in use before it ships keep unlimited
+projects permanently. That promise can only be kept with evidence recorded
+*before* the cap exists: afterwards there is no way to tell whether a
+two-project library was started under the old terms or the new ones.
+
+So these tests guard a contract with no current caller. The failure they exist
+to prevent is silent and one-way — an upgrade that restamps an old library
+revokes an exemption that was promised in public, and nothing would surface it.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def test_fresh_library_is_stamped(tmp_db):
+    import config
+    import db
+
+    origin = db.get_library_origin()
+    assert origin is not None, "a newly initialised library must record its origin"
+    assert origin["version"] == config.VERSION
+    assert origin["created_at"], "the stamp must carry a timestamp"
+
+
+def test_reinit_does_not_restamp(tmp_db, monkeypatch):
+    """An upgrade must not overwrite the stamp — that would revoke the exemption.
+
+    This is the one that matters. `INSERT OR IGNORE` makes it true; an upsert or
+    a plain INSERT-after-DELETE would not, and the damage would be invisible:
+    the library keeps working, just silently reclassified as post-cap.
+    """
+    import config
+    import db
+
+    first = db.get_library_origin()
+    assert first is not None
+
+    # Simulate the user upgrading to a later build and reopening the library.
+    monkeypatch.setattr(config, "VERSION", "99.0.0")
+    db.init_db()
+
+    after = db.get_library_origin()
+    assert after["version"] == first["version"], (
+        "re-initialising under a newer version restamped the library; "
+        "an upgraded library would lose its pre-cap exemption"
+    )
+    assert after["created_at"] == first["created_at"]
+
+
+def test_legacy_library_without_the_table_reads_as_exempt(tmp_db):
+    """No row is the oldest case, so it must read as None rather than raise.
+
+    Libraries created before this code existed carry no `library_meta` at all.
+    Every build that shipped before it allowed unlimited projects, so callers
+    must treat None as exempt. A crash here would turn the licensing question
+    into an outage for exactly the longest-standing users.
+    """
+    import db
+
+    with db.get_conn() as conn:
+        conn.execute("DROP TABLE IF EXISTS library_meta")
+
+    assert db.get_library_origin() is None
+
+
+def test_row_present_but_key_missing_reads_as_exempt(tmp_db):
+    """Table there, key gone — still the permissive answer, not an exception."""
+    import db
+
+    with db.get_conn() as conn:
+        conn.execute("DELETE FROM library_meta WHERE key='first_seen_version'")
+
+    assert db.get_library_origin() is None
+
+
+def test_stamp_survives_other_init_work(tmp_db, monkeypatch):
+    """init_db does a lot besides this; the stamp must not be collateral damage."""
+    import config
+    import db
+
+    before = db.get_library_origin()
+    for v in ("0.99.0", "1.0.0", "2.5.1"):
+        monkeypatch.setattr(config, "VERSION", v)
+        db.init_db()
+    assert db.get_library_origin() == before


### PR DESCRIPTION
feat(licensing): 先種 grandfather 錨點，並停止用現在式描述不存在的限制

上一輪 Hevin 問「CLI 抓下來也是只有三個專案嗎」。實查答案是**沒有**——
全 repo 零 gate（`MAX_PROJECTS` / `project_limit` / `is_pro` / `license_key`
全部零命中；`per_project_limit` 是搜尋筆數、`is_processed` 是去重、
`geo.py` 的 "Two-tier" 是地理解析）。而且不只專案數，**跨專案聚合也沒
gate** —— `federation.py` 與 `/api/search/all` 對所有人開放。

也就是說 Pro 規劃的兩項功能，現在全部使用者都在用。而昨天上線的產品頁
用**現在式**寫「免費：3 個專案」「跨專案聚合：—」，描述的是一個不存在
的狀態。今天下載的人拿到的跟頁面寫的不一樣。

**兩件事分開修。**

**① 軟體端：先種錨點（`db.library_meta`）**

這件事的時效性比 gate 本身早，而且是單向的。已公開的承諾是「在限制生效
之前已在使用的素材庫永久不受限制」——要兌現它，必須在 gate 存在**之前**
就記下證據：gate 上線之後，再也無法分辨一個兩專案的素材庫是在舊條款下
開始的，還是新條款。行為推論（「已經超過三個」）只接得住已經超標的人，
接不住今天兩個、明年五個的那些，而他們正是在「無限」前提下入場的。

`INSERT OR IGNORE` 而非 upsert：**升級絕不可重新蓋章**，那會靜默撤銷一個
公開承諾過的豁免，而且不會有任何徵狀。mutation 驗過——改成 `OR REPLACE`
後 5 支測試紅 2 支，且紅的正是守這條的那兩支。

key 命名為 `first_seen_version` 而非 `created_with_version`：既有素材庫
升級後也會在下次 init 被蓋章，那時後者就是假的。兩者在判定上等價（都
< cap 版本），但名字不能騙人。

無 row 讀作豁免而非錯誤：那是最舊的情況（本段程式碼存在之前建的庫），
而所有更早的版本都允許無限專案。表不存在也接住不 raise —— 唯讀或半遷移
的舊庫不該把授權問題變成當機。

這是善意承諾不是 DRM，那一列可以隨手改掉，沒關係：授權靠條款生效，不靠
資料庫。

**② 文案：停止描述不存在的狀態**

產品頁對照表改成兩行（「目前不限 / 未來版本起，新安裝為 3 個」），並說明
承諾已寫進軟體。`pro-addon-license.md` 與 `PUBLIC-INTEREST.md` 中英各補
現況說明。刻意不寫死是哪一版生效——那個版本還沒決定，寫死等於再造一個
會漂的數字。

1440px 渲染驗過。全套 1312 passed（+5）。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
