### PR TITLE
docs(changelog): cut v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+## v1.0.0 - 2026-08-18
+
+**1.0 because the product now has a front door, and the licence finally says one thing.**
+
+Not a feature milestone — v0.12.1 already indexed a 1,506-clip production library and shipped
+on three platforms. What was missing was everything around it: the only way to download arkiv
+was a GitHub Releases page, the repository's homepage field pointed at an Instagram account,
+and the licence required a paragraph of explanation before a working editor could tell whether
+they were allowed to use it on a paying job. All three are now answered, so the version number
+stops pretending this is still a preview.
+
+The change that made the rest possible is the licence. Under PolyForm-NC, a freelance editor
+organising a client's footage was outside the terms from their first project, while the README
+told them they were free up to three — a promise the licence did not authorise. PolyForm
+Perimeter replaces that with one sentence, and a product page can now lead with it.
+
+Nothing is on sale. The paid tier is defined and its terms are published, but no shipped build
+caps anything, and there is no payment path yet.
+
 ### Changed
 - **License: PolyForm Noncommercial 1.0.0 → PolyForm Perimeter 1.0.1. Using arkiv commercially is now free.** The NC license restricted *use of the software itself* to noncommercial purposes, and PolyForm-NC defines the permitted personal case as use "without any anticipated commercial application". A freelance editor organising a paying client's footage has an anticipated commercial application from the first project — so under the old terms, essentially every professional in arkiv's target audience needed a separate commercial license, and the README told them the opposite. The public wording promised free use with payment only past three projects; the license did not authorise that promise. Perimeter's Noncompete section replaces the whole problem with one sentence: "Any purpose is a permitted purpose, except for providing to others any product that competes with the software."
 

--- a/config.py
+++ b/config.py
@@ -10,7 +10,7 @@ BASE_DIR = Path(__file__).parent
 # Backend product version. Keep in sync with the release tag + frontend
 # version.js at release time. Served by GET /api/version and included in
 # GET /api/health so a user/support can identify the build.
-VERSION = "0.12.1"
+VERSION = "1.0.0"
 
 # Codex Round-2 audit (J3): without bounds, ARKIV_PROXIES_DIR=/etc would have
 # arkiv write generated proxy mp4 files into /etc on every HEVC ingest. Same

--- a/docs/index.html
+++ b/docs/index.html
@@ -158,7 +158,7 @@ footer a:hover{color:var(--cyan)}
       </a>
     </div>
     <p class="dl-note">
-      最新版 <span class="mono">v0.12.1</span>　·　安裝前請先看下方
+      最新版 <span class="mono">v1.0.0</span>　·　安裝前請先看下方
       <a href="#real">系統需求</a>　·　English: <a href="https://github.com/vulture-s/arkiv#readme">README</a>
     </p>
   </div>

--- a/frontend/src/lib/version.js
+++ b/frontend/src/lib/version.js
@@ -2,4 +2,4 @@
 // The label had drifted to a stale v0.9.2 across a dozen files while the app
 // shipped v0.10.0, because every route hardcoded its own copy — importing this
 // const keeps the version from going stale per-file again.
-export const VERSION = 'v0.12.1'
+export const VERSION = 'v1.0.0'

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arkiv"
-version = "0.12.1"
+version = "1.0.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arkiv"
-version = "0.12.1"
+version = "1.0.0"
 description = "arkiv — Local Media Asset Manager"
 authors = ["Hevin Yeh"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui-org/nicegui/main/tauri/src-tauri/tauri.conf.json",
   "productName": "arkiv",
-  "version": "0.12.1",
+  "version": "1.0.0",
   "identifier": "com.hevin.arkiv",
   "build": {
     "devUrl": "http://localhost:8501",


### PR DESCRIPTION
docs(changelog): cut v1.0.0

五處版本號一起改（tauri.conf.json / Cargo.toml / Cargo.lock root entry /
config.py / frontend version.js）+ 產品頁的版本行。`tests/test_version_sync.py`
（#323 剛加）在五處一致時綠 —— 這是第一次發版有守衛擋著，前兩次漂移
（#244、#311）都是事後才發現。

1.0 的理由不是功能。v0.12.1 就已經索引過 1,506 支真實案件素材、三平台出貨。
缺的是它周圍的東西：唯一的下載方式是 GitHub Releases 頁、repo 的 homepage
欄位指向 Instagram、而授權要講一整段話，剪輯師才判斷得出自己接案能不能用。
三件今天都有答案了，版本號沒有理由繼續假裝這還是預覽。

使其他事情成立的是授權那一步。PolyForm-NC 下，接案剪輯師從第一個專案起
就在條款之外，而 README 告訴他三個專案以內免費——那是 license 沒授權我們
講的話。Perimeter 用一句話取代它，產品頁才有辦法拿它當開場。

沒有任何東西在賣。付費層已定義、條款已公開，但沒有任何出貨版本設限，
也還沒有付款路徑。

全套 1312 passed / 7 skipped。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
