### PR TITLE
feat(site): 訂閱表單支援 Mailchimp（EMAIL 大寫欄位 + JSONP）

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -306,6 +306,17 @@ footer a:hover{color:var(--cyan)}
       endpoint   https://formspree.io/f/<FORM_ID>
       emailField email                ← 支援 CORS，能拿到真實成功／失敗
 
+    Mailchimp                          ← 需額外設 mode: "jsonp"
+      endpoint   https://<DC>.list-manage.com/subscribe/post-json?u=<U>&id=<ID>
+      emailField EMAIL                 ← 全大寫，是 merge tag 不是欄位名
+      · 取得方式：Mailchimp → Audience → Signup forms → Embedded form，
+        表單 action 內就含 <DC>（如 us21）、u=、id= 三個值。
+        把 /subscribe/post 改成 /subscribe/post-json 即可。
+      · list-manage.com **不支援 CORS**，所以走 JSONP；否則每次送出都會
+        被帶離本站。
+      · Mailchimp 會把「已訂閱過」當成 error 回，訊息含 HTML，故顯示前
+        去標籤並改寫成人話。
+
   送出邏輯：先試 fetch（拿得到真答案就顯示真結果）；若因 CORS 或網路失敗，
   退回原生 form submit（會離開本站，但由對方站台自己顯示確認）。
   **永遠不在無法確認的情況下顯示「訂閱成功」。**
@@ -346,6 +357,7 @@ footer a:hover{color:var(--cyan)}
   const SIGNUP = {
     endpoint: "",
     emailField: "email",
+    mode: "fetch",        // Mailchimp 要改成 "jsonp"
   };
 
   (function () {
@@ -373,6 +385,43 @@ footer a:hover{color:var(--cyan)}
       e.preventDefault();
       btn.disabled = true;
       say("送出中…");
+
+      if (SIGNUP.mode === "jsonp") {
+        // Mailchimp：list-manage.com 無 CORS，fetch 一定失敗。JSONP 是唯一
+        // 能留在本站又拿到真實回應的方式。
+        const cb = "mcCallback" + Date.now();
+        const url = SIGNUP.endpoint
+          + (SIGNUP.endpoint.indexOf("?") === -1 ? "?" : "&")
+          + encodeURIComponent(SIGNUP.emailField) + "=" + encodeURIComponent(email.value)
+          + "&c=" + cb;
+        const tag = document.createElement("script");
+        let settled = false;
+
+        const done = function (ok, msg) {
+          if (settled) return;
+          settled = true;
+          try { delete window[cb]; } catch (e) { window[cb] = undefined; }
+          tag.remove();
+          if (ok) { say(msg, "ok"); form.reset(); }
+          else { say(msg, "bad"); btn.disabled = false; }
+        };
+
+        window[cb] = function (res) {
+          if (res && res.result === "success") return done(true, "訂閱成功，謝謝。");
+          // Mailchimp 的 msg 夾 HTML，且「已訂閱」也走 error
+          const raw = (res && res.msg ? String(res.msg) : "").replace(/<[^>]*>/g, "");
+          if (/already subscribed/i.test(raw)) return done(false, "這個信箱已經訂閱過了。");
+          done(false, raw ? "訂閱失敗：" + raw : "訂閱失敗，請稍後再試。");
+        };
+
+        // 對方沒回 = 拿不到答案，同樣不宣稱成功
+        tag.onerror = function () { done(false, "訂閱失敗，請稍後再試，或直接來信。"); };
+        setTimeout(function () { done(false, "訂閱逾時，請稍後再試。"); }, 10000);
+
+        tag.src = url;
+        document.body.appendChild(tag);
+        return;
+      }
 
       const body = new FormData();
       body.append(SIGNUP.emailField, email.value);


### PR DESCRIPTION
feat(site): 訂閱表單支援 Mailchimp（EMAIL 大寫欄位 + JSONP）

Hevin 已有 Mailchimp（Waffle House 的名單），不必另開帳號。但 Mailchimp
接法跟前三家都不同，直接填會踩兩個坑：

**① 欄位名是 `EMAIL`，全大寫。** 那是 merge tag 不是一般欄位名。填成
`email` 會靜默收不到 —— 跟上一支修掉的 Kit `email_address` 完全同型。

**② `list-manage.com` 不支援 CORS。** fetch 一定 throw，於是每次送出都會
走「退回原生 submit」那條，**每個訂閱的人都被帶離本站**。能用，但那是
fallback 不該當主路徑。

所以加 `mode: "jsonp"`：用 script 標籤打 `/subscribe/post-json`，留在原頁
且拿得到真實回應。三件對 Mailchimp 特有的處理：

- **「已訂閱過」它回的是 error**，不是 success。原樣顯示會讓老訂閱者看到
  「訂閱失敗」而以為壞了。改寫成「這個信箱已經訂閱過了。」
- **msg 夾 HTML**（`<a href>`、`<b>`）。顯示前去標籤，否則畫面出現裸標記。
- **script 載入失敗與逾時（10s）都當失敗**。JSONP 沒有 response status，
  不主動處理就會永遠停在「送出中…」—— 又一個靜默失敗。

**JSONP 的髒污也清掉**：callback 從 `window` 刪除、script 標籤移除，並用
`settled` 旗標防止 onerror 與 timeout 重複觸發。實測驗過零殘留全域變數、
零殘留 script 標籤。

**四條路徑實測**（playwright + 本機 JSONP 假伺服器）：成功／已訂閱→友善
訊息／HTML 錯誤→去標籤／404 載入失敗→報錯不靜默。四條都留在原頁、
按鈕都放回讓人重試。

仍待 Hevin：從 Mailchimp → Audience → Signup forms → Embedded form 取得
`<DC>` / `u=` / `id=` 三個值填進 SIGNUP。⚠️ **arkiv 要用自己的 audience 或
tag**，不能混進 WH 那 361 人的音響消費者名單。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
