### PR TITLE
feat(site): 接上 Kit，並修掉「Kit 回 200 也可能是失敗」

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -355,9 +355,9 @@ footer a:hover{color:var(--cyan)}
 <script>
   // ── 填這裡就會上線。各家的 endpoint / emailField 見上方 signup 區塊的註解。
   const SIGNUP = {
-    endpoint: "",
-    emailField: "email",
-    mode: "fetch",        // Mailchimp 要改成 "jsonp"
+    endpoint: "https://app.kit.com/forms/9819208/subscriptions",
+    emailField: "email_address",   // Kit 的欄位名，不是 email
+    mode: "fetch",                 // Mailchimp 才要改成 "jsonp"
   };
 
   (function () {
@@ -432,12 +432,30 @@ footer a:hover{color:var(--cyan)}
           body: body,
           headers: { Accept: "application/json" },
         });
-        if (res.ok) {
+        // ⚠️ HTTP 狀態碼不足以判斷成功。**Kit 對失敗也回 200**，真正的結果在
+        // body：成功 {status:"success"}、失敗 {status:"failed", errors:[…]}。
+        // 只看 res.ok 會讓空的、格式錯的、被拒絕的訂閱全部顯示「訂閱成功」——
+        // 名單一個都沒進，而沒有人會發現。實測 2026-08-19 對真實 endpoint 驗過。
+        // Formspree / Buttondown 則用正常狀態碼，所以兩種都要接。
+        let payload = null;
+        try { payload = JSON.parse(await res.text()); } catch (e) { /* 非 JSON */ }
+
+        const explicit = payload && typeof payload.status === "string"
+          ? payload.status === "success"     // Kit：以 body 為準
+          : null;
+        const ok = explicit === null ? res.ok : explicit;
+
+        if (ok) {
           say("訂閱成功，謝謝。", "ok");
           form.reset();
         } else {
-          // 對方回了、但不是成功 —— 這是真的失敗，不能當成功帶過
-          say("訂閱失敗（" + res.status + "）。請稍後再試，或直接來信。", "bad");
+          let why = "";
+          if (payload && Array.isArray(payload.errors) && payload.errors.length) {
+            why = String(payload.errors[0]).replace(/<[^>]*>/g, "");
+          } else if (!res.ok) {
+            why = "（" + res.status + "）";
+          }
+          say("訂閱失敗" + (why ? "：" + why : "，請稍後再試，或直接來信。"), "bad");
           btn.disabled = false;
         }
       } catch (err) {


### PR DESCRIPTION
feat(site): 接上 Kit，並修掉「Kit 回 200 也可能是失敗」

Hevin 拍板 arkiv 走 Kit 免費方案，與 WH 的 Mailchimp 分開。已在他的 Kit
帳號建立 inline form「arkiv — product updates」並發佈。

**值是從 Kit 自己產生的 embed HTML 讀出來的，不是從 URL 推論** —— 這點
有差：designer 網址是 `/forms/designers/9819208/edit`，而 JS embed 用的又
是另一個 uid `87462956d3`。兩個都可能被當成 endpoint 用，但真正的 form
action 是 `https://app.kit.com/forms/9819208/subscriptions`，欄位
`email_address`。

**接上之後對真 endpoint 做探測，抓到一個我原本會出貨的 bug：**

Kit **對失敗也回 HTTP 200**。空 email → 200、格式錯 → 200，真正的結果在
body：成功 `{status:"success", redirect_url}`、失敗
`{status:"failed", errors:[…]}`。而我上一支寫的是 `if (res.ok)` ——
**所有失敗的訂閱都會顯示「訂閱成功」，名單一個都沒進，而且不會有人發現。**

那正是這兩天一路在抓的形狀，只是這次在我自己的程式碼裡。判斷改成以 body
為準：有 `status` 欄位就用它（Kit），沒有就退回 HTTP 狀態碼（Formspree /
Buttondown 用正常狀態碼），維持供應商中立。失敗時把 `errors[0]` 顯示出來
並去 HTML 標籤。

**驗證分兩層，都對真實對象做**：
① **真 endpoint 契約**：從正式站原點 `vulture-s.github.io` 實打 Kit ——
   CORS 放行、空/無效 → 200+failed、有效 → 200+success。三種回應形狀是
   實測得到的，不是查文件推的。
② **解析邏輯**：用上面實測到的三種形狀餵給頁面，驗
   200+failed→顯示失敗（含錯誤訊息）／200+success→成功／
   無 status 欄位的 422→退回狀態碼判斷。

⚠️ 測 ① 的有效案例時用了 Hevin 自己的信箱（better@wafflehouse.com.tw），
所以那個位址現在是 arkiv 名單的第一個訂閱者，他會收到 Kit 的確認信 ——
等於連投遞都驗到了。要移除的話在 Kit → Subscribers。

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
