### PR TITLE
feat(licensing): 免費額度 gate —— 專案數 3 + 跨專案聚合，含 grandfather

### DIFF
--- a/bins.py
+++ b/bins.py
@@ -35,6 +35,21 @@ class BinsError(Exception):
     pass
 
 
+class BinEntitlementError(BinsError):
+    """A bin operation refused because it needs the Pro add-on.
+
+    Subclasses BinsError so every existing `except BinsError` keeps working —
+    but is its own type so the API layer can answer 403 with a machine-readable
+    code instead of folding a licensing refusal into a generic 400. A caller
+    that cannot tell "you may not" from "you asked wrong" cannot show the user
+    the one thing that would help: what to do next.
+    """
+
+    def __init__(self, message, code="cross_project"):
+        super(BinEntitlementError, self).__init__(message)
+        self.code = code
+
+
 # Per-item reachability, surfaced in GET /api/bins/{id} and gated before copy.
 # OK plus the HealthStatus values (passed through) plus three bin-specific ones.
 STATUS_OK = "ok"
@@ -264,9 +279,39 @@ def add_items(bin_id: str, items: List[Dict[str, Any]]) -> Bin:
             raise BinsError("bin not found: {0}".format(bin_id))
         existing = {item.key() for item in target.items}
         now = _now_iso()
+
+        # A bin holding items from more than one project IS the "collections
+        # spanning projects" half of the Pro cross-project feature
+        # (docs/pro-addon-license.md). Gate the operation that INTRODUCES a new
+        # project into a bin — not the bin's existing contents.
+        #
+        # That distinction is the whole design. Refusing to touch a bin that is
+        # already cross-project would retroactively break data the user already
+        # has, which is the one thing the grandfather promise exists to prevent;
+        # and it would punish exactly the pre-cap installs the promise protects.
+        # So adding items from a project the bin already contains stays allowed
+        # even on the free tier, while widening the bin to a NEW project is what
+        # requires entitlement.
+        parsed = [BinItem.from_mapping(raw) for raw in items or []]
+        incoming_projects = {
+            item.project_name for item in parsed if item.key() not in existing
+        }
+        existing_projects = {item.project_name for item in target.items}
+        if incoming_projects and not incoming_projects.issubset(existing_projects):
+            if len(existing_projects | incoming_projects) > 1:
+                # Lazy, matching bin_item_status above: pure-CRUD callers and
+                # tests should not pay for the registry/health import chain.
+                import entitlements
+                from projects import known_project_dbs
+
+                verdict = entitlements.check_cross_project(
+                    db_paths=known_project_dbs()
+                )
+                if not verdict.allowed:
+                    raise BinEntitlementError(verdict.reason, verdict.code)
+
         added = 0
-        for raw in items or []:
-            item = BinItem.from_mapping(raw)
+        for item in parsed:
             if item.key() in existing:
                 continue
             item.added_at = now

--- a/docs/index.html
+++ b/docs/index.html
@@ -257,14 +257,14 @@ footer a:hover{color:var(--cyan)}
       <tbody>
         <tr><td>全部索引與搜尋功能</td><td><b>✓</b></td><td><b>✓</b></td></tr>
         <tr><td>商業使用</td><td><b>✓</b></td><td><b>✓</b></td></tr>
-        <tr><td>專案數</td><td><b>目前不限</b><br><span class="future">未來版本起，新安裝為 3 個</span></td><td><b>無限</b></td></tr>
-        <tr><td>跨專案聚合搜尋</td><td><b>目前開放</b><br><span class="future">未來版本起，新安裝不含</span></td><td><b>✓</b></td></tr>
+        <tr><td>專案數</td><td><b>目前不限</b><br><span class="future">1.1.0 起，新安裝為 3 個</span></td><td><b>無限</b></td></tr>
+        <tr><td>跨專案聚合搜尋</td><td><b>目前開放</b><br><span class="future">1.1.0 起，新安裝不含</span></td><td><b>✓</b></td></tr>
         <tr><td>價格</td><td><b>NT$0</b></td><td><b>NT$3,000</b> 一次買斷</td></tr>
       </tbody>
     </table>
     <p class="tier-note">
-      <b style="color:var(--ink)">目前版本不設任何限制</b> —— 上表 Pro 欄的兩項功能，現在所有使用者都可使用。
-      免費額度將自未來某一版起對<b style="color:var(--ink)">新安裝</b>生效；
+      <b style="color:var(--ink)">目前版本（1.0.0）不設任何限制</b> —— 上表 Pro 欄的兩項功能，現在所有使用者都可使用。
+      免費額度自 <b style="color:var(--ink)">1.1.0</b> 起對<b style="color:var(--ink)">新安裝</b>生效；
       <b style="color:var(--ink)">在該版之前已在使用的素材庫，永久保留現有的無限制狀態</b>，這項承諾已寫入軟體：
       素材庫會在初次建立時記錄版本，作為日後判定的依據。
       <br>Pro 尚未開放購買 ——

--- a/docs/pro-addon-license.md
+++ b/docs/pro-addon-license.md
@@ -30,13 +30,16 @@ things the free core does not provide:
 | Projects | Up to 3 | Unlimited |
 | Cross-project aggregation (search and collections spanning projects) | — | ✅ |
 
-> **Current builds impose neither limit.** No shipped version of arkiv caps
-> projects or withholds cross-project aggregation; the table describes the
-> intended tiers, not today's behaviour. The free allowance will apply to **new
-> installations** from a future release onward. **Libraries already in use
-> before that release keep unlimited projects permanently** — the software
-> records the version a library was first seen under (`library_meta.
-> first_seen_version`) so this can be honoured rather than guessed at.
+> **Current builds impose neither limit.** No shipped version of arkiv up to and
+> including 1.0.0 caps projects or withholds cross-project aggregation; the
+> table describes the intended tiers, not today's behaviour. The free allowance
+> applies to **new installations** from **release 1.1.0** onward. **An
+> installation already in use before 1.1.0 keeps BOTH — unlimited projects and
+> cross-project aggregation — permanently**, not merely the project count. The
+> software records the version a library was first seen under
+> (`library_meta.first_seen_version`) so this can be honoured rather than
+> guessed at, and a build older than 1.1.0 does not enforce the allowance at
+> all.
 
 The add-on is **not** covered by the PolyForm Perimeter License. It is
 distributed under the terms on this page.
@@ -179,11 +182,12 @@ arkiv 本體（ingest、轉錄、視覺標註、語意搜尋、chat、NLE／DIT 
 | 專案數 | 最多 3 個 | 無限 |
 | 跨專案聚合（跨專案搜尋與精選集） | — | ✅ |
 
-> **現行版本兩項限制均未實施。** 目前已發布的任何版本都不限制專案數，
+> **現行版本兩項限制均未實施。** 截至 1.0.0 為止已發布的任何版本都不限制專案數，
 > 亦未保留跨專案聚合功能；上表描述的是規劃中的方案分層，而非現況。
-> 免費額度將自未來某一版起對**新安裝**生效；**在該版之前已在使用的素材庫，
-> 永久保留無限制專案數** —— 軟體會記錄素材庫初次使用時的版本
-> （`library_meta.first_seen_version`），使此一承諾得以查證而非事後推測。
+> 免費額度自 **1.1.0** 起對**新安裝**生效；**在 1.1.0 之前已在使用的安裝，
+> 永久保留兩項功能 —— 無限專案數與跨專案聚合**，不限於專案數一項。
+> 軟體會記錄素材庫初次使用時的版本（`library_meta.first_seen_version`），
+> 使此一承諾得以查證而非事後推測；且早於 1.1.0 的版本完全不執行此額度。
 
 附加元件**不在** PolyForm Perimeter 授權範圍內，依本頁條款授權。
 

--- a/entitlements.py
+++ b/entitlements.py
@@ -365,13 +365,13 @@ def check_cross_project(db_paths=None, pro=None, grandfathered=None):
     """May this install aggregate across projects (search / collections)?
 
     Same exemption rules as the project cap. The published zh product page says
-    of cross-project search: "未來版本起，新安裝不含" — from a future release,
-    NEW installs do not include it — which grants existing installs the same
-    permanent keep that the projects row grants. The English terms spell the
-    keep out only for projects; treating cross-project the same way is the
-    reading that keeps both promises rather than the one that breaks the zh
-    page. (`docs/pro-addon-license.md` should be tightened to match; tracked in
-    the todo rather than silently diverging here.)
+    of cross-project search: "新安裝不含" — NEW installs do not include it —
+    which grants existing installs the same permanent keep that the projects row
+    grants. The English terms used to spell the keep out for projects only;
+    treating cross-project the same way is the reading that keeps both promises
+    rather than the one that breaks the zh page, and
+    `docs/pro-addon-license.md` was tightened in the same change to say so in
+    both languages rather than leave the code and the terms disagreeing.
     """
     if not cap_is_active():
         return Verdict(

--- a/entitlements.py
+++ b/entitlements.py
@@ -1,0 +1,429 @@
+"""Free-tier limits, grandfathering, and Pro add-on entitlement.
+
+Single choke-point for every "is this allowed on the free tier?" question. The
+published terms (`docs/pro-addon-license.md`, and the product page) promise
+exactly two things beyond the free core:
+
+    Projects                       free: up to 3      Pro: unlimited
+    Cross-project aggregation      free: —            Pro: yes
+    (search and collections spanning projects)
+
+and one guarantee about the transition:
+
+    "The free allowance will apply to NEW INSTALLATIONS from a future release
+     onward. Libraries already in use before that release keep unlimited
+     projects permanently."
+
+That promise is why this module exists as its own leaf rather than as three
+`if` statements at the call sites: the grandfathering rule has to be answered
+identically everywhere, and it is the kind of rule that silently rots when
+copy-pasted (see `mediatypes.py` for the same lesson learned the hard way).
+
+## This is a goodwill promise, not DRM
+
+`db.py`'s `first_seen_version` comment already states the posture and this
+module keeps it: the anchor row is trivially editable, the licence file is
+unsigned, and none of it is obfuscated. The licence is enforced by its terms,
+not by the database. What the code owes the user is that the *honest* cases
+come out right — not that the dishonest ones are impossible.
+
+The practical consequence is a hard rule followed throughout this module:
+
+    **Every uncertainty resolves to "allowed".**
+
+A missing anchor, an unreadable DB, a corrupt registry, a malformed version
+string — all of them mean "we cannot prove this install is new", and the only
+acceptable way to be wrong here is in the user's favour. Failing the other way
+would revoke the exemption from exactly the users who have held it longest,
+which is the one outcome the published promise forbids.
+
+## Why the cap version is a constant, not `config.VERSION`
+
+`CAP_VERSION` is the release in which the cap first takes effect, and it is the
+permanent grandfathering boundary. It must stay pinned to that release forever
+— reading it from `config.VERSION` would move the boundary on every subsequent
+release and quietly revoke every exemption granted so far.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+from typing import List
+
+import config
+
+
+# ── the published tier ────────────────────────────────────────────────────────
+
+# `docs/pro-addon-license.md`: "Projects — Free core: Up to 3".
+FREE_PROJECT_LIMIT = 3
+
+# The release in which the cap first bites. Libraries first seen under any
+# EARLIER version — or under no recorded version at all — are exempt forever.
+# Changing this value after 1.1.0 ships would retroactively revoke exemptions;
+# it is a historical fact from that point on, not a tunable.
+CAP_VERSION = "1.1.0"
+
+
+class Verdict(object):
+    """Outcome of an entitlement check.
+
+    Carries `reason` even when allowed, because the call sites need to explain
+    themselves either way: a refusal has to say what is missing (PR #315 — a
+    control that just goes grey is a control that lies about why), and an
+    allow-by-grandfather is worth surfacing so a user who expects the cap is not
+    left wondering whether it silently failed.
+    """
+
+    __slots__ = ("allowed", "code", "reason")
+
+    def __init__(self, allowed, code, reason):
+        self.allowed = bool(allowed)
+        self.code = code
+        self.reason = reason
+
+    def __repr__(self):  # pragma: no cover - debugging aid
+        return "Verdict(allowed={0!r}, code={1!r}, reason={2!r})".format(
+            self.allowed, self.code, self.reason
+        )
+
+
+# ── version comparison ────────────────────────────────────────────────────────
+
+def parse_version(text):
+    """`"1.10.2"` -> `(1, 10, 2)`, or None when it is not a usable version.
+
+    Tuple comparison, never string comparison: `"1.10.0" < "1.9.0"` is True
+    lexically and false in fact, and that single mistake would hand the cap to
+    every user on a double-digit minor release.
+
+    Trailing pre-release/build suffixes (`"1.1.0-rc1"`, `"1.1.0+win"`) are
+    reduced to their numeric core rather than rejected — a build that stamped a
+    suffixed version is still evidence of when the library was in use, and
+    rejecting it would push a real, dated library into the "unknown" bucket.
+    """
+    if text is None:
+        return None
+    head = str(text).strip()
+    if not head:
+        return None
+    for separator in ("-", "+", " "):
+        head = head.split(separator, 1)[0]
+    parts = head.split(".")
+    numbers = []
+    for part in parts:
+        if not part.isdigit():
+            return None
+        numbers.append(int(part))
+    if not numbers:
+        return None
+    # Pad so (1, 1) and (1, 1, 0) compare equal rather than short-tuple-less-than.
+    while len(numbers) < 3:
+        numbers.append(0)
+    return tuple(numbers[:3])
+
+
+def cap_is_active():
+    """Is the cap in force in THIS build at all?
+
+    False on every build older than `CAP_VERSION`. The terms say the allowance
+    applies "from a future release onward", so a build that predates that
+    release must not enforce it — no matter what the registry happens to look
+    like.
+
+    Without this, the gate bites early in a case that is easy to miss: an
+    install that registered several project roots but has never ingested into
+    them has no `project.db` files, so there is no anchor anywhere, so nothing
+    reads as grandfathered — and a 1.0.0 build would refuse the fourth project
+    even though 1.0.0 promised no limit at all. The grandfather machinery
+    answers "is this install old?"; only this function answers "is the rule even
+    in effect yet?", and conflating the two enforces a rule before its own
+    start date.
+
+    It also means merging the gate does not arm it. Arming happens in the
+    release that sets `config.VERSION` to `CAP_VERSION`, which is deliberate:
+    the boundary is a published date-like promise, not a merge time.
+    """
+    return not predates_cap(config.VERSION)
+
+
+def predates_cap(version_text):
+    """True when a library stamped `version_text` is grandfathered.
+
+    None / unparseable / absent all return True. See the module docstring: an
+    unreadable stamp is not evidence that the library is new, and the published
+    promise makes "we cannot tell" mean "exempt".
+    """
+    parsed = parse_version(version_text)
+    if parsed is None:
+        return True
+    cap = parse_version(CAP_VERSION)
+    if cap is None:  # pragma: no cover - CAP_VERSION is a literal we control
+        return True
+    return parsed < cap
+
+
+# ── reading the anchor out of an arbitrary project DB ─────────────────────────
+
+def read_library_origin(db_path):
+    """`first_seen_version` from a project DB, or None when there is no answer.
+
+    Opened read-only via a `mode=ro` URI, mirroring `projects._media_row_count`:
+    probing somebody's library for a licensing question must never create a stub
+    file nor leave -wal/-shm side files next to their corpus. A licensing check
+    that mutates the thing it inspects is not acceptable at any severity.
+
+    `db.get_library_origin()` answers the same question for the CURRENT install
+    only (it goes through `config.DB_PATH`). The cap is a machine-level question
+    over every registered project, so it needs the path-taking form as well.
+    """
+    try:
+        path = Path(db_path)
+        if not path.exists():
+            return None
+        uri = path.resolve(strict=False).as_uri() + "?mode=ro"
+    except (OSError, ValueError):
+        return None
+    conn = None
+    try:
+        conn = sqlite3.connect(uri, uri=True, timeout=5)
+        row = conn.execute(
+            "SELECT value FROM library_meta WHERE key='first_seen_version'"
+        ).fetchone()
+    except sqlite3.Error:
+        return None
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+    if not row:
+        return None
+    return row[0]
+
+
+# ── Pro entitlement ───────────────────────────────────────────────────────────
+
+def _license_file_path():
+    return Path(
+        os.getenv("ARKIV_PRO_LICENSE", str(Path.home() / ".arkiv" / "pro-license.json"))
+    ).expanduser()
+
+
+def _pro_from_license_file():
+    """True when a readable licence record names a licensee and a key.
+
+    Deliberately unsigned and unverified. The add-on is sold as a named,
+    perpetual licence recorded in the public licensee registry; the file exists
+    so an install can tell the user (and this code) which licence it is running
+    under, not to make forgery hard. Forgery is already trivial by editing this
+    module, and pretending otherwise would only cost honest users a support
+    ticket when their licence file fails to parse on a plane.
+    """
+    path = _license_file_path()
+    try:
+        if not path.exists():
+            return False
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, ValueError):
+        # Unreadable or corrupt: not proof of entitlement, but also not an
+        # error worth raising into an unrelated user action.
+        return False
+    if not isinstance(data, dict):
+        return False
+    return bool(str(data.get("licensee", "")).strip()) and bool(
+        str(data.get("key", "")).strip()
+    )
+
+
+def _pro_from_addon_module():
+    """True when the closed-source add-on is installed and reports a licence.
+
+    The add-on is a separate distribution and is NOT in this repo, so this is an
+    interface definition as much as a check: if `arkiv_pro` is importable, core
+    asks it via `has_valid_license()` when that hook exists, and otherwise
+    treats its mere presence as the answer. Presence-as-answer is the lenient
+    branch on purpose — a user who paid and installed the component should not
+    be gated by core's expectations about the component's internals.
+    """
+    try:
+        import arkiv_pro  # type: ignore
+    except Exception:
+        # ImportError in the normal case; anything else means a broken add-on
+        # install, which must not take an unrelated user action down with it.
+        return False
+    hook = getattr(arkiv_pro, "has_valid_license", None)
+    if hook is None:
+        return True
+    try:
+        return bool(hook())
+    except Exception:
+        return False
+
+
+def has_pro():
+    """True when this install is entitled to the Pro features.
+
+    Two independent routes, either one sufficient (Hevin 2026-08-19): the add-on
+    module being importable, or a licence file being present. Two routes because
+    each covers the other's failure: a user who installed the component but
+    never placed a licence file still works, and a user whose component is not
+    on this machine's import path (a packaged .app, a different venv) can still
+    be recognised.
+    """
+    return _pro_from_addon_module() or _pro_from_license_file()
+
+
+# ── the machine-level grandfather question ────────────────────────────────────
+
+def install_is_grandfathered(db_paths):
+    """True when this install was already in use before `CAP_VERSION`.
+
+    The unit is the INSTALL, not the individual library, because that is what
+    the published terms promise: "the free allowance will apply to NEW
+    INSTALLATIONS from a future release onward". An install holding any library
+    that predates the cap is by definition not a new installation.
+
+    An install with no libraries at all has no evidence of prior use and is
+    therefore NOT grandfathered — that is the genuinely fresh install the cap is
+    aimed at. This is the one place where absence of evidence is read as
+    evidence of absence, and it is safe because it costs such a user nothing:
+    they have zero projects, so the cap of three cannot bite them today, and by
+    the time it could they will have been stamped with the current version.
+    """
+    for db_path in db_paths or []:
+        origin = read_library_origin(db_path)
+        if origin is None:
+            # Either the DB predates the anchor entirely, or it is unreadable.
+            # Both mean "cannot prove this is new" — but only count it when the
+            # library actually exists, so that a registry entry pointing at a
+            # deleted/unmounted project does not manufacture an exemption out of
+            # nothing. (An unmounted NAS project is exactly the case that would
+            # otherwise flip an install to exempt on a bad-mount day and back
+            # again the next.)
+            try:
+                if Path(db_path).exists():
+                    return True
+            except OSError:
+                continue
+            continue
+        if predates_cap(origin):
+            return True
+    return False
+
+
+# ── the three published gates ─────────────────────────────────────────────────
+
+def check_add_project(existing_count, db_paths=None, pro=None, grandfathered=None):
+    """May this install register one more project?
+
+    `existing_count` is the number already registered. `pro` / `grandfathered`
+    are injectable so call sites that already computed them (and every test) do
+    not pay for repeated DB probes — but both default to being worked out here,
+    so a call site can never accidentally skip the check by omitting an argument.
+    """
+    if not cap_is_active():
+        return Verdict(
+            True,
+            "cap_inactive",
+            "This build predates the {0} free-tier allowance; projects are "
+            "unlimited.".format(CAP_VERSION),
+        )
+    if pro is None:
+        pro = has_pro()
+    if pro:
+        return Verdict(True, "pro", "Pro add-on licensed — projects are unlimited.")
+    if grandfathered is None:
+        grandfathered = install_is_grandfathered(db_paths or [])
+    if grandfathered:
+        return Verdict(
+            True,
+            "grandfathered",
+            "This installation was in use before {0}, so its project limit is "
+            "permanently lifted.".format(CAP_VERSION),
+        )
+    if existing_count < FREE_PROJECT_LIMIT:
+        return Verdict(
+            True,
+            "within_free_tier",
+            "{0} of {1} free projects used.".format(existing_count, FREE_PROJECT_LIMIT),
+        )
+    return Verdict(
+        False,
+        "project_limit",
+        "The free tier allows {0} projects and this installation already has "
+        "{1}. Remove a project, or license the Pro add-on for unlimited "
+        "projects.".format(FREE_PROJECT_LIMIT, existing_count),
+    )
+
+
+def check_cross_project(db_paths=None, pro=None, grandfathered=None):
+    """May this install aggregate across projects (search / collections)?
+
+    Same exemption rules as the project cap. The published zh product page says
+    of cross-project search: "未來版本起，新安裝不含" — from a future release,
+    NEW installs do not include it — which grants existing installs the same
+    permanent keep that the projects row grants. The English terms spell the
+    keep out only for projects; treating cross-project the same way is the
+    reading that keeps both promises rather than the one that breaks the zh
+    page. (`docs/pro-addon-license.md` should be tightened to match; tracked in
+    the todo rather than silently diverging here.)
+    """
+    if not cap_is_active():
+        return Verdict(
+            True,
+            "cap_inactive",
+            "This build predates the {0} free-tier allowance; cross-project "
+            "aggregation is unrestricted.".format(CAP_VERSION),
+        )
+    if pro is None:
+        pro = has_pro()
+    if pro:
+        return Verdict(True, "pro", "Pro add-on licensed — cross-project aggregation is available.")
+    if grandfathered is None:
+        grandfathered = install_is_grandfathered(db_paths or [])
+    if grandfathered:
+        return Verdict(
+            True,
+            "grandfathered",
+            "This installation was in use before {0}, so cross-project "
+            "aggregation stays available.".format(CAP_VERSION),
+        )
+    return Verdict(
+        False,
+        "cross_project",
+        "Cross-project search and collections are part of the Pro add-on. Each "
+        "project can still be searched on its own.",
+    )
+
+
+def status(existing_count, db_paths=None):
+    """Everything the UI needs to describe the current tier, in one probe.
+
+    One function so the frontend never has to assemble the tier from three
+    separate calls that could disagree mid-flight.
+    """
+    pro = has_pro()
+    grandfathered = install_is_grandfathered(db_paths or []) if not pro else False
+    add = check_add_project(existing_count, pro=pro, grandfathered=grandfathered)
+    cross = check_cross_project(pro=pro, grandfathered=grandfathered)
+    return {
+        # Reported explicitly so an inert gate is visible rather than silent. A
+        # build that carries the code but predates CAP_VERSION allows
+        # everything, and "allowed" alone cannot be told apart from "entitled" —
+        # which is precisely how a shipped-but-dead gate goes unnoticed.
+        "armed": cap_is_active(),
+        "pro": pro,
+        "grandfathered": grandfathered,
+        "cap_version": CAP_VERSION,
+        "free_project_limit": FREE_PROJECT_LIMIT,
+        "projects_used": existing_count,
+        "can_add_project": add.allowed,
+        "add_project_reason": add.reason,
+        "cross_project": cross.allowed,
+        "cross_project_reason": cross.reason,
+    }

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -24,13 +24,30 @@ class ApiError extends Error {
     // toast that shows e.message surfaces WHY it failed (e.g. "找不到媒體檔案") instead
     // of an opaque "arkiv API 500 on /path". body is usually {detail: "..."}.
     const detail = body && typeof body === 'object' ? body.detail : body
-    const suffix = detail
-      ? `：${typeof detail === 'string' ? detail : JSON.stringify(detail)}`
+    // ...but the entitlement refusals (403 {code, message}) send a STRUCTURED
+    // detail, and JSON.stringify would put raw JSON in front of the user. The
+    // code half is for this file to branch on; the message half is the only
+    // part a person should ever read. A refusal that renders as
+    // `{"code":"project_limit",...}` tells the user less than the plain
+    // sentence it contains, which defeats the reason the message exists.
+    const human =
+      detail && typeof detail === 'object' && typeof detail.message === 'string'
+        ? detail.message
+        : detail
+    const suffix = human
+      ? `：${typeof human === 'string' ? human : JSON.stringify(human)}`
       : ''
     super(`arkiv API ${status} on ${path}${suffix}`)
     this.status = status
     this.path = path
     this.body = body
+    // Machine-readable reason when the backend sent one ('project_limit',
+    // 'cross_project'), null otherwise — so a caller can offer the right next
+    // step without string-matching a localised sentence.
+    this.code =
+      detail && typeof detail === 'object' && typeof detail.code === 'string'
+        ? detail.code
+        : null
   }
 }
 

--- a/frontend/tests/apiError.test.mjs
+++ b/frontend/tests/apiError.test.mjs
@@ -1,0 +1,58 @@
+// ApiError message folding — node:test, no runner dependency (CI already has Node 20).
+//
+// The free-tier gate made the backend send STRUCTURED 403 details
+// ({code, message}) for the first time. Every other endpoint sends a plain
+// string, so the existing fold path had never met an object it was supposed to
+// read rather than dump — and the fallback it did have (JSON.stringify) turns a
+// refusal into raw JSON in a toast. These pin the two halves apart: the human
+// sentence goes in the message, the code stays machine-readable.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { ApiError } from '../src/lib/api.js'
+
+test('structured detail shows its message, not its JSON', () => {
+  const err = new ApiError(403, '/api/projects', {
+    detail: {
+      code: 'project_limit',
+      message: 'The free tier allows 3 projects and this installation already has 3.',
+    },
+  })
+  assert.match(err.message, /The free tier allows 3 projects/)
+  // The failure this guards: the user reading braces and quotes instead of a sentence.
+  assert.ok(!err.message.includes('{'), `raw JSON leaked into: ${err.message}`)
+  assert.ok(!err.message.includes('"code"'), `raw JSON leaked into: ${err.message}`)
+})
+
+test('structured detail keeps the code for callers to branch on', () => {
+  const err = new ApiError(403, '/api/bins/x/items', {
+    detail: { code: 'cross_project', message: 'Cross-project collections are Pro.' },
+  })
+  assert.equal(err.code, 'cross_project')
+  assert.equal(err.status, 403)
+})
+
+test('plain string details still fold exactly as before', () => {
+  // Regression guard: the overwhelming majority of endpoints send a string, and
+  // the structured branch must not have changed what they render.
+  const err = new ApiError(404, '/api/media/9', { detail: '找不到媒體檔案' })
+  assert.match(err.message, /找不到媒體檔案/)
+  assert.equal(err.code, null)
+})
+
+test('an object detail without a message is still not swallowed', () => {
+  // Not every dict detail is an entitlement refusal — FastAPI's own validation
+  // errors are lists/dicts too. Showing their JSON is ugly but showing NOTHING
+  // would be worse, so the stringify fallback has to survive.
+  const err = new ApiError(422, '/api/search/query', {
+    detail: [{ loc: ['body', 'field'], msg: 'field required' }],
+  })
+  assert.match(err.message, /field required/)
+  assert.equal(err.code, null)
+})
+
+test('a body with no detail at all degrades to the bare status line', () => {
+  const err = new ApiError(500, '/api/stats', null)
+  assert.equal(err.message, 'arkiv API 500 on /api/stats')
+  assert.equal(err.code, null)
+})

--- a/projects.py
+++ b/projects.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
+import entitlements
 from health import HealthStatus, project_health
 
 
@@ -23,6 +24,20 @@ _REGISTRY_LOCK = threading.Lock()
 
 class RegistryError(Exception):
     pass
+
+
+class ProjectEntitlementError(RegistryError):
+    """Registration refused by the free-tier project cap.
+
+    Subclasses RegistryError so existing handlers keep catching it, but is its
+    own type so the API can answer 403 with a code rather than a generic 400 —
+    "you have hit the free limit" and "your request was malformed" need
+    different words in front of the user, and only one of them has a next step.
+    """
+
+    def __init__(self, message, code="project_limit"):
+        super(ProjectEntitlementError, self).__init__(message)
+        self.code = code
 
 
 def _default_registry_path() -> Path:
@@ -107,6 +122,57 @@ def resolve_project_db(project_root, explicit=None) -> Path:
         if _media_row_count(legacy_db) > 0:
             return legacy_db
     return project_db
+
+
+def _known_project_dbs(registry_projects) -> List[Path]:
+    """Every project DB this install knows about, for the grandfather probe.
+
+    Registry entries plus ``ARKIV_PROJECT_ROOTS``. Env roots are included
+    because an install driving its projects entirely through the env var is
+    still an install with libraries in use, and omitting them would cap exactly
+    the long-time operator the exemption exists to protect.
+
+    Resolution goes through ``resolve_project_db`` so a pre-8.0c library that
+    still keeps its corpus in ``.arkiv/media.db`` is probed at the file that
+    actually holds its anchor — those are the OLDEST libraries in the wild and
+    the ones with the strongest claim to the exemption.
+    """
+    paths = []
+    seen = set()
+    for project in registry_projects or []:
+        try:
+            db_path = resolve_project_db(project.path)
+        except OSError:
+            continue
+        key = str(db_path).casefold()
+        if key not in seen:
+            seen.add(key)
+            paths.append(db_path)
+    for root in _split_roots(os.getenv("ARKIV_PROJECT_ROOTS", "")):
+        try:
+            db_path = resolve_project_db(Path(root).expanduser())
+        except OSError:
+            continue
+        key = str(db_path).casefold()
+        if key not in seen:
+            seen.add(key)
+            paths.append(db_path)
+    return paths
+
+
+def known_project_dbs() -> List[Path]:
+    """`_known_project_dbs` over the registry as it currently stands.
+
+    A corrupt registry degrades to the env-sourced roots rather than raising:
+    the caller is asking a licensing question, and a broken registry file is not
+    evidence that the install is new. Callers that need the registry itself
+    still get their RegistryError from `list_registry_projects()`.
+    """
+    try:
+        registry_projects = list_registry_projects()
+    except RegistryError:
+        registry_projects = []
+    return _known_project_dbs(registry_projects)
 
 
 @dataclass
@@ -259,6 +325,22 @@ def add_project(name: str, path: str, tags: Optional[List[str]] = None) -> Proje
             existing_path_key = _normalize_key(project_path)
             if any(p.key() == existing_path_key for p in projects):
                 raise RegistryError("project path already registered: {0}".format(path))
+
+            # Free-tier project cap. Only re-registration under an existing name
+            # reaches the branch above, and that leaves the count unchanged — so
+            # the check belongs here, on the one path that actually grows the
+            # registry. Gating both would refuse to let a capped user RENAME or
+            # relocate a project they already own, which the terms never claimed.
+            #
+            # Evidence for the grandfather test is every project already known
+            # to this install, env-sourced roots included: they are libraries in
+            # use, and the published promise is about use, not about which file
+            # happens to record them.
+            verdict = entitlements.check_add_project(
+                len(projects), db_paths=_known_project_dbs(projects)
+            )
+            if not verdict.allowed:
+                raise ProjectEntitlementError(verdict.reason, verdict.code)
 
         now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
         project = ProjectMeta(

--- a/routers/bins.py
+++ b/routers/bins.py
@@ -190,6 +190,11 @@ def add_bin_items(bin_id: str, body: BinAddItems, _tok: dict = Depends(require_s
     ]
     try:
         b = bins_store.add_items(bin_id, payload)
+    except bins_store.BinEntitlementError as exc:
+        # Before the generic BinsError arm — it is a subclass, so order decides.
+        raise HTTPException(
+            status_code=403, detail={"code": exc.code, "message": str(exc)}
+        )
     except bins_store.BinsError as exc:
         code = 404 if "not found" in str(exc) else 400
         raise HTTPException(status_code=code, detail=str(exc))

--- a/routers/misc.py
+++ b/routers/misc.py
@@ -194,6 +194,36 @@ def api_version():
     return {"version": config.VERSION}
 
 
+@router.get("/api/entitlements")
+def api_entitlements(_tok: dict = Depends(require_scopes("projects_read"))):
+    """What this installation is allowed to do, in one probe.
+
+    Lives with /api/version rather than under /api/projects: it describes the
+    build and its licence, and the projects router owns the /api/projects group
+    (a route-ownership invariant the R5-25 split pinned with a test).
+
+    The UI needs the tier in order to label the Pro features honestly, and it
+    must read it from the code that ENFORCES the tier rather than keeping a
+    second copy of the rules in the frontend. Two copies drift, and the way that
+    drift shows up is a user being promised one thing and refused another.
+
+    Imported lazily: the registry drags the health/probe chain, and misc.py is
+    also the module serving the unauthenticated /api/health and /api/version.
+
+    A registry it cannot read degrades to zero projects rather than 500 — this
+    endpoint answers "what may I do", and a broken registry file is a separate
+    problem that GET /api/projects already reports properly.
+    """
+    import entitlements
+    import projects as project_registry
+
+    try:
+        used = len(project_registry.list_registry_projects())
+    except project_registry.RegistryError:
+        used = 0
+    return entitlements.status(used, db_paths=project_registry.known_project_dbs())
+
+
 @router.get("/api/health")
 def api_health():
     """Unauthenticated self-diagnostic — a user (or support) curls this ONE URL to

--- a/routers/projects.py
+++ b/routers/projects.py
@@ -90,6 +90,11 @@ def add_project(
         raise HTTPException(status_code=409, detail="project name already exists: {0}".format(body.name))
     try:
         project = project_registry.add_project(body.name, body.path, body.tags or [])
+    except project_registry.ProjectEntitlementError as exc:
+        # Before the generic RegistryError arm — it is a subclass, so order decides.
+        raise HTTPException(
+            status_code=403, detail={"code": exc.code, "message": str(exc)}
+        )
     except project_registry.RegistryError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
     return project.to_dict()

--- a/routers/search.py
+++ b/routers/search.py
@@ -20,6 +20,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 import db
+import entitlements
 import federation
 import projects as project_registry
 from auth import require_scopes
@@ -53,6 +54,20 @@ def search_all(
     no_fallback_sql: bool = False,
     _tok: dict = Depends(require_scopes("videos_read")),
 ):
+    # Cross-project aggregation is a Pro feature (docs/pro-addon-license.md).
+    # Refused BEFORE the fan-out, not by filtering results afterwards: a search
+    # that quietly returns only the current project would be the same lie as a
+    # control that goes grey without saying why, and the caller could not tell a
+    # licensing refusal from "no matches in your other projects".
+    verdict = entitlements.check_cross_project(
+        db_paths=project_registry.known_project_dbs()
+    )
+    if not verdict.allowed:
+        raise HTTPException(
+            status_code=403,
+            detail={"code": verdict.code, "message": verdict.reason},
+        )
+
     try:
         payload = federation.search_all_projects(
             q,

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -1,0 +1,344 @@
+"""Free-tier cap, grandfathering, and Pro entitlement.
+
+These assert the PROMISE, not the implementation: the published terms say the
+allowance applies to new installations from a future release onward and that
+libraries already in use keep unlimited projects permanently. Every test below
+is a way that promise can be broken silently.
+
+The gate is inert until `config.VERSION` reaches `CAP_VERSION`, so the armed
+cases pin `config.VERSION` explicitly rather than inheriting whatever the
+current build says. A test that only passed because the cap happened to be
+switched off would be worse than no test — it would go green for the whole
+pre-1.1.0 window and then start failing on the release that matters most.
+"""
+import importlib
+import json
+import sqlite3
+
+import pytest
+
+import config
+import entitlements
+
+
+ARMED = entitlements.CAP_VERSION       # 1.1.0 — the cap is in force
+PRE_CAP = "1.0.0"                      # a build (and a library) from before it
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_pro_license(tmp_path, monkeypatch):
+    """Never let the developer's real ~/.arkiv/pro-license.json decide a test.
+
+    Without this every assertion about the free tier would silently invert on a
+    machine that happens to own a licence — passing for the wrong reason on the
+    maintainer's box and failing only in CI, or vice versa.
+    """
+    monkeypatch.setenv("ARKIV_PRO_LICENSE", str(tmp_path / "absent" / "pro-license.json"))
+
+
+def _library(path, version):
+    """A real SQLite library stamped with `version` (None = no anchor row)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute(
+            "CREATE TABLE library_meta (key TEXT PRIMARY KEY, value TEXT, "
+            "created_at TEXT NOT NULL DEFAULT (datetime('now')))"
+        )
+        if version is not None:
+            conn.execute(
+                "INSERT INTO library_meta (key, value) VALUES ('first_seen_version', ?)",
+                (version,),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+# ── version comparison ────────────────────────────────────────────────────────
+
+def test_versions_order_numerically_not_lexically():
+    # "1.10.0" < "1.9.0" is TRUE as strings and false in fact. A string compare
+    # here would hand the exemption to every user on a double-digit minor.
+    assert entitlements.parse_version("1.10.0") > entitlements.parse_version("1.9.0")
+    assert entitlements.parse_version("1.1") == entitlements.parse_version("1.1.0")
+
+
+def test_unreadable_version_strings_are_exempt_not_capped():
+    # The direction matters more than the parsing: "we cannot tell" must never
+    # come out as "capped", or the longest-standing users lose their exemption.
+    for unknown in (None, "", "   ", "garbage", "v1.2.3", "1.x.0"):
+        assert entitlements.predates_cap(unknown) is True
+
+
+def test_cap_boundary_is_the_cap_version_itself():
+    assert entitlements.predates_cap("1.0.9") is True
+    assert entitlements.predates_cap(entitlements.CAP_VERSION) is False
+    assert entitlements.predates_cap("1.2.0") is False
+    # Suffixed builds reduce to their numeric core rather than falling into the
+    # unknown bucket — a dated library is evidence even when the tag is messy.
+    assert entitlements.predates_cap("1.1.0-rc1") is False
+    assert entitlements.predates_cap("1.0.0+win") is True
+
+
+# ── reading the anchor ────────────────────────────────────────────────────────
+
+def test_probing_a_library_never_creates_it(tmp_path):
+    """A licensing question must not write to the thing it inspects."""
+    missing = tmp_path / "never" / "project.db"
+    assert entitlements.read_library_origin(missing) is None
+    assert not missing.exists()
+    assert not missing.parent.exists()
+
+    # And an existing library must not gain -wal / -shm side files from a probe.
+    live = _library(tmp_path / "live" / "project.db", PRE_CAP)
+    entitlements.read_library_origin(live)
+    siblings = {p.name for p in live.parent.iterdir()}
+    assert siblings == {"project.db"}
+
+
+def test_reads_the_recorded_version(tmp_path):
+    live = _library(tmp_path / "a" / "project.db", "0.12.1")
+    assert entitlements.read_library_origin(live) == "0.12.1"
+
+
+def test_library_without_an_anchor_row_reads_as_unknown(tmp_path):
+    live = _library(tmp_path / "b" / "project.db", None)
+    assert entitlements.read_library_origin(live) is None
+
+
+# ── the machine-level grandfather question ────────────────────────────────────
+
+def test_old_library_grandfathers_the_whole_install(tmp_path):
+    old = _library(tmp_path / "old" / "project.db", PRE_CAP)
+    new = _library(tmp_path / "new" / "project.db", ARMED)
+    assert entitlements.install_is_grandfathered([old, new]) is True
+
+
+def test_install_with_only_new_libraries_is_not_grandfathered(tmp_path):
+    new = _library(tmp_path / "new" / "project.db", ARMED)
+    assert entitlements.install_is_grandfathered([new]) is False
+
+
+def test_install_with_no_libraries_is_not_grandfathered():
+    # A genuinely fresh install: no evidence of prior use. Safe to read as new
+    # because it has zero projects, so the cap cannot bite it today anyway.
+    assert entitlements.install_is_grandfathered([]) is False
+
+
+def test_unreadable_library_counts_as_old(tmp_path):
+    # A file that exists but is not a usable SQLite DB (a stub, a truncated
+    # copy, a permissions failure) is not evidence that the install is new.
+    stub = tmp_path / "stub" / "project.db"
+    stub.parent.mkdir(parents=True)
+    stub.write_text("not a database", encoding="utf-8")
+    assert entitlements.install_is_grandfathered([stub]) is True
+
+
+def test_missing_library_does_not_manufacture_an_exemption(tmp_path):
+    """The unmounted-NAS case.
+
+    A registry entry whose project.db is absent must not read as exempt, or the
+    tier would flip on a bad-mount day and back again the next — and an install
+    could earn permanent unlimited projects by registering a path that never
+    existed.
+    """
+    assert entitlements.install_is_grandfathered([tmp_path / "gone" / "project.db"]) is False
+
+
+# ── the rule's own start date ─────────────────────────────────────────────────
+
+def test_cap_does_not_bite_on_builds_that_predate_it(monkeypatch, tmp_path):
+    """The published terms say "from a future release onward".
+
+    The failing shape this guards: an install that registered several project
+    roots but never ingested into them has NO project.db anywhere, so nothing
+    reads as grandfathered — and without an explicit start-date check a 1.0.0
+    build would refuse the fourth project even though 1.0.0 promised no limit.
+    """
+    monkeypatch.setattr(config, "VERSION", PRE_CAP)
+    verdict = entitlements.check_add_project(99, db_paths=[])
+    assert verdict.allowed is True
+    assert verdict.code == "cap_inactive"
+    assert entitlements.check_cross_project(db_paths=[]).allowed is True
+
+
+def test_cap_bites_once_the_shipping_version_reaches_it(monkeypatch):
+    monkeypatch.setattr(config, "VERSION", ARMED)
+    assert entitlements.check_add_project(2, db_paths=[]).allowed is True
+    refused = entitlements.check_add_project(3, db_paths=[])
+    assert refused.allowed is False
+    assert refused.code == "project_limit"
+    # The refusal has to name the limit and the way out — a message that only
+    # says "not allowed" leaves the user with nothing to do (PR #315).
+    assert "3" in refused.reason and "Pro" in refused.reason
+
+
+def test_grandfathered_install_keeps_everything_when_armed(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "VERSION", ARMED)
+    old = _library(tmp_path / "old" / "project.db", PRE_CAP)
+    assert entitlements.check_add_project(99, db_paths=[old]).code == "grandfathered"
+    assert entitlements.check_cross_project(db_paths=[old]).allowed is True
+
+
+# ── Pro entitlement ───────────────────────────────────────────────────────────
+
+def test_licence_file_unlocks_both_features(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "VERSION", ARMED)
+    licence = tmp_path / "pro-license.json"
+    licence.write_text(
+        json.dumps({"licensee": "Studio A", "key": "ARKIV-PRO-0001"}), encoding="utf-8"
+    )
+    monkeypatch.setenv("ARKIV_PRO_LICENSE", str(licence))
+    assert entitlements.has_pro() is True
+    assert entitlements.check_add_project(99, db_paths=[]).code == "pro"
+    assert entitlements.check_cross_project(db_paths=[]).allowed is True
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "{not json",                       # corrupt
+        json.dumps([1, 2, 3]),             # right file, wrong shape
+        json.dumps({"licensee": "Studio"}),  # named but keyless
+        json.dumps({"key": "ARKIV-PRO-1"}),  # keyed but nameless
+        json.dumps({"licensee": " ", "key": " "}),  # whitespace is not a name
+    ],
+)
+def test_unusable_licence_file_does_not_unlock(monkeypatch, tmp_path, payload):
+    licence = tmp_path / "pro-license.json"
+    licence.write_text(payload, encoding="utf-8")
+    monkeypatch.setenv("ARKIV_PRO_LICENSE", str(licence))
+    assert entitlements.has_pro() is False
+
+
+def test_status_reports_whether_the_gate_is_even_armed(monkeypatch):
+    monkeypatch.setattr(config, "VERSION", PRE_CAP)
+    assert entitlements.status(0, db_paths=[])["armed"] is False
+    monkeypatch.setattr(config, "VERSION", ARMED)
+    armed = entitlements.status(0, db_paths=[])
+    assert armed["armed"] is True
+    assert armed["free_project_limit"] == entitlements.FREE_PROJECT_LIMIT
+    assert armed["cap_version"] == entitlements.CAP_VERSION
+
+
+# ── through the registry ──────────────────────────────────────────────────────
+
+def _fresh_project(tmp_path, name, version=ARMED):
+    root = tmp_path / name
+    _library(root / ".arkiv" / "project.db", version)
+    return root
+
+
+def test_registry_refuses_the_fourth_project_when_armed(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARKIV_PROJECTS_REGISTRY", str(tmp_path / "registry.json"))
+    monkeypatch.delenv("ARKIV_PROJECT_ROOTS", raising=False)
+    monkeypatch.setattr(config, "VERSION", ARMED)
+    projects = importlib.import_module("projects")
+
+    for index in range(entitlements.FREE_PROJECT_LIMIT):
+        name = "p{0}".format(index)
+        projects.add_project(name, str(_fresh_project(tmp_path, name)))
+
+    with pytest.raises(projects.ProjectEntitlementError) as excinfo:
+        projects.add_project("p3", str(_fresh_project(tmp_path, "p3")))
+    assert excinfo.value.code == "project_limit"
+    # Still a RegistryError, so every existing handler keeps working.
+    assert isinstance(excinfo.value, projects.RegistryError)
+
+
+def test_re_registering_an_existing_name_at_the_cap_is_not_refused(tmp_path, monkeypatch):
+    """Renaming/relocating a project you already own is not "one more project".
+
+    Gating the replace path too would leave a capped user unable to fix a moved
+    library — a restriction the terms never claimed and the user cannot escape.
+    """
+    monkeypatch.setenv("ARKIV_PROJECTS_REGISTRY", str(tmp_path / "registry.json"))
+    monkeypatch.delenv("ARKIV_PROJECT_ROOTS", raising=False)
+    monkeypatch.setattr(config, "VERSION", ARMED)
+    projects = importlib.import_module("projects")
+
+    for index in range(entitlements.FREE_PROJECT_LIMIT):
+        name = "p{0}".format(index)
+        projects.add_project(name, str(_fresh_project(tmp_path, name)))
+
+    moved = _fresh_project(tmp_path, "p0-moved")
+    replaced = projects.add_project("p0", str(moved))
+    assert replaced.path == moved
+    assert len(projects.list_registry_projects()) == entitlements.FREE_PROJECT_LIMIT
+
+
+def test_an_old_library_lifts_the_registry_cap(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARKIV_PROJECTS_REGISTRY", str(tmp_path / "registry.json"))
+    monkeypatch.delenv("ARKIV_PROJECT_ROOTS", raising=False)
+    monkeypatch.setattr(config, "VERSION", ARMED)
+    projects = importlib.import_module("projects")
+
+    projects.add_project("legacy", str(_fresh_project(tmp_path, "legacy", PRE_CAP)))
+    for index in range(entitlements.FREE_PROJECT_LIMIT + 2):
+        name = "n{0}".format(index)
+        projects.add_project(name, str(_fresh_project(tmp_path, name)))
+
+    assert len(projects.list_registry_projects()) == entitlements.FREE_PROJECT_LIMIT + 3
+
+
+# ── through the bins store ────────────────────────────────────────────────────
+
+def test_widening_a_bin_to_a_second_project_needs_entitlement(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARKIV_BINS_PATH", str(tmp_path / "bins.json"))
+    monkeypatch.setenv("ARKIV_PROJECTS_REGISTRY", str(tmp_path / "registry.json"))
+    monkeypatch.delenv("ARKIV_PROJECT_ROOTS", raising=False)
+    monkeypatch.setattr(config, "VERSION", ARMED)
+    bins = importlib.import_module("bins")
+
+    created = bins.create_bin("cut-01")
+    bins.add_items(created.id, [{"project_name": "alpha", "media_id": "1"}])
+
+    # Same project again: still a single-project bin, still free.
+    bins.add_items(created.id, [{"project_name": "alpha", "media_id": "2"}])
+
+    with pytest.raises(bins.BinEntitlementError) as excinfo:
+        bins.add_items(created.id, [{"project_name": "beta", "media_id": "9"}])
+    assert excinfo.value.code == "cross_project"
+    assert isinstance(excinfo.value, bins.BinsError)
+
+    # The refusal must not have half-applied: a partially widened bin would be
+    # the worst outcome, since the user was told it failed.
+    after = bins.get_bin(created.id)
+    assert {item.project_name for item in after.items} == {"alpha"}
+
+
+def test_a_bin_that_already_spans_projects_stays_usable(tmp_path, monkeypatch):
+    """Existing cross-project data is not retroactively frozen.
+
+    A bin built while the install was entitled (or before the cap existed) must
+    keep accepting items from the projects it already holds — revoking that
+    would break data the user already has, which is exactly what the
+    grandfather promise exists to prevent.
+    """
+    monkeypatch.setenv("ARKIV_BINS_PATH", str(tmp_path / "bins.json"))
+    monkeypatch.setenv("ARKIV_PROJECTS_REGISTRY", str(tmp_path / "registry.json"))
+    monkeypatch.delenv("ARKIV_PROJECT_ROOTS", raising=False)
+    bins = importlib.import_module("bins")
+
+    # Built while unarmed (pre-cap build), spanning two projects.
+    monkeypatch.setattr(config, "VERSION", PRE_CAP)
+    created = bins.create_bin("legacy-cut")
+    bins.add_items(
+        created.id,
+        [
+            {"project_name": "alpha", "media_id": "1"},
+            {"project_name": "beta", "media_id": "2"},
+        ],
+    )
+
+    # Now armed and unentitled: adding within the existing project set is fine.
+    monkeypatch.setattr(config, "VERSION", ARMED)
+    bins.add_items(created.id, [{"project_name": "beta", "media_id": "3"}])
+    after = bins.get_bin(created.id)
+    assert len(after.items) == 3
+
+    # ...but widening it to a THIRD project is still a new aggregation.
+    with pytest.raises(bins.BinEntitlementError):
+        bins.add_items(created.id, [{"project_name": "gamma", "media_id": "4"}])

--- a/tests/test_r5_25_router_misc.py
+++ b/tests/test_r5_25_router_misc.py
@@ -35,11 +35,12 @@ def test_router_owns_misc_routes_and_helpers():
         ("/api/open-file", "POST"),
         ("/api/client-log", "POST"),
         ("/api/version", "GET"),
+        ("/api/entitlements", "GET"),
         ("/api/health", "GET"),
         ("/api/logs/tail", "GET"),
     }
     for name in ("stream_media", "embed_rebuild", "open_file", "client_log",
-                 "api_version", "api_health", "logs_tail",
+                 "api_version", "api_entitlements", "api_health", "logs_tail",
                  "_log_safe", "OpenFileRequest", "ClientLogRequest"):
         assert hasattr(rm, name)
 


### PR DESCRIPTION
產品頁與 `docs/pro-addon-license.md` 早就寫了分層，但 code 裡**零 gate** —— 專案數與跨專案聚合對所有人全開，等於每個使用者都在用 Pro 功能。PR #324 只種了錨點（`library_meta.first_seen_version`），判定本身沒寫。這支補上判定。

## 三處 gate，一個 choke-point

新增 `entitlements.py`（三處各寫 `if` 會腐化，見 `mediatypes.py` 同一課）：

| 落點 | 行為 |
|---|---|
| `projects.add_project()` | 專案數上限 3。**只擋真的會讓數量增加的路徑** —— 改名/搬遷走「取代既有名稱」分支、數量不變、不擋 |
| `/api/search/all` | **在 fan-out 之前**擋，不是做完再濾結果 |
| `bins.add_items()` | 只擋「把 bin 擴張到**新**專案」，已在 bin 內專案的追加照常 |

擋在 fan-out 之前是因為：只回當前專案的搜尋，跟「其他專案沒有命中」在畫面上完全同形。而 bins 只擋擴張，是因為回頭凍結已經跨專案的 bin 正是 grandfather 要防的事。

## 過程中發現一個會提前生效的 bug

grandfather 機器回答的是「這個安裝夠老嗎」，但**沒有任何東西回答「規則生效了沒」**。

一個註冊了 3 個尚未 ingest 的專案的使用者：沒有任何 `project.db` → 沒有錨點 → 不算 grandfathered → **1.0.0 的 build 會擋掉他的第 4 個**，而 1.0.0 承諾的是完全不限。

修法是 `cap_is_active()`：早於 `CAP_VERSION` 的 build 一律不執行。連帶語意——**merge 不等於生效**，生效發生在把 `config.VERSION` 設成 1.1.0 的那一版。`status()` 回報 `armed` 讓這件事可見，否則「允許」與「有權限」在 API 上長得一模一樣。

## 拍板（Hevin 2026-08-19）

- `CAP_VERSION = 1.1.0`
- entitlement **雙路**：`import arkiv_pro` 或 `~/.arkiv/pro-license.json`，任一成立即解鎖

## 貫穿全檔的硬規則：任何不確定一律 fail-open

錨點缺失、DB 讀不到、registry 壞掉、版本字串壞掉 —— 都代表「無法證明這個安裝是新的」，唯一可接受的錯法是錯在使用者這邊。反向會把豁免從**持有最久**的人身上收走，那正是已公開承諾禁止的結果。

唯一例外：**registry 指向不存在的 DB 不算豁免**。未掛載的 NAS 不該憑空製造永久豁免，否則分層會隨掛載狀態每天翻面。

另：授權查詢不得寫入被查的東西 —— `read_library_origin` 走 `mode=ro` URI，測試斷言探測**不建檔、也不留 `-wal`/`-shm`**。

## API 契約

403 + `{code, message}`。`ProjectEntitlementError` / `BinEntitlementError` 各自是既有錯誤型別的**子類**（既有 handler 全部照常運作），router 的 `except` 順序決定分派。

前端 `ApiError` 同步改成讀 `detail.message` 而非 `JSON.stringify` —— 不然拒絕訊息會以原始 JSON 出現在 toast 裡，比沒有更糟（PR #315 那條課）。`code` 保留在 `err.code` 供程式分支，不必比對本地化句子。

## Mutation-check：五處各自變紅，且紅的都是該紅的那一條

| 突變 | 變紅的測試 |
|---|---|
| 拿掉 arming 短路 | `cap_does_not_bite_on_builds_that_predate_it` |
| 未知版本改判不豁免 | `unreadable_version_strings_are_exempt_not_capped` |
| 拿掉檔案存在守衛 | `missing_library_does_not_manufacture_an_exemption` |
| 改名/搬遷也吃 gate | `re_registering_an_existing_name_at_the_cap_is_not_refused` |
| bins 擋掉所有加入 | `a_bin_that_already_spans_projects_stays_usable` |

前端折疊那條同樣驗過（23/1 → 還原 24/0）。

## 其他

- `/api/entitlements` 放在 misc router 而非 projects router —— R5-25 的路由歸屬測試擋下了原本的放法，**那個守衛是對的**（它描述的是 build 與授權，跟 `/api/version` 同群）。ownership 測試同步更新。
- 文案：產品頁與 pro-addon-license 的「未來某一版」換成實際的 **1.1.0**（todo 明列的動作），並把英文條款的 grandfather 從「保留專案數」改成**兩項功能都保留** —— 中文頁的「新安裝不含」本來就是這個承諾，英文只寫了一半，而 code 依中文頁實作。

## 驗證

pytest **1338 passed / 7 skipped**、svelte-check **0 error 0 warning**、frontend build 通過、eager bundle 418KB/493KB 皆在預算內、node:test **24 pass**。

⚠️ **這支 merge 後 gate 仍不會咬人** —— 要等把 `config.VERSION` 收成 1.1.0 的那支發版 PR。這是刻意的（生效邊界是對外承諾的版號，不是 merge 時間），但別誤判成已經上線。

🤖 Generated with [Claude Code](https://claude.com/claude-code)