### PR TITLE
release(v1.1.0): 免費額度從「寫在頁面上」變成「軟體真的在執行」

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,72 @@
 
 ## Unreleased
 
+## v1.1.0 - 2026-08-19
+
+**The free allowance the product page has described for months now exists in the software.**
+
+Every build up to and including 1.0.0 shipped with the tier table published and *nothing
+enforcing it* — `project_limit`, `entitlement` and `is_pro` had zero hits across the whole
+repository. v1.0.0's own notes said it plainly ("no shipped build caps anything"), so this is
+not a regression being fixed; it is the other half of a design finally arriving. Until now
+every user was running the Pro feature set.
+
+**If you already use arkiv, nothing changes for you — permanently.** The allowance applies to
+installations that begin with 1.1.0 or later. An installation already in use before this
+release keeps *both* Pro features, unlimited projects and cross-project aggregation, forever.
+That is not a grace period and not a setting: 1.0.0 recorded the version each library was first
+seen under (`library_meta.first_seen_version`), specifically so this could be honoured from a
+record instead of guessed at afterwards. A build older than 1.1.0 does not enforce the
+allowance at all.
+
+**The add-on is still not on sale.** The tier is now enforced, but the Pro component and a
+payment path do not exist yet, so a new installation that reaches three projects cannot
+currently buy its way past it. The refusal points at the published terms, which state their own
+availability. If that limit is in your way today, say so — the grandfathering rule is generous
+by design and the terms have a public-interest route.
+
+### Added
+- **Free tier: 3 projects, no cross-project aggregation — enforced.** A single decision point
+  (`entitlements.py`) answers every "is this allowed?" question, rather than three independent
+  `if`s that would drift apart the way the extension sets did before `mediatypes.py`. Three
+  enforcement points, each with a deliberate choice about *where* to stop:
+  - `projects.add_project()` — only the path that actually grows the registry. Re-registering
+    an existing name (a rename, or a library that moved) leaves the count unchanged and is not
+    refused; gating it would leave someone at the limit unable to repair a project they already
+    own, which the terms never claimed.
+  - `GET /api/search/all` — refused *before* the fan-out, not by filtering results afterwards.
+    A federated search that quietly returned only the current project would be indistinguishable
+    on screen from "your other projects had no matches".
+  - `bins.add_items()` — refuses only the operation that widens a collection to a *new* project.
+    Adding to a project the collection already contains stays available, so existing
+    cross-project collections are never retroactively frozen.
+- **`GET /api/entitlements`** — the tier, in one probe, from the code that enforces it. Reports
+  `armed` explicitly, because "allowed" and "entitled" are otherwise indistinguishable through
+  the API, and that is exactly how a shipped-but-inert gate goes unnoticed.
+- **Pro entitlement detection**, two independent routes, either sufficient: the closed-source
+  `arkiv_pro` component being importable, or `~/.arkiv/pro-license.json` naming a licensee and a
+  key. Unsigned and unobfuscated on purpose — the licence is enforced by its terms, not by the
+  database, and the anchor row has always been trivially editable.
+
+### Fixed
+- **The cap would have taken effect one release early for a specific user.** The grandfathering
+  machinery answers "has this installation been in use for a while?", but nothing answered "is
+  the rule in force yet?". An installation that had registered several project roots without
+  ingesting into them owns no `project.db`, therefore no version anchor, therefore reads as new
+  — and a 1.0.0 build would have refused its fourth project even though 1.0.0 promised no limit
+  at all. Builds older than the allowance now decline to enforce it regardless of what the
+  registry looks like.
+- **Refusals reached the UI as raw JSON.** The new 403s carry a structured `{code, message}`
+  detail — the first endpoint to do so — and the client folded any non-string detail through
+  `JSON.stringify`, putting braces and quotes in a toast where a sentence belonged. The client
+  now shows the message and keeps the code on the error for callers to branch on.
+
+### Changed
+- Product page and `docs/pro-addon-license.md` state 1.1.0 as the boundary instead of "a future
+  release", and the English terms now spell out that a grandfathered installation keeps **both**
+  features. The Chinese page had always promised that ("新安裝不含"); the English had only
+  spelled it out for the project count, and the code follows the stronger reading.
+
 ## v1.0.0 - 2026-08-18
 
 **1.0 because the product now has a front door, and the licence finally says one thing.**

--- a/config.py
+++ b/config.py
@@ -10,7 +10,7 @@ BASE_DIR = Path(__file__).parent
 # Backend product version. Keep in sync with the release tag + frontend
 # version.js at release time. Served by GET /api/version and included in
 # GET /api/health so a user/support can identify the build.
-VERSION = "1.0.0"
+VERSION = "1.1.0"
 
 # Codex Round-2 audit (J3): without bounds, ARKIV_PROXIES_DIR=/etc would have
 # arkiv write generated proxy mp4 files into /etc on every HEVC ingest. Same

--- a/docs/index.html
+++ b/docs/index.html
@@ -257,16 +257,16 @@ footer a:hover{color:var(--cyan)}
       <tbody>
         <tr><td>全部索引與搜尋功能</td><td><b>✓</b></td><td><b>✓</b></td></tr>
         <tr><td>商業使用</td><td><b>✓</b></td><td><b>✓</b></td></tr>
-        <tr><td>專案數</td><td><b>目前不限</b><br><span class="future">1.1.0 起，新安裝為 3 個</span></td><td><b>無限</b></td></tr>
-        <tr><td>跨專案聚合搜尋</td><td><b>目前開放</b><br><span class="future">1.1.0 起，新安裝不含</span></td><td><b>✓</b></td></tr>
+        <tr><td>專案數</td><td><b>3 個</b><br><span class="future">1.1.0 前已在使用的安裝：不限</span></td><td><b>無限</b></td></tr>
+        <tr><td>跨專案聚合搜尋</td><td><b>—</b><br><span class="future">1.1.0 前已在使用的安裝：保留</span></td><td><b>✓</b></td></tr>
         <tr><td>價格</td><td><b>NT$0</b></td><td><b>NT$3,000</b> 一次買斷</td></tr>
       </tbody>
     </table>
     <p class="tier-note">
-      <b style="color:var(--ink)">目前版本（1.0.0）不設任何限制</b> —— 上表 Pro 欄的兩項功能，現在所有使用者都可使用。
-      免費額度自 <b style="color:var(--ink)">1.1.0</b> 起對<b style="color:var(--ink)">新安裝</b>生效；
-      <b style="color:var(--ink)">在該版之前已在使用的素材庫，永久保留現有的無限制狀態</b>，這項承諾已寫入軟體：
-      素材庫會在初次建立時記錄版本，作為日後判定的依據。
+      免費額度自 <b style="color:var(--ink)">1.1.0</b>（本版）起生效，<b style="color:var(--ink)">只對新安裝</b>。
+      <b style="color:var(--ink)">在 1.1.0 之前已在使用的安裝，永久保留兩項功能 —— 無限專案數與跨專案聚合</b>，
+      這項承諾已寫入軟體：素材庫在初次使用時就記錄了版本，判定依該紀錄而非事後推測。
+      1.0.0 及更早的版本完全不執行此額度。
       <br>Pro 尚未開放購買 ——
       <a href="https://github.com/vulture-s/arkiv/blob/main/docs/pro-addon-license.md">條款先公開</a>，
       供事前查閱。紀錄片、非營利、檔案保存與公共教育類製作，

--- a/docs/pro-addon-license.md
+++ b/docs/pro-addon-license.md
@@ -30,16 +30,14 @@ things the free core does not provide:
 | Projects | Up to 3 | Unlimited |
 | Cross-project aggregation (search and collections spanning projects) | — | ✅ |
 
-> **Current builds impose neither limit.** No shipped version of arkiv up to and
-> including 1.0.0 caps projects or withholds cross-project aggregation; the
-> table describes the intended tiers, not today's behaviour. The free allowance
-> applies to **new installations** from **release 1.1.0** onward. **An
-> installation already in use before 1.1.0 keeps BOTH — unlimited projects and
-> cross-project aggregation — permanently**, not merely the project count. The
-> software records the version a library was first seen under
-> (`library_meta.first_seen_version`) so this can be honoured rather than
-> guessed at, and a build older than 1.1.0 does not enforce the allowance at
-> all.
+> **In effect from release 1.1.0.** No shipped version up to and including 1.0.0
+> capped projects or withheld cross-project aggregation, and those builds do not
+> enforce the allowance at all. From 1.1.0 the free allowance applies to **new
+> installations**. **An installation already in use before 1.1.0 keeps BOTH —
+> unlimited projects and cross-project aggregation — permanently**, not merely
+> the project count. The software records the version a library was first seen
+> under (`library_meta.first_seen_version`) so this is honoured from the record
+> rather than guessed at after the fact.
 
 The add-on is **not** covered by the PolyForm Perimeter License. It is
 distributed under the terms on this page.
@@ -182,12 +180,12 @@ arkiv 本體（ingest、轉錄、視覺標註、語意搜尋、chat、NLE／DIT 
 | 專案數 | 最多 3 個 | 無限 |
 | 跨專案聚合（跨專案搜尋與精選集） | — | ✅ |
 
-> **現行版本兩項限制均未實施。** 截至 1.0.0 為止已發布的任何版本都不限制專案數，
-> 亦未保留跨專案聚合功能；上表描述的是規劃中的方案分層，而非現況。
-> 免費額度自 **1.1.0** 起對**新安裝**生效；**在 1.1.0 之前已在使用的安裝，
+> **自 1.1.0 起實施。** 截至 1.0.0 為止已發布的任何版本都不限制專案數、
+> 亦未保留跨專案聚合功能，且那些版本完全不執行此額度。
+> 自 1.1.0 起，免費額度對**新安裝**生效；**在 1.1.0 之前已在使用的安裝，
 > 永久保留兩項功能 —— 無限專案數與跨專案聚合**，不限於專案數一項。
 > 軟體會記錄素材庫初次使用時的版本（`library_meta.first_seen_version`），
-> 使此一承諾得以查證而非事後推測；且早於 1.1.0 的版本完全不執行此額度。
+> 此一承諾依該紀錄履行，而非事後推測。
 
 附加元件**不在** PolyForm Perimeter 授權範圍內，依本頁條款授權。
 

--- a/entitlements.py
+++ b/entitlements.py
@@ -355,9 +355,16 @@ def check_add_project(existing_count, db_paths=None, pro=None, grandfathered=Non
     return Verdict(
         False,
         "project_limit",
+        # Points at the terms rather than asserting the add-on can be bought:
+        # as of 1.1.0 it is not on sale yet, and a refusal that tells someone to
+        # go and buy something that does not exist is a dead end wearing the
+        # costume of a next step. The terms page states its own availability, so
+        # this sentence stays true both before and after it ships.
         "The free tier allows {0} projects and this installation already has "
-        "{1}. Remove a project, or license the Pro add-on for unlimited "
-        "projects.".format(FREE_PROJECT_LIMIT, existing_count),
+        "{1}. Remove a project, or see the Pro add-on terms "
+        "(docs/pro-addon-license.md) for unlimited projects.".format(
+            FREE_PROJECT_LIMIT, existing_count
+        ),
     )
 
 

--- a/frontend/src/lib/version.js
+++ b/frontend/src/lib/version.js
@@ -2,4 +2,4 @@
 // The label had drifted to a stale v0.9.2 across a dozen files while the app
 // shipped v0.10.0, because every route hardcoded its own copy — importing this
 // const keeps the version from going stale per-file again.
-export const VERSION = 'v1.0.0'
+export const VERSION = 'v1.1.0'

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arkiv"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arkiv"
-version = "1.0.0"
+version = "1.1.0"
 description = "arkiv — Local Media Asset Manager"
 authors = ["Hevin Yeh"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui-org/nicegui/main/tauri/src-tauri/tauri.conf.json",
   "productName": "arkiv",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "identifier": "com.hevin.arkiv",
   "build": {
     "devUrl": "http://localhost:8501",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,30 @@ _install_fake_modules()
 
 
 @pytest.fixture
+def pro_entitled(tmp_path, monkeypatch):
+    """Run a test as an installation that owns the Pro add-on.
+
+    For tests whose SUBJECT is a cross-project feature — federated search path
+    sanitisation, bin dedup/copy across projects — rather than the licence gate
+    itself. Post-1.1.0 those features need entitlement, so without this the test
+    would be asserting on a 403 and quietly stop covering the thing it was
+    written for.
+
+    Deliberately opt-in per test rather than autouse. An autouse version would
+    switch the gate off for the whole suite, and the next regression that
+    wrongly opened a Pro feature to the free tier would go green — the exact
+    failure mode this fixture exists to avoid creating. `tests/
+    test_entitlements.py` does NOT use it and keeps asserting the refusals.
+    """
+    licence = tmp_path / "pro-license.json"
+    licence.write_text(
+        json.dumps({"licensee": "test suite", "key": "TEST-PRO"}), encoding="utf-8"
+    )
+    monkeypatch.setenv("ARKIV_PRO_LICENSE", str(licence))
+    return licence
+
+
+@pytest.fixture
 def tmp_db(tmp_path, monkeypatch):
     config = importlib.import_module("config")
     db = importlib.import_module("db")

--- a/tests/test_bin_copy.py
+++ b/tests/test_bin_copy.py
@@ -94,7 +94,7 @@ def test_copy_skips_index_when_ingest_slot_busy(fastapi_client, tmp_path, monkey
     server._release_ingest_slot()
 
 
-def test_copy_reference_gates_unreachable_and_registers_new(fastapi_client, tmp_path, monkeypatch):
+def test_copy_reference_gates_unreachable_and_registers_new(fastapi_client, tmp_path, monkeypatch, pro_entitled):
     bins = _setup(tmp_path, monkeypatch)
     calls = _stub_ingest(monkeypatch)
 
@@ -179,7 +179,7 @@ def test_copy_mode_copies_verified_bytes_and_keeps_source(fastapi_client, tmp_pa
     assert str(copied) in calls[0]["cmd"]
 
 
-def test_copy_same_basename_never_clobbers(fastapi_client, tmp_path, monkeypatch):
+def test_copy_same_basename_never_clobbers(fastapi_client, tmp_path, monkeypatch, pro_entitled):
     """fable-audit 2026-07-12 CRITICAL #3: two clips sharing a basename (C0001.MP4
     from two different source projects) must both survive the copy — the second must
     NOT os.replace over the first. Pre-fix, verified-copy reported `copied: 2` while

--- a/tests/test_bins.py
+++ b/tests/test_bins.py
@@ -59,7 +59,7 @@ def test_bin_crud_round_trip(tmp_path, monkeypatch):
     assert bins.list_bins() == []
 
 
-def test_add_items_dedupes_and_preserves_order(tmp_path, monkeypatch):
+def test_add_items_dedupes_and_preserves_order(tmp_path, monkeypatch, pro_entitled):
     bins = _fresh_bins(tmp_path, monkeypatch)
     b = bins.create_bin("selection")
     bins.add_items(b.id, [

--- a/tests/test_search_all_path_leak.py
+++ b/tests/test_search_all_path_leak.py
@@ -46,7 +46,7 @@ def _leaky_payload(*args, **kwargs):
     }
 
 
-def test_search_all_strips_absolute_paths_from_items_and_errors(fastapi_client, monkeypatch):
+def test_search_all_strips_absolute_paths_from_items_and_errors(fastapi_client, monkeypatch, pro_entitled):
     monkeypatch.setattr(federation, "search_all_projects", _leaky_payload)
 
     resp = fastapi_client.get("/api/search/all", params={"q": "x"})
@@ -70,7 +70,7 @@ def test_search_all_strips_absolute_paths_from_items_and_errors(fastapi_client, 
     assert "/Volumes/" not in blob
 
 
-def test_search_all_handles_none_project_path_in_errors(fastapi_client, monkeypatch):
+def test_search_all_handles_none_project_path_in_errors(fastapi_client, monkeypatch, pro_entitled):
     # the "no matching projects" error path sets project_path=None — must not crash
     def _payload(*a, **k):
         return {
@@ -92,7 +92,7 @@ WIN_ABS = "C:\\Users\\me\\secret-proj\\footage\\clip.mov"
 WIN_ROOT = "C:\\Users\\me\\secret-proj"
 
 
-def test_search_all_strips_windows_style_absolute_paths(fastapi_client, monkeypatch):
+def test_search_all_strips_windows_style_absolute_paths(fastapi_client, monkeypatch, pro_entitled):
     def _payload(*a, **k):
         return {
             "query": "x", "total_results": 1, "projects_queried": 2, "projects_failed": 1,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1597,7 +1597,7 @@ def test_cache_info_does_not_return_absolute_paths(fastapi_client):
         assert "path" not in info, f"cache '{name}' must not expose its absolute path"
 
 
-def test_search_all_strips_absolute_and_project_paths(fastapi_client, monkeypatch):
+def test_search_all_strips_absolute_and_project_paths(fastapi_client, monkeypatch, pro_entitled):
     """Codex: /api/search/all must not leak absolute media/project paths to a
     videos_read client. absolute_path dropped, path → relative, project_path →
     basename."""
@@ -1623,7 +1623,7 @@ def test_search_all_strips_absolute_and_project_paths(fastapi_client, monkeypatc
     assert "/Volumes" not in item["project_path"]
 
 
-def test_search_all_basenames_absolute_relative_path_edge(fastapi_client, monkeypatch):
+def test_search_all_basenames_absolute_relative_path_edge(fastapi_client, monkeypatch, pro_entitled):
     """Edge: federation may hand back an absolute relative_path (empty stored
     path). The boundary must still basename it, never emit the absolute path."""
     import server


### PR DESCRIPTION
接續 #332。那支把 gate 寫好但**刻意沒有生效** —— `cap_is_active()` 讓早於 `CAP_VERSION` 的 build 完全不執行額度。這支把 `config.VERSION` 推到 **1.1.0**，gate 從這一刻起真的咬人。

實測確認武裝：`cap_is_active=True`／第 4 個專案回 `project_limit`／跨專案回 `cross_project`。

## 五處版號

含 `Cargo.lock` 的 root `arkiv` entry —— 正是讓 v0.2~v0.10 整段 tag 歷史漂成 0.2.0 的那一處。`test_version_sync.py` 守著。

## 收版號當下才會現形的東西：8 支既有測試變紅

全部是在測**跨專案功能本身**（federated search 的路徑洩漏消毒、bin dedup、bin copy），現在被自己的 gate 擋掉。

修法是新增 `pro_entitled` fixture 並**逐支明確掛上**。**刻意不是 autouse** —— autouse 會把整個 suite 的 gate 關掉，下一次「不小心把 Pro 功能開放給免費層」的迴歸就會全綠通過，正是這個 fixture 存在要避免的失敗。`tests/test_entitlements.py` 不使用它，繼續斷言拒絕。

## ⚠️ add-on 仍未開賣，這是刻意記下的取捨

Pro 本體與收款管道都還不存在（todo (c)），所以**撞到 3 個專案上限的新安裝目前無法付錢買過去**。

原本的拒絕訊息寫「license the Pro add-on」，那會把人指向一個買不到的東西 —— 穿著「下一步」外衣的死路。改成指向條款頁（那頁自己會說明開賣狀態），所以這句在開賣前後都成立、不會過期。

## 文案改成現在式

產品頁原本寫「目前版本（1.0.0）不設任何限制」，**這一版一出就是假的**。改成「自 1.1.0（本版）起生效，只對新安裝；1.1.0 之前已在使用的安裝永久保留兩項功能」。`pro-addon-license.md` 中英兩處同步。

## 既有使用者

**永久不受影響**，而且那是靠 1.0.0 就種下的 `library_meta.first_seen_version` 錨點履行的，不是靠猜。這也是為什麼早發比晚發便宜 —— 每拖一版，永久豁免的母體就多一批。

## 驗證

pytest **1338 passed / 7 skipped**、svelte-check **0 error 0 warning**、build 通過、node:test **24 pass**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)