### PR TITLE
chore(site): 官網掛上 GA4（沿用 WH 的 Google Tag）

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,15 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+
+<!-- Google tag (gtag.js) — 與 wafflehouse.com.tw 共用同一個 Google Tag，供跨站歸因比對 -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=GT-WB2F3LB8"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'GT-WB2F3LB8');
+</script>
 <title>arkiv — 拍過的東西，找得回來</title>
 <meta name="description" content="本機優先的 AI 素材索引層。自動轉錄、看懂畫面，用中文問句找到那顆鏡頭。Resolve 原生、零雲端、免費且商用不受限。">
 <meta property="og:title" content="arkiv — 拍過的東西，找得回來">


### PR DESCRIPTION
在 `docs/index.html` 的 `<head>` 加九行 gtag，讓 arkiv 官網開始收流量資料。

## 為什麼

arkiv 站目前**零 analytics、零外部 script** —— 沒有任何流量資料。而購買動線的規劃是導到 `wafflehouse.com.tw` 結帳（借立凡的法人與金流，避開為 vulture 另設公司的時間與登記成本）。

在零資料的狀態下決定「arkiv 站要不要整個搬進 WH」是難逆的決定。**先花十分鐘掛上量測、跑兩週，再用資料決定。**

## 為什麼沿用 `GT-WB2F3LB8`（WH 的 Google Tag）

另開 property 資料比較乾淨，但**跨站比不起來** —— 使用者從 arkiv 跳到 WH 結帳時，「原本從哪來」會在跳轉那一刻斷掉。同一個 tag 才串得起來。

## 為什麼從 `main` 切

GitHub Pages 從 **`main` 的 `/docs`** 發布。而 `release/v1.1.0` 領先 main 一個 commit，**且正好改到 `docs/index.html`** —— 內容是 1.1.0 免費額度上線後的定價表文案（「自 1.1.0（本版）起生效」）。從 release 切，這支 merge 回 main 會把那段文案提前推上線。

## 配套（在 GA 後台，不在這個 repo）

跨網域連結設定已加入兩條「包含」條件：`vulture-s.github.io`、`wafflehouse.com.tw`。**沒有那步，跨網域跳轉會被算成新工作階段、來源變 `github.io / referral`。**

## ⚠️ 一個刻意的取捨

這頁的 meta description 寫「**零雲端**」，而本 PR 讓它開始載 Google 的追蹤。無 cookie 的替代方案（Plausible / Cloudflare Web Analytics）做不到跨站比對，所以選了 GA。若日後品牌上決定不要，移除只需刪這九行。

## 驗證

- HTML tag 配對：剝除 HTML 註解後 `<script>` 3/3（註解裡有一個文字形式的 `<script>`，會讓天真的計數看起來像 4/3）
- UTF-8 中文可讀
- 未 staged `settings.local.json` / credentials
- 未跑 `health.py` —— 本次僅變更靜態 landing page，不觸及 Python 應用

## merge 之後

merge 那一刻就是開始收資料的時間點，**兩週觀察期從那天起算**。
接著要驗：無痕視窗開站 → GA4 即時報表 30 秒內看得到。

🤖 Generated with [Claude Code](https://claude.com/claude-code)