### PR TITLE
fix(licensing): 「永久」豁免不該因為 NAS 當天沒掛載就消失

### DIFF
--- a/entitlements.py
+++ b/entitlements.py
@@ -280,6 +280,97 @@ def has_pro():
 
 # ── the machine-level grandfather question ────────────────────────────────────
 
+def _install_meta_path():
+    """Install-level state that has to outlive any single library being reachable.
+
+    Sits beside `pro-license.json` in `~/.arkiv/` rather than inside a project,
+    because the fact it records is about the INSTALL — and the entire point is
+    for it to survive the libraries that evidenced it being unmounted, renamed,
+    or deleted.
+    """
+    return Path(
+        os.getenv(
+            "ARKIV_INSTALL_META", str(Path.home() / ".arkiv" / "install-meta.json")
+        )
+    ).expanduser()
+
+
+def _read_grandfather_latch():
+    """True when an earlier run already observed a pre-cap library on this install.
+
+    Missing, unreadable, or corrupt all read as False, and that is not a
+    revocation: a False here only means this call falls through to the live scan
+    below — exactly the behaviour this function had before the latch existed.
+    The latch can therefore only ever add exemptions, never remove them.
+    """
+    try:
+        path = _install_meta_path()
+        if not path.exists():
+            return False
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, ValueError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    return data.get("grandfathered") is True
+
+
+def _record_grandfather_latch(evidence):
+    """Record, once, that this install was observed holding a pre-cap library.
+
+    One-way by construction: this only ever writes `true`, and nothing anywhere
+    in this module writes `false`. That asymmetry is the whole mechanism — it
+    can grant an exemption but never revoke one, and it cannot invent one
+    either, because it records only what was actually observed on disk.
+
+    Best-effort. A read-only home, a full disk, or a race with a second arkiv
+    process must not turn a licensing *check* into a user-visible failure: the
+    caller has already decided the answer is True, and persistence is an
+    optimisation for the NEXT call, not part of this one's correctness. Unknown
+    keys are preserved so a later writer of this file is not clobbered.
+
+    This does not contradict `read_library_origin`'s rule about never mutating
+    what it inspects. That rule protects the USER'S corpus — no stub DBs, no
+    -wal files next to their footage. This writes arkiv's own install-level
+    state under `~/.arkiv/`, never anything inside a project.
+
+    Written via a per-writer temp name + `os.replace`, per `projects.save_registry`
+    and `bins.py`. Deliberately NOT reusing `ingest._atomic_write_json`: this
+    module is a leaf on stdlib + `config` (see the module docstring), and
+    importing `ingest` for six lines would drag the entire ingest dependency
+    graph into every licensing question.
+    """
+    path = _install_meta_path()
+    payload = {}
+    try:
+        if path.exists():
+            with path.open("r", encoding="utf-8") as handle:
+                existing = json.load(handle)
+            if isinstance(existing, dict):
+                payload = existing
+    except (OSError, ValueError):
+        payload = {}
+    if payload.get("grandfathered") is True:
+        return
+    payload["grandfathered"] = True
+    payload["grandfathered_evidence"] = str(evidence)
+    payload["grandfathered_cap_version"] = CAP_VERSION
+    tmp = None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name("%s.%d.tmp" % (path.name, os.getpid()))
+        with tmp.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2)
+        os.replace(str(tmp), str(path))
+    except (OSError, ValueError):
+        if tmp is not None:
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+
 def install_is_grandfathered(db_paths):
     """True when this install was already in use before `CAP_VERSION`.
 
@@ -294,7 +385,28 @@ def install_is_grandfathered(db_paths):
     evidence of absence, and it is safe because it costs such a user nothing:
     they have zero projects, so the cap of three cannot bite them today, and by
     the time it could they will have been stamped with the current version.
+
+    ## Why the answer is latched
+
+    The scan below can only see libraries reachable RIGHT NOW. A user whose
+    grandfathered corpus lives on a NAS is not a new installation on the morning
+    that NAS fails to mount — but an unlatched scan says they are, and the cap
+    then refuses a fourth project and cross-project search while telling them to
+    buy Pro. The page promises the exemption "permanently"; an answer that
+    depends on today's mount state is the wrong shape no matter which way it
+    errs, and it violates this module's own rule that every uncertainty must
+    resolve in the user's favour.
+
+    So the observation is recorded the first time it is made, and from then on
+    the record is the answer. This is the same move `db.first_seen_version`
+    makes: write the fact down while it is still observable, so that a later
+    judgement does not depend on it still being observable. It also matches the
+    promise's wording more exactly than a live scan does — the subject is an
+    *install that was already in use*, so deleting that old library afterwards
+    does not turn the install back into a new one.
     """
+    if _read_grandfather_latch():
+        return True
     for db_path in db_paths or []:
         origin = read_library_origin(db_path)
         if origin is None:
@@ -302,16 +414,19 @@ def install_is_grandfathered(db_paths):
             # Both mean "cannot prove this is new" — but only count it when the
             # library actually exists, so that a registry entry pointing at a
             # deleted/unmounted project does not manufacture an exemption out of
-            # nothing. (An unmounted NAS project is exactly the case that would
-            # otherwise flip an install to exempt on a bad-mount day and back
-            # again the next.)
+            # nothing. Requiring existence is safe in the other direction only
+            # because of the latch above: an install that has ever been seen
+            # holding this library keeps the exemption even once the path stops
+            # resolving.
             try:
                 if Path(db_path).exists():
+                    _record_grandfather_latch(db_path)
                     return True
             except OSError:
                 continue
             continue
         if predates_cap(origin):
+            _record_grandfather_latch(db_path)
             return True
     return False
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,28 @@ def _install_fake_modules():
 _install_fake_modules()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_install_meta(tmp_path, monkeypatch):
+    """Keep the grandfather latch out of the developer's real home directory.
+
+    `entitlements._record_grandfather_latch` WRITES `~/.arkiv/install-meta.json`
+    the first time an install is observed to predate the cap, and more than ten
+    test modules reach that code path through `projects.add_project`,
+    `/api/search/all`, and the bins helpers. Without this fixture the suite
+    would leave a real latch on the maintainer's machine and then read it back
+    on the next run — every free-tier assertion silently inverting, green for
+    the wrong reason locally and red only in CI.
+
+    Autouse, unlike `pro_entitled` below, precisely because it does not switch
+    any gate off: it points at a path that does not exist, so the latch is
+    simply absent and every test still exercises the live scan it was written
+    for. A test that wants a latch writes one at this path itself.
+    """
+    monkeypatch.setenv(
+        "ARKIV_INSTALL_META", str(tmp_path / "install-state" / "install-meta.json")
+    )
+
+
 @pytest.fixture
 def pro_entitled(tmp_path, monkeypatch):
     """Run a test as an installation that owns the Pro add-on.

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -147,6 +147,84 @@ def test_missing_library_does_not_manufacture_an_exemption(tmp_path):
     assert entitlements.install_is_grandfathered([tmp_path / "gone" / "project.db"]) is False
 
 
+# ── the latch: an exemption seen once must not depend on today's mounts ───────
+
+def test_grandfathered_install_survives_its_library_becoming_unreachable(
+    monkeypatch, tmp_path
+):
+    """"Permanently" cannot mean "until the NAS fails to mount".
+
+    The shape the latch exists for: one pre-cap library on removable storage,
+    observed while mounted, unreachable on a later run. Without the latch that
+    second run reads exactly like a fresh install — the cap refuses a fourth
+    project and cross-project search, and tells a permanently exempt user to buy
+    Pro because their NAS did not come up this morning.
+
+    Asserted at the verdict level as well as the predicate, because the verdicts
+    are what the published promise is actually about.
+    """
+    monkeypatch.setattr(config, "VERSION", ARMED)
+    nas = _library(tmp_path / "nas" / "project.db", PRE_CAP)
+    assert entitlements.install_is_grandfathered([nas]) is True
+
+    nas.unlink()  # the mount goes away; the registry entry does not
+    assert entitlements.install_is_grandfathered([nas]) is True
+    assert entitlements.check_add_project(99, db_paths=[nas]).code == "grandfathered"
+    assert entitlements.check_cross_project(db_paths=[nas]).allowed is True
+
+
+def test_no_latch_is_written_when_nothing_predates_the_cap(monkeypatch, tmp_path):
+    """The latch may only record what was observed, never invent it.
+
+    Pairs with `test_missing_library_does_not_manufacture_an_exemption`: that
+    one guards the scan, this one guards the store the scan now writes to.
+    """
+    monkeypatch.setattr(config, "VERSION", ARMED)
+    new = _library(tmp_path / "new" / "project.db", ARMED)
+    assert entitlements.install_is_grandfathered([new]) is False
+    assert entitlements._install_meta_path().exists() is False
+
+
+def test_a_corrupt_latch_is_not_a_revocation(monkeypatch, tmp_path):
+    """An unreadable latch falls through to the live scan, per the module rule."""
+    monkeypatch.setattr(config, "VERSION", ARMED)
+    latch = entitlements._install_meta_path()
+    latch.parent.mkdir(parents=True, exist_ok=True)
+    latch.write_text("{ not json", encoding="utf-8")
+    old = _library(tmp_path / "old" / "project.db", PRE_CAP)
+    assert entitlements.install_is_grandfathered([old]) is True
+
+
+def test_latch_write_preserves_unrelated_keys(monkeypatch, tmp_path):
+    """A licensing write must not clobber whatever else lives in this file."""
+    monkeypatch.setattr(config, "VERSION", ARMED)
+    latch = entitlements._install_meta_path()
+    latch.parent.mkdir(parents=True, exist_ok=True)
+    latch.write_text(json.dumps({"some_other_setting": "keep me"}), encoding="utf-8")
+    old = _library(tmp_path / "old" / "project.db", PRE_CAP)
+    assert entitlements.install_is_grandfathered([old]) is True
+
+    data = json.loads(latch.read_text(encoding="utf-8"))
+    assert data["grandfathered"] is True
+    assert data["some_other_setting"] == "keep me"
+
+
+def test_a_latch_that_cannot_be_written_still_answers(monkeypatch, tmp_path):
+    """A read-only home must not turn a licensing check into a user-facing error.
+
+    Persistence is an optimisation for the next call; this call already knows
+    the answer and has to return it either way.
+    """
+    monkeypatch.setattr(config, "VERSION", ARMED)
+    old = _library(tmp_path / "old" / "project.db", PRE_CAP)
+    blocker = tmp_path / "blocker"
+    blocker.write_text("a file where a directory would have to be", encoding="utf-8")
+    monkeypatch.setattr(
+        entitlements, "_install_meta_path", lambda: blocker / "install-meta.json"
+    )
+    assert entitlements.install_is_grandfathered([old]) is True
+
+
 # ── the rule's own start date ─────────────────────────────────────────────────
 
 def test_cap_does_not_bite_on_builds_that_predate_it(monkeypatch, tmp_path):


### PR DESCRIPTION
## 問題

`install_is_grandfathered` 每次都重算，而它只看得到**當下可讀到**的素材庫。一個永久豁免的使用者，在 NAS 沒掛載那天會被判成全新安裝 —— 加第 4 個專案與跨專案聚合都被拒，還收到一則叫他買 Pro 的訊息。而產品頁寫的是「永久保留」。

實測重現，同一台機器、同一份 registry，只差有沒有掛載：

| | grandfathered | 加第 4 個專案 | 跨專案聚合 |
|---|---|---|---|
| NAS 掛著 | `True` | ✅ | ✅ |
| NAS 沒掛載 | `False` | ❌ `project_limit` | ❌ `cross_project` |

對 NAS 為主的使用者特別會咬，而那正是 arkiv 的主要 persona。

## 這違反的是本模組自己寫下的硬規則

`entitlements.py` 的 docstring 明講 **“Every uncertainty resolves to allowed”**。「路徑讀不到」在 code 眼中無法分辨「被刪掉」還是「沒掛載」—— 那就是 uncertainty，照規則該判 allowed。

原本要求檔案必須存在，是為了防另一個方向（stale registry 憑空生出豁免）。**該顧慮成立，但只算了一邊**：製造出來的豁免只是少收錢、沒人看得到；弄丟的豁免是使用者眼睛看得到的毀約。

## 修法：單向 latch

跟 `db.first_seen_version` 同一個形狀 —— **在還觀察得到的時候把事實記下來，別讓日後的判斷依賴它還觀察得到**。install 只要曾被觀察到持有 1.1.0 之前的素材庫，就在 `~/.arkiv/install-meta.json` 蓋印記，之後只讀印記。

**只寫 `true`、永不寫 `false`**，所以它只能授予、不能撤銷；也不會憑空製造豁免，因為它記的只有真的在磁碟上觀察到的事。原本那條「檔案必須存在」保留不動 —— 有了 latch 之後它在另一個方向才是安全的。

順帶更貼近頁面用字：承諾的主體是「在 1.1.0 之前**已在使用的安裝**」，所以日後把舊庫刪掉也不該讓這個安裝變回新安裝。重算邏輯做不到這件事。

## 取捨

- 讀不到／損毀的 latch 一律 `False` ＝ 退回原本的即時掃描，**不是撤銷**
- 寫入是 best-effort：唯讀家目錄、磁碟滿、與另一個 arkiv 行程競爭，都不得把授權「檢查」變成使用者看得到的錯誤。保留未知 key 不覆蓋
- per-writer 暫存檔名 + `os.replace`，比照 `projects.save_registry` / `bins.py`
- **刻意不重用** `ingest._atomic_write_json`：本模組是只依賴 stdlib + `config` 的 leaf，為六行把整個 ingest 依賴圖拖進授權判定不划算
- 不牴觸 `read_library_origin` 的「不可變動被檢查對象」：那條保護的是**使用者的素材庫**，這裡寫的是 arkiv 自己在 `~/.arkiv/` 的狀態

## 測試

5 支新測，**mutation-check 過**：

- 停掉 latch 讀取 → 只有 `test_grandfathered_install_survives_its_library_becoming_unreachable` 紅
- 把 read-modify-write 改成覆寫 → 只有 `test_latch_write_preserves_unrelated_keys` 紅

`tests/conftest.py` 新增 autouse `_isolate_install_meta`。latch 是**寫入**，而十幾個測試檔會經由 `projects.add_project` / `/api/search/all` / bins 走到它 —— 沒有隔離會在維護者機器上留下真的 latch，再被下一輪讀回來，**每條免費層斷言都會靜默反轉**（本機綠、CI 紅，或反過來）。指向不存在的路徑，所以每支測試仍走即時掃描。

全套 **1343 passed / 7 skipped**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)