### PR TITLE
fix(release): 出貨的 .dmg/.exe 會夾帶開發機的 .env

### DIFF
--- a/src-tauri/assemble-backend-win.ps1
+++ b/src-tauri/assemble-backend-win.ps1
@@ -160,6 +160,16 @@ Write-Host "[assemble] arkiv source (runtime .py + routers + built SPA; no tests
 # enumerate, and 20 of them turned into robocopy's "directories failed" count ->
 # exit 9. A CI runner checks out clean and never sees them, so this only ever
 # bites a real workstation -- the one machine that also does the release build.
+# .env* is excluded because this is a DENYLIST, and a denylist that misses a
+# secret is a silent leak rather than a loud failure: install.sh does
+# `cp .env.example .env`, and .env.example tells you to fill in
+# ARKIV_TOKEN_HMAC_KEY, ARKIV_ADMIN_BOOTSTRAP_TOKEN and ARKIV_PG_DSN (which
+# carries a DB password). Without it a release built on a real workstation ships
+# that file inside the .exe/.msi for anyone to read. .dockerignore already
+# excludes .env; this is the same discipline for the Tauri path.
+# .env.example goes too -- nothing at runtime reads it (config._load_env only
+# looks for .env), so shipping it only widens the pattern we have to police.
+# bench_*.json is called out in .gitignore as containing private transcripts.
 Invoke-Robocopy -Source $REPO -Dest (Join-Path $BACKEND 'src') -ExtraArgs @(
     '/XD',
     (Join-Path $REPO '.git'),
@@ -178,8 +188,21 @@ Invoke-Robocopy -Source $REPO -Dest (Join-Path $BACKEND 'src') -ExtraArgs @(
     (Join-Path $REPO 'waveforms'),
     (Join-Path $REPO '.tmp-camera-report-tests'),
     'node_modules', '__pycache__', '.pytest_cache', '.ruff_cache',
-    '/XF', '*.pyc'
+    '/XF', '*.pyc', '.env', '.env.*'
 )
+
+# Fail loud rather than ship quietly. Not redundant with /XF above: robocopy is
+# not run with /MIR here, so a .env copied in by an OLDER build of this script is
+# still sitting in $BACKEND\src and would ship even now that the exclude exists.
+# A denylist only stops the patterns someone remembered; this stops the class.
+$leaked = @(Get-ChildItem -LiteralPath (Join-Path $BACKEND 'src') -Recurse -Force -File -Filter '.env*' -ErrorAction SilentlyContinue)
+if ($leaked.Count -gt 0) {
+    Write-Host "ERROR: dotenv file(s) found in the assembled backend -- refusing to ship." -ForegroundColor Red
+    $leaked | ForEach-Object { Write-Host "  $($_.FullName)" -ForegroundColor Red }
+    Write-Host "       Delete them from $(Join-Path $BACKEND 'src') and re-run. If you added a" -ForegroundColor Red
+    Write-Host "       new dotenv variant, add it to the /XF list above too." -ForegroundColor Red
+    exit 1
+}
 
 if (-not (Test-Path (Join-Path $BACKEND 'src\frontend\dist\index.html'))) {
     Write-Warning "frontend\dist\index.html missing -- run 'cd frontend; npm run build' first,"

--- a/src-tauri/assemble-backend.sh
+++ b/src-tauri/assemble-backend.sh
@@ -54,13 +54,48 @@ echo "[assemble] arkiv source (runtime .py + routers + built SPA; no tests/docs/
 # The server imports many top-level modules + the routers package, and serves the
 # SPA from ./frontend/dist relative to its cwd. Copy generously (repo minus the
 # heavy/irrelevant dirs) so no runtime import is missed.
+#
+# .env* is excluded because this is a DENYLIST and a denylist that misses a
+# secret is a silent leak, not a loud failure: install.sh does `cp .env.example
+# .env`, and .env.example tells you to fill in ARKIV_TOKEN_HMAC_KEY,
+# ARKIV_ADMIN_BOOTSTRAP_TOKEN and ARKIV_PG_DSN (which carries a DB password).
+# Without this line a release built on a real workstation ships that file inside
+# the .dmg, where anyone who downloads it can read it. .dockerignore already got
+# this right; this is the same discipline for the Tauri path.
+# .env.example goes too — nothing at runtime reads it (config._load_env only
+# looks for .env), so shipping it only widens the pattern we have to police.
+#
+# The scratch dirs mirror what assemble-backend-win.ps1 already excludes: they
+# are a dev box's local data. bench_*.json is called out in .gitignore as
+# containing private transcripts and filenames.
 rsync -a \
-  --exclude '.git/' --exclude '.venv/' --exclude 'node_modules/' \
+  --exclude '.git/' --exclude '.venv/' --exclude '.venv-pack/' \
+  --exclude 'node_modules/' \
   --exclude 'src-tauri/' --exclude 'tests/' --exclude 'docs/' \
   --exclude 'frontend/node_modules/' --exclude 'frontend/src/' \
   --exclude '__pycache__/' --exclude '*.pyc' \
+  --exclude '.pytest_cache/' --exclude '.ruff_cache/' \
   --exclude '.arkiv/' --exclude 'chroma_db/' \
+  --exclude '.env*' \
+  --exclude 'temp/' --exclude 'thumbnails/' --exclude 'proxies/' \
+  --exclude 'waveforms/' --exclude '.tmp-camera-report-tests/' \
+  --exclude 'bench_*.json' \
   "$REPO/" "$BACKEND/src/"
+
+# Fail loud rather than ship quietly. Two reasons this guard is not redundant
+# with the --exclude above:
+#   1. This rsync has no --delete (unlike the site-packages one), so a .env
+#      copied in by an OLDER build of this script is still sitting in
+#      $BACKEND/src and would ship even now that the exclude exists.
+#   2. A denylist only stops the patterns someone remembered. This stops the
+#      whole class.
+if find "$BACKEND/src" -name '.env*' -type f | grep -q .; then
+  echo "ERROR: dotenv file(s) found in the assembled backend — refusing to ship." >&2
+  find "$BACKEND/src" -name '.env*' -type f >&2
+  echo "       Delete them from $BACKEND/src and re-run. If you added a new" >&2
+  echo "       dotenv variant, add it to the rsync --exclude list above too." >&2
+  exit 1
+fi
 
 if [ ! -f "$BACKEND/src/frontend/dist/index.html" ]; then
   echo "WARN: frontend/dist/index.html missing — run 'cd frontend && npm run build' first," >&2

--- a/tests/test_assemble_no_secrets.py
+++ b/tests/test_assemble_no_secrets.py
@@ -1,0 +1,142 @@
+"""The assemble scripts must never copy a dotenv file into a shipped bundle.
+
+Both `src-tauri/assemble-backend.sh` (macOS) and
+`src-tauri/assemble-backend-win.ps1` (Windows) build the bundle by copying the
+whole repo minus a *denylist* of heavy or irrelevant directories. The comment in
+the shell script says the strategy out loud: "Copy generously (repo minus the
+heavy/irrelevant dirs) so no runtime import is missed."
+
+That trade is fine for source files and fatal for secrets. Until 2026-08-20
+neither denylist mentioned `.env`, while `install.sh` does `cp .env.example .env`
+and `.env.example` instructs the reader to fill in `ARKIV_TOKEN_HMAC_KEY`,
+`ARKIV_ADMIN_BOOTSTRAP_TOKEN` and `ARKIV_PG_DSN` — the last of which carries a
+database password. A release built on a real workstation (the only kind of
+machine that has a filled-in `.env`) would therefore ship the developer's
+credentials inside the `.dmg`/`.exe`, readable by anyone who downloads it. A CI
+runner checks out clean and never has a `.env`, so CI could not surface this.
+
+`.dockerignore` already excluded `.env`; the Tauri path had simply never had the
+same rule applied. This pins both halves of the fix:
+
+  1. the copy step excludes `.env*`, and
+  2. a post-copy guard fails the build if one is present anyway.
+
+(2) is not redundant with (1). Neither copy runs with `--delete`/`/MIR`, so a
+`.env` deposited by an older build of these scripts still sits in
+`src-tauri/backend/src/` and would ship regardless of the new exclude. A
+denylist stops the patterns someone remembered; the guard stops the class.
+
+If you add a new dotenv variant or rename these scripts, update the constants
+below rather than deleting the test — the invariant is "no dotenv reaches a
+bundle", not "these exact strings appear".
+"""
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+SH = ROOT / "src-tauri" / "assemble-backend.sh"
+PS1 = ROOT / "src-tauri" / "assemble-backend-win.ps1"
+
+# The glob every layer agrees on. Deliberately covers `.env.example` too: nothing
+# at runtime reads it (config._load_env only looks for `.env`), so shipping it
+# would only widen the surface the guard has to police.
+DOTENV_GLOB = ".env*"
+
+
+@pytest.mark.parametrize("script", [SH, PS1], ids=["macos-sh", "windows-ps1"])
+def test_assemble_script_exists(script: Path) -> None:
+    assert script.is_file(), (
+        f"{script.relative_to(ROOT)} is missing. If the assemble step was renamed, "
+        "point this test at the new file rather than dropping the check."
+    )
+
+
+def test_macos_script_excludes_dotenv() -> None:
+    body = SH.read_text(encoding="utf-8")
+    assert f"--exclude '{DOTENV_GLOB}'" in body, (
+        "assemble-backend.sh no longer excludes .env* from the source rsync. "
+        "That copy is a denylist over the whole repo, so removing this line means "
+        "a workstation build ships the developer's .env inside the .dmg."
+    )
+
+
+def test_windows_script_excludes_dotenv() -> None:
+    body = PS1.read_text(encoding="utf-8")
+    # robocopy /XF takes exact names or wildcards; `.env` alone would not cover
+    # `.env.local`, so both forms have to be present.
+    for pattern in ("'.env'", "'.env.*'"):
+        assert pattern in body, (
+            f"assemble-backend-win.ps1 no longer passes {pattern} to robocopy /XF. "
+            "That copy is a denylist over the whole repo, so removing this means a "
+            "workstation build ships the developer's .env inside the .exe/.msi."
+        )
+
+
+@pytest.mark.parametrize("script", [SH, PS1], ids=["macos-sh", "windows-ps1"])
+def test_assemble_script_has_post_copy_guard(script: Path) -> None:
+    """The exclude alone cannot clean up after an older build. The guard can."""
+    body = script.read_text(encoding="utf-8")
+    assert DOTENV_GLOB in body and "refusing to ship" in body, (
+        f"{script.relative_to(ROOT)} lost its post-copy dotenv guard. The copy step "
+        "runs without --delete/--mir, so a .env left behind by a previous build is "
+        "still in src-tauri/backend/src/ and ships even when the exclude is present. "
+        "The guard is what makes that a build failure instead of a silent leak."
+    )
+
+
+def test_guard_glob_actually_matches_a_planted_dotenv() -> None:
+    """Assert the pattern works, not just that it is spelled somewhere.
+
+    A guard whose glob quietly stops matching is worse than no guard: the build
+    goes green and the leak returns. This plants the files the guard exists to
+    catch and one it must ignore.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        src = Path(tmp) / "src"
+        (src / "routers").mkdir(parents=True)
+        (src / "config.py").write_text("VERSION = '0'\n", encoding="utf-8")
+        (src / "routers" / "admin.py").write_text("x = 1\n", encoding="utf-8")
+
+        matched = sorted(p.name for p in src.rglob(DOTENV_GLOB) if p.is_file())
+        assert matched == [], f"clean tree should not trip the guard, got {matched}"
+
+        (src / ".env").write_text("ARKIV_TOKEN_HMAC_KEY=nope\n", encoding="utf-8")
+        (src / ".env.local").write_text("ARKIV_PG_DSN=nope\n", encoding="utf-8")
+        (src / ".env.example").write_text("# template\n", encoding="utf-8")
+
+        matched = sorted(p.name for p in src.rglob(DOTENV_GLOB) if p.is_file())
+        assert matched == [".env", ".env.example", ".env.local"], (
+            f"guard glob {DOTENV_GLOB!r} missed a dotenv variant: {matched}"
+        )
+
+
+def _bash_available() -> bool:
+    try:
+        return subprocess.run(["bash", "-c", "true"], capture_output=True).returncode == 0
+    except (OSError, FileNotFoundError):  # no bash on PATH at all
+        return False
+
+
+@pytest.mark.skipif(not _bash_available(), reason="bash unavailable")
+def test_macos_script_is_valid_bash() -> None:
+    """A guard that never runs because the script is unparseable protects nothing.
+
+    Two Windows-specific details, both load-bearing:
+
+    * The script is piped in on stdin rather than passed as a path argument. The
+      only `bash` on PATH under Windows is Git Bash, whose MSYS layer rewrites
+      Windows-style path arguments and turns `C:\\Users\\...` into an unopenable
+      `C:Usersuser...` (exit 127, "No such file or directory").
+    * It is piped as **bytes**, not text. `text=True` runs stdin through a
+      TextIOWrapper, which on Windows translates every `\\n` into `\\r\\n`; bash
+      then reports a bogus `syntax error: unexpected end of file` on a file that
+      is perfectly valid. The bytes path reproduces the file exactly.
+    """
+    proc = subprocess.run(["bash", "-n"], input=SH.read_bytes(), capture_output=True)
+    assert proc.returncode == 0, f"bash -n failed:\n{proc.stderr.decode(errors='replace')}"


### PR DESCRIPTION
## 問題

兩支 assemble 腳本用**黑名單**把整個 repo 複製進 bundle，清單裡沒有 `.env`。

```
install.sh:173      cp .env.example .env
.env.example:63     ARKIV_ADMIN_BOOTSTRAP_TOKEN=...
.env.example:74     ARKIV_TOKEN_HMAC_KEY=...
config.py:534       ARKIV_PG_DSN  ← DSN 帶資料庫密碼
```

→ **在一台真的有填過 `.env` 的工作站上跑 release build，會把自己的 token 與 DB 密碼打包進 `.dmg` / `.exe`，任何人下載後解開就讀得到。**

CI runner 是乾淨 checkout、永遠沒有 `.env`，所以 CI 測不到；唯一會中的機器正好就是實際做發版的那一台。`.dockerignore:11` 早就排掉 `.env`，這條紀律只是沒套到 Tauri 這條路。

**目前無實際外洩** —— 這台機器的 arkiv 根目錄剛好只有 `.env.example`。

## 修法（兩層，第二層不是多餘）

1. 兩支腳本排除 `.env*`（含 `.env.example`：runtime 沒有東西讀它，留著只是讓要巡的 pattern 變寬）
2. 複製後 guard，發現任何 dotenv 就讓建置失敗

**(2) 必要的理由**：兩個複製都沒有 `--delete` / `/MIR`，舊版腳本已複製進 `src-tauri/backend/src/` 的 `.env` 會原地留著，就算現在有排除也照樣出貨。實測本機那個目錄裡確實躺著上一輪留下的 `.env.example` 與 `bench_ingest.json`（後者 `.gitignore` 註明含 private transcripts）。

順帶把 macOS 版對齊 Windows 版已有的 scratch 排除，兩邊都加 `bench_*.json`。

## 驗證

- 新增 `tests/test_assemble_no_secrets.py`（8 tests）釘住不變量
- **變異驗證四處全紅且紅在對的那條**：拿掉 sh 的 exclude / 拿掉 ps1 的 `'.env.*'` / 拿掉 guard 訊息 / 弄壞 sh 語法
- guard 對現存殘留目錄實跑會攔（抓到 `.env.example`），乾淨目錄放行
- 本機全套 **1280 passed / 22 skipped**
- ⚠️ `tests/test_offload.py` 有 5 紅，**在乾淨的 main 上一樣紅**（`TypeError: data must be str, not NoneType`），與本 PR 無關

## 副作用（先講）

Guard 對 `.env*` 一律攔，包含 `.env.example`。所以**下一次本機建置會失敗**，直到把 `src-tauri/backend/src/` 裡上一輪留下的 `.env.example` 刪掉。這是刻意的：能容忍殘留的 `.env.example`，就等於能容忍殘留的真 `.env`。錯誤訊息有寫該怎麼做。

🤖 Generated with [Claude Code](https://claude.com/claude-code)