### PR TITLE
fix(licensing): 舊庫升級到 1.1.0 的瞬間被蓋章，永久豁免當場消失

### DIFF
--- a/db.py
+++ b/db.py
@@ -13,6 +13,14 @@ import mediatypes
 from contextlib import contextmanager
 
 
+# Stamped as `first_seen_version` for a library that already existed before the
+# provenance anchor shipped: we know it predates the anchor, but not under which
+# build, and a made-up number would claim otherwise. `entitlements` treats an
+# unparseable version as exempt by design, so this reads as grandfathered — see
+# the long comment at the INSERT in init_db() for why that matters.
+PRE_ANCHOR_VERSION = "pre-anchor"
+
+
 # R5-23 (#54): the DB path is a SINGLE source of truth reached ONLY through
 # get_db_path()/set_db_path(). Previously db.py did `from config import DB_PATH`
 # (a frozen value copy) while `--db` rebound db.DB_PATH and health/server read
@@ -226,6 +234,14 @@ def _backfill_shot_date(conn):
 def init_db():
     with get_conn() as conn:
         conn.execute("PRAGMA journal_mode=WAL")
+        # Asked BEFORE any CREATE TABLE below, because that is the only moment
+        # the answer still exists: once `media` is created we can no longer tell
+        # a library that has been in use for a year from one born on this line.
+        # Consumed by the provenance stamp further down — see the long comment
+        # there for why the distinction decides a published promise.
+        library_predates_this_init = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='media'"
+        ).fetchone() is not None
         conn.execute("""
             CREATE TABLE IF NOT EXISTS media (
                 id             INTEGER PRIMARY KEY,
@@ -522,6 +538,40 @@ def init_db():
         # older, so absence reads as exempt. This is a goodwill promise, not
         # DRM — the row is trivially editable and that is fine; the licence is
         # enforced by its terms, not by the database.
+        #
+        # ── why the stamped VALUE is conditional ──────────────────────────────
+        # The paragraph above says absence reads as exempt. This INSERT is what
+        # destroys that absence, so what it writes decides whether the promise
+        # survives.
+        #
+        # Stamping `_config.VERSION` unconditionally is only correct while that
+        # version predates the cap. That was true for exactly one release: the
+        # anchor shipped in 1.0.0 and the cap armed in 1.1.0, one day apart. A
+        # user who upgraded straight from 0.12.x to 1.1.0 — i.e. almost anyone,
+        # since people upgrade to the newest release, not to whichever one
+        # happened to carry the anchor — would have their long-standing library
+        # stamped `1.1.0` on first open and silently lose the exemption the
+        # product page promises permanently. Reproduced end to end before this
+        # change: stamp 1.1.0 -> grandfathered False -> the 4th project and
+        # cross-project search both refused, with a message telling them to buy
+        # Pro.
+        #
+        # `entitlements`' latch cannot save them either: init_db runs when the
+        # app opens, long before any entitlement question is asked, so there is
+        # never a moment where the pre-cap state is observable to be latched.
+        #
+        # So the stamp records what is actually known. A `media` table that
+        # existed BEFORE this init is proof the library was in use under an
+        # earlier build — we just cannot say which one, and `pre-anchor` says
+        # exactly that instead of inventing a number. `entitlements.parse_version`
+        # returns None for it and `predates_cap(None)` is True, per that module's
+        # documented rule that every uncertainty resolves in the user's favour.
+        #
+        # This is the "behavioural inference" the note above rejects, but for a
+        # different question: rejected was "does it already hold more than three
+        # projects", which only catches libraries that had already exceeded the
+        # cap. "Did this library exist at all before this code ran" has no such
+        # blind spot.
         conn.execute("""
             CREATE TABLE IF NOT EXISTS library_meta (
                 key        TEXT PRIMARY KEY,
@@ -531,7 +581,7 @@ def init_db():
         """)
         conn.execute(
             "INSERT OR IGNORE INTO library_meta (key, value) VALUES ('first_seen_version', ?)",
-            (_config.VERSION,),
+            (PRE_ANCHOR_VERSION if library_predates_this_init else _config.VERSION,),
         )
 
         # audit M6: PRAGMA foreign_keys was never enabled before, so orphan

--- a/tests/test_library_origin.py
+++ b/tests/test_library_origin.py
@@ -1,15 +1,16 @@
 """The grandfathering stamp: written once, never restamped, absent means exempt.
 
-Nothing reads this yet. It ships ahead of the feature it serves on purpose —
-the free-tier project cap does not exist in any build in the wild, and the
-published terms promise that libraries in use before it ships keep unlimited
-projects permanently. That promise can only be kept with evidence recorded
-*before* the cap exists: afterwards there is no way to tell whether a
-two-project library was started under the old terms or the new ones.
+The published terms promise that libraries in use before the free-tier cap
+shipped keep unlimited projects permanently. That promise can only be kept with
+evidence recorded *before* the cap exists: afterwards there is no way to tell
+whether a two-project library was started under the old terms or the new ones.
 
-So these tests guard a contract with no current caller. The failure they exist
-to prevent is silent and one-way — an upgrade that restamps an old library
-revokes an exemption that was promised in public, and nothing would surface it.
+The failure these exist to prevent is silent and one-way — anything that
+reclassifies an old library as post-cap revokes an exemption promised in public,
+the library keeps working, and nothing surfaces it.
+
+(This file used to open with "nothing reads this yet". `entitlements` reads it
+now — the cap armed in 1.1.0.)
 """
 from __future__ import annotations
 
@@ -51,6 +52,75 @@ def test_reinit_does_not_restamp(tmp_db, monkeypatch):
         "an upgraded library would lose its pre-cap exemption"
     )
     assert after["created_at"] == first["created_at"]
+
+
+def test_library_that_predates_the_anchor_is_not_stamped_with_the_current_version(
+    tmp_path, monkeypatch
+):
+    """The upgrade path that skipped the anchor's one-release window.
+
+    The anchor shipped in 1.0.0 and the cap armed in 1.1.0 — one day apart.
+    Anyone upgrading straight from 0.12.x to 1.1.0 (i.e. to the newest release,
+    which is what people do) opens a long-standing library whose first init
+    under the new build is also its first stamp. Stamping the CURRENT version
+    there marks a years-old library as post-cap and silently revokes the
+    exemption the product page promises permanently.
+
+    `entitlements`' latch cannot cover this: `init_db` runs when the app opens,
+    before any entitlement question is asked, so the pre-cap state is never
+    observable to be latched.
+    """
+    import config
+    import db
+    import entitlements
+    import sqlite3
+
+    db_path = tmp_path / "old.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    monkeypatch.setattr(config, "VERSION", "1.0.0")
+    db.init_db()
+
+    # A 0.12.x-era library: real content, and never stamped because no build it
+    # ever ran carried the anchor.
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("DROP TABLE library_meta")
+        conn.execute("INSERT INTO media (path, filename) VALUES ('/a.mp4','a.mp4')")
+        conn.commit()
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(config, "VERSION", entitlements.CAP_VERSION)
+    db.init_db()
+
+    origin = db.get_library_origin()
+    assert origin["version"] == db.PRE_ANCHOR_VERSION, (
+        "an existing library was stamped with the capped version on first open; "
+        "its permanent exemption is gone"
+    )
+    assert entitlements.install_is_grandfathered([db_path]) is True
+    assert entitlements.check_add_project(99, db_paths=[db_path]).allowed is True
+    assert entitlements.check_cross_project(db_paths=[db_path]).allowed is True
+
+
+def test_a_genuinely_new_library_is_still_capped(tmp_path, monkeypatch):
+    """The other direction: the fix above must not exempt everybody.
+
+    A library created BY the capped build has no prior use to honour, so it must
+    carry the real version and the cap must bite.
+    """
+    import config
+    import db
+    import entitlements
+
+    db_path = tmp_path / "new.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    monkeypatch.setattr(config, "VERSION", entitlements.CAP_VERSION)
+    db.init_db()
+
+    assert db.get_library_origin()["version"] == entitlements.CAP_VERSION
+    assert entitlements.install_is_grandfathered([db_path]) is False
+    assert entitlements.check_add_project(3, db_paths=[db_path]).allowed is False
 
 
 def test_legacy_library_without_the_table_reads_as_exempt(tmp_db):


### PR DESCRIPTION
## 問題

錨點的設計假設是「錨點版本先出、cap 後出」，中間讓既有使用者被蓋上一個 pre-cap 的版本號。

**實際窗口只有一天** —— 錨點在 `1.0.0`（08-18）、cap 在 `1.1.0`（08-19）。而人會升級到「最新版」，不會特地停在剛好帶錨點的那一版。

所以從 `0.12.x` 直接升到 `1.1.0` 的人，那個用了很久的庫在第一次開啟時就被蓋上 `first_seen_version = 1.1.0`，於是被當成「新安裝」。實測重現：

```
蓋章 1.1.0 → grandfathered False → 第 4 個專案 ❌ project_limit
                                 → 跨專案聚合  ❌ cross_project
```

而畫面會叫他去買 Pro。

#336 的 latch 救不了這個：`init_db` 在開 app 時就跑，**遠早於任何授權提問**，所以「這個庫是 pre-cap」從來沒有一個時刻是可觀察、可記錄的。

## 根因：同一段註解裡的兩句話互相抵銷

> A library with no row at all predates this stamp, which is strictly older, so **absence reads as exempt**.

> an existing library upgrading into a build that carries this code **gets stamped on its next init**.

讀取端把「沒有 row」當豁免，寫入端卻在第一次有機會時就把那個「沒有」消滅掉。兩者**只有在「蓋的版本早於 cap」時才相容**。

## 修法

蓋章前先問「這個庫本來就存在嗎」—— 在任何 `CREATE TABLE` **之前**查 `sqlite_master` 有沒有 `media`。那是唯一還問得到的時刻：一旦建了表，就再也分不出「用了一年的庫」和「這行剛生出來的庫」。

| 情況 | 蓋的值 | 結果 |
|---|---|---|
| 本來就存在 + 沒有錨點 | `PRE_ANCHOR_VERSION = "pre-anchor"` | 永久豁免 ✅ |
| 真正新建的庫 | `config.VERSION` | cap 照樣咬 ✅ |

**值刻意不是數字**：我們知道它早於錨點，但不知道是哪一版，編一個版本號等於宣稱一件不知道的事。`entitlements.parse_version` 對它回 `None`，而 `predates_cap(None)` 是 `True` —— 走的是該模組**已明文寫下**的「任何不確定一律 fail-open」規則，不是巧合。

這確實是原註解否決過的「行為推斷」，但問的是不同問題：被否決的是「是不是已經超過三個專案」（只抓得到已經超標的人）；「這個庫在這段程式跑之前存不存在」沒有那個盲點。

## 測試

2 支新測，**mutation-check 兩處**：

- 恢復成無條件蓋當前版本 → 只有 `test_library_that_predates_the_anchor_...` 紅
- 把探測釘成 `True`（人人豁免）→ 只有「全新庫仍被擋」那兩支紅

全套 **1353 passed / 7 skipped**。

順帶修掉該檔開頭已過時的一句「Nothing reads this yet」—— cap 在 1.1.0 已經 armed，`entitlements` 正在讀它。

🤖 Generated with [Claude Code](https://claude.com/claude-code)