### PR TITLE
ci(release): 快取 Tauri 打包工具鏈，拔掉發版路徑上的兩次網路賭注

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,6 +249,76 @@ jobs:
       - name: Install tauri-cli
         run: cargo install tauri-cli --version "^2.0" --locked
 
+      # -- Cache the bundler's packaging toolchain --------------------------
+      # tauri-bundler downloads WiX and NSIS from GitHub *at build time*, so every
+      # release stakes itself on two network round-trips. v0.12.1's Windows leg lost
+      # that bet on its very first run: the .msi was already built and the NSIS step
+      # died on `Downloading .../nsis-3.11.zip` -> `io: Peer disconnected`; a re-run
+      # passed. That is a structural weakness, not flaky noise -- and a retry wrapper
+      # would only re-roll the same dice, because it still downloads. This removes
+      # the dice.
+      #
+      # WHERE: tauri-bundler resolves its tools dir as `dirs::cache_dir()/tauri`,
+      # which is `%LOCALAPPDATA%\tauri` on Windows, then unpacks `NSIS/` and
+      # `WixTools314/` inside it (~125 MB together).
+      #
+      # SCOPE CAVEAT -- this is what makes the difference between working and being
+      # decorative: a tag run SAVES into the `refs/tags/<tag>` scope, and "workflow
+      # runs cannot restore caches created for different tag names", so a cache
+      # written by v0.12.2 is dead weight for v0.12.3. Restores DO fall back to the
+      # default branch, so the entry that actually serves releases has to be written
+      # by a run whose ref IS main -- i.e. the `workflow_dispatch` dry-run this
+      # workflow already supports. Run that once on main to prime it; every tag
+      # release restores from it afterwards.
+      - name: Resolve the Tauri toolchain dir + cache key
+        id: tauritools
+        shell: bash
+        run: |
+          # Forward slashes: actions/cache globs its `path` input, and there a
+          # backslash is an escape character rather than a separator.
+          dir="${LOCALAPPDATA//\\//}/tauri"
+          # Pre-create it so the post-job save cannot fail path validation on a
+          # build that produced no bundle at all. The bundler only probes the
+          # NSIS/ and WixTools314/ children, so an empty parent is invisible to it.
+          mkdir -p "$dir"
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+
+          # Key on the RESOLVED tauri-cli version rather than the "^2.0" range in
+          # the step above: what lands in this dir is decided by the bundler
+          # compiled into whichever 2.x `cargo install` just picked.
+          ver="$(cargo tauri --version 2>/dev/null | tr -d '\r' | head -1 | awk '{print $NF}')"
+          case "$ver" in
+            2.*) ;;
+            *)
+              # Unparseable -> fall back to a key that CANNOT hit. Degrading to
+              # today's behaviour (download every time) is the safe direction; a
+              # constant fallback key would silently pin a stale toolchain forever.
+              echo "::warning::could not read tauri-cli version (got '$ver'); toolchain cache disabled for this run"
+              ver="unresolved-${GITHUB_RUN_ID}"
+              ;;
+          esac
+          echo "cli=$ver" >> "$GITHUB_OUTPUT"
+          echo "tauri-cli $ver -> caching $dir"
+
+      # HIT  = a previous run on this scope already built with the same tauri-cli
+      #        version. That is every release after the first, on the same 2.x.
+      # MISS = tauri-cli resolved to a new 2.x, so the toolchain it wants may differ
+      #        -> full re-download, then saved under the new key. Also a miss the
+      #        first time ever, by definition.
+      #
+      # No `restore-keys` prefix, deliberately. WiX unpacks into a version-stamped
+      # `WixTools314/` and self-invalidates by name, but NSIS unpacks into a plain
+      # `NSIS/` and the bundler only checks that the directory EXISTS (plus a hash
+      # check on its own nsis_tauri_utils.dll -- not on the NSIS 3.x base). A prefix
+      # fallback would therefore hand a newer bundler an older base NSIS and it
+      # would use it without a word. A miss costs exactly what today already costs,
+      # so tight beats loose here.
+      - name: Cache the Tauri packaging toolchain (WiX + NSIS)
+        uses: actions/cache@v6
+        with:
+          path: ${{ steps.tauritools.outputs.dir }}
+          key: tauri-toolchain-${{ runner.os }}-cli-${{ steps.tauritools.outputs.cli }}
+
       - name: Build app + installers
         working-directory: src-tauri
         run: cargo tauri build


### PR DESCRIPTION
Tauri 的 bundler 在**建置當下**才從 GitHub 抓 WiX 與 NSIS，所以每次發版都押注兩次外部連線。`v0.12.1` 的 Windows 腿首跑就輸了這一把：`.msi` 已經產出，NSIS 那步掛在 `Downloading .../nsis-3.11.zip` → `io: Peer disconnected`，重跑才過。

**這是結構性弱點，不是偶發雜訊。** 加 retry 只是把同一顆骰子再擲一次（它仍然要下載）；把工具鏈快取起來才是把骰子拿掉。

只動 `release-windows` job：**+70 / −0，單一 hunk**。

---

## 落點是查出來的，不是猜的

`tauri-bundler` 把工具目錄解為 `dirs::cache_dir()/tauri`，Windows 上即 `%LOCALAPPDATA%\tauri`：

```rust
// crates/tauri-bundler/src/bundle/windows/nsis/mod.rs
let tauri_tools_path = settings
  .local_tools_directory()
  .map(|d| d.join(".tauri"))
  .unwrap_or_else(|| dirs::cache_dir().unwrap().join("tauri"));
let nsis_toolset_path = tauri_tools_path.join("NSIS");
if !nsis_toolset_path.exists() { get_and_extract_nsis(...)?; }
```
```rust
// crates/tauri-bundler/src/bundle/windows/msi/mod.rs
let wix_path = tauri_tools_path.join("WixTools314");
if !wix_path.exists() { get_and_extract_wix(&wix_path)?; }
```

兩個子目錄合計約 125 MB。

---

## cache key 的設計：什麼該命中、什麼該 miss

Key＝`tauri-toolchain-${{ runner.os }}-cli-<實際解出來的 tauri-cli 版本>`。

| 情況 | 結果 | 為什麼 |
|---|---|---|
| 同一個 tauri-cli 2.x 再跑一次 | **HIT** | 工具鏈由 bundler 決定，bundler 由 tauri-cli 版本決定 |
| tauri-cli 解到新的 2.x | **MISS** → 重抓 → 存新 key | 新 bundler 可能要新工具鏈，不該吃舊的 |
| 史上第一次 | MISS | 定義上如此 |
| 版號解析失敗 | MISS（key 帶 run id，不可能命中） | 見下 |

**綁「解出來的版本」而不是 `^2.0` 這個範圍**：範圍是浮動的，拿範圍當 key 等於把兩個不同 bundler 的產物混進同一格。

**刻意不給 `restore-keys` 前綴。** WiX 解到帶版號的 `WixTools314/`，會自己因為名稱失效；但 NSIS 解到的是**沒有版號的 `NSIS/`**，而上面那段原始碼顯示 bundler 只檢查該目錄「**存不存在**」（外加它自己那顆 `nsis_tauri_utils.dll` 的雜湊 —— 不驗 NSIS 3.x 本體）。前綴 fallback 會把舊的 NSIS 交給新的 bundler，而且它會默默用下去。**miss 的代價就是今天的代價，所以這裡寧緊勿鬆。**

同理，版號解析失敗時退到 `unresolved-${GITHUB_RUN_ID}`（保證 miss）而不是固定字串：退化成今天的行為（每次都下載）是安全方向，固定 key 反而會把過期工具鏈永久釘住。

---

## ⚠️ scope 眉角 —— 這點決定這支是有用還是裝飾

GitHub 的 cache 有分支/tag 隔離。[官方文件](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#restrictions-for-accessing-a-cache)：

> Workflow runs also cannot restore caches created for different tag names. For example, a cache created for the tag `release-a` with the base `main` would not be accessible to a workflow run triggered for the tag `release-b` with the base `main`.

> Workflow runs can restore caches created in either the current branch or **the default branch** (usually `main`).

推論：**tag 觸發的 run 把 cache 存進 `refs/tags/<tag>`，那份對下一個 tag 是死的**；但 restore 會回退到預設分支。所以真正服務發版的那份，必須由 **ref 就是 `main`** 的 run 寫入 —— 也就是這支 workflow 本來就支援的 `workflow_dispatch` dry-run（文件也確認 `workflow_dispatch` 是少數可以寫入預設分支 scope 的 trigger 之一）。

**→ merge 後在 `main` 上手動跑一次 Release 的 `workflow_dispatch` 把 cache 暖起來，之後每次 tag 發版才吃得到。** 沒做這一步的話這支會每次 miss，等於沒加。

---

## 驗收證據

**① 語法**

```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"   # 通過
$ actionlint .github/workflows/release.yml
baseline (HEAD) exit=0
changed        exit=0
```
（actionlint 1.7.12；本機無 shellcheck，故 `run:` 區塊未過 shellcheck 一關。）

**② 我實際跑了那段 shell，不是只用看的** —— 從 parse 完的 YAML 把 `run:` 抽出來執行，所以連跳脫都驗到了：

```
=== CASE 1: 正常路徑 ===
tauri-cli 2.9.1 -> caching C:/Users/runneradmin/AppData/Local/tauri
dir=C:/Users/runneradmin/AppData/Local/tauri
cli=2.9.1                      → key: tauri-toolchain-Windows-cli-2.9.1

=== CASE 2: 版號讀不到 ===
::warning::could not read tauri-cli version (got 'garbage'); toolchain cache disabled for this run
cli=unresolved-12345           → 保證 miss
```

`$LOCALAPPDATA` 的反斜線有轉成正斜線（`actions/cache` 的 `path` 走 glob，反斜線在那裡是跳脫字元不是分隔符），CRLF 也有剝掉。

**③ 不影響 windows 腿以外的任何 job**

```
$ git diff --stat
 .github/workflows/release.yml | 70 +++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 70 insertions(+)

$ git diff -U0 | grep '^@@'
@@ -251,0 +252,70 @@          ← 單一 hunk，0 刪除

job 起始行：release=27, release-windows=174
```
插入點在第 252 行，穩穩落在 `release-windows` 內。macOS 腿**一行未改**，`ci.yml` 未動。

---

## ⚠️ 沒有驗證到的部分（誠實記錄）

**我無法證明 cache restore 真的命中，除非實際跑一次 release —— 而本項紅線明訂不得為了測試推 tag。上面是設計論證＋語法/shell 驗證，不是實測命中。**

第二次跑之後該怎麼判讀：

1. **`Cache the Tauri packaging toolchain (WiX + NSIS)` 這一步的 log**
   - 命中：`Cache restored from key: tauri-toolchain-Windows-cli-2.9.1`
   - 沒命中：`Cache not found for input keys: tauri-toolchain-Windows-cli-2.9.1`
2. **`Build app + installers` 這一步的 log** —— 真正的證據在這裡。命中的話**不該再出現** `Downloading https://github.com/tauri-apps/binary-releases/releases/download/nsis-3.11/nsis-3.11.zip` 與 WiX 的對應那行。restore 說命中、但這兩行還在，就代表快取到的目錄結構不對（例如 `path` 解析錯）。
3. **post-job** 應出現 `Cache saved with key: ...`；若寫的是 tag scope，見上面的 scope 段。

沒命中的三種判讀順序：**(a)** 是不是還沒在 `main` 上跑過 dispatch 把 cache 暖起來（最可能）；**(b)** `tauri-cli` 是不是跳版了（看 `Resolve the Tauri toolchain dir + cache key` 印出的版號）；**(c)** 才去懷疑 `path`。

---

## follow-up

不在本 PR 射程，列著不動手：

1. **`assemble-backend-win.ps1` 的註解與程式碼對不上（`bench_*.json`）** —— 該檔第 172 行寫著 `# bench_*.json is called out in .gitignore as containing private transcripts.`，讀起來像是有排除；但第 191 行實際的 `/XF` 是 `'*.pyc', '.env', '.env.*'`，**沒有 `bench_*.json`**。mac 版有排除。逐項比對兩邊 source-copy 的排除清單後，這是**唯一**的真實落差（其餘差異都只是 rsync 與 robocopy 的寫法不同），而且方向跟直覺相反 —— 一般以為落後的是 mac 版。影響面：在真實工作機上做 Windows release build 時，`bench_*.json`（含私人逐字稿與檔名）會被打進 `.exe`/`.msi`，而那是要上 GitHub Release 的產物。CI 乾淨 checkout 看不到，只有實機 build 會中 —— 跟 #308 那批「三個坑只在真實工作機發作」同一個形狀。一個 token 的修法，但不在 W3-5 射程內，故未動。
2. **`release.yml` 兩腿共用 Release 的乾淨解** —— 目前靠 `needs: release` 序列化避免兩個 job 同時對同一個 Release 做 create-or-update，代價是 tag 建置時間變成兩者相加。乾淨做法＝兩腿都只上傳 artifact、第三個 `publish` job 統一建 Release。
3. **cache 暖機可以自動化** —— 與其倚賴人記得在 `main` 上手動跑 dispatch，可以在 `ci.yml` 的 `push: branches: [main]` 加一支只做「install tauri-cli + 觸發一次 bundle」的極小 job 把預設分支 scope 餵飽。有成本，值不值得看發版頻率。
4. **Authenticode 簽章（W5）** 仍未做，維持未簽 + SmartScreen 一次性警告。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
