### PR TITLE
fix(release): win 版的註解宣稱排除 bench_*.json，實際的 /XF 沒有它

### DIFF
--- a/src-tauri/assemble-backend-win.ps1
+++ b/src-tauri/assemble-backend-win.ps1
@@ -188,7 +188,7 @@ Invoke-Robocopy -Source $REPO -Dest (Join-Path $BACKEND 'src') -ExtraArgs @(
     (Join-Path $REPO 'waveforms'),
     (Join-Path $REPO '.tmp-camera-report-tests'),
     'node_modules', '__pycache__', '.pytest_cache', '.ruff_cache',
-    '/XF', '*.pyc', '.env', '.env.*'
+    '/XF', '*.pyc', '.env', '.env.*', 'bench_*.json'
 )
 
 # Fail loud rather than ship quietly. Not redundant with /XF above: robocopy is


### PR DESCRIPTION
## 註解宣稱了它自己沒做的事

`src-tauri/assemble-backend-win.ps1:172`：

```powershell
# bench_*.json is called out in .gitignore as containing private transcripts.
```

`:191` 實際的排除清單：

```powershell
'/XF', '*.pyc', '.env', '.env.*'
```

**沒有 `bench_*.json`。** 而 mac 版 `assemble-backend.sh:82` 有：

```bash
--exclude 'bench_*.json' \
```

## 後果

在**真實工作機**做 Windows release build 時，含私人逐字稿與檔名的 `bench_*.json` 會被打進要上傳到 GitHub Release 的 `.exe` / `.msi`。

⚠️ **乾淨的 CI checkout 看不到這件事** —— 那裡根本沒有 bench 檔，所以 `test-windows` 綠不代表安全。這跟 PR #308 那批「只在真實工作機發作」是同一個形狀。

## 修法

一個 token。**沒有設計決定要做** —— 註解已經宣告了預期行為，只是 code 沒做到；補上之後兩邊排除清單一致。

```diff
-    '/XF', '*.pyc', '.env', '.env.*'
+    '/XF', '*.pyc', '.env', '.env.*', 'bench_*.json'
```

## 驗證

| | mac (`assemble-backend.sh`) | win (`.ps1`) 改前 | win 改後 |
|---|---|---|---|
| `temp/` `thumbnails/` `proxies/` `waveforms/` | ✅ | ✅ | ✅ |
| `.env` / `.env.*` | ✅ | ✅ | ✅ |
| **`bench_*.json`** | ✅ | ❌ | ✅ |

⚠️ **誠實記錄**：我**沒有**在 Windows 上實跑 robocopy 驗證這個 pattern —— 這是唯讀環境。`/XF` 吃檔名 glob，`bench_*.json` 與同清單裡既有的 `.env.*` 同形，但**若要當證據用請自行在 Windows 上驗一次**。

## 出處

發現於 hevin-ai-os 四波收斂計畫 **Wave 3 / W3-5** 的查證過程 —— 該項（`assemble-backend.sh` 的 scratch-dir 缺口）本身確認**早已由 PR #337 完成**，這是查證時反方向撞到的真缺口。不在原射程內，故獨立成一支 PR。

## follow-up（本 PR 不做）

- mac 版有一道 `.env*` 的 **fail-loud 事後掃描**（rsync 之後再 `find` 一次，理由是「denylist 只擋得住有人記得的 pattern」）。win 版也有同型的 `.env*` 掃描，但**兩邊都沒有對 `bench_*.json` 做同樣的事** —— denylist 補上了，class-level 的守衛沒有。要不要加是獨立判斷。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
