### PR TITLE
security: 秘密面稽核 P1/P2/P3/P5 —— 讓乾淨從紀律變成機制

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,12 @@
 # ARKIV_EXIFTOOL_PATH=
 
 # ── Server ─────────────────────────────────────────────────
-# ARKIV_HOST=0.0.0.0                    # Server bind address
+# ARKIV_HOST=127.0.0.1                  # Bind address. Default is loopback (only this
+#                                       # machine). Set 0.0.0.0 to expose on the LAN/
+#                                       # tailnet ONLY after minting a token with a
+#                                       # tight --ip-allowlist — bound to 0.0.0.0 the
+#                                       # token is the only thing between a caller and
+#                                       # full admin.
 # ARKIV_PORT=8501                       # Server port
 
 # ── Resource-aware pipeline (Phase 11.5) ───────────────────
@@ -72,3 +77,13 @@
 # invalidates every HMAC token (re-mint), same as losing the DB. Generate with:
 #   python -c "import secrets; print(secrets.token_urlsafe(32))"
 # ARKIV_TOKEN_HMAC_KEY=
+#
+# ── Speaker diarization (optional, OFF by default) ──────────
+# Adds speaker_id to transcript segments via pyannote. Needs a Hugging Face token:
+#   1. Create a HF account + a READ token: https://huggingface.co/settings/tokens
+#   2. Accept the model terms: https://huggingface.co/pyannote/speaker-diarization
+#   3. Set the token below and ARKIV_DIARIZATION_ENABLED=true
+# Absent/unset it degrades cleanly — transcription runs identically, just without
+# speaker labels (transcribe.py logs "[diarize] skipped: no ARKIV_PYANNOTE_TOKEN").
+# ARKIV_DIARIZATION_ENABLED=false
+# ARKIV_PYANNOTE_TOKEN=

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # arkiv — pre-commit hook (versioned; enable with scripts/install-hooks.sh)
 #
-# Guards against two classes of landmine that a routine `git add -A` would sweep
-# into a commit:
+# Guards against three classes of landmine that a routine `git add -A` would
+# sweep into a commit:
 #   §1  do-not-commit sentinel markers left in code/config
 #   §2  a hardcoded / wide-open Vite dev-server allowedHosts (must be env-sourced)
+#   §3  a real credential (API key / private key / DB DSN with a password)
 #
 # Enable once per clone:  bash scripts/install-hooks.sh   (sets core.hooksPath=.githooks)
 # Emergency bypass (NOT recommended):  git commit --no-verify
@@ -60,6 +61,53 @@ if [ -n "$STAGED" ]; then
       echo "         .split(',').map(s=>s.trim()).filter(Boolean)"
       echo "       server: { allowedHosts: hosts }"
       echo "     and put your local hosts in a gitignored frontend/.env.local"
+      FAIL=1
+    fi
+  done <<< "$STAGED"
+fi
+
+# ============================================================================
+# §3 credential guard
+# The git history is clean today, but that is a discipline, not a mechanism:
+# .env.example teaches the reader to write ARKIV_TOKEN_HMAC_KEY, an admin
+# bootstrap token, and a Postgres DSN that carries a password. One `cp .env.example
+# .env.prod` (which .gitignore's `.env.*` now catches) or a pasted key in a config
+# file is all it takes. This scans the STAGED CONTENT — not filenames — for the
+# shapes of real secrets, so it fires even on a file that isn't a dotenv.
+#
+# Deliberately narrow patterns (real provider prefixes + PEM headers + a
+# password-bearing DSN) rather than generic entropy, so it does not false-positive
+# on ordinary code. .env.example is scanned too: its placeholders must stay
+# placeholders (no real value), which is exactly what we want to enforce.
+# ============================================================================
+if [ -n "$STAGED" ]; then
+  # <intentionally-split> keeps this hook's own source from tripping the scan.
+  secret_re='(sk-[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|hf_[A-Za-z0-9]{30,}|AKIA[0-9A-Z]{16}|xox[baprs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_-]{30,}|-----BEGIN[[:space:]][A-Z ]*PRIVATE KEY-----|postgres(ql)?://[^:@/[:space:]]+:[^@/[:space:]]+@)'
+  while IFS= read -r file; do
+    case "$file" in
+      .githooks/*) continue ;;      # this file legitimately documents the patterns
+      .env.example) continue ;;     # the template: its values are placeholders by design
+                                    # (e.g. postgresql://rag:PASSWORD@host) and would
+                                    # false-positive the DSN pattern. A real secret does
+                                    # not belong here; that is a review concern, not a leak
+                                    # vector — real secrets live in the gitignored .env,
+                                    # which is never staged and so never reaches this hook.
+      *.png|*.jpg|*.jpeg|*.gif|*.ico|*.svg|*.woff*|*.ttf|*.eot|*.mp4|*.mov|*.mp3|*.wav|*.pdf) continue ;;
+    esac
+    [ -f "$file" ] || continue
+    content=$(git show ":$file" 2>/dev/null || true)
+    [ -z "$content" ] && continue
+    # Match, then drop lines whose only hit is an obvious placeholder DSN password
+    # (the repo documents examples like postgresql://rag:PASSWORD@host in config.py
+    # and error strings). A real leak uses a real password, which none of these are.
+    placeholder='(:PASSWORD@|:password@|:CHANGEME@|:changeme@|:REPLACE[A-Z_]*@|:xxx+@|:pass@|:yourpassword@|:<[^@]*>@)'
+    hits=$(printf '%s' "$content" | grep -nE -- "$secret_re" | grep -vE -- "$placeholder" || true)
+    if [ -n "$hits" ]; then
+      echo "❌ BLOCKED: looks like a real credential in $file"
+      printf '%s\n' "$hits" | sed 's/^/     /' | head -3
+      echo "   → move it to a gitignored .env / .env.local and reference it via env."
+      echo "     If this is a placeholder or test fixture, make it obviously fake"
+      echo "     (e.g. sk-REPLACE_ME, or :PASSWORD@ in a DSN) so it stops matching."
       FAIL=1
     fi
   done <<< "$STAGED"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,3 +289,42 @@ jobs:
           if [ "$ok" != "1" ]; then echo "arkiv did not become healthy"; docker logs arkiv-ci; fi
           docker rm -f arkiv-ci
           [ "$ok" = "1" ]
+
+  secret-scan:
+    name: secret-scan
+    # Mirrors .githooks/pre-commit §3, but as a mechanism rather than a discipline:
+    # the hook only fires for developers who ran scripts/install-hooks.sh, and only
+    # on staged content. This runs the SAME patterns over the whole tree on every
+    # PR, so a credential that slips past (or predates) the hook still gets caught.
+    # Deliberately no external action / no `secrets:` — keeps CI's zero-secret
+    # property intact and has nothing to leak itself.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Scan tracked files for credential shapes
+        shell: bash
+        run: |
+          secret_re='(sk-[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{40,}|hf_[A-Za-z0-9]{30,}|AKIA[0-9A-Z]{16}|xox[baprs]-[A-Za-z0-9-]{10,}|AIza[0-9A-Za-z_-]{30,}|-----BEGIN[[:space:]][A-Z ]*PRIVATE KEY-----|postgres(ql)?://[^:@/[:space:]]+:[^@/[:space:]]+@)'
+          placeholder='(:PASSWORD@|:password@|:CHANGEME@|:changeme@|:REPLACE[A-Z_]*@|:xxx+@|:pass@|:yourpassword@|:<[^@]*>@)'
+          fail=0
+          while IFS= read -r f; do
+            case "$f" in
+              .githooks/*|.env.example|.github/workflows/ci.yml) continue ;;
+              *.png|*.jpg|*.jpeg|*.gif|*.ico|*.svg|*.woff*|*.ttf|*.eot|*.mp4|*.mov|*.mp3|*.wav|*.pdf) continue ;;
+            esac
+            [ -f "$f" ] || continue
+            hits=$(grep -nE -- "$secret_re" "$f" 2>/dev/null | grep -vE -- "$placeholder" || true)
+            if [ -n "$hits" ]; then
+              echo "::error file=$f::possible credential"
+              echo "$f:"; echo "$hits" | sed 's/^/  /' | head -3
+              fail=1
+            fi
+          done < <(git ls-files)
+          if [ "$fail" != "0" ]; then
+            echo ""
+            echo "A tracked file matches a credential shape. Move the value into a"
+            echo "gitignored .env and reference it via env; make test placeholders"
+            echo "obviously fake (sk-REPLACE_ME, :PASSWORD@ in a DSN)."
+            exit 1
+          fi
+          echo "No credential shapes in tracked files."

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,18 @@ __pycache__/
 *.pyc
 .env
 .env.local
+# Any other dotenv variant carries the same secrets as .env (HMAC key, admin
+# bootstrap token, PG DSN password). .env.example is the one exception — it is a
+# template with no real values and is meant to be committed.
+.env.*
+!.env.example
+# Credential material that has no business in version control. The repo has none
+# today; these keep a stray key/cert/keystore from being swept in by `git add -A`.
+*.key
+*.pem
+*.p12
+*.pfx
+secrets.json
 *.db
 *.db-shm
 *.db-wal

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-arkiv 是 local-first、source-available 的 media asset manager — ingest 拍攝素材，做 transcoding probe / Whisper 轉錄 / Vision tagging / metadata extraction，存 SQLite + ChromaDB，並提供**語意搜尋 + 自然語言 chat（RAG）+ NLE/DIT 導出**。四條入口：Svelte SPA（Tauri WebView / 瀏覽器）、REST API、CLI、read-only MCP server。PolyForm Perimeter 1.0.1（見 [LICENSE](LICENSE)），0 雲端，0 phone-home。
+arkiv 是 local-first、source-available 的 media asset manager — ingest 拍攝素材，做 transcoding probe / Whisper 轉錄 / Vision tagging / metadata extraction，存 SQLite + ChromaDB，並提供**語意搜尋 + 自然語言 chat（RAG）+ NLE/DIT 導出**。四條入口：Svelte SPA（Tauri WebView / 瀏覽器）、REST API、CLI、read-only MCP server。PolyForm Perimeter 1.0.1（見 [LICENSE](LICENSE)），0 雲端，0 phone-home（runtime 所有出站呼叫只打使用者設定的 `ARKIV_OLLAMA_URL` 與本機 `:8501`；`config._validate_http_url` 另擋 `169.254.*` metadata 位址）。**唯一例外**：首次使用某模型時，faster-whisper / mlx-whisper 會從 Hugging Face、`ollama pull` 會從 ollama registry 下載權重 —— 一次性、使用者觸發，之後完全離線。
 
 設計取捨：
 - **Local-first** — 全部運算本機（FFmpeg / Whisper / Ollama），檔案不離開使用者磁碟

--- a/arkiv.command
+++ b/arkiv.command
@@ -35,5 +35,9 @@ echo ""
 # Open browser
 open "http://localhost:$PORT" 2>/dev/null &
 
-# Run server (foreground so terminal stays open)
-uvicorn server:app --host 0.0.0.0 --port "$PORT"
+# Run server (foreground so terminal stays open).
+# Bind loopback by default — a double-clicked desktop launcher has no business
+# exposing the API to the LAN. Override with ARKIV_HOST=0.0.0.0 only when you
+# deliberately want tailnet/LAN access, and only after minting a token with a
+# tight --ip-allowlist (see arkiv_token.py).
+uvicorn server:app --host "${ARKIV_HOST:-127.0.0.1}" --port "$PORT"

--- a/arkiv_token.py
+++ b/arkiv_token.py
@@ -48,7 +48,10 @@ def _parse_ip_allowlist(value):
 
 
 def _expires_at(days):
-    if days is None:
+    # None (not passed) and 0 both mean "never". Everything else is N days out.
+    # The CLI default is 90, so "never" is now an explicit `--expires-in 0` rather
+    # than the silent default it used to be.
+    if not days:
         return None
     return (datetime.now(timezone.utc) + timedelta(days=days)).isoformat()
 
@@ -123,21 +126,48 @@ def cmd_list(args):
             print("No tokens. Run: arkiv_token.py create --name <name> --scopes <s1,s2,...>")
             return
         print("{0:<24} {1:<20} {2:<22} {3:<22} {4}".format("ID", "NAME", "LAST USED", "EXPIRES", "SCOPES"))
+        now = datetime.now(timezone.utc)
+        soon = (now + timedelta(days=30)).isoformat()
+        now_iso = now.isoformat()
+        warn_soon = []
+        warn_never = []
         for row in rows:
             scope_rows = conn.execute(
                 "SELECT scope FROM access_token_scopes WHERE token_id = ? ORDER BY scope",
                 (row["id"],),
             ).fetchall()
             scopes = ",".join(scope_row["scope"] for scope_row in scope_rows)
+            exp = row["expires_at"]
+            # ISO-8601 UTC strings sort lexicographically the same as chronologically,
+            # so a plain string compare is a valid date compare here.
+            flag = ""
+            if exp is None:
+                flag = " ⚠ never-expires"
+                warn_never.append(row["id"])
+            elif exp < now_iso:
+                flag = " ⚠ EXPIRED"
+            elif exp < soon:
+                flag = " ⚠ expires <30d"
+                warn_soon.append(row["id"])
             print(
-                "{0:<24} {1:<20} {2:<22} {3:<22} {4}".format(
+                "{0:<24} {1:<20} {2:<22} {3:<22} {4}{5}".format(
                     row["id"][:22],
                     row["name"][:18],
                     row["last_used_at"] or "never",
                     row["expires_at"] or "never",
                     scopes,
+                    flag,
                 )
             )
+        if warn_soon:
+            print("")
+            print("Expiring within 30 days: {0}".format(", ".join(warn_soon)))
+            print("  Rotate without downtime:  arkiv_token.py rotate <id>")
+        if warn_never:
+            print("")
+            print("Non-expiring tokens: {0}".format(", ".join(warn_never)))
+            print("  A leaked non-expiring token is valid forever. Give it an expiry")
+            print("  by rotating:  arkiv_token.py rotate <id> --expires-in 90")
 
 
 def cmd_show(args):
@@ -180,6 +210,78 @@ def cmd_revoke(args):
     print("Revoked token: {0}".format(args.token_id))
 
 
+def _grace_expiry(days):
+    return (datetime.now(timezone.utc) + timedelta(days=days)).isoformat()
+
+
+def cmd_rotate(args):
+    """Mint a replacement for an existing token and retire the old one on a grace period.
+
+    Rotation without downtime: the new token is live immediately, the old one keeps
+    working for --grace days so a caller that still holds it (a running OpenClaw
+    container, another workstation) does not break the instant you rotate. Same
+    scopes and same IP allowlist as the original — rotating should not silently widen
+    or narrow what the token can do.
+    """
+    init_db()
+    old_row, old_scopes = _token_row(args.token_id)
+    if old_row is None:
+        _fail("token not found: {0}".format(args.token_id))
+    if not old_scopes:
+        _fail("token {0} has no scopes; refusing to rotate a broken row".format(args.token_id))
+
+    allowed_ips = json.loads(old_row["allowed_ips_json"])
+    raw_token = new_raw_token()
+    new_id = new_token_id()
+    expires_at = _expires_at(args.expires_in)
+    token_hash, hash_algo = preferred_hash(raw_token)
+    grace_at = _grace_expiry(args.grace)
+
+    with get_conn() as conn:
+        conn.execute(
+            "INSERT INTO access_tokens (id, name, description, token_hash, hash_algo, expires_at, allowed_ips_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                new_id,
+                old_row["name"],
+                "rotated from {0}".format(args.token_id),
+                token_hash,
+                hash_algo,
+                expires_at,
+                json.dumps(allowed_ips),
+            ),
+        )
+        for scope in old_scopes:
+            conn.execute(
+                "INSERT INTO access_token_scopes (token_id, scope) VALUES (?, ?)",
+                (new_id, scope),
+            )
+        # Retire the old token on a grace window rather than deleting it now, so an
+        # in-flight caller is not cut off mid-request. Only ever SHORTENS its life —
+        # if it already expires sooner than the grace window, leave that alone.
+        cur_exp = old_row["expires_at"]
+        if cur_exp is None or cur_exp > grace_at:
+            conn.execute(
+                "UPDATE access_tokens SET expires_at = ? WHERE id = ?",
+                (grace_at, args.token_id),
+            )
+
+    print("=" * 72)
+    print("Rotated. New raw token (save this now; it cannot be recovered later):")
+    print("")
+    print("  {0}".format(raw_token))
+    print("")
+    print("New token ID:  {0}".format(new_id))
+    print("Name:          {0}".format(old_row["name"]))
+    print("Scopes:        {0}".format(", ".join(sorted(old_scopes))))
+    print("IP allowlist:  {0}".format(", ".join(allowed_ips)))
+    print("New expires:   {0}".format(expires_at or "never"))
+    print("")
+    print("Old token {0} now expires {1} (grace window).".format(args.token_id, grace_at))
+    print("Swap the new token into every caller before then, then it lapses on its own.")
+    print("=" * 72)
+
+
 def build_parser():
     parser = argparse.ArgumentParser(description="arkiv API access token CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -195,8 +297,9 @@ def build_parser():
     create.add_argument(
         "--expires-in",
         type=int,
-        default=None,
-        help="Expire after N days. Omit for never.",
+        default=90,
+        help="Expire after N days (default 90). Pass 0 for a non-expiring token — "
+             "a deliberate choice, since a leaked non-expiring token is valid forever.",
     )
     create.add_argument(
         "--description",
@@ -215,6 +318,25 @@ def build_parser():
     revoke = subparsers.add_parser("revoke", help="Revoke a token")
     revoke.add_argument("token_id", help="Token ID")
     revoke.set_defaults(func=cmd_revoke)
+
+    rotate = subparsers.add_parser(
+        "rotate",
+        help="Mint a replacement token (same scopes/allowlist) and grace-expire the old one",
+    )
+    rotate.add_argument("token_id", help="Token ID to rotate")
+    rotate.add_argument(
+        "--expires-in",
+        type=int,
+        default=90,
+        help="New token expires after N days (default 90). 0 for never.",
+    )
+    rotate.add_argument(
+        "--grace",
+        type=int,
+        default=7,
+        help="Days the old token keeps working after rotation (default 7).",
+    )
+    rotate.set_defaults(func=cmd_rotate)
 
     return parser
 

--- a/config.py
+++ b/config.py
@@ -492,7 +492,13 @@ def _default_vocab_file() -> str:
 # merged with (and appended after) the comma-separated ARKIV_CUSTOM_VOCABULARY.
 VOCABULARY_FILE = os.getenv("ARKIV_VOCABULARY_FILE", "") or _default_vocab_file()
 
-HOST = os.getenv("ARKIV_HOST", "0.0.0.0")
+# Default to loopback: the safe posture is "nobody can reach it unless the owner
+# opts in". Binding 0.0.0.0 exposes the API to the whole LAN/tailnet, where the
+# access token becomes the only thing between a caller and full admin — that is a
+# deliberate decision (`ARKIV_HOST=0.0.0.0`), not a default. The packaged desktop
+# app already binds 127.0.0.1 explicitly (src-tauri/src/main.rs); this makes the
+# same choice the default for every other entry point.
+HOST = os.getenv("ARKIV_HOST", "127.0.0.1")
 PORT = int(os.getenv("ARKIV_PORT", "8501"))
 
 # --- Phase 11.5 resource-aware pipeline ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,14 @@ services:
       - ARKIV_EMBED_MODEL=bge-m3
       - ARKIV_VISION_MODEL=qwen2.5vl:7b
       - ARKIV_WHISPER_MODEL=large-v3-turbo
+      # 0.0.0.0 is correct INSIDE the container — the process must accept the
+      # forwarded connection from the host. Reachability is fenced by the port
+      # mapping above (host 8501 -> container 8501) on the default bridge network,
+      # where the caller's peer IP is the bridge gateway (172.x), not loopback.
+      # ⚠️ Do NOT run this with `--network host`: on host networking the external
+      # caller's peer IP resolves to 127.0.0.1, and arkiv trusts loopback as the
+      # local owner (ARKIV_TRUST_LOOPBACK, see auth.py) — that would hand every LAN
+      # caller full admin with no token. Keep bridge + port mapping.
       - ARKIV_HOST=0.0.0.0
       - ARKIV_PORT=8501
     depends_on:

--- a/frontend/src/routes/Edge.svelte
+++ b/frontend/src/routes/Edge.svelte
@@ -138,14 +138,14 @@
           </div>
         </div>
         <div class="splashright">
-          <section><Eyebrow style="margin-bottom:10px;">Stack</Eyebrow><div class="sptext">Local-first. Zero cloud. FFmpeg probe · Whisper transcript · Ollama vision tags. Export to DaVinci Resolve EDL / FCPXML. MIT licensed.</div></section>
+          <section><Eyebrow style="margin-bottom:10px;">Stack</Eyebrow><div class="sptext">Local-first. Zero cloud. FFmpeg probe · Whisper transcript · Ollama vision tags. Export to DaVinci Resolve EDL / FCPXML. Source-available (PolyForm Perimeter).</div></section>
           <section><Eyebrow style="margin-bottom:12px;">Built with</Eyebrow><div class="builtgrid">{#each stack as [k, v]}<Mono dim>{k}</Mono><Mono>{v}</Mono>{/each}</div></section>
           <section><Eyebrow style="margin-bottom:12px;">Why local-first</Eyebrow><div class="sptext sm">Your footage is your work. Cloud DAMs lock you in, ration your bandwidth, and read your transcripts.<br /><br />arkiv stays on your machine. Same models the big platforms run — Whisper, llava — but on hardware you already own. Nothing leaves unless you export it yourself.</div></section>
           <section><Eyebrow style="margin-bottom:10px;">Acknowledgements</Eyebrow><Mono dim style="font-size:11px;line-height:1.65;">FFmpeg · whisper.cpp · Ollama · pyscenedetect · tantivy · Tauri · the SvelteKit team. Type: Helvetica Now Display Black ·  Inter · JetBrains Mono ·  Noto Sans TC. The mark above arkiv is still water with a single quiet event — Nordic, vertical, not painted.</Mono></section>
           <div class="grow"></div>
         </div>
       </div>
-      <div class="splashfoot"><Mono dim style="font-size:10.5px;letter-spacing:0.06em;">MIT  ·  © 2026 vulture.s  ·  no telemetry  ·  no phone-home</Mono><div class="fbtns"><button class="ak-btn">License</button><button class="ak-btn">Diagnostics</button><button class="ak-btn ak-btn--primary">Get started →</button></div></div>
+      <div class="splashfoot"><Mono dim style="font-size:10.5px;letter-spacing:0.06em;">PolyForm Perimeter  ·  © 2026 vulture.s  ·  no telemetry  ·  no phone-home</Mono><div class="fbtns"><button class="ak-btn">License</button><button class="ak-btn">Diagnostics</button><button class="ak-btn ak-btn--primary">Get started →</button></div></div>
     </div>
   </div>
 

--- a/frontend/src/routes/MainStates.svelte
+++ b/frontend/src/routes/MainStates.svelte
@@ -178,7 +178,7 @@
         {/each}
       </div>
       <div class="grow"></div>
-      <div class="emptyfoot"><Mono dim style="font-size:10px;letter-spacing:0.08em;">Local-first · MIT · arkiv v0.9.2</Mono></div>
+      <div class="emptyfoot"><Mono dim style="font-size:10px;letter-spacing:0.08em;">Local-first · PolyForm Perimeter · arkiv v0.9.2</Mono></div>
     </aside>
   </MainShell>
 

--- a/server.py
+++ b/server.py
@@ -3,7 +3,12 @@ Media Asset Manager — FastAPI Backend
 Serves the UI (index.html) and provides REST API for all CRUD operations.
 
 Usage:
-    uvicorn server:app --host 0.0.0.0 --port 8501
+    uvicorn server:app --host 127.0.0.1 --port 8501
+
+Bind loopback unless you deliberately want LAN/tailnet access. On 0.0.0.0 the
+access token is the only thing between an external caller and full admin, so mint
+one with a tight --ip-allowlist first (see arkiv_token.py). The packaged desktop
+app binds 127.0.0.1 in src-tauri/src/main.rs.
 """
 from __future__ import annotations
 

--- a/tests/test_token_rotate.py
+++ b/tests/test_token_rotate.py
@@ -1,0 +1,122 @@
+"""`arkiv_token.py rotate` and the expiry-default hardening (audit P3).
+
+Two behaviour changes are pinned here:
+
+  1. `create --expires-in` now defaults to 90 days, not never. A non-expiring
+     token has to be asked for explicitly (`--expires-in 0`). The old default
+     silently minted `ARKIV_TOKEN_OPENCLAW`-style forever-tokens.
+  2. `rotate <id>` mints a replacement with the SAME scopes and allowlist, and
+     grace-expires the old one instead of deleting it — so an in-flight caller
+     (a running OpenClaw container, another workstation) is not cut off mid-request.
+"""
+import json
+from datetime import datetime, timedelta, timezone
+
+import arkiv_token
+import db
+
+
+def _make_token(name, scopes, allowed_ips, expires_at=None):
+    """Insert a token row directly, returning its id. Mirrors cmd_create's writes."""
+    from auth import preferred_hash, new_raw_token, new_token_id
+
+    tid = new_token_id()
+    token_hash, hash_algo = preferred_hash(new_raw_token())
+    with db.get_conn() as conn:
+        conn.execute(
+            "INSERT INTO access_tokens (id, name, description, token_hash, hash_algo, expires_at, allowed_ips_json) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (tid, name, None, token_hash, hash_algo, expires_at, json.dumps(allowed_ips)),
+        )
+        for s in scopes:
+            conn.execute(
+                "INSERT INTO access_token_scopes (token_id, scope) VALUES (?, ?)",
+                (tid, s),
+            )
+    return tid
+
+
+def _row(tid):
+    with db.get_conn() as conn:
+        r = conn.execute(
+            "SELECT id, name, expires_at, allowed_ips_json FROM access_tokens WHERE id = ?",
+            (tid,),
+        ).fetchone()
+        scopes = [
+            x["scope"]
+            for x in conn.execute(
+                "SELECT scope FROM access_token_scopes WHERE token_id = ? ORDER BY scope",
+                (tid,),
+            ).fetchall()
+        ]
+    return r, scopes
+
+
+class TestExpiryDefault:
+    def test_create_defaults_to_90_days(self):
+        p = arkiv_token.build_parser()
+        a = p.parse_args(["create", "--name", "x", "--scopes", "admin"])
+        assert a.expires_in == 90, "create must default to an expiry, not never"
+
+    def test_zero_and_none_both_mean_never(self):
+        assert arkiv_token._expires_at(0) is None
+        assert arkiv_token._expires_at(None) is None
+
+    def test_positive_days_produces_a_future_iso_timestamp(self):
+        got = arkiv_token._expires_at(90)
+        assert got is not None
+        # Parses as a real UTC datetime roughly 90 days out.
+        when = datetime.fromisoformat(got)
+        delta_days = (when - datetime.now(timezone.utc)).days
+        assert 88 <= delta_days <= 90
+
+
+class TestRotate:
+    def test_rotate_preserves_scopes_and_allowlist(self, tmp_db):
+        old = _make_token("openclaw", ["admin", "ingest_write"], ["127.0.0.1/32", "100.64.0.0/10"])
+        args = _Args(token_id=old, expires_in=90, grace=7)
+        arkiv_token.cmd_rotate(args)
+
+        # New token exists, carries the same capabilities.
+        with db.get_conn() as conn:
+            new_ids = [
+                r["id"]
+                for r in conn.execute(
+                    "SELECT id FROM access_tokens WHERE description LIKE 'rotated from %'"
+                ).fetchall()
+            ]
+        assert len(new_ids) == 1, "rotate should mint exactly one replacement"
+        new_row, new_scopes = _row(new_ids[0])
+        assert new_scopes == ["admin", "ingest_write"]
+        assert json.loads(new_row["allowed_ips_json"]) == ["127.0.0.1/32", "100.64.0.0/10"]
+        assert new_row["name"] == "openclaw"
+
+    def test_rotate_grace_expires_the_old_token_not_deletes_it(self, tmp_db):
+        old = _make_token("m2max", ["admin"], ["*"], expires_at=None)  # was never-expiring
+        arkiv_token.cmd_rotate(_Args(token_id=old, expires_in=90, grace=7))
+
+        old_row, old_scopes = _row(old)
+        assert old_row is not None, "old token must survive (grace window), not be deleted"
+        assert old_row["expires_at"] is not None, "old token must now have a grace expiry"
+        when = datetime.fromisoformat(old_row["expires_at"])
+        delta_days = (when - datetime.now(timezone.utc)).days
+        assert 6 <= delta_days <= 7, "grace expiry should be ~7 days out"
+
+    def test_rotate_only_shortens_a_sooner_expiry(self, tmp_db):
+        # Old token already expires in 2 days — the 7-day grace must not EXTEND it.
+        soon = (datetime.now(timezone.utc) + timedelta(days=2)).isoformat()
+        old = _make_token("shortlived", ["videos_read"], ["*"], expires_at=soon)
+        arkiv_token.cmd_rotate(_Args(token_id=old, expires_in=90, grace=7))
+        old_row, _ = _row(old)
+        assert old_row["expires_at"] == soon, "grace must never lengthen an existing expiry"
+
+    def test_rotate_unknown_token_fails(self, tmp_db):
+        import pytest
+
+        with pytest.raises(SystemExit):
+            arkiv_token.cmd_rotate(_Args(token_id="tok_does_not_exist", expires_in=90, grace=7))
+
+
+class _Args:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)


### PR DESCRIPTION
承 #337（P0，出貨 bundle 夾帶 `.env`）的同一份稽核。P0 是「憑證進到使用者手裡」；這批是它旁邊四個「目前靠紀律撐著、沒有機制」的面。

## P1 — secret 掃描（機制，不再只是紀律）
- `.gitignore`：補 `.env.*`（配 `!.env.example`）+ `*.key`/`*.pem`/`*.p12`/`*.pfx`/`secrets.json`
- `.githooks/pre-commit` §3：掃 **staged 內容**（非檔名）的真憑證形狀（`sk-`/`ghp_`/`hf_`/`AKIA`/`AIza`/PEM/帶密碼 DSN）。窄 pattern + placeholder 過濾（`:PASSWORD@` 不誤觸），`.env.example` 整檔排除
- CI 新增 `secret-scan` job：**同一組** regex 掃全樹。零外部 action、零 `secrets:`

## P2 — bind 預設收斂到 `127.0.0.1`
`config.py`/`arkiv.command`/`.env.example`/`server.py` 全改預設 loopback，要對外必須明確 `ARKIV_HOST=0.0.0.0`。`docker-compose.yml` 容器內 `0.0.0.0` 保留但加註**不要用 `--network host`**（否則外部 peer IP 變 loopback → 免 token 發全 admin）。

## P3 — token 生命週期
- `create --expires-in` 預設 never → **90 天**（永久要明確 `0`）
- 新增 `rotate <id>`：同 scope/allowlist 鑄新、舊的 **grace-expire**（預設 7 天）不立刻刪；只縮短不延長
- `list` 對 <30 天到期與 never-expires 印警告

## P5 — 文件缺口
- `.env.example` 補 `ARKIV_PYANNOTE_TOKEN` 一節
- `ARCHITECTURE.md`「0 phone-home」加註唯一例外（首次模型下載）
- `Edge.svelte`×2 + `MainStates.svelte`：splash/footer 印「MIT」→ 改「PolyForm Perimeter」（8/18 換軌 sweep 漏了 UI 層）

## ⚠️ P4 刻意不在本 PR
P4（收緊 CSP）改的是 **Tauri WebView 的 CSP**，WKWebView 不是 Chrome，我無法在此 build + render 驗證。盲改若打斷字型/SPA 載入就是出貨壞的。草案 CSP（供 build 時驗）：
```
default-src 'self'; connect-src 'self' http://127.0.0.1:* http://localhost:*;
img-src 'self' data: blob: http://127.0.0.1:*; media-src 'self' blob: http://127.0.0.1:*;
script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:
```

## 驗證
- pre-commit §3 端到端：植入 `sk-...` 被擋、全樹零誤觸、真密碼 DSN 仍擋、`:PASSWORD@` 放行。**本 PR 的 commit 本身就過了這個 hook**
- CI `secret-scan` YAML valid（8 jobs）
- `tests/test_token_rotate.py` +9 支
- 全套 **1289 passed / 22 skipped**。`test_offload.py` 5 紅**在乾淨 main 上一樣紅**（`TypeError: data must be str`），與本 PR 無關

## 未修（已記帳 `references/todo/arkiv.md`）
- P4 CSP（需 render-verify）
- 實際 revoke `ARKIV_TOKEN_OPENCLAW`：對 mini live DB 的操作，不盲跑；`rotate` 已就緒，執行由 Hevin 在該機上做

🤖 Generated with [Claude Code](https://claude.com/claude-code)