### PR TITLE
fix(licensing): grandfather 判定從來沒看過「這個安裝正在用的那個庫」

### DIFF
--- a/projects.py
+++ b/projects.py
@@ -124,13 +124,48 @@ def resolve_project_db(project_root, explicit=None) -> Path:
     return project_db
 
 
+def _own_library_db() -> Optional[Path]:
+    """This install's CURRENT library — the one it has open right now.
+
+    Everything else `_known_project_dbs` collects is a library the user pointed
+    the install AT. This is the one it is actually using, which makes it the
+    strongest evidence that the install was in use before the cap — and it was
+    the one thing the grandfather probe never looked at.
+
+    `config.DB_PATH` first, because that is the resolved answer for this install
+    (and honours `ARKIV_DB_PATH` / a test that points config at a tmp library).
+    Only when that file does not exist do we fall back to resolving the root,
+    which is where `resolve_project_db` finds a pre-8.0c `.arkiv/media.db` —
+    the oldest libraries in the wild and the ones with the strongest claim.
+    """
+    import config as _config
+
+    try:
+        candidate = Path(_config.DB_PATH)
+        if candidate.exists():
+            return candidate
+        return resolve_project_db(Path(_config.PROJECT_ROOT))
+    except (OSError, ValueError):
+        return None
+
+
 def _known_project_dbs(registry_projects) -> List[Path]:
     """Every project DB this install knows about, for the grandfather probe.
 
-    Registry entries plus ``ARKIV_PROJECT_ROOTS``. Env roots are included
-    because an install driving its projects entirely through the env var is
-    still an install with libraries in use, and omitting them would cap exactly
-    the long-time operator the exemption exists to protect.
+    The install's OWN current library, plus registry entries, plus
+    ``ARKIV_PROJECT_ROOTS``. Env roots are included because an install driving
+    its projects entirely through the env var is still an install with libraries
+    in use, and omitting them would cap exactly the long-time operator the
+    exemption exists to protect.
+
+    The own-library entry is first, and its absence was a shipped bug (v1.1.0):
+    a user who never registered a second project produced an EMPTY list here, so
+    the probe had nothing to look at and every such install reported
+    `grandfathered: false` — cross-project search refused — no matter how old the
+    library it had open. Both earlier fixes in this area were inert against it:
+    the stamp (`db.PRE_ANCHOR_VERSION`) marked that library correctly and the
+    latch (`entitlements._record_grandfather_latch`) stood ready to remember it,
+    but nothing ever put it in the set being scanned.
 
     Resolution goes through ``resolve_project_db`` so a pre-8.0c library that
     still keeps its corpus in ``.arkiv/media.db`` is probed at the file that
@@ -139,6 +174,10 @@ def _known_project_dbs(registry_projects) -> List[Path]:
     """
     paths = []
     seen = set()
+    own = _own_library_db()
+    if own is not None:
+        seen.add(str(own).casefold())
+        paths.append(own)
     for project in registry_projects or []:
         try:
             db_path = resolve_project_db(project.path)

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -26,6 +26,30 @@ PRE_CAP = "1.0.0"                      # a build (and a library) from before it
 
 
 @pytest.fixture(autouse=True)
+def _no_ambient_own_library(tmp_path, monkeypatch):
+    """Never let the maintainer's real library decide a test in this file.
+
+    `projects._known_project_dbs` includes THIS install's current library
+    (`config.DB_PATH`, falling back to resolving `config.PROJECT_ROOT`). On a
+    maintainer's machine that resolves to the repo's own `.arkiv/` — an old,
+    exempt library — so every "the cap refuses this" assertion below would pass
+    locally for the wrong reason and flip in CI, where no such library exists.
+
+    Same shape as `_no_ambient_pro_license`, arriving through a different door.
+    Scoped to this module rather than `conftest.py` on purpose: pointing every
+    test in the suite at an absent DB makes the server tests boot a FRESH
+    library, which first-run then seeds with the four sample clips — measured,
+    not guessed (67 failures).
+
+    Points at paths that do not exist, so the own-library entry is present but
+    carries no evidence either way. Tests that need a real one assign
+    `config.DB_PATH` themselves and win, being set up after this.
+    """
+    monkeypatch.setattr(config, "DB_PATH", tmp_path / "absent" / "project.db")
+    monkeypatch.setattr(config, "PROJECT_ROOT", tmp_path / "absent")
+
+
+@pytest.fixture(autouse=True)
 def _no_ambient_pro_license(tmp_path, monkeypatch):
     """Never let the developer's real ~/.arkiv/pro-license.json decide a test.
 
@@ -223,6 +247,65 @@ def test_a_latch_that_cannot_be_written_still_answers(monkeypatch, tmp_path):
         entitlements, "_install_meta_path", lambda: blocker / "install-meta.json"
     )
     assert entitlements.install_is_grandfathered([old]) is True
+
+
+# ── the library the install actually has open ─────────────────────────────────
+
+def test_the_installs_own_library_counts_as_evidence(monkeypatch, tmp_path):
+    """An install with no REGISTERED projects still has the library it is using.
+
+    This was a shipped bug (v1.1.0). `known_project_dbs()` collected registry
+    entries and `ARKIV_PROJECT_ROOTS` and nothing else, so the overwhelmingly
+    common install — one library, never registered a second project — produced
+    an EMPTY list, and the probe reported `grandfathered: false` no matter how
+    old the library it had open.
+
+    The two earlier fixes in this area were both inert against it: the stamp
+    marked that library `pre-anchor` correctly, and the latch stood ready to
+    remember it, but nothing ever put it in the set being scanned. Asserted here
+    rather than in `test_projects.py` because what broke was the promise, not
+    the registry.
+    """
+    import config
+    import projects as project_registry
+
+    monkeypatch.setenv("ARKIV_PROJECTS_REGISTRY", str(tmp_path / "empty.json"))
+    monkeypatch.setattr(config, "VERSION", ARMED)
+    own = _library(tmp_path / "own" / "project.db", PRE_CAP)
+    monkeypatch.setattr(config, "DB_PATH", own)
+
+    assert project_registry.list_registry_projects() == []
+    assert own in project_registry.known_project_dbs(), (
+        "the library this install has open is missing from the grandfather probe"
+    )
+    paths = project_registry.known_project_dbs()
+    assert entitlements.install_is_grandfathered(paths) is True
+    assert entitlements.check_cross_project(db_paths=paths).allowed is True
+
+
+def test_registering_a_new_project_does_not_drop_the_own_library(monkeypatch, tmp_path):
+    """Adding a fresh project must not push the old library out of the evidence.
+
+    The live shape that exposed the bug: a grandfathered install registers ONE
+    new project (created by the capped build, so stamped with the current
+    version). If the probe sees only the registry, the whole install flips to
+    not-grandfathered — registering a project would revoke an exemption.
+    """
+    import config
+    import projects as project_registry
+
+    monkeypatch.setenv("ARKIV_PROJECTS_REGISTRY", str(tmp_path / "reg.json"))
+    monkeypatch.setattr(config, "VERSION", ARMED)
+    own = _library(tmp_path / "own" / "project.db", PRE_CAP)
+    monkeypatch.setattr(config, "DB_PATH", own)
+
+    fresh_root = tmp_path / "fresh"
+    _library(fresh_root / ".arkiv" / "project.db", ARMED)
+    project_registry.add_project("fresh", fresh_root)
+
+    paths = project_registry.known_project_dbs()
+    assert entitlements.install_is_grandfathered(paths) is True
+    assert entitlements.check_cross_project(db_paths=paths).allowed is True
 
 
 # ── the rule's own start date ─────────────────────────────────────────────────


### PR DESCRIPTION
## 發現於實機，不是讀 code 讀出來的

M2 上的 app 回報 `grandfathered: false`、跨專案聚合被拒 —— 但它自己那個庫的錨點明明是 `pre-anchor`。

```json
{"armed":true,"pro":false,"grandfathered":false,"projects_used":1,
 "cross_project":false,
 "cross_project_reason":"Cross-project search and collections are part of the Pro add-on."}
```

## 根因

`projects._known_project_dbs` 的 docstring 寫「Every project DB **this install knows about**」，實際只收兩個來源：registry 條目 + `ARKIV_PROJECT_ROOTS`。

**唯獨漏掉 `config.PROJECT_ROOT` —— app 此刻正開著的那個庫。** 而那是「這個安裝早就在用了」最強的一份證據。

後果（**v1.1.0 已出貨**）：一個從沒註冊過第二個專案的使用者，也就是絕大多數使用者，在這裡拿到**空陣列** → 判定無從看起 → 不論手上的庫多老，一律 `grandfathered: false`、跨專案搜尋被拒。

**而且前兩支修正對他完全無效**：#339 把那個庫正確蓋成 `pre-anchor`、#336 的 latch 準備好要記住它，但沒有任何東西把它放進被掃描的集合。**同一家族的第四次 —— 證據存在，機制不看它。**

## 實測（乾淨 latch）

| | `known_project_dbs()` | 自己的庫在裡面 | grandfathered | 跨專案 |
|---|---|---|---|---|
| 修正前 | `['/Volumes/ROG 2TB/…']` | ❌ | `False` | ❌ `cross_project` |
| 修正後 | `['~/Library/…/com.hevin.arkiv/…', '/Volumes/…']` | ✅ | `True` | ✅ `grandfathered` |

## 修法

新增 `_own_library_db()`，排在清單第一位：

1. 先取 `config.DB_PATH` —— 這台安裝已解析好的答案，且尊重 `ARKIV_DB_PATH` 與測試的 monkeypatch
2. 只有該檔**不存在**時才回退去解 `config.PROJECT_ROOT` —— 那正是 `resolve_project_db` 找得到 pre-8.0c `.arkiv/media.db` 的路徑，**最老的庫、也是最有資格被豁免的那批**

四個呼叫點（`bins` / `projects.add_project` / `/api/entitlements` / `/api/search/all`）全部是授權判定，所以加自己的庫對每一個都是對的，不會誤傷。

## 測試

2 支新測，**mutation-check**：把 `own` 釘成 `None` → 只有這兩支紅。

⚠️ **過程中我先把隔離寫成 conftest 的 autouse，造成 67 支紅** —— 指向不存在的 DB 會讓 server 測試開出一個全新庫，然後 first-run 把 4 支範例片 seed 進去、污染斷言（`assert 'clips/caminandes_llama.mp4' == '專案A/clip.mp4'`）。改成只掛在 `test_entitlements.py` 的模組層級。

那 3 支原本就存在的測試確實需要這個隔離，否則它們是靠「維護者機器上剛好有一個豁免的庫」才會過 —— 本機綠、CI 紅的典型。

全套 **1362 passed / 7 skipped**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)