### PR TITLE
release(v1.1.1): 1.1.0 承諾的豁免，這一版才真的守得住

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 ## Unreleased
 
+## v1.1.1 - 2026-08-21
+
+**1.1.0 shipped the free allowance. It also shipped three ways for a long-time user to lose
+the exemption 1.1.0 had just promised them.** All three are fixed here. If you have been using
+arkiv since before 1.1.0, this release is the one that actually keeps that promise.
+
+They are the same bug wearing three faces: the guarantee is written down in one place, and the
+code that honours it depends on an observation that can disappear.
+
+### Fixed
+
+- **Your exemption no longer depends on whether a drive is mounted today.** The check only ever
+  looked at libraries reachable *at that moment*, so an install whose grandfathered corpus lives
+  on a NAS looked like a brand-new install on any morning the NAS did not mount — refusing a
+  fourth project and cross-project search, and pointing the user at a Pro add-on they should
+  never have been asked to buy. The observation is now recorded the first time it is made and
+  the record is the answer, the same move `first_seen_version` makes: write the fact down while
+  it is still observable. The record can only ever grant, never revoke.
+- **Upgrading straight from 0.12.x no longer costs you the exemption.** The provenance anchor
+  assumed it would ship a release or two ahead of the cap; in fact the window was one day
+  (anchor in 1.0.0, cap in 1.1.0). Anyone who upgraded to the newest release rather than to
+  whichever one happened to carry the anchor had their years-old library stamped `1.1.0` on
+  first open and silently reclassified as new. An existing library is now stamped `pre-anchor`
+  — which is what is actually known about it — instead of a version number it never ran.
+- **The library you have open now counts as evidence.** The grandfather probe collected
+  registered projects and an environment variable and nothing else, so the ordinary install —
+  one library, no second project ever registered — produced an empty set and reported itself as
+  new no matter how old that library was. This is why the two fixes above did not help anyone on
+  their own: they marked the library correctly and stood ready to remember it, while nothing put
+  it in front of the check.
+- **Local builds no longer bundle a developer's `.env`.** Both assemble scripts copied the repo
+  into the bundle through a denylist that did not list `.env`. **Artifacts published from this
+  repository are unaffected** — releases build from a clean CI checkout, where a gitignored
+  `.env` does not exist — but anyone building an installer on their own machine was shipping
+  their own secrets. The Windows script's exclusion list also claimed to drop `bench_*.json`
+  while its `/XF` arguments did not.
+
+### Changed
+
+- **Frontend moved to Svelte 5** (with Vite 8, `vite-plugin-svelte` 7 and `svelte-spa-router` 5).
+  No behaviour change is intended; it is here because the dependency set had been pinned by it
+  for weeks. Verified by rendering the real UI on both platforms rather than by the build going
+  green — a build that compiles proves nothing about a framework whose breaking change is at
+  mount time. The initial bundle dropped from ~404 kB to ~219 kB as a side effect.
+- Release builds cache the Tauri packaging toolchain instead of downloading WiX and NSIS during
+  every build, which had already failed one release mid-flight.
+
 ## v1.1.0 - 2026-08-19
 
 **The free allowance the product page has described for months now exists in the software.**

--- a/config.py
+++ b/config.py
@@ -10,7 +10,7 @@ BASE_DIR = Path(__file__).parent
 # Backend product version. Keep in sync with the release tag + frontend
 # version.js at release time. Served by GET /api/version and included in
 # GET /api/health so a user/support can identify the build.
-VERSION = "1.1.0"
+VERSION = "1.1.1"
 
 # Codex Round-2 audit (J3): without bounds, ARKIV_PROXIES_DIR=/etc would have
 # arkiv write generated proxy mp4 files into /etc on every HEVC ingest. Same

--- a/frontend/src/lib/version.js
+++ b/frontend/src/lib/version.js
@@ -2,4 +2,4 @@
 // The label had drifted to a stale v0.9.2 across a dozen files while the app
 // shipped v0.10.0, because every route hardcoded its own copy — importing this
 // const keeps the version from going stale per-file again.
-export const VERSION = 'v1.1.0'
+export const VERSION = 'v1.1.1'

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arkiv"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arkiv"
-version = "1.1.0"
+version = "1.1.1"
 description = "arkiv — Local Media Asset Manager"
 authors = ["Hevin Yeh"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui-org/nicegui/main/tauri/src-tauri/tauri.conf.json",
   "productName": "arkiv",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "identifier": "com.hevin.arkiv",
   "build": {
     "devUrl": "http://localhost:8501",


### PR DESCRIPTION
**1.1.0 出貨了免費額度，同時也出貨了三種讓老使用者失去「剛剛才被承諾的豁免」的方式。** 三個都在這一版修掉。

三支是同一個 bug 的三張臉：**保證寫在一個地方，而執行它的程式依賴一個會消失的觀察。**

| PR | 觀察在什麼時候消失 |
|---|---|
| #336 | NAS 沒掛載那天，證據讀不到 |
| #339 | `CREATE TABLE` 之後，「這個庫本來就存在」再也看不出來 |
| #343 | 證據一直在 —— 但檢查根本沒把它放進掃描範圍 |

**#343 是關鍵**：沒有它，前兩支對真實使用者**毫無作用**。#339 把庫正確蓋成 `pre-anchor`、#336 的 latch 準備好記住它，而 `_known_project_dbs` 從來沒把「這個安裝正開著的那個庫」放進去 —— 一個從沒註冊過第二個專案的使用者（絕大多數）拿到空陣列，判定無從看起。

## 另含

- **#337 / #341** 本機 build 會夾帶開發者的 `.env`。⚠️ **已發佈產物不受影響** —— release 走 CI 乾淨 checkout，gitignored 的 `.env` 在那裡不存在；受影響的是「在自己機器上建安裝檔的人」（開發者 / fork 作者）
- **#338** Svelte 4→5（+ Vite 8 / vite-plugin-svelte 7 / spa-router 5）。initial bundle 404 kB → 219 kB
- **#340** Tauri 打包工具鏈快取，拔掉發版路徑上的網路賭注

## 版號取 patch

十支裡**沒有任何新功能**；三支授權修正是讓軟體符合已公開的承諾，Svelte 5 是內部遷移、無意造成行為改變。

## 驗證

| | |
|---|---|
| 五處版號同步 | ✅ `test_version_sync` 6 綠 |
| pytest | ✅ 1362 passed / 7 skipped |
| svelte-check | ✅ 39 檔 0 error **0 warning** |
| node:test | ✅ 24/24 |
| **macOS 實機** | ✅ 視窗渲染逐張看過；Finder 選資料夾 / 取消後再點 / 下拉選單 / 防呆 四項全過 |
| **Windows 實機** | ✅ `msedgewebview2.exe` 在跑、`GET /assets/index-*.js 200`、0 traceback |

**Svelte 5 是靠渲染驗的，不是靠 build 綠。** 一個編得過的 build 對「breaking change 發生在 mount 時」的框架什麼都證明不了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)