### PR TITLE
perf(release): 每次發版花 20 分鐘重編一個不會變的 binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,21 @@ on:
 permissions:
   contents: write   # create the Release + upload assets
 
+env:
+  # Pinned, not a range. `cargo install tauri-cli --version "^2.0"` resolves at RUN
+  # time, so two releases can embed different bundlers with nothing in the repo
+  # changing — v1.1.0 and v1.1.1 both happened to land on 2.11.4, one day apart, so
+  # this is a hole that has not bitten yet rather than a bug being fixed.
+  #
+  # Pinning is also what makes the cache below correct: the key can be computed
+  # BEFORE the install, instead of reading the version back out of the binary the
+  # install just produced.
+  #
+  # Bumping: change this one value (both legs read it). Check the tauri-cli
+  # changelog for bundler behaviour first — this is the thing that builds the
+  # .dmg/.exe/.msi, so a surprise here surfaces as a broken installer, not a red CI.
+  TAURI_CLI_VERSION: "2.11.4"
+
 jobs:
   release:
     runs-on: macos-latest   # Apple Silicon — assemble-backend.sh bundles an aarch64-apple-darwin Python
@@ -108,8 +123,40 @@ jobs:
         run: bash src-tauri/assemble-backend.sh
 
       - uses: dtolnay/rust-toolchain@stable
+
+      # -- tauri-cli: cache the BINARY, don't rebuild it every release ---------
+      # `cargo install tauri-cli` compiles the CLI from source. Measured on the
+      # v1.1.1 tag run (32446240446): 9m38s on the macOS leg and 10m05s on the
+      # Windows one — ~20 minutes per release spent producing a binary that is
+      # byte-identical to the last one, because the version is pinned above.
+      #
+      # This is a different cache from the WiX/NSIS one further down in the
+      # Windows leg (#340). That one holds what the BUNDLER downloads at build
+      # time; this one holds the CLI itself. #340 hit on v1.1.1 (2s) while this
+      # cost stayed — the two were conflated in the notes at the time.
+      #
+      # Only the binary is cached, not ~/.cargo/registry: the registry is large,
+      # varies with the toolchain, and is worthless on a hit (nothing compiles).
+      - name: Cache tauri-cli binary
+        id: tauri-cli-cache
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/bin/cargo-tauri
+            ~/.cargo/bin/cargo-tauri.exe
+          key: tauri-cli-${{ runner.os }}-${{ env.TAURI_CLI_VERSION }}
+
       - name: Install tauri-cli
-        run: cargo install tauri-cli --version "^2.0" --locked
+        if: steps.tauri-cli-cache.outputs.cache-hit != 'true'
+        run: cargo install tauri-cli --version "${{ env.TAURI_CLI_VERSION }}" --locked
+
+      # A restored binary is only useful if it actually runs; a cache poisoned by
+      # a partial upload would otherwise surface much later as a confusing bundler
+      # failure. Cheap to check, and it also prints the version into the log so a
+      # future "which bundler built this installer?" is answerable from the run.
+      - name: Verify tauri-cli
+        shell: bash
+        run: cargo tauri --version
 
       - name: Import Apple signing cert (only when configured)
         if: steps.signcfg.outputs.signing == 'full'
@@ -246,8 +293,40 @@ jobs:
         run: .\src-tauri\assemble-backend-win.ps1
 
       - uses: dtolnay/rust-toolchain@stable
+
+      # -- tauri-cli: cache the BINARY, don't rebuild it every release ---------
+      # `cargo install tauri-cli` compiles the CLI from source. Measured on the
+      # v1.1.1 tag run (32446240446): 9m38s on the macOS leg and 10m05s on the
+      # Windows one — ~20 minutes per release spent producing a binary that is
+      # byte-identical to the last one, because the version is pinned above.
+      #
+      # This is a different cache from the WiX/NSIS one further down in the
+      # Windows leg (#340). That one holds what the BUNDLER downloads at build
+      # time; this one holds the CLI itself. #340 hit on v1.1.1 (2s) while this
+      # cost stayed — the two were conflated in the notes at the time.
+      #
+      # Only the binary is cached, not ~/.cargo/registry: the registry is large,
+      # varies with the toolchain, and is worthless on a hit (nothing compiles).
+      - name: Cache tauri-cli binary
+        id: tauri-cli-cache
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/bin/cargo-tauri
+            ~/.cargo/bin/cargo-tauri.exe
+          key: tauri-cli-${{ runner.os }}-${{ env.TAURI_CLI_VERSION }}
+
       - name: Install tauri-cli
-        run: cargo install tauri-cli --version "^2.0" --locked
+        if: steps.tauri-cli-cache.outputs.cache-hit != 'true'
+        run: cargo install tauri-cli --version "${{ env.TAURI_CLI_VERSION }}" --locked
+
+      # A restored binary is only useful if it actually runs; a cache poisoned by
+      # a partial upload would otherwise surface much later as a confusing bundler
+      # failure. Cheap to check, and it also prints the version into the log so a
+      # future "which bundler built this installer?" is answerable from the run.
+      - name: Verify tauri-cli
+        shell: bash
+        run: cargo tauri --version
 
       # -- Cache the bundler's packaging toolchain --------------------------
       # tauri-bundler downloads WiX and NSIS from GitHub *at build time*, so every


### PR DESCRIPTION
## 實測（v1.1.1 tag run `32446240446`）

| 步驟 | 耗時 |
|---|---|
| mac leg `Install tauri-cli` | **9m38s** |
| windows leg `Install tauri-cli` | **10m05s** |
| WiX/NSIS 快取（#340） | 2s ✅ |
| Build app + installers | 19m54s |

`cargo install tauri-cli` 每次都從原始碼編，兩腿相加 **~19m43s** —— 而產出的 binary 每次都一樣。**這比 #340 修掉的那個網路賭注貴得多。**

## 這是跟 #340 不同的快取

| | 存什麼 | v1.1.1 |
|---|---|---|
| #340 | bundler 在建置當下下載的 **WiX/NSIS**（Windows 專屬）| ✅ hit，2 秒 |
| 本 PR | **CLI 本體** | ❌ 完全沒被快取 |

兩者在當時的紀錄裡被混為一談 —— todo 那條「工具鏈快取一次都沒吃到」引用的是 **mac leg 的 `Install tauri-cli` 9m38s**，而那步跟 #340 無關（mac 根本沒有 WiX/NSIS）。兩邊的觀察各自都對，只是指向不同的東西。

## 修法

- `TAURI_CLI_VERSION` 釘成 `2.11.4`，放 workflow 層級供兩腿共用
- 快取 binary 本身，key = OS + 版本；hit 就跳過 install
- **加一步 `cargo tauri --version` 驗證**：還原的 binary 要真的跑得動，否則被污染的快取會在很後面才以「bundler 壞掉」的形式出現。順帶把版本印進 log —— 日後問「哪個 bundler 建的這包」查得到

只快取 binary、**不**快取 `~/.cargo/registry`：registry 大、隨 toolchain 變，而且在 hit 的情況下毫無用處（根本沒東西要編）。

## 釘版號的第二個好處

`--version "^2.0"` 在**執行當下**解析 → 兩次發版可能用不同 bundler，而 repo 一行都沒改。

實查 v1.1.0 與 v1.1.1 **都是 2.11.4**（相隔一天，不意外）—— 所以這是**還沒咬到的洞，不是在修既成的 bug**，我不誇大它。

也因為釘住了，**快取 key 才能在 install 之前算出來**，而不必從剛裝好的 binary 反讀版本。

## 驗收方式

下次發版看 `Install tauri-cli` 這步：**被跳過**（cache hit）＝生效；仍然跑 9~10 分鐘＝沒吃到。`Verify tauri-cli` 那步無論如何都會印出版本。

⚠️ 首次合併後的第一次發版仍會是 miss（快取要先被種下），跟 #340 同樣的節奏。

🤖 Generated with [Claude Code](https://claude.com/claude-code)