### PR TITLE
fix(release): 出貨守衛只擋它點名的那一類，而它存在的理由正是「別只擋想得到的」

### DIFF
--- a/src-tauri/assemble-backend-win.ps1
+++ b/src-tauri/assemble-backend-win.ps1
@@ -195,12 +195,32 @@ Invoke-Robocopy -Source $REPO -Dest (Join-Path $BACKEND 'src') -ExtraArgs @(
 # not run with /MIR here, so a .env copied in by an OLDER build of this script is
 # still sitting in $BACKEND\src and would ship even now that the exclude exists.
 # A denylist only stops the patterns someone remembered; this stops the class.
-$leaked = @(Get-ChildItem -LiteralPath (Join-Path $BACKEND 'src') -Recurse -Force -File -Filter '.env*' -ErrorAction SilentlyContinue)
-if ($leaked.Count -gt 0) {
-    Write-Host "ERROR: dotenv file(s) found in the assembled backend -- refusing to ship." -ForegroundColor Red
-    $leaked | ForEach-Object { Write-Host "  $($_.FullName)" -ForegroundColor Red }
-    Write-Host "       Delete them from $(Join-Path $BACKEND 'src') and re-run. If you added a" -ForegroundColor Red
-    Write-Host "       new dotenv variant, add it to the /XF list above too." -ForegroundColor Red
+#
+# One list, one scan. The previous version hard-coded '.env*' twice, so the guard
+# covered the class it named and nothing else -- the same "only what someone
+# remembered" failure it exists to prevent, one level up. Adding a pattern is now
+# a single line here, and the error names which pattern caught the file.
+$NeverShip = @(
+    '.env*'         # secrets -- see the /XF note above
+    'bench_*.json'  # dev-machine benchmark logs: GPU model + the filenames of
+                    # whatever was last ingested. On a real workstation that is a
+                    # list of client media. Added to /XF on 2026-08-20 (#341), but
+                    # the reason above is exactly why /XF is not enough: a staging
+                    # dir assembled BEFORE that still has one sitting in it.
+)
+$srcDir = Join-Path $BACKEND 'src'
+$anyLeaked = $false
+foreach ($pat in $NeverShip) {
+    $hits = @(Get-ChildItem -LiteralPath $srcDir -Recurse -Force -File -Filter $pat -ErrorAction SilentlyContinue)
+    if ($hits.Count -eq 0) { continue }
+    $anyLeaked = $true
+    Write-Host "ERROR: '$pat' matched inside the assembled backend -- refusing to ship." -ForegroundColor Red
+    $hits | ForEach-Object { Write-Host "  $($_.FullName)" -ForegroundColor Red }
+}
+if ($anyLeaked) {
+    Write-Host "       Delete them from $srcDir and re-run. If this is a new file" -ForegroundColor Red
+    Write-Host "       class that must never ship, add it to BOTH the /XF list above" -ForegroundColor Red
+    Write-Host "       and `$NeverShip here (and to assemble-backend.sh)." -ForegroundColor Red
     exit 1
 }
 

--- a/src-tauri/assemble-backend.sh
+++ b/src-tauri/assemble-backend.sh
@@ -89,11 +89,31 @@ rsync -a \
 #      $BACKEND/src and would ship even now that the exclude exists.
 #   2. A denylist only stops the patterns someone remembered. This stops the
 #      whole class.
-if find "$BACKEND/src" -name '.env*' -type f | grep -q .; then
-  echo "ERROR: dotenv file(s) found in the assembled backend — refusing to ship." >&2
-  find "$BACKEND/src" -name '.env*' -type f >&2
-  echo "       Delete them from $BACKEND/src and re-run. If you added a new" >&2
-  echo "       dotenv variant, add it to the rsync --exclude list above too." >&2
+#
+# One list, one scan. The previous version hard-coded '.env*' twice, so the guard
+# covered the class it named and nothing else — the same "only what someone
+# remembered" failure it exists to prevent, one level up. Adding a pattern is now
+# a single line here, and the error names which pattern caught the file.
+NEVER_SHIP=(
+  '.env*'         # secrets — see the --exclude note above
+  'bench_*.json'  # dev-machine benchmark logs: GPU model + the filenames of
+                  # whatever was last ingested. On a real workstation that is a
+                  # list of client media. Excluded since 2026-08-20 (#341), but
+                  # reason 1 above is exactly why the exclude is not enough: a
+                  # staging dir assembled BEFORE that still has one sitting in it.
+)
+leaked=0
+for pat in "${NEVER_SHIP[@]}"; do
+  hits="$(find "$BACKEND/src" -name "$pat" -type f)"
+  [ -n "$hits" ] || continue
+  leaked=1
+  echo "ERROR: '$pat' matched inside the assembled backend — refusing to ship." >&2
+  printf '%s\n' "$hits" >&2
+done
+if [ "$leaked" -ne 0 ]; then
+  echo "       Delete them from $BACKEND/src and re-run. If this is a new file" >&2
+  echo "       class that must never ship, add it to BOTH the rsync --exclude" >&2
+  echo "       list above and NEVER_SHIP here (and to assemble-backend-win.ps1)." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## 守衛在高一層重演了它要防的失敗

兩支 assemble 腳本都有一段事後 fail-loud 掃描，註解寫得很清楚：

> A denylist only stops the patterns someone remembered. **This stops the class.**

但它掃的只有 `.env*` —— **它擋的正好只有它自己點名的那一類**。

## `bench_*.json` 是第二個具體成員

兩支的 denylist **都已經**排除它（win 是 2026-08-20 #341 加的）。但那段掃描存在的**第一個理由**恰好適用：

> rsync/robocopy 都沒有 `--delete`/`/MIR`，**舊版建置留在 staging 的檔案現在仍會出貨**

而 `bench_*.json` 是 08-20 才進 `/XF` 的 —— **在那之前組裝過的目錄裡就可能躺著一個**。

## 內容實查，不憑印象判嚴重度

`bench_ingest.json`：**沒有**絕對路徑，但有 **GPU 型號**（`Apple M2 Max (Metal 4)`）與**逐檔檔名**。在真實工作機上那是一份客戶素材檔名清單。

嚴重度**遠低於** `.env`（無憑證），但形狀同族 —— 開發機產物混進出貨包，跟 Phase 8.0c「fresh clone 帶著維護者 proxy 路徑、曝光別人素材」同類。

## 修法

掃描改成**清單驅動**（`NEVER_SHIP` / `$NeverShip`）：加一個 pattern 就是加一行，而且錯誤訊息會**指名是哪個 pattern 命中**，不必讀者自己猜。兩支同步。

## 驗證

**從真實檔案抽出該段直接跑**（不是驗我另寫的副本）：

| 情境 | exit |
|---|---|
| 乾淨 | 0 ✅ |
| `.env` | 1 ✅ |
| `bench_ingest.json` | 1 ✅ |
| `bench_stt.json` | 1 ✅ |

**對照舊邏輯**：`bench_ingest.json` → **放行**（會出貨）。

`.ps1` 保持純 ASCII —— PowerShell 5.1 用機器 ANSI codepage 讀無 BOM 檔，多位元組字元會在 **parse 階段**炸掉（CLAUDE.md 記過的坑）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)