### PR TITLE
test(licensing): Pro add-on 那條介面從來沒對任何東西跑過

### DIFF
--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -14,6 +14,8 @@ pre-1.1.0 window and then start failing on the release that matters most.
 import importlib
 import json
 import sqlite3
+import sys
+import types
 
 import pytest
 
@@ -306,6 +308,101 @@ def test_registering_a_new_project_does_not_drop_the_own_library(monkeypatch, tm
     paths = project_registry.known_project_dbs()
     assert entitlements.install_is_grandfathered(paths) is True
     assert entitlements.check_cross_project(db_paths=paths).allowed is True
+
+
+# ── the Pro add-on interface ──────────────────────────────────────────────────
+#
+# `entitlements._pro_from_addon_module` is a contract with a component that does
+# not exist yet: the add-on is a separate distribution, so until it ships this
+# branch of `has_pro()` has never run against anything. That is exactly why it is
+# worth pinning now — the day the add-on arrives, a mistake here means either a
+# paying user is refused (bad) or the gate is bypassed (worse), and neither shows
+# up as a red test unless the contract was written down as one.
+#
+# The module is injected through `sys.modules`, the same trick `conftest.py` uses
+# for torch/chromadb. `_pro_from_addon_module` does `import arkiv_pro` INSIDE the
+# function, so the injection is seen on every call without reloading anything.
+
+
+def _install_addon(monkeypatch, **attrs):
+    """Make `import arkiv_pro` succeed, carrying whatever attributes are given."""
+    mod = types.ModuleType("arkiv_pro")
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    monkeypatch.setitem(sys.modules, "arkiv_pro", mod)
+    return mod
+
+
+def test_addon_reporting_a_valid_licence_grants_pro(monkeypatch):
+    _install_addon(monkeypatch, has_valid_license=lambda: True)
+    assert entitlements.has_pro() is True
+
+
+def test_addon_reporting_an_invalid_licence_does_not_grant_pro(monkeypatch):
+    """Installed but unlicensed is NOT entitled — otherwise the component being
+    on disk would itself be the licence."""
+    _install_addon(monkeypatch, has_valid_license=lambda: False)
+    assert entitlements.has_pro() is False
+
+
+def test_addon_without_the_hook_counts_as_pro(monkeypatch):
+    """Presence-as-answer is the deliberate lenient branch (see the docstring).
+
+    Pinned because it is the one that looks like an oversight: a reader tightening
+    this to "no hook means no licence" would gate a user who paid and installed
+    the component, on core's expectations about the component's internals.
+    """
+    _install_addon(monkeypatch)
+    assert entitlements.has_pro() is True
+
+
+def test_a_hook_that_raises_does_not_grant_pro_and_does_not_propagate(monkeypatch):
+    """A broken add-on must not take an unrelated user action down with it.
+
+    `has_pro()` is called on the path of adding a project and of searching; an
+    exception escaping here would surface as a 500 on an action that has nothing
+    to do with licensing.
+    """
+    def _boom():
+        raise RuntimeError("add-on internal error")
+
+    _install_addon(monkeypatch, has_valid_license=_boom)
+    assert entitlements.has_pro() is False
+
+
+def test_a_broken_addon_import_does_not_grant_pro(monkeypatch):
+    """`except Exception`, not `except ImportError`.
+
+    A half-installed component raises something other than ImportError on import
+    — and that is not proof of entitlement. Narrowing the catch here would turn a
+    broken add-on into a 500 on an unrelated action.
+
+    `sys.modules["arkiv_pro"] = None` is the documented way to make an import
+    raise: CPython treats a None entry as "this import must fail".
+    """
+    monkeypatch.setitem(sys.modules, "arkiv_pro", None)
+    assert entitlements.has_pro() is False
+
+
+def test_pro_lifts_the_cap_end_to_end(monkeypatch, tmp_path):
+    """The predicate is not the point — the verdicts are.
+
+    Mirrors the #343 lesson: a function returning the right answer proves nothing
+    about the call sites reaching it. This asserts through `check_add_project` /
+    `check_cross_project`, on an install that is otherwise capped (armed, not
+    grandfathered, already at the free limit).
+    """
+    monkeypatch.setattr(config, "VERSION", ARMED)
+    new = _library(tmp_path / "new" / "project.db", ARMED)
+
+    refused = entitlements.check_add_project(entitlements.FREE_PROJECT_LIMIT, db_paths=[new])
+    assert refused.allowed is False and refused.code == "project_limit"
+    assert entitlements.check_cross_project(db_paths=[new]).allowed is False
+
+    _install_addon(monkeypatch, has_valid_license=lambda: True)
+    allowed = entitlements.check_add_project(entitlements.FREE_PROJECT_LIMIT, db_paths=[new])
+    assert allowed.allowed is True and allowed.code == "pro"
+    assert entitlements.check_cross_project(db_paths=[new]).allowed is True
 
 
 # ── the rule's own start date ─────────────────────────────────────────────────


### PR DESCRIPTION
## 缺口

`has_pro()` 有兩條路：

| 路徑 | 測試 |
|---|---|
| 授權檔 | ✅ 有 |
| **add-on 模組在場** | ❌ **零**（`grep -rn 'arkiv_pro' tests/` = 0 命中）|

那條路沒被測，是因為 add-on 是**還不存在的獨立產出物** —— 而那正是該現在釘住它的理由。

等它真的出貨那天，core 這側是未經證實的，而**判錯的兩個方向都不會以紅測試的形式出現**：付錢的人被拒（糟），或 gate 被繞過（更糟）。

## 做法

模組經 `sys.modules` 注入，跟 `conftest.py` 對 torch/chromadb 用的是同一招。`_pro_from_addon_module` 的 `import arkiv_pro` 在**函式內**，所以每次呼叫都看得到注入，不必 reload。

## 6 支新測 —— 把介面的每個分支寫成合約

| 情境 | 期望 | 為什麼要釘 |
|---|---|---|
| hook 回 `True` | Pro | |
| hook 回 `False` | **不是** Pro | 裝了但沒授權 ≠ 有授權，否則「元件在磁碟上」本身就成了授權 |
| **沒有 hook** | Pro | presence-as-answer 是刻意的寬鬆分支。**釘住是因為它看起來最像疏漏** —— 收緊它會用 core 對元件內部的期待，去擋一個付過錢的人 |
| hook 拋例外 | 不是 Pro，**且不外傳** | `has_pro()` 跑在「加專案」與「搜尋」的路徑上；例外逃出去會變成一個跟授權無關的動作噴 500 |
| import 拋非 `ImportError` | 不是 Pro | `except Exception` 不是 `except ImportError` —— 半裝好的元件不是授權的證明 |
| **Pro 端到端解除 cap** | 放行 | 走 `check_add_project` / `check_cross_project` 斷言，**不只驗謂詞** |

最後一支是照 **#343 的教訓**寫的：函式給對答案，證明不了呼叫端有拿到它。

## mutation-check 三處，紅的都是該紅的

| mutation | 結果 |
|---|---|
| 沒有 hook → 改判不是 Pro | 1 紅 |
| hook 例外 → 改判是 Pro | 1 紅 |
| import 失敗 → 改判是 Pro | 2 紅 |

⚠️ 第三處**第一次的錨點沒對上、mutation 根本沒套用**，那次的「全綠」不算數 —— 換錨點重跑才是真的。（這週第三次遇到「量測本身沒生效卻讀出結論」。）

全套 **1368 passed / 7 skipped**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)