### PR TITLE
release(v1.1.2): 為了讓建置路徑的三個改動被真的發版跑一次

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## Unreleased
 
+## v1.1.2 - 2026-08-24
+
+**Nothing in this release changes what arkiv does.** It exists so that three changes to the
+build and packaging path get exercised by a real release instead of waiting for the next one
+that happens to carry a feature — a release pipeline that has only ever been reasoned about is
+not a verified one. If you are on 1.1.1 there is no reason to update.
+
+### Fixed
+
+- **A local build no longer ships a developer's benchmark logs.** Both assemble scripts already
+  excluded them, and both already refused to ship a stray `.env` — but that refusal only looked
+  for the one pattern it named, which is the "only what someone remembered" failure it exists to
+  prevent, one level up. The check is now driven by a list, so covering a new file class is one
+  line and the error says which pattern matched. `bench_*.json` is the second entry: it carries
+  the machine's GPU model and the filenames of whatever was last ingested, which on a working
+  editor is a list of client media. **Artifacts published from this repository were never
+  affected** — releases build from a clean CI checkout.
+
+### Changed
+
+- **Release builds no longer recompile `tauri-cli` from source every time.** Measured on the
+  1.1.1 tag run: 9m38s on macOS and 10m05s on Windows, producing a binary identical to the last
+  one. The CLI version is now pinned and the built binary cached. Pinning also closes a hole
+  that had not yet bitten: `--version "^2.0"` resolves at run time, so two releases could embed
+  different bundlers with nothing in the repository changing.
+- The Pro add-on interface (`arkiv_pro`) now has tests. The component ships separately and does
+  not exist yet, which is exactly why the contract is worth writing down now: when it arrives, a
+  mistake on this side either refuses a paying user or bypasses the tier, and neither shows up
+  as a failing test unless the contract was pinned first.
+
 ## v1.1.1 - 2026-08-21
 
 **1.1.0 shipped the free allowance. It also shipped three ways for a long-time user to lose

--- a/config.py
+++ b/config.py
@@ -10,7 +10,7 @@ BASE_DIR = Path(__file__).parent
 # Backend product version. Keep in sync with the release tag + frontend
 # version.js at release time. Served by GET /api/version and included in
 # GET /api/health so a user/support can identify the build.
-VERSION = "1.1.1"
+VERSION = "1.1.2"
 
 # Codex Round-2 audit (J3): without bounds, ARKIV_PROXIES_DIR=/etc would have
 # arkiv write generated proxy mp4 files into /etc on every HEVC ingest. Same

--- a/frontend/src/lib/version.js
+++ b/frontend/src/lib/version.js
@@ -2,4 +2,4 @@
 // The label had drifted to a stale v0.9.2 across a dozen files while the app
 // shipped v0.10.0, because every route hardcoded its own copy — importing this
 // const keeps the version from going stale per-file again.
-export const VERSION = 'v1.1.1'
+export const VERSION = 'v1.1.2'

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arkiv"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arkiv"
-version = "1.1.1"
+version = "1.1.2"
 description = "arkiv — Local Media Asset Manager"
 authors = ["Hevin Yeh"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui-org/nicegui/main/tauri/src-tauri/tauri.conf.json",
   "productName": "arkiv",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "identifier": "com.hevin.arkiv",
   "build": {
     "devUrl": "http://localhost:8501",


### PR DESCRIPTION
**這一版對使用者沒有任何新東西。** 1.1.1 的使用者沒有理由更新。

發它的唯一理由：#345 / #346 / #347 都動在**建置與打包路徑**上，而那條路徑**只被推論過、沒被驗證過** —— 只被推論過的發版管線不算驗證過的發版管線。

## 要驗的三件（下次 run 直接看）

| | 怎麼看 | 對照組（v1.1.1）|
|---|---|---|
| **#345 快取** | `Install tauri-cli` 這步**被跳過**＝ cache hit | mac 9m38s + win 10m05s |
| **#346 守衛** | 兩腿 assemble 都要過（沒有誤擋）| — |
| **序列化代價** | 兩腿相加剩多少 wall clock | 52m13s（並行理論值 33m26s）|

## CHANGELOG

誠實標明 **"Nothing in this release changes what arkiv does"**，並寫清楚 bench 那條的射程：**已發佈產物從來不受影響**（release 走 CI 乾淨 checkout），受影響的是在自己機器上建安裝檔的人。

五處版號同步（`test_version_sync` 6 綠）。全套 **1368 passed / 7 skipped**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)