### PR TITLE
test(transcribe): _vad_filter 沒有測試，因為它在測試裡根本跑不起來

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,11 @@ def _install_fake_modules():
             return False
 
     fake_torch.cuda = _Cuda()
+    # `_vad_filter` does `torch.from_numpy(audio)` purely to hand silero a tensor;
+    # it never calls a tensor method itself. Identity keeps the numpy array flowing
+    # through, which is what the energy-VAD fixture below wants to slice. Without
+    # this the function cannot be executed at all — see the note on soundfile.
+    fake_torch.from_numpy = lambda a: a
     sys.modules.setdefault("torch", fake_torch)
 
     fake_silero = types.ModuleType("silero_vad")
@@ -35,9 +40,45 @@ def _install_fake_modules():
     fake_silero.load_silero_vad = lambda *args, **kwargs: object()
     sys.modules.setdefault("silero_vad", fake_silero)
 
+    # soundfile is a real dependency (requirements.txt), but CI does NOT install it
+    # — ci.yml hand-picks its packages and soundfile is not on the list — so the fake
+    # is load-bearing there and cannot simply be deleted.
+    #
+    # It used to be inert: read() returned ([], 16000) and write() dropped its input
+    # on the floor. Combined with torch having no from_numpy, that made
+    # `transcribe._vad_filter` *structurally unreachable* in the suite: it could not
+    # be executed even by a test that wanted to. That is why a timestamp bug in it
+    # went unnoticed — not because nobody wrote the test, but because nobody could.
+    #
+    # Backed by stdlib `wave` (mono 16-bit PCM ↔ float32), which is all the
+    # transcription path ever asks of it: _to_wav already produces mono 16 kHz.
     fake_soundfile = types.ModuleType("soundfile")
-    fake_soundfile.read = lambda *args, **kwargs: ([], 16000)
-    fake_soundfile.write = lambda *args, **kwargs: None
+
+    def _sf_read(path, dtype="float32"):
+        import numpy as _np
+        import wave as _wave
+
+        with _wave.open(str(path), "rb") as w:
+            sr = w.getframerate()
+            raw = w.readframes(w.getnframes())
+        data = _np.frombuffer(raw, dtype="<i2").astype("float32") / 32768.0
+        return data, sr
+
+    def _sf_write(path, data, samplerate, *args, **kwargs):
+        import numpy as _np
+        import wave as _wave
+
+        arr = _np.asarray(data, dtype="float32")
+        pcm = _np.clip(arr, -1.0, 1.0)
+        pcm = (pcm * 32767.0).astype("<i2")
+        with _wave.open(str(path), "wb") as w:
+            w.setnchannels(1)
+            w.setsampwidth(2)
+            w.setframerate(int(samplerate))
+            w.writeframes(pcm.tobytes())
+
+    fake_soundfile.read = _sf_read
+    fake_soundfile.write = _sf_write
     sys.modules.setdefault("soundfile", fake_soundfile)
 
     # Production mlx_whisper.transcribe returns {text, language, segments=[
@@ -115,6 +156,80 @@ def _install_fake_modules():
 
 
 _install_fake_modules()
+
+
+@pytest.fixture
+def synth_wav(tmp_path):
+    """Build a mono 16 kHz wav from a (kind, seconds) script, and say where the speech is.
+
+    Returns `make(script) -> (path, samples, sample_rate, speech_windows)` where
+    `speech_windows` is the ground truth in ORIGINAL-media seconds — the thing a
+    transcript timestamp is supposed to agree with.
+
+        path, audio, sr, truth = make([("silence", 3), ("tone", 1), ("silence", 4)])
+        # truth == [(3.0, 4.0)]
+    """
+    import numpy as np
+    import soundfile as sf
+
+    def make(script, sample_rate=16000, freq=220.0):
+        parts, windows, cursor = [], [], 0.0
+        for kind, seconds in script:
+            n = int(round(seconds * sample_rate))
+            if kind == "tone":
+                t = np.arange(n, dtype="float32") / sample_rate
+                parts.append((0.6 * np.sin(2 * np.pi * freq * t)).astype("float32"))
+                windows.append((cursor, cursor + seconds))
+            else:
+                parts.append(np.zeros(n, dtype="float32"))
+            cursor += seconds
+        audio = np.concatenate(parts) if parts else np.zeros(0, dtype="float32")
+        path = tmp_path / "synth-{0}.wav".format(len(list(tmp_path.iterdir())))
+        sf.write(str(path), audio, sample_rate)
+        return str(path), audio, sample_rate, windows
+
+    return make
+
+
+@pytest.fixture
+def energy_vad(monkeypatch):
+    """Replace Silero with a deterministic energy gate, in the module that uses it.
+
+    `transcribe.py:14` does `from silero_vad import get_speech_timestamps`, so the
+    name is bound into `transcribe` — patch it there, not on the fake module.
+
+    Why not the real Silero: `load_silero_vad()` downloads a model (three runners,
+    three chances to flake), the torch wheel CI deliberately avoids is ~2 GB, and
+    real stamps move with the model version — the test would then assert against a
+    moving target instead of against our own arithmetic. Our arithmetic is what broke.
+    """
+    import numpy as np
+
+    def _fake(tensor, model, sampling_rate=16000, min_silence_duration_ms=300,
+              speech_pad_ms=0, threshold=0.5, **kwargs):
+        audio = np.asarray(tensor, dtype="float32")
+        frame = max(1, int(sampling_rate * 0.03))
+        loud = [
+            (i, min(i + frame, len(audio)))
+            for i in range(0, len(audio), frame)
+            if len(audio[i:i + frame]) and float(np.max(np.abs(audio[i:i + frame]))) > 0.1
+        ]
+        stamps = []
+        for start, end in loud:
+            if stamps and start - stamps[-1]["end"] <= int(sampling_rate * min_silence_duration_ms / 1000.0):
+                stamps[-1]["end"] = end
+            else:
+                stamps.append({"start": start, "end": end})
+        pad = int(sampling_rate * speech_pad_ms / 1000.0)
+        if pad:
+            for s in stamps:
+                s["start"] = max(0, s["start"] - pad)
+                s["end"] = min(len(audio), s["end"] + pad)
+        return stamps
+
+    transcribe = importlib.import_module("transcribe")
+    monkeypatch.setattr(transcribe, "get_speech_timestamps", _fake)
+    return _fake
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_transcribe_vad_filter.py
+++ b/tests/test_transcribe_vad_filter.py
@@ -1,0 +1,130 @@
+"""`_vad_filter` — the function that had no tests, in the file that could not run it.
+
+Until this file, `transcribe._vad_filter` was unreachable from the suite for three
+independent reasons: the silero fake returned `[]` so control left at the no-speech
+guard, `torch` had no `from_numpy`, and `soundfile.read` returned `([], 16000)`.
+Every place the function appeared in a test it was monkeypatched to identity
+(`test_transcribe_faster_whisper.py:142,157`, `test_zh_convert.py:81`).
+
+So this is a characterisation file first and a regression file second. It pins what
+the function does TODAY — including the part that is wrong — because the repo's rule
+is that a red test never gets merged. The next commit changes the behaviour and flips
+the assertion that names the defect; anything that changes here without that commit
+is an accident.
+
+The defect, stated once: VAD concatenates only the speech it keeps and returns the
+path to that gapless wav. The `stamps` — the only record of where that speech came
+from — go out of scope. Whisper then reports timestamps against gapless audio while
+every other clock in arkiv (frames, waveform, `<video>.currentTime`, EDL source TC)
+is original-media time.
+"""
+from __future__ import annotations
+
+import wave
+
+import pytest
+
+import transcribe
+
+
+def _wav_seconds(path):
+    with wave.open(str(path), "rb") as w:
+        return w.getnframes() / float(w.getframerate())
+
+
+# ── the fixtures work at all ──────────────────────────────────────────────────
+
+def test_synth_wav_round_trips_through_the_soundfile_fake(synth_wav):
+    """If this fails, nothing else in the file means anything."""
+    path, audio, sr, truth = synth_wav([("silence", 1), ("tone", 2), ("silence", 1)])
+    assert sr == 16000
+    assert _wav_seconds(path) == pytest.approx(4.0, abs=0.01)
+    assert truth == [(1.0, 3.0)]
+
+
+def test_energy_vad_finds_the_speech_we_planted(synth_wav, energy_vad):
+    _path, audio, sr, truth = synth_wav([("silence", 3), ("tone", 1), ("silence", 6)])
+    stamps = transcribe.get_speech_timestamps(audio, object(), sampling_rate=sr)
+    assert len(stamps) == 1
+    assert stamps[0]["start"] / sr == pytest.approx(3.0, abs=0.05)
+    assert stamps[0]["end"] / sr == pytest.approx(4.0, abs=0.05)
+
+
+# ── passthrough branches ──────────────────────────────────────────────────────
+
+def test_returns_the_original_path_when_vad_is_disabled(synth_wav, monkeypatch):
+    monkeypatch.setattr(transcribe, "VAD_ENABLED", False)
+    path, _audio, _sr, _truth = synth_wav([("tone", 1)])
+    assert transcribe._vad_filter(path) == path
+
+
+def test_returns_the_original_path_on_sample_rate_mismatch(synth_wav, monkeypatch):
+    """A safety valve: VAD is skipped rather than run against the wrong rate."""
+    monkeypatch.setattr(transcribe, "VAD_ENABLED", True)
+    path, _audio, _sr, _truth = synth_wav([("tone", 1)])
+    assert transcribe._vad_filter(path, sample_rate=48000) == path
+
+
+def test_returns_none_when_there_is_no_speech(synth_wav, energy_vad, monkeypatch):
+    monkeypatch.setattr(transcribe, "VAD_ENABLED", True)
+    path, _audio, _sr, _truth = synth_wav([("silence", 2)])
+    assert transcribe._vad_filter(path) is None
+
+
+# ── the trimming branch, and the defect it hides ──────────────────────────────
+
+def test_trimmed_wav_keeps_only_the_speech(synth_wav, energy_vad, monkeypatch):
+    monkeypatch.setattr(transcribe, "VAD_ENABLED", True)
+    path, _audio, _sr, _truth = synth_wav(
+        [("silence", 3), ("tone", 1), ("silence", 4), ("tone", 1), ("silence", 1)]
+    )
+    out = transcribe._vad_filter(path)
+    assert out != path
+    # 2 s of speech survives out of a 10 s file. `speech_pad_ms=150` widens each
+    # kept region a little, so this is a band rather than an equality.
+    assert 2.0 <= _wav_seconds(out) <= 2.7
+    assert _wav_seconds(path) == pytest.approx(10.0, abs=0.01)
+
+
+def test_todays_return_is_a_path_alone__so_the_mapping_is_lost(
+    synth_wav, energy_vad, monkeypatch
+):
+    """THE DEFECT, pinned so the fix has something to flip.
+
+    `_vad_filter` computed exactly the information needed to translate a gapless
+    timestamp back to media time — `stamps` — and then returned a string. Nothing
+    else in the process ever sees it, and the wav it describes is unlinked shortly
+    after (`transcribe.py:258`).
+
+    When this assertion starts failing, that is the fix landing, not a regression:
+    the next commit widens the return to `(path, offset_map)`.
+    """
+    monkeypatch.setattr(transcribe, "VAD_ENABLED", True)
+    path, _audio, _sr, _truth = synth_wav([("silence", 3), ("tone", 1), ("silence", 2)])
+    out = transcribe._vad_filter(path)
+    assert isinstance(out, str)
+
+
+def test_speech_that_starts_late_is_reported_from_zero(
+    synth_wav, energy_vad, monkeypatch
+):
+    """The user-visible consequence, expressed in audio rather than in types.
+
+    The single word in this file is at 5.0 s. After VAD it sits at ~0.0 s in the
+    audio whisper actually reads, so whisper says "0.0" and arkiv stores "0.0" —
+    a transcript line whose click seeks five seconds early.
+
+    Pinned here as an offset measured from the trimmed file, so the assertion
+    survives the fix; the fix's own test asserts the corrected value end to end.
+    """
+    monkeypatch.setattr(transcribe, "VAD_ENABLED", True)
+    path, _audio, sr, truth = synth_wav([("silence", 5), ("tone", 1), ("silence", 1)])
+    assert truth == [(5.0, 6.0)]
+
+    out = transcribe._vad_filter(path)
+    import soundfile as sf
+
+    trimmed, _ = sf.read(out, dtype="float32")
+    # The speech now begins within a padding-width of the start of the file.
+    first_loud = next(i for i, v in enumerate(trimmed) if abs(float(v)) > 0.1)
+    assert first_loud / sr < 0.2, "speech should sit at the head of the trimmed wav"


### PR DESCRIPTION
外部貢獻者 **Penny** 回報「點時間碼跳轉會對不上、或跑回 00:00」。追下去發現那是 **arkiv 的 bug**：`_vad_filter` 把 VAD 保留的語音接成無間隙 wav，只回傳路徑 —— `stamps`（語音在原始音檔中的位置）就此消失，而 whisper 之後報的每個時間碼都相對於那個無間隙檔。

**這支 PR 不修它。** 它讓那個函式**第一次能在測試裡被執行**。

## 為什麼過去不能

三重保險，任何一層都足以擋住：

| 假件 | 行為 | 後果 |
|---|---|---|
| `silero_vad` | `get_speech_timestamps` 回 `[]` | 控制流在「無語音」就離開 |
| `torch` | 沒有 `from_numpy` | tensor 那行直接炸 |
| `soundfile` | `read` 回 `([], 16000)` | 沒有音訊可裁 |

而它出現在測試裡的三個地方全都被 monkeypatch 成 identity（`test_transcribe_faster_whisper.py:142,157`、`test_zh_convert.py:81`）。

> **那個 bug 不是「沒人寫測試」，是沒人寫得了。**

## 改動

- `torch` 假件補 `from_numpy`（identity —— `_vad_filter` 只是要給 silero 一個 tensor，自己不呼叫任何 tensor 方法）
- `soundfile` 假件改成 **stdlib `wave` 支撐的真實 read/write**（mono 16-bit PCM ↔ float32，正是轉錄路徑唯一用到的形狀）

  ⚠️ **假件不能刪**：`soundfile` 與 `silero-vad` 雖然在 `requirements.txt`，但 **`ci.yml` 是手挑清單、兩者都不在裡面**。差點就照「它們是真相依，別假造」改下去 —— 那會本機綠、CI 紅。

- 新 fixture `synth_wav`：照 `(kind, seconds)` 腳本合成音檔，並回傳 **ground truth**（語音在原始媒體時間軸的位置）
- 新 fixture `energy_vad`：決定性的能量閘取代 Silero，patch 在 `transcribe` 模組上（`transcribe.py:14` 是 from-import，名字綁在那裡）

  不裝真 Silero 的理由：`load_silero_vad()` 要下載模型（三個 runner，三次 flake 機會）、torch wheel 是 CI 刻意避開的 2GB、真 stamps 隨模型版本漂 —— 那會變成**對著會動的目標斷言**，而壞掉的是我們自己的算術。

## 8 支新測記錄的是「今天」

repo 規則不准 merge 紅的測試，所以這裡記錄現況（含那個 bug）。其中兩支是**給下一支 PR 翻的**：

- `test_todays_return_is_a_path_alone__so_the_mapping_is_lost` — 斷言回傳是 `str`
- `test_speech_that_starts_late_is_reported_from_zero`

下一支把回傳變成 `(path, offset_map)` 時它們會紅 —— **那是修正落地，不是回歸**。註解裡寫明了。

全套 **1376 passed / 7 skipped**（1368 + 8）。

Co-authored-by: Penny

🤖 Generated with [Claude Code](https://claude.com/claude-code)