### PR TITLE
fix(transcribe): whisper 的時間碼是無間隙語音時間，不是媒體時間

### DIFF
--- a/config.py
+++ b/config.py
@@ -338,6 +338,13 @@ _diar = os.getenv("ARKIV_DIARIZATION_ENABLED", "").strip().lower()
 DIARIZATION_ENABLED = _diar in ("1", "true", "yes", "on")
 PYANNOTE_TOKEN = os.getenv("ARKIV_PYANNOTE_TOKEN", "").strip()
 
+# Silero's own default. Exposed because it is the one VAD knob that changes BOTH
+# what audio reaches whisper and the offset map used to put its timestamps back on
+# the media timeline — so changing it invalidates timings stored under the old
+# value. Deliberately not a whisper-guard layer key: those layers are a benchmark
+# ladder that gets serialised into run snapshots, and this is an operator override.
+VAD_THRESHOLD = float(os.getenv("ARKIV_VAD_THRESHOLD", "0.5"))
+
 WHISPER_GUARD_DEFAULT_MODE = 4
 WHISPER_GUARD_LAYERS = {
     0: {

--- a/tests/test_transcribe_faster_whisper.py
+++ b/tests/test_transcribe_faster_whisper.py
@@ -139,7 +139,7 @@ def test_dispatcher_routes_to_faster_whisper_on_non_mac(monkeypatch, hermetic):
     faster-whisper path: _to_wav → _vad_filter → _transcribe_faster_whisper."""
     monkeypatch.setattr(transcribe, "_USE_MLX", False)
     monkeypatch.setattr(transcribe, "_to_wav", lambda p: "/fake_to.wav")
-    monkeypatch.setattr(transcribe, "_vad_filter", lambda w: w)  # speech present, no trim
+    monkeypatch.setattr(transcribe, "_vad_filter", lambda w: (w, None))  # speech present, no trim
     segs = [FakeSegment("路由測試", 0.0, 1.0, words=[FakeWord("路由測試", 0.0, 1.0, 0.8)])]
     monkeypatch.setattr(transcribe, "_fw_model", FakeModel(segs, FakeInfo("zh")))
 
@@ -154,7 +154,7 @@ def test_dispatcher_no_speech_returns_empty(monkeypatch, hermetic):
     """VAD finding no speech short-circuits to the empty contract."""
     monkeypatch.setattr(transcribe, "_USE_MLX", False)
     monkeypatch.setattr(transcribe, "_to_wav", lambda p: "/fake_to.wav")
-    monkeypatch.setattr(transcribe, "_vad_filter", lambda w: None)  # no speech
+    monkeypatch.setattr(transcribe, "_vad_filter", lambda w: (None, None))  # no speech
 
     assert transcribe.transcribe("/clip.mp4", language="zh") == ("", "", [], [])
 

--- a/tests/test_transcribe_vad_filter.py
+++ b/tests/test_transcribe_vad_filter.py
@@ -1,22 +1,19 @@
-"""`_vad_filter` — the function that had no tests, in the file that could not run it.
+"""`_vad_filter` and the remap that puts whisper's clock back on the media timeline.
 
-Until this file, `transcribe._vad_filter` was unreachable from the suite for three
-independent reasons: the silero fake returned `[]` so control left at the no-speech
-guard, `torch` had no `from_numpy`, and `soundfile.read` returned `([], 16000)`.
-Every place the function appeared in a test it was monkeypatched to identity
-(`test_transcribe_faster_whisper.py:142,157`, `test_zh_convert.py:81`).
+VAD physically removes silence before whisper ever sees the audio, so whisper
+reports timestamps against a *gapless* file while every other clock in arkiv —
+frames, waveform, `<video>.currentTime`, EDL source TC — is original-media time.
+Until the commit that added `offset_map`, nothing bridged the two: `_vad_filter`
+computed exactly the information needed and then returned a bare path.
 
-So this is a characterisation file first and a regression file second. It pins what
-the function does TODAY — including the part that is wrong — because the repo's rule
-is that a red test never gets merged. The next commit changes the behaviour and flips
-the assertion that names the defect; anything that changes here without that commit
-is an accident.
+The user-visible symptom, reported by an external contributor: clicking a
+transcript line seeks early, by the total silence removed before that line, so the
+error grows through the clip.
 
-The defect, stated once: VAD concatenates only the speech it keeps and returns the
-path to that gapless wav. The `stamps` — the only record of where that speech came
-from — go out of scope. Whisper then reports timestamps against gapless audio while
-every other clock in arkiv (frames, waveform, `<video>.currentTime`, EDL source TC)
-is original-media time.
+The load-bearing test here is `test_every_segment_window_contains_audio_energy`.
+It encodes no arithmetic — it slices the ORIGINAL samples at each returned
+timestamp and asserts something is audible there — so it survives refactors of the
+mapping and would have failed on day one.
 """
 from __future__ import annotations
 
@@ -25,6 +22,32 @@ import wave
 import pytest
 
 import transcribe
+
+
+class _Seg:
+    """Minimal faster-whisper segment. Times are in whatever clock the backend saw."""
+
+    def __init__(self, text, start, end):
+        self.text = text
+        self.start = start
+        self.end = end
+        self.no_speech_prob = 0.01
+        self.avg_logprob = -0.2
+        self.compression_ratio = 1.2
+        self.words = []
+
+
+class _Info:
+    def __init__(self, language="zh"):
+        self.language = language
+
+
+class _Model:
+    def __init__(self, segments, info):
+        self._segments, self._info = segments, info
+
+    def transcribe(self, *args, **kwargs):
+        return self._segments, self._info
 
 
 def _wav_seconds(path):
@@ -36,95 +59,287 @@ def _wav_seconds(path):
 
 def test_synth_wav_round_trips_through_the_soundfile_fake(synth_wav):
     """If this fails, nothing else in the file means anything."""
-    path, audio, sr, truth = synth_wav([("silence", 1), ("tone", 2), ("silence", 1)])
+    path, _audio, sr, truth = synth_wav([("silence", 1), ("tone", 2), ("silence", 1)])
     assert sr == 16000
     assert _wav_seconds(path) == pytest.approx(4.0, abs=0.01)
     assert truth == [(1.0, 3.0)]
 
 
 def test_energy_vad_finds_the_speech_we_planted(synth_wav, energy_vad):
-    _path, audio, sr, truth = synth_wav([("silence", 3), ("tone", 1), ("silence", 6)])
+    _path, audio, sr, _truth = synth_wav([("silence", 3), ("tone", 1), ("silence", 6)])
     stamps = transcribe.get_speech_timestamps(audio, object(), sampling_rate=sr)
     assert len(stamps) == 1
     assert stamps[0]["start"] / sr == pytest.approx(3.0, abs=0.05)
     assert stamps[0]["end"] / sr == pytest.approx(4.0, abs=0.05)
 
 
-# ── passthrough branches ──────────────────────────────────────────────────────
+# ── passthrough branches: the two clocks are already the same ─────────────────
 
-def test_returns_the_original_path_when_vad_is_disabled(synth_wav, monkeypatch):
+def test_vad_disabled_returns_the_original_path_and_no_map(synth_wav, monkeypatch):
     monkeypatch.setattr(transcribe, "VAD_ENABLED", False)
     path, _audio, _sr, _truth = synth_wav([("tone", 1)])
-    assert transcribe._vad_filter(path) == path
+    assert transcribe._vad_filter(path) == (path, None)
 
 
-def test_returns_the_original_path_on_sample_rate_mismatch(synth_wav, monkeypatch):
-    """A safety valve: VAD is skipped rather than run against the wrong rate."""
+def test_sample_rate_mismatch_returns_the_original_path_and_no_map(synth_wav, monkeypatch):
+    """A safety valve: VAD is skipped rather than run against the wrong rate.
+
+    The `None` matters as much as the path — a caller that remapped here would be
+    translating a clock that was never compressed.
+    """
     monkeypatch.setattr(transcribe, "VAD_ENABLED", True)
     path, _audio, _sr, _truth = synth_wav([("tone", 1)])
-    assert transcribe._vad_filter(path, sample_rate=48000) == path
+    assert transcribe._vad_filter(path, sample_rate=48000) == (path, None)
 
 
-def test_returns_none_when_there_is_no_speech(synth_wav, energy_vad, monkeypatch):
+def test_no_speech_returns_none_none(synth_wav, energy_vad, monkeypatch):
     monkeypatch.setattr(transcribe, "VAD_ENABLED", True)
     path, _audio, _sr, _truth = synth_wav([("silence", 2)])
-    assert transcribe._vad_filter(path) is None
+    assert transcribe._vad_filter(path) == (None, None)
 
 
-# ── the trimming branch, and the defect it hides ──────────────────────────────
+# ── the trimming branch ───────────────────────────────────────────────────────
 
 def test_trimmed_wav_keeps_only_the_speech(synth_wav, energy_vad, monkeypatch):
     monkeypatch.setattr(transcribe, "VAD_ENABLED", True)
     path, _audio, _sr, _truth = synth_wav(
         [("silence", 3), ("tone", 1), ("silence", 4), ("tone", 1), ("silence", 1)]
     )
-    out = transcribe._vad_filter(path)
+    out, offset_map = transcribe._vad_filter(path)
     assert out != path
-    # 2 s of speech survives out of a 10 s file. `speech_pad_ms=150` widens each
-    # kept region a little, so this is a band rather than an equality.
+    assert offset_map is not None
+    # 2 s of speech out of a 10 s file; `speech_pad_ms=150` widens each kept region
+    # a little, so this is a band rather than an equality.
     assert 2.0 <= _wav_seconds(out) <= 2.7
     assert _wav_seconds(path) == pytest.approx(10.0, abs=0.01)
 
 
-def test_todays_return_is_a_path_alone__so_the_mapping_is_lost(
+def test_offset_map_records_where_each_kept_chunk_came_from(
     synth_wav, energy_vad, monkeypatch
 ):
-    """THE DEFECT, pinned so the fix has something to flip.
+    """The triple that makes the translation possible.
 
-    `_vad_filter` computed exactly the information needed to translate a gapless
-    timestamp back to media time — `stamps` — and then returned a string. Nothing
-    else in the process ever sees it, and the wav it describes is unlinked shortly
-    after (`transcribe.py:258`).
-
-    When this assertion starts failing, that is the fix landing, not a regression:
-    the next commit widens the return to `(path, offset_map)`.
+    Two 1-second words at 3 s and 8 s become a ~2-second gapless file, and the map
+    says so: chunk 0 sits at the head of the trimmed file and came from ~3 s;
+    chunk 1 follows it and came from ~8 s.
     """
     monkeypatch.setattr(transcribe, "VAD_ENABLED", True)
-    path, _audio, _sr, _truth = synth_wav([("silence", 3), ("tone", 1), ("silence", 2)])
-    out = transcribe._vad_filter(path)
-    assert isinstance(out, str)
+    path, _audio, _sr, truth = synth_wav(
+        [("silence", 3), ("tone", 1), ("silence", 4), ("tone", 1), ("silence", 1)]
+    )
+    assert truth == [(3.0, 4.0), (8.0, 9.0)]
+
+    _out, offset_map = transcribe._vad_filter(path)
+    assert len(offset_map) == 2
+
+    (t0_start, t0_end, o0), (t1_start, t1_end, o1) = offset_map
+    assert t0_start == 0.0
+    assert o0 == pytest.approx(3.0, abs=0.2)
+    assert o1 == pytest.approx(8.0, abs=0.2)
+    # The trimmed timeline is contiguous by construction — no gaps for a lookup
+    # to fall into.
+    assert t1_start == pytest.approx(t0_end, abs=1e-9)
+    assert t1_end > t1_start
 
 
-def test_speech_that_starts_late_is_reported_from_zero(
-    synth_wav, energy_vad, monkeypatch
+def test_zero_width_stamp_is_dropped(synth_wav, monkeypatch):
+    """A degenerate stamp would add a triple whose window swallows later lookups."""
+    monkeypatch.setattr(transcribe, "VAD_ENABLED", True)
+    path, _audio, sr, _truth = synth_wav([("silence", 1), ("tone", 1)])
+    monkeypatch.setattr(
+        transcribe,
+        "get_speech_timestamps",
+        lambda *a, **k: [{"start": 100, "end": 100}, {"start": sr, "end": 2 * sr}],
+    )
+    _out, offset_map = transcribe._vad_filter(path)
+    assert len(offset_map) == 1
+    assert offset_map[0][2] == pytest.approx(1.0, abs=1e-6)
+
+
+def test_a_stamp_running_past_the_audio_does_not_desync_the_map(synth_wav, monkeypatch):
+    """Why the cursor measures the slice instead of trusting the stamp.
+
+    `speech_pad_ms` widens every stamp, and a stamp near the end can be widened
+    past the last sample. numpy silently returns a SHORTER slice; stamp arithmetic
+    (`end - start`) does not know that. Trusting the stamp would put every later
+    triple's `trimmed_start` beyond where its audio actually sits, and the error
+    would accumulate down the file.
+
+    Silero clamps today, which is why this needs an explicit unclamped stamp: the
+    defence is against the next VAD, not the current one.
+    """
+    monkeypatch.setattr(transcribe, "VAD_ENABLED", True)
+    path, audio, sr, _truth = synth_wav([("tone", 1), ("silence", 1), ("tone", 1)])
+    over = len(audio) + sr  # one second past the end of the file
+    monkeypatch.setattr(
+        transcribe,
+        "get_speech_timestamps",
+        lambda *a, **k: [{"start": 0, "end": sr}, {"start": 2 * sr, "end": over}],
+    )
+
+    _out, offset_map = transcribe._vad_filter(path)
+    assert len(offset_map) == 2
+
+    # Chunk 1 is really 1 s (3 s of audio minus its 2 s start), not the 2 s the
+    # stamp claims — so chunk 1 occupies [1.0, 2.0) of the trimmed timeline.
+    assert offset_map[1][0] == pytest.approx(1.0, abs=1e-6)
+    assert offset_map[1][1] == pytest.approx(2.0, abs=1e-6)
+    assert offset_map[1][2] == pytest.approx(2.0, abs=1e-6)
+    # And the map must still describe a contiguous timeline.
+    assert offset_map[1][0] == pytest.approx(offset_map[0][1], abs=1e-9)
+
+
+# ── _remap_vad_time: the arithmetic, pinned ───────────────────────────────────
+
+_MAP = [(0.0, 1.0, 3.0), (1.0, 2.0, 8.0)]
+_ENDS = [m[1] for m in _MAP]
+
+
+@pytest.mark.parametrize(
+    "trimmed, original",
+    [
+        (0.0, 3.0),    # head of the first kept chunk
+        (0.5, 3.5),    # inside it
+        (1.0, 4.0),    # the boundary belongs to the EARLIER chunk
+        (1.001, 8.001),  # a hair later belongs to the next one
+        (2.0, 9.0),    # tail of the last chunk
+    ],
+)
+def test_remap_translates_gapless_seconds_to_media_seconds(trimmed, original):
+    assert transcribe._remap_vad_time(trimmed, _MAP, _ENDS) == pytest.approx(original)
+
+
+def test_remap_extrapolates_past_the_last_chunk_rather_than_clamping():
+    """Whisper pads to 30 s windows and can report an end past the audio.
+
+    Clamping would stack every trailing cue on one instant; running slightly long
+    is the better failure.
+    """
+    assert transcribe._remap_vad_time(2.5, _MAP, _ENDS) == pytest.approx(9.5)
+
+
+def test_remap_result_times_is_identity_without_a_map():
+    """whisperx reads the original audio; VAD-off reads it too. Neither may shift."""
+    segs = [{"start": 1.0, "end": 2.0, "text": "x"}]
+    words = [{"start": 1.0, "end": 1.5, "word": "x"}]
+    out = transcribe._remap_result_times("x", "zh", segs, words, None)
+    assert out == ("x", "zh", segs, words)
+
+
+def test_remap_result_times_preserves_other_keys():
+    """`speaker_id` is attached before the remap runs and must survive it."""
+    segs = [{"start": 0.0, "end": 1.0, "text": "x", "speaker_id": "SPEAKER_01"}]
+    _t, _l, out_segs, _w = transcribe._remap_result_times("x", "zh", segs, [], _MAP)
+    assert out_segs[0]["speaker_id"] == "SPEAKER_01"
+    assert out_segs[0]["start"] == pytest.approx(3.0)
+
+
+def test_words_still_sit_inside_their_segment_after_remapping():
+    """`_postprocess` filters words by midpoint containment inside segments.
+
+    That invariant silently depends on both being on the same clock; remapping them
+    with the same map is what keeps it true. Never asserted before this file.
+    """
+    segs = [{"start": 0.0, "end": 1.0, "text": "x"}]
+    words = [{"start": 0.2, "end": 0.4, "word": "x"}]
+    _t, _l, out_segs, out_words = transcribe._remap_result_times("x", "zh", segs, words, _MAP)
+    mid = (out_words[0]["start"] + out_words[0]["end"]) / 2
+    assert out_segs[0]["start"] <= mid <= out_segs[0]["end"]
+
+
+# ── end to end: the assertion the suite never had ─────────────────────────────
+
+def _run_end_to_end(monkeypatch, synth_wav, energy_vad, script, texts):
+    """Drive `transcribe()` over synthetic audio with a fake backend.
+
+    The fake backend's segment times are DERIVED from the offset map rather than
+    hard-coded, because `speech_pad_ms=150` widens every kept chunk — guessing
+    "chunk 1 starts at 1.0" is wrong by the padding, and a test that guesses would
+    fail against a correct implementation. One segment is placed just inside the
+    head of each kept chunk, which is exactly where whisper would put a word that
+    begins as soon as the speech does.
+    """
+    monkeypatch.setattr(transcribe, "_USE_MLX", False)
+    monkeypatch.setattr(transcribe, "VAD_ENABLED", True)
+    monkeypatch.setattr(transcribe, "LLM_POLISH", False)
+    monkeypatch.setattr(transcribe, "FILTER_WORDS", "")
+    monkeypatch.setattr(transcribe, "CUSTOM_VOCABULARY", "")
+    path, audio, sr, truth = synth_wav(script)
+
+    import shutil
+
+    copy = path + ".copy.wav"  # transcribe() unlinks what _to_wav hands it
+    shutil.copyfile(path, copy)
+    monkeypatch.setattr(transcribe, "_to_wav", lambda p: copy)
+
+    captured = {}
+    real_vad = transcribe._vad_filter
+
+    def _spy(wav, sample_rate=16000):
+        out, offset_map = real_vad(wav, sample_rate)
+        captured["map"] = offset_map
+        # Now that the chunk layout is known, stock the backend with times inside it.
+        segs = [
+            _Seg(text, round(t_start + 0.05, 3), round(t_end - 0.05, 3))
+            for text, (t_start, t_end, _orig) in zip(texts, offset_map or [])
+        ]
+        transcribe._fw_model = _Model(segs, _Info("zh"))
+        return out, offset_map
+
+    monkeypatch.setattr(transcribe, "_vad_filter", _spy)
+    monkeypatch.setattr(transcribe, "_fw_model", _Model([], _Info("zh")))
+
+    _text, _lang, segments, _words = transcribe.transcribe("/clip.mp4", language="zh")
+    return segments, audio, sr, truth
+
+
+def test_segment_start_is_the_real_position_in_the_source_media(
+    monkeypatch, synth_wav, energy_vad
 ):
-    """The user-visible consequence, expressed in audio rather than in types.
+    """The bug, expressed as the number a user would check.
 
-    The single word in this file is at 5.0 s. After VAD it sits at ~0.0 s in the
-    audio whisper actually reads, so whisper says "0.0" and arkiv stores "0.0" —
-    a transcript line whose click seeks five seconds early.
-
-    Pinned here as an offset measured from the trimmed file, so the assertion
-    survives the fix; the fix's own test asserts the corrected value end to end.
+    Two words, at 3 s and 8 s of a 10 s clip. After VAD they sit back-to-back, so
+    whisper honestly reports 0-1 s and 1-2 s. Before the remap arkiv stored those
+    verbatim and a click on the second line seeked to 1 s — six seconds early.
     """
-    monkeypatch.setattr(transcribe, "VAD_ENABLED", True)
-    path, _audio, sr, truth = synth_wav([("silence", 5), ("tone", 1), ("silence", 1)])
-    assert truth == [(5.0, 6.0)]
+    segments, _audio, _sr, truth = _run_end_to_end(
+        monkeypatch,
+        synth_wav,
+        energy_vad,
+        [("silence", 3), ("tone", 1), ("silence", 4), ("tone", 1), ("silence", 1)],
+        ["第一段", "第二段"],
+    )
+    assert truth == [(3.0, 4.0), (8.0, 9.0)]
+    assert len(segments) == 2
+    assert segments[0]["start"] == pytest.approx(3.0, abs=0.2)
+    assert segments[0]["end"] == pytest.approx(4.0, abs=0.2)
+    assert segments[1]["start"] == pytest.approx(8.0, abs=0.2)
+    assert segments[1]["end"] == pytest.approx(9.0, abs=0.2)
 
-    out = transcribe._vad_filter(path)
-    import soundfile as sf
 
-    trimmed, _ = sf.read(out, dtype="float32")
-    # The speech now begins within a padding-width of the start of the file.
-    first_loud = next(i for i, v in enumerate(trimmed) if abs(float(v)) > 0.1)
-    assert first_loud / sr < 0.2, "speech should sit at the head of the trimmed wav"
+def test_every_segment_window_contains_audio_energy(
+    monkeypatch, synth_wav, energy_vad
+):
+    """The guard that catches the NEXT one.
+
+    No arithmetic, no expected constants: slice the ORIGINAL samples at each
+    timestamp arkiv reports and require something audible there. It survives any
+    refactor of the mapping, and catches sign errors, off-by-one-chunk errors, and
+    a future change to `speech_pad_ms`.
+
+    Before the fix, segment two pointed at 1.0-2.0 s — pure silence.
+    """
+    import numpy as np
+
+    segments, audio, sr, _truth = _run_end_to_end(
+        monkeypatch,
+        synth_wav,
+        energy_vad,
+        [("silence", 3), ("tone", 1), ("silence", 4), ("tone", 1), ("silence", 1)],
+        ["第一段", "第二段"],
+    )
+    for seg in segments:
+        window = audio[int(seg["start"] * sr):int(seg["end"] * sr)]
+        assert len(window), "segment {0} points past the end of the audio".format(seg)
+        peak = float(np.max(np.abs(window)))
+        assert peak > 0.1, "segment {0} points at silence (peak {1:.3f})".format(seg, peak)

--- a/tests/test_zh_convert.py
+++ b/tests/test_zh_convert.py
@@ -78,7 +78,7 @@ def test_transcribe_wires_zh_conversion(monkeypatch):
     tr = importlib.import_module("transcribe")
     monkeypatch.setattr(tr, "_to_wav", lambda p: "/tmp/arkiv_zhwire_nonexistent.wav")
     monkeypatch.setattr(tr, "_USE_MLX", True)
-    monkeypatch.setattr(tr, "_vad_filter", lambda w: w)  # pass through, no cleanup branch
+    monkeypatch.setattr(tr, "_vad_filter", lambda w: (w, None))  # pass through, no cleanup branch
     monkeypatch.setattr(tr, "_transcribe_mlx", lambda w, lang: (
         "内存和软件", "zh",
         [{"start": 0.0, "end": 1.0, "text": "内存和软件"}],

--- a/transcribe.py
+++ b/transcribe.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import bisect
 import json
 import os
 import subprocess
@@ -28,6 +29,7 @@ from config import (
     FFMPEG_PATH,
     DIARIZATION_ENABLED,
     PYANNOTE_TOKEN,
+    VAD_THRESHOLD,
 )
 from llm import chat
 NO_SPEECH_THRESHOLD = 0.6
@@ -144,25 +146,58 @@ def _get_vad_model():
 
 
 def _vad_filter(wav_path: str, sample_rate: int = 16000):
-    """Run Silero VAD on WAV, return new WAV with only speech segments.
-    Returns None if no speech detected. Returns original path if VAD disabled."""
+    """Run Silero VAD, returning (wav_to_transcribe, offset_map).
+
+    The second element is the whole point. VAD physically removes silence, so the
+    audio whisper reads is shorter than the file the user has open and every
+    timestamp it reports is in *gapless-speech* time. `offset_map` is what
+    translates back:
+
+        [(trimmed_start, trimmed_end, original_start), ...]   # seconds
+
+    one triple per kept chunk, in concatenation order. `None` means the two clocks
+    are already the same (VAD off, sample-rate skip) and the caller must not remap.
+
+    Returns `(None, None)` when there is no speech at all.
+
+    Before this returned a bare path, and the stamps — the only record of where the
+    kept speech came from — went out of scope. Nothing downstream could recover it:
+    the trimmed wav is unlinked moments later, so the mapping had to be built here
+    or not at all.
+    """
     if not VAD_ENABLED:
-        return wav_path
+        return wav_path, None
 
     audio, sr = sf.read(wav_path, dtype="float32")
     if sr != sample_rate:
-        return wav_path  # safety: skip VAD if sample rate mismatch
+        return wav_path, None  # safety: skip VAD if sample rate mismatch
 
     tensor = torch.from_numpy(audio)
     stamps = get_speech_timestamps(tensor, _get_vad_model(),
                                    sampling_rate=sample_rate,
                                    min_silence_duration_ms=300,
-                                   speech_pad_ms=150)
+                                   speech_pad_ms=150,
+                                   threshold=VAD_THRESHOLD)
     if not stamps:
-        return None  # no speech at all
+        return None, None  # no speech at all
 
-    # Concatenate speech segments
-    chunks = [audio[s["start"]:s["end"]] for s in stamps]
+    # Concatenate speech segments, recording where each one came from.
+    #
+    # The cursor advances by the chunk's ACTUAL length rather than by
+    # (end - start) arithmetic on the stamp: `speech_pad_ms` widens stamps and can
+    # make neighbours overlap, and a clamped slice is then shorter than the stamp
+    # claims. Measuring the slice keeps the map exact by construction.
+    chunks, offset_map, cursor = [], [], 0.0
+    for s in stamps:
+        chunk = audio[s["start"]:s["end"]]
+        if not len(chunk):
+            continue  # a zero-width stamp would add a triple that swallows later lookups
+        dur = len(chunk) / float(sample_rate)
+        offset_map.append((cursor, cursor + dur, s["start"] / float(sample_rate)))
+        cursor += dur
+        chunks.append(chunk)
+    if not chunks:
+        return None, None
     speech = np.concatenate(chunks)
 
     _fd, out = tempfile.mkstemp(suffix=".wav"); os.close(_fd)
@@ -173,7 +208,49 @@ def _vad_filter(wav_path: str, sample_rate: int = 16000):
         raise
     kept = len(speech) / max(len(audio), 1)
     print(f"  [VAD] kept {kept:.0%} of audio ({len(stamps)} segments)", flush=True)
-    return out
+    return out, offset_map
+
+
+def _remap_vad_time(t: float, offset_map, ends) -> float:
+    """One gapless-speech second → the second it came from in the source media.
+
+    The trimmed timeline is contiguous by construction (`trimmed_end[i]` ==
+    `trimmed_start[i+1]`), so `t` can never land in a gap and the first chunk whose
+    end is at or past `t` is the right one. `bisect` rather than a scan because a
+    long clip is hundreds of chunks and thousands of words.
+
+    Past the last chunk we extrapolate instead of clamping. Whisper pads to 30 s
+    windows and can report an `end` a hair beyond the audio; clamping would stack
+    every trailing cue on one instant, which is worse than a cue that runs slightly
+    long.
+    """
+    i = bisect.bisect_left(ends, t)
+    if i >= len(offset_map):
+        i = len(offset_map) - 1
+    trimmed_start, _trimmed_end, original_start = offset_map[i]
+    return original_start + (t - trimmed_start)
+
+
+def _remap_result_times(text, lang, segments, words, offset_map):
+    """Rewrite segment and word times from gapless-speech time to media time.
+
+    Returns new dicts rather than mutating: `speaker_id` and any future key rides
+    along via `{**s}`, and a pure function is testable without building a whole
+    transcription. `offset_map is None` (whisperx, VAD off) is the identity.
+    """
+    if not offset_map:
+        return text, lang, segments, words
+
+    ends = [o[1] for o in offset_map]
+
+    def _fix(item):
+        return {
+            **item,
+            "start": round(_remap_vad_time(float(item.get("start", 0) or 0), offset_map, ends), 3),
+            "end": round(_remap_vad_time(float(item.get("end", 0) or 0), offset_map, ends), 3),
+        }
+
+    return text, lang, [_fix(s) for s in segments or []], [_fix(w) for w in words or []]
 
 
 def warm_up():
@@ -233,9 +310,12 @@ def transcribe(media_path: str, language=None) -> tuple:
     if not wav:
         return "", "", [], []
 
+    # None means "the backend read the original audio, so its clock is already
+    # media time". The whisperx branch below never trims, and so never sets it.
+    offset_map = None
     try:
         if _USE_MLX:
-            vad_wav = _vad_filter(wav)
+            vad_wav, offset_map = _vad_filter(wav)
             if vad_wav is None:
                 return "", "", [], []
             try:
@@ -246,7 +326,7 @@ def transcribe(media_path: str, language=None) -> tuple:
         elif _non_mac_backend() == "whisperx":
             result = _transcribe_whisperx(wav, language)
         else:
-            vad_wav = _vad_filter(wav)
+            vad_wav, offset_map = _vad_filter(wav)
             if vad_wav is None:
                 return "", "", [], []
             try:
@@ -256,6 +336,11 @@ def transcribe(media_path: str, language=None) -> tuple:
                     Path(vad_wav).unlink(missing_ok=True)
     finally:
         Path(wav).unlink(missing_ok=True)
+    # Put the timestamps back on the media timeline BEFORE anything else sees them.
+    # Everything downstream — SRT cue times, /api/media/{id}/segments, the MCP
+    # get_transcript contract, click-to-seek — reads these as "seconds from the
+    # start of the clip", so gapless-speech time must not escape this function.
+    result = _remap_result_times(*result, offset_map=offset_map)
     # Phase 9.8b: whisper emits Simplified for zh — store Taiwan Traditional so the
     # search index / UI / every export are Traditional (write-path; see zh_convert).
     return zh_convert.convert_result(*result)


### PR DESCRIPTION
VAD 在 whisper 看到音檔**之前**就把靜音實體移除了，所以 whisper 報的時間碼相對於一個「無間隙」的檔案，而 arkiv 裡其他每一個時鐘 —— frames、波形、`<video>.currentTime`、EDL source TC —— 都是原始媒體時間。

**沒有東西橋接這兩者。** `_vad_filter` 算出了唯一能橋接的資訊（`stamps`），然後回傳一個字串路徑；裁切檔在幾行之後就被 `unlink`，映射關係永久遺失。

使用者看到的症狀（外部貢獻者 **Penny** 回報）：點逐字稿跳轉會提早，提早的量等於那一行之前被移除的靜音總和 —— **誤差沿著片子累積遞增**。

| 後端 | 讀哪個音檔 | 受影響 |
|---|---|---|
| `_transcribe_mlx`（所有 Mac）| VAD 裁切檔 | ❌ |
| `_transcribe_faster_whisper`（非 Mac 預設）| VAD 裁切檔 | ❌ |
| `_transcribe_whisperx` | 原始 wav | ✅ |

**三個後端對「3.5 秒」的定義並不一致。** 而 whisper-guard 五層全部 `vad_enabled: True`，沒有出貨設定關得掉。

## 修法

`_vad_filter` 回傳 `(wav, offset_map)`：

```
offset_map = [(trimmed_start, trimmed_end, original_start), ...]   # 秒
```

每個保留區塊一個三元組。`None` 表示兩個時鐘本來就相同（VAD 關閉／取樣率不符），呼叫端不得 remap。

- `_remap_vad_time` 用 **`bisect`**（3.9 安全）—— 長片是數百區塊 × 數千字。裁切時間軸依構造連續（`trimmed_end[i] == trimmed_start[i+1]`），查詢不可能落進空隙
- 超過最後一個區塊時**外推而非 clamp**：whisper 補到 30 秒窗口、可能報出超過音檔長度的 end；clamp 會讓所有結尾 cue 疊在同一瞬間，比稍微跑長更糟
- `_remap_result_times` 回**新 dict**：`speaker_id` 靠 `{**s}` 跟著走，純函式不必建整個轉錄就測得到
- 呼叫點在刪暫存檔的 `finally` **之後**、`zh_convert.convert_result` **之前** —— 無間隙時間不得逃出這個函式

另加 `config.VAD_THRESHOLD`（預設 0.5 = silero 原值，no-op）。它是唯一同時改變「哪些音訊進 whisper」與「offset map」的旋鈕 → **改它會讓舊值下存的時間碼失效**，註解寫明了。

## ⚠️ mutation-check 抓到我自己的一個空頭宣稱

游標用「實際切片長度」而非 stamp 算術 —— 我原本只在註解裡宣稱這比較安全。**mutation 改成 stamp 算術，20 支全綠** → 那個宣稱沒有測試支撐。

原因：Silero 會 clamp 邊界，所以兩種寫法**今天等價**。補了測試造出真正的分歧（尾端超出音檔的 stamp 讓 numpy 靜默回傳較短切片，而 stamp 算術不知道，偏差沿檔案累積）。**防的是下一個 VAD，不是現在這個。**

## 測試

20 支（8 支特性測試翻成正確行為 + 12 支新增）。mutation-check 四處全紅：

| mutation | 結果 |
|---|---|
| remap 整個不做 | 2 紅 |
| 回傳 `None` 不回 map | 4 紅 |
| 游標改用 stamp 算術 | 1 紅（補測試後）|
| 邊界改 `bisect_right` | 1 紅 |

**最該留的是 `test_every_segment_window_contains_audio_energy`** —— 它不編碼任何算術，只是切原始樣本、斷言那裡聽得到東西。活得過任何重構，而且從第一天就會紅。

全套 **1388 passed / 7 skipped**。

⚠️ **已索引的庫需要重跑轉錄** —— `stamps` 從未被持久化，所以沒有 offset-only backfill 可做。修復另行安排。

Co-authored-by: Penny

🤖 Generated with [Claude Code](https://claude.com/claude-code)