### PR TITLE
fix(llm): 潤稿在長逐字稿上靜默逾時，然後退回未標點原文

### DIFF
--- a/llm.py
+++ b/llm.py
@@ -42,6 +42,8 @@ def chat(
     json_mode: bool = False,
     schema: Optional[Dict[str, Any]] = None,
     provider: Provider = Provider.OLLAMA,
+    timeout: int = 120,
+    temperature: Optional[float] = None,
 ) -> Dict[str, Any]:
     """Call the chat model. `json_mode` asks for syntactically valid JSON; it does
     NOT constrain the shape, so the model can answer a "return {"groups":[...]}"
@@ -67,8 +69,15 @@ def chat(
         payload["format"] = schema
     elif json_mode:
         payload["format"] = "json"
+    # Left unset by default on purpose: forcing a temperature here would silently
+    # change tag generation (ingest.py) and every RAG answer (chat.py).
+    if temperature is not None:
+        payload["options"] = {"temperature": temperature}
 
-    response = _ollama_post("/api/chat", payload, timeout=120)
+    # 120 s stays the default for the ten existing call sites — chat.py's
+    # interactive RAG path SHOULD fail fast. Only long-form work (transcript
+    # polish) asks for patience, and it asks explicitly.
+    response = _ollama_post("/api/chat", payload, timeout=timeout)
     response.raise_for_status()
     data = response.json()
     return {

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -158,3 +158,68 @@ def test_chat_uses_default_model_if_none(monkeypatch):
     llm.chat("hello")
 
     assert captured["model"] == "sentinel-model"
+
+
+# ── long-form callers ask for patience explicitly ────────────────────────────
+# Transcript polish needs 20+ minutes on a laptop; interactive RAG must fail fast.
+# Both parameters therefore keep their old defaults, and only the caller that
+# needs the difference states it. See tests/test_transcribe_polish.py.
+
+class _EchoResponse(object):
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return {"message": {"content": "ok"}}
+
+
+def _capture_post(monkeypatch, llm):
+    captured = {}
+
+    def fake_post(url, json, timeout):
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return _EchoResponse()
+
+    monkeypatch.setattr(llm.requests, "post", fake_post)
+    return captured
+
+
+def test_chat_forwards_an_explicit_timeout(monkeypatch):
+    llm = importlib.import_module("llm")
+    captured = _capture_post(monkeypatch, llm)
+
+    llm.chat("hello", timeout=900)
+
+    assert captured["timeout"] == 900
+
+
+def test_chat_omits_options_unless_temperature_is_given(monkeypatch):
+    """An unset temperature must stay unset: sending Ollama's default explicitly
+    would silently change tag generation (ingest.py) and every RAG answer."""
+    llm = importlib.import_module("llm")
+    captured = _capture_post(monkeypatch, llm)
+
+    llm.chat("hello")
+
+    assert "options" not in captured["json"]
+
+
+def test_chat_sends_an_explicit_temperature(monkeypatch):
+    llm = importlib.import_module("llm")
+    captured = _capture_post(monkeypatch, llm)
+
+    llm.chat("hello", temperature=0.2)
+
+    assert captured["json"]["options"] == {"temperature": 0.2}
+
+
+def test_chat_temperature_zero_is_not_treated_as_unset(monkeypatch):
+    """`if temperature:` would drop 0.0 — the one value a caller is most likely to
+    want when it asks for determinism."""
+    llm = importlib.import_module("llm")
+    captured = _capture_post(monkeypatch, llm)
+
+    llm.chat("hello", temperature=0.0)
+
+    assert captured["json"]["options"] == {"temperature": 0.0}

--- a/tests/test_transcribe_polish.py
+++ b/tests/test_transcribe_polish.py
@@ -1,0 +1,190 @@
+"""LLM polish — the step that was failing silently on every long transcript.
+
+`_llm_polish` sent the whole transcript in one `chat()` call, and `chat()` hard-coded
+a 120 s timeout. qwen2.5:14b writes roughly 3-4 characters/second locally, so a
+4,000-character transcript needs 20+ minutes: the request timed out, a bare
+`except: pass` swallowed the exception, and the caller got back raw unpunctuated
+Whisper output — indistinguishable from a transcript the model had chosen not to
+change. Nothing was logged, so it looked like polish "just wasn't very good on long
+clips".
+
+The fix has two halves and BOTH matter:
+
+* chunking + a real timeout, so long transcripts can finish at all;
+* a total **budget**, because a bigger timeout alone would trade a silent 120 s
+  failure for a genuine 20-70 minute one — held inside the shared ingest slot,
+  with every other clip in the queue waiting behind it. Past the budget the
+  remaining chunks come back raw, which is the old outcome, but bounded and said
+  out loud.
+"""
+from __future__ import annotations
+
+import types
+
+import pytest
+
+import transcribe
+
+
+@pytest.fixture
+def polish_calls(monkeypatch):
+    """Record every `chat()` the polish path makes; echo the prompt's transcript back.
+
+    The fake returns the input text unchanged, which passes the length-ratio guard,
+    so a test only has to look at what was *asked* unless it wants to script a failure.
+    """
+    calls = []
+
+    def fake_chat(prompt, model=None, timeout=None, temperature=None, **kw):
+        body = prompt.split("原始逐字稿：\n", 1)[1].rsplit("\n\n校正後：", 1)[0]
+        calls.append({"text": body, "timeout": timeout, "temperature": temperature,
+                      "model": model})
+        return {"text": body}
+
+    monkeypatch.setattr(transcribe, "chat", fake_chat)
+    return calls
+
+
+def _segments(count, size=40):
+    """`count` space-free pieces, the shape `_postprocess` joins with a single space."""
+    return ["字{0}".format(i) * (size // 2) for i in range(count)]
+
+
+# ── chunking ─────────────────────────────────────────────────────────────────
+
+def test_chunks_never_split_a_segment():
+    """The load-bearing property. A boundary inside a segment would hand the model
+    half a sentence and get back a confidently punctuated half-sentence."""
+    segs = _segments(30)
+    chunks = transcribe._polish_chunks(" ".join(segs))
+
+    assert len(chunks) > 1, "test is vacuous unless the text actually splits"
+    for chunk in chunks:
+        for piece in chunk.split(" "):
+            assert piece in segs, "chunk boundary landed inside a segment: {0!r}".format(piece)
+
+
+def test_chunking_loses_nothing():
+    segs = _segments(30)
+    chunks = transcribe._polish_chunks(" ".join(segs))
+    assert " ".join(chunks) == " ".join(segs)
+
+
+def test_chunks_respect_the_size_limit():
+    chunks = transcribe._polish_chunks(" ".join(_segments(30)), max_chars=120)
+    assert all(len(c) <= 120 for c in chunks)
+
+
+def test_a_single_oversized_segment_is_not_chopped():
+    """One 900-character segment has no space to break on. Sending it whole is
+    correct — chopping mid-sentence to satisfy the limit would be worse."""
+    giant = "話" * 900
+    assert transcribe._polish_chunks(giant, max_chars=300) == [giant]
+
+
+def test_short_text_stays_one_call(polish_calls):
+    transcribe._llm_polish_batched("短短一句", "zh")
+    assert len(polish_calls) == 1
+
+
+# ── timeout + temperature reach the model ────────────────────────────────────
+
+def test_polish_asks_for_the_long_timeout(polish_calls):
+    """120 s is right for interactive RAG and wrong for this. If polish stops
+    passing its own timeout it silently inherits the fast-fail default again."""
+    transcribe._llm_polish("一句話", "zh")
+
+    assert polish_calls[0]["timeout"] == transcribe._LLM_POLISH_TIMEOUT_S
+    assert polish_calls[0]["timeout"] > 120
+
+
+def test_polish_pins_a_low_temperature(polish_calls):
+    """Correcting homophones is not a creative task."""
+    transcribe._llm_polish("一句話", "zh")
+    assert polish_calls[0]["temperature"] == 0.2
+
+
+# ── failure is per chunk, and it is announced ────────────────────────────────
+
+def test_one_failing_chunk_degrades_only_itself(monkeypatch, capsys):
+    segs = _segments(30)
+    text = " ".join(segs)
+    chunks = transcribe._polish_chunks(text)
+    assert len(chunks) >= 3
+
+    def flaky(prompt, model=None, timeout=None, temperature=None, **kw):
+        body = prompt.split("原始逐字稿：\n", 1)[1].rsplit("\n\n校正後：", 1)[0]
+        if body == chunks[1]:
+            raise TimeoutError("read timed out")
+        return {"text": body + "。"}
+
+    monkeypatch.setattr(transcribe, "chat", flaky)
+    out = transcribe._llm_polish_batched(text, "zh")
+
+    # The failed chunk came back raw; its neighbours are still polished.
+    assert chunks[0] + "。" in out
+    assert chunks[2] + "。" in out
+    assert chunks[1] + "。" not in out and chunks[1] in out
+    assert "TimeoutError" in capsys.readouterr().out, "a swallowed failure is the original bug"
+
+
+def test_a_wildly_wrong_length_is_rejected_per_chunk(monkeypatch, capsys):
+    """The model occasionally answers with a summary, or with its own commentary.
+    Before chunking, one such answer discarded the entire transcript."""
+    monkeypatch.setattr(transcribe, "chat",
+                        lambda prompt, **kw: {"text": "好"})  # far shorter than the input
+
+    assert transcribe._llm_polish("一" * 200, "zh") == "一" * 200
+    assert "rejected" in capsys.readouterr().out
+
+
+# ── the budget ───────────────────────────────────────────────────────────────
+
+def _fake_clock(monkeypatch, ticks):
+    """Replace transcribe's `time` module reference — not the real one, which pytest
+    itself uses — with a clock that advances by `ticks` seconds per reading."""
+    state = {"t": 0.0}
+
+    def monotonic():
+        now = state["t"]
+        state["t"] += ticks
+        return now
+
+    monkeypatch.setattr(transcribe, "time", types.SimpleNamespace(monotonic=monotonic))
+
+
+def test_budget_stops_polishing_and_returns_the_rest_raw(monkeypatch, polish_calls, capsys):
+    """Without this, the "fix" would hold the shared ingest slot for as long as the
+    model wanted — worse for the queue than the silent failure it replaced."""
+    segs = _segments(30)
+    text = " ".join(segs)
+    chunks = transcribe._polish_chunks(text)
+    assert len(chunks) >= 4
+
+    # The clock is read once before the loop and once per chunk: 0 s, then 60,
+    # 120, 180 — so the third chunk is the first one over a 150 s budget.
+    monkeypatch.setattr(transcribe, "_LLM_POLISH_BUDGET_S", 150)
+    _fake_clock(monkeypatch, ticks=60)
+
+    out = transcribe._llm_polish_batched(text, "zh")
+
+    assert len(polish_calls) == 2, "budget must stop the loop, not merely warn"
+    assert out == text, "unpolished chunks are returned verbatim, never dropped"
+    assert "budget reached" in capsys.readouterr().out
+
+
+def test_budget_does_not_fire_when_there_is_time(monkeypatch, polish_calls):
+    segs = _segments(30)
+    text = " ".join(segs)
+    chunks = transcribe._polish_chunks(text)
+
+    monkeypatch.setattr(transcribe, "_LLM_POLISH_BUDGET_S", 10_000)
+    _fake_clock(monkeypatch, ticks=1)
+
+    transcribe._llm_polish_batched(text, "zh")
+    assert len(polish_calls) == len(chunks)
+
+
+def test_empty_text_makes_no_calls(polish_calls):
+    assert transcribe._llm_polish_batched("   ", "zh") == "   "
+    assert polish_calls == []

--- a/transcribe.py
+++ b/transcribe.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 import tempfile
 import threading
+import time
 import platform
 from pathlib import Path
 
@@ -38,6 +39,15 @@ WHISPER_LANGUAGE_HINT = None
 WHISPER_LLM_MODEL = "qwen2.5:14b"
 VAD_ENABLED = True
 LLM_POLISH = True
+
+# Polish is the slowest thing in the pipeline: ~3-4 chars/s locally, so a whole
+# transcript in one call blows any sane timeout. Chunked, with a ceiling on the
+# total — the ceiling matters because polish runs inside the shared ingest slot,
+# so an unbounded retry would make the queue worse than the silent failure it
+# replaces. Both are overridable for a machine with a faster box behind Ollama.
+_LLM_POLISH_CHUNK_CHARS = 300
+_LLM_POLISH_TIMEOUT_S = int(os.getenv("ARKIV_LLM_POLISH_TIMEOUT", "300"))
+_LLM_POLISH_BUDGET_S = int(os.getenv("ARKIV_LLM_POLISH_BUDGET", "900"))
 
 # ── Platform Detection ───────────────────────────────────────────────────────
 _USE_MLX = platform.system() == "Darwin" and platform.machine() == "arm64"
@@ -643,7 +653,7 @@ def _postprocess(text: str, lang: str, segments: list, language: str,
 
     # Step 5: LLM polish
     if LLM_POLISH and len(filtered_text) > 10:
-        filtered_text = _llm_polish(filtered_text, language)
+        filtered_text = _llm_polish_batched(filtered_text, language)
 
     # Step 6: words_json reconciliation. The per-segment filter above rebuilt
     # timed_segments from the SURVIVING segments, but `words` still carries every
@@ -726,13 +736,74 @@ def _llm_polish(text: str, language: str = "zh") -> str:
 校正後："""
 
     try:
-        result = chat(prompt, model=MODEL)
+        result = chat(prompt, model=MODEL, timeout=_LLM_POLISH_TIMEOUT_S, temperature=0.2)
         polished = result.get("text", "").strip()
         if polished and 0.5 < len(polished) / max(len(text), 1) < 2.0:
             return polished
-    except Exception:
-        pass
+        print("  [polish] rejected (length ratio out of range), keeping raw text", flush=True)
+    except Exception as exc:
+        # This used to be a bare `except: pass`, and that silence is the whole
+        # reason a 120 s timeout went unnoticed for months: a transcript long
+        # enough to blow the budget came back as raw, unpunctuated Whisper output
+        # and looked exactly like a transcript the model had declined to improve.
+        print(f"  [polish] skipped ({type(exc).__name__}): {exc}", flush=True)
     return text
+
+
+def _polish_chunks(text: str, max_chars: int = _LLM_POLISH_CHUNK_CHARS) -> list:
+    """Greedily pack `text` into ≤max_chars pieces, splitting only on spaces.
+
+    A space is exactly where `_postprocess` joined the kept segments, so a chunk
+    boundary can never land inside one — the model always sees whole segments.
+    """
+    words, chunks, current = text.split(" "), [], ""
+    for word in words:
+        if current and len(current) + 1 + len(word) > max_chars:
+            chunks.append(current)
+            current = word
+        else:
+            current = f"{current} {word}" if current else word
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _llm_polish_batched(text: str, language: str = "zh") -> str:
+    """Polish a transcript in pieces, under a total time budget.
+
+    Why pieces: qwen2.5:14b runs at roughly 3-4 characters/second locally, so a
+    4,000-character transcript needs 20+ minutes in one call. It blew the old
+    hardcoded 120 s timeout, the exception was swallowed, and the user silently got
+    raw unpunctuated text.
+
+    Why a BUDGET and not just a bigger timeout: raising the timeout alone converts
+    a silent 120 s failure into a real 20-70 minute one, held inside the shared
+    ingest slot — every other clip in the queue waits behind it. Past the budget the
+    remaining chunks are returned raw, which is the same outcome as before but
+    bounded and announced.
+
+    The length-ratio guard now applies per chunk, so one bad chunk degrades 300
+    characters rather than the whole transcript.
+    """
+    if not text.strip():
+        return text
+    chunks = _polish_chunks(text)
+    if len(chunks) <= 1:
+        return _llm_polish(text, language)
+
+    started, out = time.monotonic(), []
+    for i, chunk in enumerate(chunks):
+        elapsed = time.monotonic() - started
+        if elapsed > _LLM_POLISH_BUDGET_S:
+            print(
+                f"  [polish] budget reached after {elapsed:.0f}s — "
+                f"{len(chunks) - i} of {len(chunks)} chunks kept raw",
+                flush=True,
+            )
+            out.extend(chunks[i:])
+            break
+        out.append(_llm_polish(chunk, language))
+    return " ".join(out)
 
 
 def _to_wav(media_path: str):


### PR DESCRIPTION
`_llm_polish` 把整篇逐字稿塞進一次 `chat()`，而 `chat()` 把 timeout 硬編成
120 秒。qwen2.5:14b 在本機大約每秒 3-4 個字 —— 4,000 字的逐字稿需要 20 分鐘
以上。requests 逾時、`except: pass` 吞掉例外、呼叫端拿回原始未標點的 Whisper
輸出，而且**看起來就像模型決定不要改**。零 log。

所以症狀是「長片的潤稿好像比較差」，而不是「潤稿失敗了」。

修法有兩半，兩半都必要：

1. **切塊 + 真正的 timeout。** `_polish_chunks` 在 `" "` 上貪婪打包成 ≤300 字
   —— 那正是 `_postprocess` 串接保留 segment 時用的分隔符，所以邊界永遠不會
   落在一個句子中間。長度比例守衛也跟著變成 per chunk：模型偶爾會回一段摘要
   或自己的說明，以前那一次就把整篇逐字稿丟掉，現在只影響 300 字。

2. **整體預算。** 只把 timeout 調大，等於把「靜默的 120 秒失敗」換成「真實的
   20–70 分鐘卡住」—— 而且卡在共用的 ingest slot 裡，佇列後面每一支都在等。
   `_LLM_POLISH_BUDGET_S`（預設 900 秒）到點就停，剩下的區塊原樣回傳並印出
   還剩幾塊。結果跟以前一樣是未潤稿的文字，差別是有界、而且說出來。

`chat()` 加 `timeout=` 與 `temperature=`，**兩個預設都不變**（120 / None）——
另外十個呼叫點一個字都沒動。chat.py 的互動 RAG 路徑本來就該快速失敗；只有
長時間工作需要耐心，而且要自己開口要。`temperature` 用 `is not None` 判斷，
不是 `if temperature:` —— 0.0 正是想要決定性的呼叫端最可能傳的值。

潤稿自己指定 `temperature=0.2`：修同音字不是創意工作。

`except` 補 log（`[polish] skipped (TimeoutError): ...`）。那個沉默是這個 bug
活了好幾個月的全部原因。

新增 12 支測試（`tests/test_transcribe_polish.py`）+ 4 支 `chat()` 參數測試：
  - 切塊永遠不切開一個 segment、不掉字、不超過上限
  - 單一超長 segment 不被硬切（沒有空白可切時，整塊送出才是對的）
  - 潤稿要到長 timeout、釘住低 temperature
  - 一塊失敗只降級那一塊，鄰居仍然潤過，而且失敗被印出來
  - 預算到點停止迴圈（不是只警告），未潤稿的區塊逐字回傳
  - `chat()` 預設不變、temperature=0.0 不被當成未設定

mutation-check 七處全紅在該紅的位置：
  拿掉預算檢查       → 預算測試紅
  丟掉未潤稿的剩餘   → 預算測試紅
  timeout 退回預設   → timeout 測試紅
  temperature 不釘   → temperature 測試紅
  按字元切而非按接點 → 邊界測試紅
  單塊失敗往外拋     → 降級測試紅
  `if temperature:`  → 0.0 測試紅

全套 1421 passed / 7 skipped。

在追 Penny 回報的時間碼問題時發現的。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>