### PR TITLE
feat(transcribe): 過長的 segment 按字幕行切開

### DIFF
--- a/tests/test_transcribe_guards.py
+++ b/tests/test_transcribe_guards.py
@@ -71,11 +71,11 @@ def test_postprocess_filters_bad_segments_but_keeps_threshold_boundary(monkeypat
     ]
     cleaned, _, timed_segments, words = transcribe._postprocess("原始文字", "zh", segments, "zh")
     assert cleaned == "這段應該保留，因為它剛好在邊界值。"
-    assert timed_segments == [{
-        "start": 0.0,
-        "end": 2.0,
-        "text": "這段應該保留，因為它剛好在邊界值。",
-    }]
+    # Exactly one segment survives the filters. It is wider than a caption line, so
+    # _split_long_segments hands it back as lines — the assertion is about which
+    # content survived and over what span, not about how it is laid out.
+    assert "".join(ts["text"] for ts in timed_segments) == "這段應該保留，因為它剛好在邊界值。"
+    assert (timed_segments[0]["start"], timed_segments[-1]["end"]) == (0.0, 2.0)
     assert words == []
 
 
@@ -120,11 +120,11 @@ def test_postprocess_removes_char_loops_and_polishes(monkeypatch):
         "zh",
     )
     assert cleaned == "校正後：字幕由，這是一段正常補充。"
-    assert timed_segments == [{
-        "start": 0.0,
-        "end": 4.0,
-        "text": "字幕由字幕由字幕由字幕由，這是一段正常補充。",
-    }]
+    # Note the segment text is NOT de-looped — char-loop removal applies to the
+    # transcript only. Same as above: assert the content and span, and let the
+    # caption-line split be tested where it belongs.
+    assert "".join(ts["text"] for ts in timed_segments) == "字幕由字幕由字幕由字幕由，這是一段正常補充。"
+    assert (timed_segments[0]["start"], timed_segments[-1]["end"]) == (0.0, 4.0)
     assert words == []
 
 

--- a/tests/test_transcribe_segment_split.py
+++ b/tests/test_transcribe_segment_split.py
@@ -1,0 +1,145 @@
+"""Segments wider than a caption line get split on the line boundaries.
+
+Whisper times whatever fits its 30-second window, so a whole sentence of dialogue
+routinely arrives as ONE segment with ONE timestamp. Everything downstream inherits
+that granularity: clicking any part of the line in the Inspector seeks to the start
+of the sentence, an SRT cue holds more text than fits the time given, and a
+frame-exact IN point can only ever be the sentence's first frame.
+
+`subtitle.wrap()` already knows where a line may break. This reuses it and shares
+the segment's span between the lines it produces, in proportion to their width.
+
+The proportional share is an estimate — it assumes an even speaking rate inside the
+segment. That is worth saying plainly: it does not make the timing exact, it makes
+the error one caption line wide instead of one sentence wide.
+"""
+from __future__ import annotations
+
+import pytest
+
+import subtitle
+import transcribe
+
+
+def _seg(text, start, end, **extra):
+    seg = {"text": text, "start": start, "end": end}
+    seg.update(extra)
+    return seg
+
+
+LONG = "這是一段很長的旁白，長到一行字幕根本放不下，所以它必須被拆開才有意義。"
+
+
+def test_a_sentence_wider_than_a_line_becomes_several_segments():
+    out = transcribe._split_long_segments([_seg(LONG, 0.0, 12.0)])
+
+    assert len(out) == len(subtitle.wrap(LONG, max_units=transcribe._MAX_SEGMENT_UNITS))
+    assert len(out) > 1
+
+
+def test_the_split_loses_no_text():
+    out = transcribe._split_long_segments([_seg(LONG, 0.0, 12.0)])
+    assert "".join(s["text"] for s in out) == LONG
+
+
+def test_the_outer_span_is_unchanged():
+    """Load-bearing: the words_json reconciliation in `_postprocess` keeps a word
+    only if its midpoint lands inside some kept segment. Shrinking or shifting the
+    outer span here would silently drop words at the edges."""
+    out = transcribe._split_long_segments([_seg(LONG, 3.5, 12.25)])
+
+    assert out[0]["start"] == 3.5
+    assert out[-1]["end"] == 12.25
+
+
+def test_pieces_are_contiguous_and_ordered():
+    out = transcribe._split_long_segments([_seg(LONG, 0.0, 12.0)])
+
+    for a, b in zip(out, out[1:]):
+        assert a["end"] == pytest.approx(b["start"], abs=1e-3)
+        assert a["start"] < a["end"]
+
+
+def test_span_follows_width_not_piece_count():
+    """Equal division would put every click at the geometric midpoint of the
+    sentence. Lines differ in width; a wider line has more speech in it."""
+    text = "短。" + "這是一段明顯長很多的句子，需要更多時間念完，所以它應該分到更長的區間。"
+    out = transcribe._split_long_segments([_seg(text, 0.0, 20.0)])
+    assert len(out) > 2
+
+    durations = [s["end"] - s["start"] for s in out]
+    widths = [subtitle.display_units(s["text"]) for s in out]
+    ratios = [d / w for d, w in zip(durations, widths)]
+
+    # Every piece gets the same seconds-per-unit — that IS proportional division.
+    assert max(ratios) == pytest.approx(min(ratios), rel=0.02)
+    # And the check that would pass under equal division too, kept explicit:
+    assert durations[0] < durations[-1]
+
+
+def test_speaker_id_and_unknown_keys_survive():
+    """Diarization runs BEFORE this, so the label is already on the segment. Any
+    future per-segment key (translation, confidence) rides along the same way."""
+    out = transcribe._split_long_segments(
+        [_seg(LONG, 0.0, 12.0, speaker_id="SPEAKER_01", translation="x")]
+    )
+
+    assert len(out) > 1
+    assert all(s["speaker_id"] == "SPEAKER_01" for s in out)
+    assert all(s["translation"] == "x" for s in out)
+
+
+def test_a_segment_that_already_fits_is_returned_untouched():
+    seg = _seg("短短一句話。", 1.0, 2.5, speaker_id="A")
+    out = transcribe._split_long_segments([seg])
+    assert out == [seg]
+
+
+def test_a_too_fast_segment_is_left_alone():
+    """A wide segment that lasts half a second would yield pieces too short to read
+    as cues, and at that scale the proportional estimate is mostly rounding error.
+    Leaving it whole is the honest outcome; the export path still wraps the line."""
+    seg = _seg(LONG, 0.0, 0.5)
+    assert transcribe._split_long_segments([seg]) == [seg]
+
+
+def test_a_zero_length_segment_is_left_alone():
+    """Dividing by a zero span would hand every piece the same instant."""
+    seg = _seg(LONG, 4.0, 4.0)
+    assert transcribe._split_long_segments([seg]) == [seg]
+
+
+def test_segments_without_timing_pass_through():
+    seg = {"text": LONG}
+    assert transcribe._split_long_segments([seg]) == [seg]
+
+
+def test_empty_text_passes_through():
+    seg = _seg("   ", 0.0, 5.0)
+    assert transcribe._split_long_segments([seg]) == [seg]
+
+
+def test_splitting_runs_after_diarization(monkeypatch):
+    """Order matters and is easy to break by moving one line. pyannote must see the
+    original sentence-length windows — half-second windows make one speaker's
+    sentence flicker between labels."""
+    monkeypatch.setattr(transcribe, "LLM_POLISH", False)
+    monkeypatch.setattr(transcribe, "FILTER_WORDS", "")
+    monkeypatch.setattr(transcribe, "DIARIZATION_ENABLED", True)
+
+    seen = {}
+
+    def fake_diarize(timed_segments, wav_path):
+        seen["count"] = len(timed_segments)
+        return [{**s, "speaker_id": "SPEAKER_00"} for s in timed_segments]
+
+    monkeypatch.setattr(transcribe, "_attach_speaker_ids", fake_diarize)
+
+    segments = [{"text": LONG, "start": 0.0, "end": 12.0,
+                 "no_speech_prob": 0.1, "avg_logprob": -0.2, "compression_ratio": 1.1}]
+    _text, _lang, out, _words = transcribe._postprocess(
+        LONG, "zh", segments, "zh", wav_path="/fake.wav"
+    )
+
+    assert seen["count"] == 1, "diarization saw the pieces, not the sentence"
+    assert len(out) > 1 and all(s["speaker_id"] == "SPEAKER_00" for s in out)

--- a/transcribe.py
+++ b/transcribe.py
@@ -16,6 +16,7 @@ import soundfile as sf
 from silero_vad import load_silero_vad, get_speech_timestamps
 import torch
 
+import subtitle
 import whisper_guard
 import zh_convert
 
@@ -48,6 +49,16 @@ LLM_POLISH = True
 _LLM_POLISH_CHUNK_CHARS = 300
 _LLM_POLISH_TIMEOUT_S = int(os.getenv("ARKIV_LLM_POLISH_TIMEOUT", "300"))
 _LLM_POLISH_BUDGET_S = int(os.getenv("ARKIV_LLM_POLISH_BUDGET", "900"))
+
+# One caption line. Whisper hands back whatever fits its 30 s window — often a
+# 40-character sentence on a single timestamp — and every consumer of that
+# timestamp (click-to-seek, SRT cues, frame-exact IN points) can then only ever
+# point at the start of the whole sentence. Matches subtitle.wrap()'s default;
+# the user-facing setting lands with the export work.
+_MAX_SEGMENT_UNITS = 14.0
+# Below this, splitting buys nothing and costs correctness: pieces that short are
+# unreadable as cues, and the proportional estimate is mostly rounding error.
+_MIN_SPLIT_PIECE_S = 0.2
 
 # ── Platform Detection ───────────────────────────────────────────────────────
 _USE_MLX = platform.system() == "Darwin" and platform.machine() == "arm64"
@@ -584,6 +595,67 @@ def _attach_speaker_ids(timed_segments: list, wav_path: str) -> list:
         return timed_segments
 
 
+def _split_long_segments(timed_segments: list, max_units: float = _MAX_SEGMENT_UNITS) -> list:
+    """Break segments that are wider than one caption line, on the line boundaries.
+
+    Whisper times a whole sentence as one segment, so a 12-second line of dialogue
+    carries exactly one timestamp. Clicking that line in the Inspector jumps to the
+    start of the sentence no matter which part of it you clicked, an SRT cue holds
+    text nobody can read in the time given, and a frame-exact IN point can only be
+    the sentence's first frame.
+
+    `subtitle.wrap()` already knows where a line may break — after CJK punctuation,
+    at spaces, never inside a Latin word or between a number and its measure word.
+    This reuses it and shares the segment's span between the resulting lines.
+
+    The span is divided **in proportion to `display_units`**, not equally: lines
+    differ in width, and equal division would place every click at the geometric
+    midpoint of the sentence rather than near the words being pointed at. It is
+    still an estimate — it assumes an even speaking rate within the segment — but
+    the error is bounded by one line, where today it is bounded by the sentence.
+
+    The last piece keeps the original `end` and the first keeps the original
+    `start`, so the segment's outer span is unchanged: the words_json
+    reconciliation above and every downstream range check see the same coverage.
+
+    Runs AFTER `_attach_speaker_ids` on purpose. A 14-unit line can be half a
+    second long, and feeding pyannote half-second windows makes one speaker's
+    sentence flicker between labels.
+    """
+    out = []
+    for seg in timed_segments:
+        text = (seg.get("text") or "").strip()
+        start, end = seg.get("start"), seg.get("end")
+        if not text or start is None or end is None:
+            out.append(seg)
+            continue
+
+        lines = subtitle.wrap(text, max_units=max_units)
+        span = float(end) - float(start)
+        # The second condition also covers a zero or inverted span: dividing one of
+        # those would hand every piece the same instant.
+        if len(lines) < 2 or span / len(lines) < _MIN_SPLIT_PIECE_S:
+            out.append(seg)
+            continue
+
+        widths = [subtitle.display_units(ln) for ln in lines]
+        total = sum(widths)
+        if total <= 0:
+            out.append(seg)
+            continue
+
+        cursor = float(start)
+        for i, (line, width) in enumerate(zip(lines, widths)):
+            last = i == len(lines) - 1
+            piece_end = float(end) if last else cursor + span * (width / total)
+            out.append({**seg,
+                        "text": line,
+                        "start": round(cursor, 3),
+                        "end": round(piece_end, 3)})
+            cursor = piece_end
+    return out
+
+
 def _postprocess(text: str, lang: str, segments: list, language: str,
                  words: list = None, wav_path: str = None) -> tuple:
     """Shared post-processing: anti-hallucination + LLM polish (+ optional A4
@@ -681,6 +753,8 @@ def _postprocess(text: str, lang: str, segments: list, language: str,
     # backend), so the labels line up with the timecodes.
     if wav_path and DIARIZATION_ENABLED:
         timed_segments = _attach_speaker_ids(timed_segments, wav_path)
+
+    timed_segments = _split_long_segments(timed_segments)
 
     return filtered_text, lang, timed_segments, words or []
 


### PR DESCRIPTION
Whisper 用它自己的 30 秒窗口決定 segment 邊界，所以整句對白經常是**一個**
segment、**一個**時間碼。下游每一個消費者都繼承那個粒度：

- Inspector 點逐字稿的任何一處，都跳到整句的開頭
- SRT 一個 cue 塞進在那段時間內讀不完的字
- frame-exact 的 IN 點只可能是整句的第一格

`subtitle.wrap()`（Phase 12.5）本來就知道一行可以斷在哪 —— CJK 標點之後、
空白處，而且不會切開拉丁單字或把數字與量詞分家。這裡重用它，再把 segment 的
時間跨度分給切出來的行。

**跨度按 `display_units` 比例分，不是等分。** 行寬不同，等分會讓每一次點擊
都落在整句的幾何中點，而不是接近被指到的那幾個字。

這仍然是估計 —— 它假設 segment 內語速均勻。值得把話講白：它不會讓時間變準確，
它讓誤差從「一整句寬」縮到「一行字幕寬」。

第一塊保留原 `start`、最後一塊保留原 `end`，所以外緣跨度不變 —— `_postprocess`
的 words_json 對帳（只保留中點落在某個保留 segment 內的字）與所有下游範圍檢查
看到的覆蓋範圍完全一樣。

**排在 `_attach_speaker_ids` 之後**，這是刻意的：一行 14 單位可能只有半秒，
餵 pyannote 半秒窗口會讓同一個人的一句話在標籤之間跳動。mutation-check 有一支
專門盯住這個順序。

守衛：切完每塊不到 0.2 秒就整段不切（那種長度當 cue 讀不了，而且在那個尺度上
比例估計幾乎只剩捨入誤差；export 端仍然會排版那一行）。同一個條件也擋掉零跨度
與反向跨度。

新增 12 支測試。另外兩支既有的 `_postprocess` 幻覺過濾測試改成斷言「內容與
外緣跨度」而不是逐字比對 segment 陣列 —— 它們測的是哪些 segment 活下來，不是
版面怎麼排。

mutation-check 六處全紅在該紅的位置：
  不呼叫切分         → 順序測試紅
  等分而非按比例     → 比例測試紅
  拿掉最短守衛       → 過快 / 零跨度兩支紅
  切分時丟掉其他 key → speaker_id 測試紅
  切分移到 diarize 前 → 順序測試紅
（外加一支 no-op 對照，確認幻覺過濾測試不會無端變紅。）

全套 1421 passed / 7 skipped。

在追 Penny 回報的時間碼問題時一併處理。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>