### PR TITLE
feat(export): UI 從來沒提供 .txt，而 server 早就支援

### DIFF
--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -291,7 +291,15 @@
   }
   const RE_LANGS = [{ code: 'zh', label: '中文' }, { code: 'en', label: 'English' }]
   $: langOpts = languages && languages.length ? languages : RE_LANGS
-  const EXPORT_FMTS = ['edl', 'fcpxml', 'srt', 'vtt']
+  const EXPORT_FMTS = ['edl', 'fcpxml', 'srt', 'vtt', 'txt']
+  // The server has served .txt since Phase 12; only the button was missing, so the
+  // one format an editor actually pastes into a script doc was unreachable from
+  // the UI. The trim note is not padding: without ✂ the file is the LLM-polished
+  // transcript, with ✂ it is the raw Whisper segment text inside the window —
+  // those are not the same document.
+  const EXPORT_TITLES = {
+    txt: '逐字稿純文字（完整標點）。設了 ✂ 範圍時輸出的是該範圍內的 segment 原文，未經潤稿',
+  }
 
   const MOCK_TRANSCRIPT = [
     ['00:05', '我們從上海一路騎到拉薩，第十七天。', false],
@@ -568,13 +576,13 @@
     <div class="exports">
       {#if onExport}
         {#each EXPORT_FMTS as fmt}
-          <button class="ak-btn exp" on:click={() => onExport(fmt, trimArgs)}>{fmt.toUpperCase()}{trimArgs ? ' ✂' : ''}</button>
+          <button class="ak-btn exp" title={EXPORT_TITLES[fmt] || ''}
+                  on:click={() => onExport(fmt, trimArgs)}>{fmt.toUpperCase()}{trimArgs ? ' ✂' : ''}</button>
         {/each}
       {:else}
-        <button class="ak-btn exp">EDL</button>
-        <button class="ak-btn exp">FCPXML</button>
-        <button class="ak-btn exp">SRT</button>
-        <button class="ak-btn exp">VTT</button>
+        {#each EXPORT_FMTS as fmt}
+          <button class="ak-btn exp">{fmt.toUpperCase()}</button>
+        {/each}
       {/if}
     </div>
     {#if onChapters || onRemotion}

--- a/tests/test_export_ui_contract.py
+++ b/tests/test_export_ui_contract.py
@@ -1,0 +1,114 @@
+"""Every format the UI offers must be a format the server actually serves.
+
+The two lists drifted for months in the cheap direction — the server had served
+`.txt` since Phase 12 and the Inspector never offered a button, so the one export
+an editor pastes straight into a script document was unreachable from the app. It
+drifts the expensive direction just as easily: a button for a format the server
+rejects is a 400 in the user's face.
+
+Nothing links the two, so this test does — by parsing the button lists out of the
+Svelte source and calling the real endpoints with them. A text comparison against a
+hard-coded set would only restate the drift somewhere else.
+
+Two lists, two endpoints, deliberately different:
+  Inspector  → GET /api/media/{id}/export/{fmt}   (one clip)
+  MainLive   → GET /api/export/timeline/{fmt}     (several clips on one timeline;
+                                                   only sequence formats make sense)
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_FRONTEND = Path(__file__).resolve().parent.parent / "frontend" / "src"
+
+
+def _fmt_list(rel_path: str) -> list:
+    """Pull `const EXPORT_FMTS = ['a', 'b']` out of a .svelte file."""
+    src = (_FRONTEND / rel_path).read_text(encoding="utf-8")
+    m = re.search(r"const EXPORT_FMTS = \[([^\]]*)\]", src)
+    assert m, "EXPORT_FMTS not found in {0} — did the constant get renamed?".format(rel_path)
+    return re.findall(r"'([^']+)'", m.group(1))
+
+
+def _seed(db):
+    segs = json.dumps([{"start": 0.0, "end": 2.0, "text": "第一句"},
+                       {"start": 2.0, "end": 4.0, "text": "第二句"}], ensure_ascii=False)
+    db.upsert({
+        "path": "/tmp/a.mp4", "filename": "a.mp4", "ext": ".mp4",
+        "duration_s": 4.0, "size_mb": 5.0, "width": 1920, "height": 1080,
+        "fps": 30.0, "has_audio": 1, "transcript": "第一句 第二句", "lang": "zh",
+        "frame_tags": "", "thumbnail_path": "", "processed_at": "2026-05-01T09:00:00",
+        "segments_json": segs,
+    })
+
+
+def test_the_lists_are_not_empty():
+    """Guard the regex itself: a silent [] would make every check below vacuous."""
+    assert _fmt_list("lib/Inspector.svelte")
+    assert _fmt_list("routes/MainLive.svelte")
+
+
+@pytest.mark.parametrize("fmt", _fmt_list("lib/Inspector.svelte"))
+def test_every_inspector_button_is_served(fastapi_client, server_module, fmt):
+    _seed(importlib.import_module("db"))
+    r = fastapi_client.get("/api/media/1/export/{0}".format(fmt))
+    assert r.status_code == 200, "{0} button → {1}: {2}".format(fmt, r.status_code, r.text[:200])
+    assert r.headers["content-disposition"].startswith("attachment")
+
+
+@pytest.mark.parametrize("fmt", _fmt_list("routes/MainLive.svelte"))
+def test_every_timeline_button_is_served(fastapi_client, server_module, fmt):
+    _seed(importlib.import_module("db"))
+    r = fastapi_client.get("/api/export/timeline/{0}?ids=1".format(fmt))
+    assert r.status_code == 200, "{0} button → {1}: {2}".format(fmt, r.status_code, r.text[:200])
+
+
+def test_txt_is_offered_for_a_single_clip(fastapi_client, server_module):
+    """The button this test was written for. Deliberately spelled out rather than
+    left implicit in the parametrised sweep above."""
+    assert "txt" in _fmt_list("lib/Inspector.svelte")
+
+    _seed(importlib.import_module("db"))
+    r = fastapi_client.get("/api/media/1/export/txt")
+
+    assert r.status_code == 200
+    assert r.text == "第一句 第二句"  # the transcript, not the segment join
+    assert r.headers["content-type"].startswith("text/plain")
+
+
+def test_trimmed_txt_is_the_segment_text_not_the_polished_transcript(fastapi_client, server_module):
+    """Why the button carries a tooltip. These two exports are different documents:
+    untrimmed returns `transcript` (LLM-polished), trimmed can only rebuild the text
+    from segments, which hold raw Whisper output. Claiming parity would be a lie the
+    user discovers by diffing two downloads."""
+    db = importlib.import_module("db")
+    segs = json.dumps([{"start": 0.0, "end": 2.0, "text": "第一句"},
+                       {"start": 2.0, "end": 4.0, "text": "第二句"}], ensure_ascii=False)
+    db.upsert({
+        "path": "/tmp/b.mp4", "filename": "b.mp4", "ext": ".mp4",
+        "duration_s": 4.0, "size_mb": 5.0, "width": 1920, "height": 1080,
+        "fps": 30.0, "has_audio": 1, "transcript": "潤稿後的整篇逐字稿。", "lang": "zh",
+        "frame_tags": "", "thumbnail_path": "", "processed_at": "2026-05-01T09:00:00",
+        "segments_json": segs,
+    })
+
+    whole = fastapi_client.get("/api/media/1/export/txt")
+    trimmed = fastapi_client.get("/api/media/1/export/txt?in_s=0&out_s=2")
+
+    assert whole.text == "潤稿後的整篇逐字稿。"
+    assert trimmed.text == "第一句"
+    assert whole.text != trimmed.text
+
+
+def test_the_tooltip_says_so():
+    """The asymmetry above is invisible in the UI unless the button explains it."""
+    src = (_FRONTEND / "lib" / "Inspector.svelte").read_text(encoding="utf-8")
+    m = re.search(r"const EXPORT_TITLES = \{(.*?)\n  \}", src, re.S)
+    assert m, "EXPORT_TITLES not found"
+    assert "txt:" in m.group(1)
+    assert "✂" in m.group(1), "the tooltip must mention the trim case, not just say '純文字'"


### PR DESCRIPTION
`/api/media/{id}/export/txt` 從 Phase 12 就在服務了 —— trim、auth、attachment
header 全都對。少的只是一顆按鈕。所以「剪接師真正會貼進腳本文件的那個格式」，
在 app 裡按不到。

Inspector 加上 TXT，並且**不宣稱 trim 對等**：

- 沒設 ✂ → 回 `transcript`，也就是 LLM 潤稿過、標點完整的整篇
- 設了 ✂ → 只能從 segments 重建，而 segments 存的是原始 Whisper 文字

那是兩份不同的文件。按鈕帶 `title` 把這件事講出來，因為使用者只有在下載兩次
去 diff 的時候才會發現。

同時補上兩份清單之間唯一的連結（`tests/test_export_ui_contract.py`）：把 UI 的
`EXPORT_FMTS` 直接從 Svelte 原始碼 parse 出來，逐個打真正的端點。

  Inspector → GET /api/media/{id}/export/{fmt}（單支）
  MainLive  → GET /api/export/timeline/{fmt}（多支排成一條時間軸）

兩份清單刻意不同（時間軸只有序列格式有意義），所以分別驗。用「跟寫死的集合做
字串比對」不行 —— 那只是把 drift 搬到另一個地方。這次的漂移是往便宜的方向
（少一顆按鈕），但反方向一樣容易：多一顆 server 不收的按鈕就是使用者臉上一個
400。

mutation-check 四處全紅在該紅的位置：
  拿掉 txt 按鈕           → txt 測試紅
  加一個 server 不收的格式 → 參數化掃描紅
  拿掉 tooltip            → tooltip 測試紅
  tooltip 不提 trim 差異   → tooltip 測試紅
（另有一支反向守衛：清單被 parse 成空的話，上面每一支都會變成空跑。）

順手把 mock（未接線）分支的四顆硬編按鈕改成跑同一份清單 —— 它們原本就已經跟
真實清單不同步了。

全套 1433 passed / 7 skipped。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>