### PR TITLE
refactor(subtitle): 把排版與渲染拆開

### DIFF
--- a/subtitle.py
+++ b/subtitle.py
@@ -12,7 +12,10 @@ Pure functions, no I/O — `segments_to_srt()` ties it to Whisper segments_json.
 """
 from __future__ import annotations
 
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
+
+# One laid-out cue: start seconds, end seconds, the lines to show.
+Cue = Tuple[float, float, List[str]]
 
 # Punctuation that a line should prefer to break AFTER (kept on the upper line).
 _BREAK_AFTER = "。，、！？；：…—)）」』】》”’"
@@ -152,22 +155,27 @@ def format_cue(index: int, start: float, end: float, lines: List[str], sep: str 
     return "{0}\n{1} --> {2}\n{3}\n".format(index, _ts(start, sep), _ts(end, sep), body)
 
 
-def segments_to_srt(
+def layout_cues(
     segments: List[Dict],
     max_units: float = 14.0,
     max_lines: int = 2,
     translate_key: Optional[str] = None,
-) -> str:
-    """Render Whisper segments to laid-out SRT.
+) -> List[Cue]:
+    """Lay Whisper segments out as cues: `[(start, end, lines), ...]`.
 
-    Each segment's text is wrapped to width-safe lines. A monolingual segment
-    that needs more than `max_lines` lines is split into multiple cues, its
-    time span divided proportionally — so a long segment never produces an
-    over-wide line nor a wall-of-text cue. A bilingual segment (translate_key
-    present) stays a single cue: original lines on top, translation below.
+    This is the layout engine on its own, with no output format attached. Each
+    segment's text is wrapped to width-safe lines. A monolingual segment needing
+    more than `max_lines` lines becomes several cues, its span divided
+    proportionally — so a long segment yields neither an over-wide line nor a
+    wall-of-text cue. A bilingual segment (translate_key present) stays one cue:
+    original lines on top, translation below.
+
+    Extracted from `segments_to_srt` because SRT was, for a long time, the only
+    caller — while the HTTP export path hand-rolled its own cue emitters and never
+    reached any of this. A renderer-independent seam is what lets every path
+    (SRT, VTT, timeline, batch) share one layout.
     """
-    out: List[str] = []
-    idx = 1
+    cues: List[Cue] = []
     for seg in segments:
         text = (seg.get("text") or "").strip()
         if not text:
@@ -177,8 +185,7 @@ def segments_to_srt(
 
         if translate_key and (seg.get(translate_key) or "").strip():
             lines = wrap(text, max_units) + wrap((seg.get(translate_key) or "").strip(), max_units)
-            out.append(format_cue(idx, start, end, lines))
-            idx += 1
+            cues.append((start, end, lines))
             continue
 
         lines = wrap(text, max_units)
@@ -189,8 +196,33 @@ def segments_to_srt(
         n = len(chunks)
         span = max(0.0, end - start)
         for ci, chunk in enumerate(chunks):
-            c_start = start + span * ci / n
-            c_end = start + span * (ci + 1) / n
-            out.append(format_cue(idx, c_start, c_end, chunk))
-            idx += 1
-    return "\n".join(out)
+            cues.append((start + span * ci / n, start + span * (ci + 1) / n, chunk))
+    return cues
+
+
+def segments_to_srt(
+    segments: List[Dict],
+    max_units: float = 14.0,
+    max_lines: int = 2,
+    translate_key: Optional[str] = None,
+) -> str:
+    """Render Whisper segments to laid-out SRT. Layout lives in `layout_cues`."""
+    cues = layout_cues(segments, max_units, max_lines, translate_key)
+    return "\n".join(format_cue(i, start, end, lines)
+                     for i, (start, end, lines) in enumerate(cues, 1))
+
+
+def segments_to_vtt(
+    segments: List[Dict],
+    max_units: float = 14.0,
+    max_lines: int = 2,
+    translate_key: Optional[str] = None,
+) -> str:
+    """Same layout, WebVTT syntax: `.` for the millisecond separator, no cue
+    numbers (they are optional in WebVTT, and the exports users already have
+    don't carry them)."""
+    cues = layout_cues(segments, max_units, max_lines, translate_key)
+    body = "\n".join("{0} --> {1}\n{2}\n".format(_ts(start, "."), _ts(end, "."),
+                                                "\n".join(lines))
+                     for start, end, lines in cues)
+    return "WEBVTT\n\n" + body

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -195,3 +195,112 @@ def test_export_srt_segments_with_non_dict_items_filtered(ex, sample_record):
                             transcript="fallback", duration_s=5.0))
     out = ex.export_srt(1)
     assert "好" in out  # the one valid dict segment is used, junk filtered
+
+
+# ── layout / render split (Phase 12.5 → the HTTP export rewiring) ─────────────
+# `segments_to_srt` was the layout engine AND the only way to reach it, which is
+# exactly why every HTTP export grew its own cue emitter instead. Layout now lives
+# in `layout_cues`; SRT and VTT are two renderers over the same list.
+
+GOLDEN_SEGMENTS = [
+    {"start": 0.0, "end": 3.0, "text": "今天天氣很好，我們去了海邊。"},
+    {"start": 3.0, "end": 4.0, "text": "   "},
+    {"start": 4.0, "end": 16.0,
+     "text": "這是一段很長的旁白，長到一行字幕根本放不下，所以引擎會把它拆成好幾個 cue，時間按比例分。"},
+    {"start": 16.0, "end": 19.5, "text": "Hello world, state-of-the-art 3.5公斤。",
+     "translation": "你好世界。"},
+]
+
+# Captured from the pre-refactor implementation. A refactor that changes one byte
+# of this changes what lands in someone's Resolve timeline.
+GOLDEN_SRT = (
+    "1\n00:00:00,000 --> 00:00:03,000\n今天天氣很好，我們去了海邊。\n"
+    "\n"
+    "2\n00:00:04,000 --> 00:00:10,000\n這是一段很長的旁白，\n長到一行字幕根本放不下，\n"
+    "\n"
+    "3\n00:00:10,000 --> 00:00:16,000\n所以引擎會把它拆成好幾個\ncue，時間按比例分。\n"
+    "\n"
+    "4\n00:00:16,000 --> 00:00:19,500\nHello world, state-of-the-art 3.5公斤。\n你好世界。\n"
+)
+
+
+def test_srt_output_is_byte_identical_after_the_extraction():
+    assert sub.segments_to_srt(GOLDEN_SEGMENTS, translate_key="translation") == GOLDEN_SRT
+
+
+def test_layout_cues_returns_start_end_lines():
+    cues = sub.layout_cues(GOLDEN_SEGMENTS, translate_key="translation")
+
+    assert cues[0] == (0.0, 3.0, ["今天天氣很好，我們去了海邊。"])
+    assert all(isinstance(lines, list) for _s, _e, lines in cues)
+
+
+def test_layout_cues_drops_blank_segments():
+    """The blank third segment must not become an empty cue with a live timestamp."""
+    cues = sub.layout_cues(GOLDEN_SEGMENTS)
+    assert all(any(ln.strip() for ln in lines) for _s, _e, lines in cues)
+    assert not any(3.0 <= s < 4.0 for s, _e, _lines in cues)
+
+
+def test_layout_cues_splits_a_long_segment_and_divides_the_span():
+    cues = sub.layout_cues([{"start": 4.0, "end": 16.0, "text": GOLDEN_SEGMENTS[2]["text"]}])
+
+    assert len(cues) == 2
+    assert cues[0][0] == 4.0 and cues[1][1] == 16.0
+    assert cues[0][1] == cues[1][0] == 10.0  # contiguous, evenly split by cue count
+
+
+def test_layout_cues_keeps_a_bilingual_segment_as_one_cue():
+    cues = sub.layout_cues([GOLDEN_SEGMENTS[3]], translate_key="translation")
+
+    assert len(cues) == 1
+    assert cues[0][2][-1] == "你好世界。"
+
+
+def test_vtt_is_the_same_layout_in_webvtt_syntax():
+    srt = sub.segments_to_srt(GOLDEN_SEGMENTS, translate_key="translation")
+    vtt = sub.segments_to_vtt(GOLDEN_SEGMENTS, translate_key="translation")
+
+    assert vtt.startswith("WEBVTT\n\n")
+    # Same cue count, same text, same times — only the syntax differs.
+    assert vtt.count(" --> ") == srt.count(" --> ")
+    assert "00:00:00.000 --> 00:00:03.000" in vtt
+    assert "00:00:00,000" not in vtt, "comma separator is SRT's, not WebVTT's"
+    for line in ("今天天氣很好，我們去了海邊。", "cue，時間按比例分。", "你好世界。"):
+        assert line in vtt
+
+
+def test_vtt_carries_no_cue_numbers():
+    """WebVTT identifiers are optional and the exports users already have omit
+    them. Adding them now would change every downloaded file."""
+    vtt = sub.segments_to_vtt(GOLDEN_SEGMENTS)
+    for block in vtt.split("\n\n")[1:]:
+        if block.strip():
+            assert block.lstrip().startswith("00:"), "cue must open with its timing line"
+
+
+def test_both_renderers_read_the_same_layout(monkeypatch):
+    """The point of the seam: change layout once, both formats follow. A renderer
+    that quietly kept its own copy would ignore this."""
+    monkeypatch.setattr(sub, "layout_cues", lambda *a, **k: [(1.0, 2.0, ["哨兵"])])
+
+    assert "哨兵" in sub.segments_to_srt(GOLDEN_SEGMENTS)
+    assert "哨兵" in sub.segments_to_vtt(GOLDEN_SEGMENTS)
+
+
+def test_a_blank_original_is_dropped_even_when_a_translation_exists():
+    """The `if not text` guard earns its place only here — in the monolingual path
+    `wrap("  ")` already returns no lines. With a translate_key, dropping the guard
+    would emit a cue carrying the translation alone, over the silence's timestamp."""
+    cues = sub.layout_cues(
+        [{"start": 1.0, "end": 2.0, "text": "   ", "translation": "你好世界。"}],
+        translate_key="translation",
+    )
+    assert cues == []
+
+
+def test_whitespace_only_text_never_becomes_a_cue():
+    """Tabs and newlines count as blank too. (Two guards can catch this — the
+    `if not text` skip above and the `if not lines` skip after wrapping — and only
+    the first is reachable; the second stays as defence, not as behaviour.)"""
+    assert sub.layout_cues([{"start": 1.0, "end": 2.0, "text": " \t\n "}]) == []


### PR DESCRIPTION
`segments_to_srt` 同時是排版引擎、也是唯一能碰到它的入口。這正是為什麼每一條
HTTP 匯出路徑都自己長了一份 cue emitter —— 想要 VTT 或 timeline SRT 的人，
沒有辦法只拿排版不拿 SRT。

抽出 `layout_cues(segments, ...) -> [(start, end, lines), ...]`：純排版、不帶
輸出格式。`segments_to_srt` 變成它上面的 renderer，新增 `segments_to_vtt`。

**輸出逐字節不變。** golden test 釘住重構前的實際輸出（含雙語 cue、空白
segment、按比例切開的長 segment），一個 byte 都不能動 —— 那是會進到別人
Resolve 時間軸的東西。

`segments_to_vtt` 不帶 cue 編號：WebVTT 的 identifier 是選配的，而使用者手上
已經有的匯出檔就沒有。現在加等於改掉每一份已下載的檔案。

新增 9 支測試。mutation-check 五處全紅在該紅的位置：
  cue 之間的分隔改掉      → golden 紅
  SRT 編號從 0 起算       → golden 紅
  VTT 用逗號當毫秒分隔    → VTT 測試紅
  空白 segment 變成 cue   → 雙語空白測試紅
  VTT 不再走共用排版      → 哨兵測試紅

一處誠實標註：`if not lines: continue` 在 `if not text: continue` 之後是**到不了
的**（非空白文字 wrap 之後不可能沒有行）。保留當防守，但不宣稱它有測試。

這支只搬東西、不接線。真正把 HTTP 匯出接到這個 seam 上的是下一支。

全套 1443 passed / 7 skipped。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>