### PR TITLE
feat(subtitle): 字幕只留 ，！？，停頓交給 cue 時間

### DIFF
--- a/subtitle.py
+++ b/subtitle.py
@@ -12,6 +12,8 @@ Pure functions, no I/O — `segments_to_srt()` ties it to Whisper segments_json.
 """
 from __future__ import annotations
 
+import re
+import unicodedata
 from typing import Dict, List, Optional, Tuple
 
 # One laid-out cue: start seconds, end seconds, the lines to show.
@@ -136,6 +138,52 @@ def wrap(text: str, max_units: float = 14.0) -> List[str]:
     return [ln for ln in lines if ln]
 
 
+# Subtitles keep only these. A cue's own start/end already expresses the pause
+# that 。 、 ； ： … — and quote marks are doing on a page, so on screen they are
+# noise competing with a 14-unit budget. `%` is punctuation by Unicode's
+# reckoning and a unit by everyone else's.
+_KEEP_PUNCT = "，,！!？?%"
+
+
+def _is_ascii_alnum(ch: str) -> bool:
+    return bool(ch) and ch.isascii() and ch.isalnum()
+
+
+def restrict_punctuation(text: str) -> str:
+    """Strip punctuation a subtitle line does not need, keeping `，！？` (and their
+    ASCII twins) — the product decision that came out of Penny's transcripts.
+
+    Two exemptions, and the second is the load-bearing one: a punctuation mark with
+    an ASCII alphanumeric on BOTH sides is kept. That one rule saves `3.5`, `12:30`,
+    `don't` and `state-of-the-art` without an allowlist of special cases, because in
+    every one of them the mark is doing structural work inside a token rather than
+    ending a clause.
+
+    Call this AFTER `wrap()`, per line. Whisper's `。、；：…` are the most valuable
+    break points `wrap()` has (`_BREAK_AFTER`); removing them first would make the
+    layout blind. And call it only when rendering — the stored transcript keeps its
+    full punctuation, so .txt stays complete, existing libraries benefit with no
+    re-transcription, and the decision stays reversible.
+    """
+    out = []
+    for i, ch in enumerate(text):
+        if not unicodedata.category(ch).startswith("P"):
+            out.append(ch)
+            continue
+        if ch in _KEEP_PUNCT:
+            out.append(ch)
+            continue
+        prev = text[i - 1] if i else ""
+        nxt = text[i + 1] if i + 1 < len(text) else ""
+        # The mark itself must be ASCII: a full-width 、 between two digits
+        # ("12:30、50%") is still a list separator, not part of either number.
+        if ch.isascii() and _is_ascii_alnum(prev) and _is_ascii_alnum(nxt):
+            out.append(ch)
+            continue
+        # dropped — a removed mark can leave two spaces behind, collapsed below.
+    return re.sub(r" {2,}", " ", "".join(out)).strip()
+
+
 def _ts(seconds: float, sep: str = ",") -> str:
     """SRT/VTT timecode HH:MM:SS,mmm.
 
@@ -200,15 +248,30 @@ def layout_cues(
     return cues
 
 
+def _render_lines(lines: List[str], restrict_punct: bool) -> List[str]:
+    """Apply the subtitle punctuation policy to already-laid-out lines.
+
+    A line can empty out entirely (`「。」`), and an empty line inside a cue would
+    render as a blank row, so those are dropped. A cue whose every line empties is
+    left with one empty string rather than no rows at all — dropping the cue here
+    would renumber everything after it, and the cue's timing is still real.
+    """
+    if not restrict_punct:
+        return lines
+    kept = [ln for ln in (restrict_punctuation(ln) for ln in lines) if ln]
+    return kept or [""]
+
+
 def segments_to_srt(
     segments: List[Dict],
     max_units: float = 14.0,
     max_lines: int = 2,
     translate_key: Optional[str] = None,
+    restrict_punct: bool = True,
 ) -> str:
     """Render Whisper segments to laid-out SRT. Layout lives in `layout_cues`."""
     cues = layout_cues(segments, max_units, max_lines, translate_key)
-    return "\n".join(format_cue(i, start, end, lines)
+    return "\n".join(format_cue(i, start, end, _render_lines(lines, restrict_punct))
                      for i, (start, end, lines) in enumerate(cues, 1))
 
 
@@ -217,12 +280,13 @@ def segments_to_vtt(
     max_units: float = 14.0,
     max_lines: int = 2,
     translate_key: Optional[str] = None,
+    restrict_punct: bool = True,
 ) -> str:
     """Same layout, WebVTT syntax: `.` for the millisecond separator, no cue
     numbers (they are optional in WebVTT, and the exports users already have
     don't carry them)."""
     cues = layout_cues(segments, max_units, max_lines, translate_key)
     body = "\n".join("{0} --> {1}\n{2}\n".format(_ts(start, "."), _ts(end, "."),
-                                                "\n".join(lines))
+                                                "\n".join(_render_lines(lines, restrict_punct)))
                      for start, end, lines in cues)
     return "WEBVTT\n\n" + body

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -224,8 +224,11 @@ GOLDEN_SRT = (
 )
 
 
-def test_srt_output_is_byte_identical_after_the_extraction():
-    assert sub.segments_to_srt(GOLDEN_SEGMENTS, translate_key="translation") == GOLDEN_SRT
+def test_srt_layout_is_byte_identical_after_the_extraction():
+    """`restrict_punct=False` is the pre-punctuation-policy output. Layout has not
+    moved a byte since the layout/render split; only the punctuation policy did."""
+    assert sub.segments_to_srt(GOLDEN_SEGMENTS, translate_key="translation",
+                               restrict_punct=False) == GOLDEN_SRT
 
 
 def test_layout_cues_returns_start_end_lines():
@@ -260,13 +263,14 @@ def test_layout_cues_keeps_a_bilingual_segment_as_one_cue():
 def test_vtt_is_the_same_layout_in_webvtt_syntax():
     srt = sub.segments_to_srt(GOLDEN_SEGMENTS, translate_key="translation")
     vtt = sub.segments_to_vtt(GOLDEN_SEGMENTS, translate_key="translation")
+    # 。 is gone from both by then — the punctuation policy, not the renderer.
 
     assert vtt.startswith("WEBVTT\n\n")
     # Same cue count, same text, same times — only the syntax differs.
     assert vtt.count(" --> ") == srt.count(" --> ")
     assert "00:00:00.000 --> 00:00:03.000" in vtt
     assert "00:00:00,000" not in vtt, "comma separator is SRT's, not WebVTT's"
-    for line in ("今天天氣很好，我們去了海邊。", "cue，時間按比例分。", "你好世界。"):
+    for line in ("今天天氣很好，我們去了海邊", "cue，時間按比例分", "你好世界"):
         assert line in vtt
 
 
@@ -304,3 +308,96 @@ def test_whitespace_only_text_never_becomes_a_cue():
     `if not text` skip above and the `if not lines` skip after wrapping — and only
     the first is reachable; the second stays as defence, not as behaviour.)"""
     assert sub.layout_cues([{"start": 1.0, "end": 2.0, "text": " \t\n "}]) == []
+
+
+# ── the punctuation policy (product decision, from Penny's transcripts) ──────
+# On screen a cue's own start/end already says "pause here", so 。、；：…— and
+# quote marks compete with a 14-unit line budget for nothing. Subtitles keep
+# ，！？ only. The stored transcript is untouched, so .txt stays complete —
+# one test below pins both halves at once, because the decision IS both halves.
+
+PUNCT_SAMPLE = "他說：「這很好。」對嗎？我想是的，3.5公斤、12:30、50%"
+
+
+def test_subtitles_keep_only_the_three_marks():
+    out = sub.restrict_punctuation(PUNCT_SAMPLE)
+
+    for gone in "。：「」、…；—":
+        assert gone not in out, "{0} should not survive into a cue".format(gone)
+    assert "，" in out and "？" in out
+
+
+def test_numbers_and_hyphenated_words_survive_intact():
+    """The exemption that makes an allowlist unnecessary: a mark with ASCII
+    alphanumerics on both sides is structural, not clause-ending."""
+    out = sub.restrict_punctuation("3.5公斤 12:30 don't state-of-the-art 50% a,b")
+
+    assert "3.5" in out
+    assert "12:30" in out
+    assert "don't" in out
+    assert "state-of-the-art" in out
+    assert "50%" in out
+    assert "a,b" in out  # ASCII comma is in the keep list anyway
+
+
+def test_a_fullwidth_mark_between_digits_is_still_dropped():
+    """The exemption requires the MARK to be ASCII too. `12:30、50%` — that 、 has a
+    digit on each side but it is a list separator, not part of either number."""
+    assert "、" not in sub.restrict_punctuation("12:30、50%")
+
+
+def test_removing_a_mark_does_not_leave_a_double_space():
+    assert sub.restrict_punctuation("word — word") == "word word"
+    assert sub.restrict_punctuation("…leading and trailing…") == "leading and trailing"
+
+
+def test_a_line_of_pure_punctuation_disappears_rather_than_rendering_blank():
+    srt = sub.segments_to_srt([{"start": 0.0, "end": 1.0, "text": "「。」"}])
+    assert srt.count("-->") == 1        # the cue and its timing are still real
+    assert "「" not in srt and "。" not in srt
+
+
+def test_an_emptied_line_is_removed_not_left_as_a_blank_row():
+    """A bilingual cue whose translation is all punctuation. Keeping the emptied
+    line would put a blank row inside the cue — which in SRT reads as the end of
+    the cue, so every parser downstream sees a stray fragment."""
+    srt = sub.segments_to_srt(
+        [{"start": 0.0, "end": 1.0, "text": "今天天氣很好", "translation": "……"}],
+        translate_key="translation",
+    )
+
+    assert srt == "1\n00:00:00,000 --> 00:00:01,000\n今天天氣很好\n"
+
+
+def test_currency_and_math_are_not_punctuation():
+    """Unicode calls these Sc/Sm, not P. Dropping them would mangle prices."""
+    assert sub.restrict_punctuation("$30 + 5 = 35") == "$30 + 5 = 35"
+
+
+def test_the_policy_is_off_when_the_caller_says_so():
+    """`restrict_punct=False` is what .txt-shaped callers use. Without a way off,
+    the decision would not be reversible."""
+    assert "。" in sub.segments_to_srt([{"start": 0.0, "end": 1.0, "text": "好。"}],
+                                      restrict_punct=False)
+
+
+def test_both_renderers_apply_the_policy():
+    segs = [{"start": 0.0, "end": 1.0, "text": PUNCT_SAMPLE}]
+    for out in (sub.segments_to_srt(segs), sub.segments_to_vtt(segs)):
+        assert "。" not in out and "「" not in out
+        assert "，" in out and "？" in out
+
+
+def test_layout_still_sees_the_punctuation_it_breaks_on():
+    """Order matters: 。、；： are `wrap()`'s most valuable break points. Stripping
+    before layout would leave it breaking on width alone."""
+    text = "第一句話說完了。第二句話也說完了。第三句話同樣說完了。"
+    cues = sub.layout_cues([{"start": 0.0, "end": 9.0, "text": text}])
+    lines = [ln for _s, _e, ls in cues for ln in ls]
+
+    assert len(lines) > 1
+    assert all(ln.endswith("。") for ln in lines[:-1]), (
+        "layout must break after 。 — it can only do that if it still sees them"
+    )
+    # ...and the rendered cue has none of them left.
+    assert "。" not in sub.segments_to_srt([{"start": 0.0, "end": 9.0, "text": text}])


### PR DESCRIPTION
產品決定（Pen 的逐字稿帶出來的）：螢幕上一個 cue 的起訖時間本身就在說「這裡
停一下」，所以 。、；：…— 與各種引號在畫面上只是跟 14 單位的行寬預算搶位置。
**字幕只留 ，！？**（含 ASCII 對應）。

`restrict_punctuation()` 丟掉 `unicodedata.category()` 開頭是 P 的字元，兩個
豁免：

1. keep list `，,！!？?%`（`%` 在 Unicode 眼裡是標點，在其他人眼裡是單位）
2. **前後都是 ASCII 英數，而且標點本身也是 ASCII** → 保留

第二條是承重的那一條：`3.5`、`12:30`、`don't`、`state-of-the-art` 全都靠它活
下來，不需要任何特例清單 —— 這些情況裡標點做的是 token 內部的結構工作，不是
結束一個子句。「標點本身也要是 ASCII」是實作時發現的：`12:30、50%` 裡那個
全形頓號前後都是數字，但它是列表分隔符，不是任一個數字的一部分。

**兩個時機都是刻意的**：

- **在 `wrap()` 之後、逐行套用。** `。、；：` 是 `wrap()` 手上最有價值的斷點
  （`_BREAK_AFTER`），先砍掉會讓排版只剩下按寬度硬斷。有一支測試同時斷言
  「排版仍然斷在 。 之後」與「算繪出來的 cue 裡一個 。 都沒有」。
- **只在 render 時套，不動儲存。** 逐字稿保留完整標點 → .txt 仍然完整、既有
  的庫不用重轉錄就立刻受惠、而且這個決定可逆（`restrict_punct=False`）。

一行有可能被清空（`「。」`），空行留在 cue 裡在 SRT 裡讀起來就是「這個 cue
結束了」，所以清空的行會被移除；整個 cue 都清空時保留一個空字串，因為丟掉
cue 會讓後面所有編號位移，而它的時間仍然是真的。

新增 10 支測試。#355 的 golden 改成用 `restrict_punct=False` 比對 —— 排版自
拆分以來一個 byte 都沒動，動的只有標點政策。

mutation-check 九處全紅在該紅的位置：
  政策沒被套用 / 被忽略  → 兩支紅
  拿掉 ASCII 條件        → 全形頓號測試紅
  拿掉鄰居豁免           → 數字與連字號測試紅
  keep list 清空 / 加 。 → 政策測試紅
  雙空白不收合           → 空白測試紅
  清空的行留成空排       → 雙語空行測試紅
  政策改在排版之前套     → 斷點測試紅

全套 1453 passed / 7 skipped。

Co-authored-by: Penny <penny@users.noreply.github.com>
Co-authored-by: Claude Opus 5 <noreply@anthropic.com>