### PR TITLE
fix(export): 使用者下載的每一份 SRT/VTT，從來沒經過排版引擎

### DIFF
--- a/export.py
+++ b/export.py
@@ -142,10 +142,14 @@ def export_srt(media_id: int, max_units: float = 14.0) -> str:
         if isinstance(parsed, list):
             segments = [s for s in parsed if isinstance(s, dict)]
     if not segments:
-        transcript = (rec.get("transcript") or "").strip()
-        if not transcript:
+        # Same fallback the HTTP export uses, so the two agree byte for byte on a
+        # record with no segments_json (a one-line transcript yields one cue either
+        # way; a multi-line one used to differ).
+        from export_builders import transcript_fallback_segments
+        segments = transcript_fallback_segments(rec.get("transcript") or "",
+                                                rec.get("duration_s") or 0.0)
+        if not segments:
             return ""
-        segments = [{"start": 0.0, "end": rec.get("duration_s") or 0.0, "text": transcript}]
     return subtitle.segments_to_srt(segments, max_units=max_units)
 
 

--- a/export_builders.py
+++ b/export_builders.py
@@ -22,6 +22,7 @@ NOTE: `_attachment_headers` (Content-Disposition builder) and `_log_safe`
 import json
 
 import db
+import subtitle
 
 
 # ── CSV (DaVinci Resolve metadata) ───────────────────────────────────────────
@@ -239,6 +240,44 @@ def _subtitle_text(text: str) -> str:
         return ""
     one_line = " ".join(text.split())  # collapses any \n / \r / blank runs
     return one_line.replace("-->", "->")
+
+
+def transcript_fallback_segments(transcript: str, duration: float) -> list:
+    """Segments for a record that has no `segments_json`, from its transcript alone.
+
+    Without timings there is nothing to be clever with: the transcript's lines get
+    an equal share of the clip. This existed three times over — once in each
+    hand-written cue emitter — and the copies had already drifted. One copy, so a
+    fix lands everywhere.
+    """
+    lines = [ln.strip() for ln in (transcript or "").split("\n") if ln.strip()]
+    if not lines:
+        return []
+    step = float(duration or 0.0) / len(lines)
+    return [{"start": i * step, "end": (i + 1) * step, "text": line}
+            for i, line in enumerate(lines)]
+
+
+def render_subtitle_cues(segments, fmt: str = "srt", max_units: float = 14.0,
+                         max_lines: int = 2) -> str:
+    """Render segments as SRT or VTT **through the Phase 12.5 layout engine**.
+
+    Every HTTP subtitle export used to build its own cues: one `f"{i}\n{ts} --> ..."`
+    loop per endpoint, three copies, none of which called `subtitle.py`. So the
+    layout engine — CJK line widths, break points, the 14-unit cap, bilingual cues —
+    was reachable only from the CLI, while every file a user actually downloaded got
+    a raw Whisper segment per cue. The roadmap's "12.5 ✅" was true for `export.py`
+    and false for every real user.
+
+    Order matters: sanitize FIRST (`_subtitle_text` neutralises a literal `-->` and
+    folds embedded newlines, either of which would forge a cue boundary), then lay
+    out, then apply the punctuation policy inside the renderer. Sanitising after
+    layout would let injected text through the line-splitter first.
+    """
+    safe = [{**seg, "text": _subtitle_text(seg.get("text") or "")}
+            for seg in segments if isinstance(seg, dict)]
+    render = subtitle.segments_to_vtt if fmt == "vtt" else subtitle.segments_to_srt
+    return render(safe, max_units=max_units, max_lines=max_lines)
 
 
 def _edl_timecode(seconds: float, fps: float, drop_frame: bool = False) -> str:

--- a/routers/export.py
+++ b/routers/export.py
@@ -37,6 +37,8 @@ from export_builders import (
     _start_tc_seconds,
     _subtitle_text,
     _subtitle_ts,
+    render_subtitle_cues,
+    transcript_fallback_segments,
 )
 from pathres import _resolve_media_path
 from reqopts import _parse_ids_query
@@ -182,7 +184,10 @@ def export_media(
     if has_trim and _segments:
         trimmed = []
         for seg in _segments:
-            s, e = seg.get("start", 0), seg.get("end", 0)
+            # `or 0`: an explicit null in segments_json (legacy rows have them)
+            # would make these comparisons raise TypeError → 500. Every other
+            # read of these fields already guards this way; this one did not.
+            s, e = seg.get("start", 0) or 0, seg.get("end", 0) or 0
             if e <= trim_in or s >= trim_out:
                 continue
             trimmed.append({
@@ -205,49 +210,15 @@ def export_media(
             headers=_attachment_headers(stem, "txt"),
         )
 
-    if fmt == "srt":
-        srt = ""
-        if _segments:
-            # Segment-aligned timestamps (precise). .get() tolerates legacy
-            # segment dicts missing keys; _subtitle_text blocks cue injection.
-            i = 1
-            for seg in _segments:
-                text = _subtitle_text(seg.get("text") or "")
-                if not text:
-                    continue
-                srt += f"{i}\n{_ts(seg.get('start', 0) or 0)} --> {_ts(seg.get('end', 0) or 0)}\n{text}\n\n"
-                i += 1
-        else:
-            # Fallback: evenly distributed
-            lines = [l.strip() for l in transcript.split("\n") if l.strip()]
-            for i, line in enumerate(lines, 1):
-                t_start = (i - 1) * (duration / max(len(lines), 1))
-                t_end = i * (duration / max(len(lines), 1))
-                srt += f"{i}\n{_ts(t_start)} --> {_ts(t_end)}\n{_subtitle_text(line)}\n\n"
+    if fmt in ("srt", "vtt"):
+        # One seam for every subtitle export (single clip, batch zip, timeline):
+        # sanitize → subtitle.layout_cues → punctuation policy. What used to be
+        # here was a hand-written cue loop that never reached the layout engine.
+        cue_segments = _segments or transcript_fallback_segments(transcript, duration)
         return HTMLResponse(
-            content=srt,
+            content=render_subtitle_cues(cue_segments, fmt),
             media_type="text/plain; charset=utf-8",
-            headers=_attachment_headers(stem, "srt"),
-        )
-
-    if fmt == "vtt":
-        vtt = "WEBVTT\n\n"
-        if _segments:
-            for seg in _segments:
-                text = _subtitle_text(seg.get("text") or "")
-                if not text:
-                    continue
-                vtt += f"{_ts(seg.get('start', 0) or 0, '.')} --> {_ts(seg.get('end', 0) or 0, '.')}\n{text}\n\n"
-        else:
-            lines = [l.strip() for l in transcript.split("\n") if l.strip()]
-            for i, line in enumerate(lines, 1):
-                t_start = (i - 1) * (duration / max(len(lines), 1))
-                t_end = i * (duration / max(len(lines), 1))
-                vtt += f"{_ts(t_start, '.')} --> {_ts(t_end, '.')}\n{_subtitle_text(line)}\n\n"
-        return HTMLResponse(
-            content=vtt,
-            media_type="text/plain; charset=utf-8",
-            headers=_attachment_headers(stem, "vtt"),
+            headers=_attachment_headers(stem, fmt),
         )
 
     if fmt in ("edl", "edl-markers"):

--- a/tests/test_export_subtitle_wiring.py
+++ b/tests/test_export_subtitle_wiring.py
@@ -1,0 +1,196 @@
+"""Every subtitle a user downloads now goes through the layout engine.
+
+`subtitle.py` — the Phase 12.5 CJK layout engine: 14-unit lines, break points,
+bilingual cues — was reachable from exactly one place: the `export.py` CLI. Every
+SRT and VTT served over HTTP came out of a hand-written `f"{i}\\n{ts} --> ..."` loop,
+one copy per endpoint, three copies in all. So the roadmap's "12.5 ✅" was true for
+a command nobody runs and false for every file a user actually downloaded: those
+carried one raw Whisper segment per cue, lines as long as Whisper felt like, and
+none of the punctuation policy.
+
+These tests are written so that any path quietly growing its own emitter again goes
+red immediately — the sentinel test replaces the engine and demands the sentinel
+appear in each output.
+"""
+from __future__ import annotations
+
+import importlib
+import io
+import json
+import re
+import zipfile
+
+import pytest
+
+import subtitle
+
+LONG = "這是一段很長的旁白，長到一行字幕根本放不下，所以引擎會把它拆成好幾行才對。"
+PUNCT = "他說：「這很好。」對嗎？我想是的，3.5公斤、12:30、50%"
+
+
+def _seed(db, **over):
+    rec = {
+        "path": "/tmp/a.mp4", "filename": "a.mp4", "ext": ".mp4",
+        "duration_s": 12.0, "size_mb": 5.0, "width": 1920, "height": 1080,
+        "fps": 30.0, "has_audio": 1, "transcript": "第一句 第二句", "lang": "zh",
+        "frame_tags": "", "thumbnail_path": "", "processed_at": "2026-05-01T09:00:00",
+        "segments_json": json.dumps(
+            [{"start": 0.0, "end": 6.0, "text": "第一句"},
+             {"start": 6.0, "end": 12.0, "text": "第二句"}], ensure_ascii=False),
+    }
+    rec.update(over)
+    db.upsert(rec)
+    return rec
+
+
+# ── the seam ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("fmt", ["srt", "vtt"])
+def test_single_clip_export_goes_through_the_layout_engine(
+    fastapi_client, server_module, monkeypatch, fmt
+):
+    _seed(importlib.import_module("db"))
+    monkeypatch.setattr(subtitle, "layout_cues", lambda *a, **k: [(1.0, 2.0, ["哨兵"])])
+
+    r = fastapi_client.get("/api/media/1/export/{0}".format(fmt))
+
+    assert r.status_code == 200
+    assert "哨兵" in r.text, "this path built its own cues instead of laying them out"
+
+
+def test_batch_zip_goes_through_the_layout_engine(
+    fastapi_client, server_module, monkeypatch
+):
+    """The zip reuses the single-clip builder, so it inherits the seam — asserted
+    rather than assumed, because 'reuses the builder' is how the copies started."""
+    _seed(importlib.import_module("db"))
+    monkeypatch.setattr(subtitle, "layout_cues", lambda *a, **k: [(1.0, 2.0, ["哨兵"])])
+
+    r = fastapi_client.post("/api/export/batch", json={"ids": [1], "fmt": "srt"})
+
+    assert r.status_code == 200
+    zf = zipfile.ZipFile(io.BytesIO(r.content))
+    assert "哨兵" in zf.read("a.srt").decode("utf-8")
+
+
+def test_cli_and_http_agree_byte_for_byte(fastapi_client, server_module):
+    """Two code paths, one output. They were free to drift and had."""
+    _seed(importlib.import_module("db"), segments_json=json.dumps(
+        [{"start": 0.0, "end": 12.0, "text": LONG}], ensure_ascii=False))
+    export = importlib.reload(importlib.import_module("export"))
+
+    http = fastapi_client.get("/api/media/1/export/srt").text
+    cli = export.export_srt(1)
+
+    assert http == cli
+
+
+def test_cli_and_http_agree_when_there_are_no_segments(fastapi_client, server_module):
+    """The fallback used to be two different guesses: the CLI made one cue for the
+    whole clip, HTTP split the transcript's lines evenly."""
+    _seed(importlib.import_module("db"), segments_json=None,
+          transcript="第一行\n第二行\n第三行")
+    export = importlib.reload(importlib.import_module("export"))
+
+    assert fastapi_client.get("/api/media/1/export/srt").text == export.export_srt(1)
+
+
+# ── what the layout engine actually buys the user ────────────────────────────
+
+def test_a_long_segment_is_wrapped_instead_of_one_endless_line(
+    fastapi_client, server_module
+):
+    _seed(importlib.import_module("db"), segments_json=json.dumps(
+        [{"start": 0.0, "end": 12.0, "text": LONG}], ensure_ascii=False))
+
+    srt = fastapi_client.get("/api/media/1/export/srt").text
+    body_lines = [ln for ln in srt.split("\n") if ln and "-->" not in ln and not ln.isdigit()]
+
+    assert len(body_lines) > 1
+    assert all(subtitle.display_units(ln) <= 14.0 for ln in body_lines), body_lines
+
+
+def test_the_punctuation_policy_reaches_the_downloaded_file(fastapi_client, server_module):
+    """The product decision, pinned at the HTTP boundary: subtitles keep ，！？ and
+    .txt keeps everything. One test for both halves, because it IS both halves."""
+    _seed(importlib.import_module("db"), transcript=PUNCT, segments_json=json.dumps(
+        [{"start": 0.0, "end": 12.0, "text": PUNCT}], ensure_ascii=False))
+
+    srt = fastapi_client.get("/api/media/1/export/srt").text
+    vtt = fastapi_client.get("/api/media/1/export/vtt").text
+    txt = fastapi_client.get("/api/media/1/export/txt").text
+
+    for cue in (srt, vtt):
+        for gone in "。：「」、":
+            assert gone not in cue
+        assert "，" in cue and "？" in cue and "%" in cue
+        assert "3.5" in cue and "12:30" in cue
+    for kept in "。：「」、，？":
+        assert kept in txt, "the stored transcript keeps its full punctuation"
+
+
+# ── the things a hand-written emitter got wrong ──────────────────────────────
+
+def test_transcript_text_cannot_forge_a_cue_boundary(fastapi_client, server_module):
+    """`-->` and embedded newlines in spoken text must not open a fake cue.
+
+    Three separate things stop this today — `_subtitle_text` neutralises the arrow,
+    `wrap()` collapses whitespace, and the punctuation policy strips the dashes —
+    so no single mutation makes this test red. It pins the OUTCOME, which is what a
+    user's parser cares about; the redundancy is deliberate, since a caller passing
+    `restrict_punct=False` would remove one of the three layers."""
+    nasty = "他說 --> 然後\n\n99\n00:00:99,000 --> 00:01:00,000\n假字幕"
+    _seed(importlib.import_module("db"), segments_json=json.dumps(
+        [{"start": 0.0, "end": 6.0, "text": nasty}], ensure_ascii=False))
+
+    srt = fastapi_client.get("/api/media/1/export/srt").text
+
+    timing = re.compile(r"^\d{2}:\d{2}:\d{2},\d{3} --> ")
+    assert sum(1 for ln in srt.split("\n") if timing.match(ln)) == 1, srt
+    assert "\n99\n" not in srt, "the injected cue number must not start a cue"
+    # The text itself survives as text — neutralised, on a body line. That is the
+    # correct outcome: sanitising must not delete what someone actually said.
+    assert "假字幕" in srt
+
+
+def test_a_null_timestamp_does_not_500_on_a_trimmed_export(fastapi_client, server_module):
+    """Legacy rows carry explicit nulls. `seg.get("start", 0)` returns None for
+    those — the default only applies to a MISSING key — and the trim comparison
+    then raises TypeError, i.e. a 500 on a real library."""
+    _seed(importlib.import_module("db"), segments_json=json.dumps(
+        [{"start": None, "end": None, "text": "沒有時間的一段"},
+         {"start": 2.0, "end": 4.0, "text": "正常的一段"}], ensure_ascii=False))
+
+    r = fastapi_client.get("/api/media/1/export/srt?in_s=1&out_s=5")
+
+    assert r.status_code == 200, r.text
+    assert "正常的一段" in r.text
+
+
+def test_vtt_still_announces_itself_when_there_is_nothing_to_say(
+    fastapi_client, server_module
+):
+    _seed(importlib.import_module("db"), segments_json=None, transcript="")
+
+    r = fastapi_client.get("/api/media/1/export/vtt")
+
+    assert r.status_code == 200
+    assert r.text.startswith("WEBVTT")
+
+
+def test_the_transcript_fallback_shares_the_clip_between_its_lines():
+    """The behaviour the three hand-written copies each re-guessed. Tested directly:
+    the CLI/HTTP parity tests above cannot see a change here, because both sides now
+    call this same function."""
+    export_builders = importlib.import_module("export_builders")
+
+    segs = export_builders.transcript_fallback_segments("第一行\n第二行\n第三行", 9.0)
+
+    assert [s["start"] for s in segs] == [0.0, 3.0, 6.0]
+    assert segs[-1]["end"] == 9.0
+    assert [s["text"] for s in segs] == ["第一行", "第二行", "第三行"]
+
+
+def test_the_transcript_fallback_is_empty_for_an_empty_transcript():
+    export_builders = importlib.import_module("export_builders")
+    assert export_builders.transcript_fallback_segments("  \n\n ", 9.0) == []


### PR DESCRIPTION
`subtitle.py` —— Phase 12.5 的 CJK 排版引擎：14 單位行寬、`_BREAK_AFTER` 斷點、
雙語 cue、不切開拉丁單字 —— 全樹只有 `export.py`（CLI）和它自己的測試 import 它。

**使用者從 UI 下載的每一份 SRT/VTT 都繞過它。** 每個端點各自手寫一份
`f"{i}\n{ts} --> ..."` 迴圈，總共三份複本，只經過一個防注入消毒器。所以 roadmap
上那個「12.5 ✅」對一個沒人在跑的 CLI 指令成立，對每一個真實使用者都不成立：
他們拿到的是一個 cue 一個原始 Whisper segment、行長由 Whisper 高興、而且完全
沒有標點政策。

新增兩個共用件（`export_builders.py`）：

- `render_subtitle_cues(segments, fmt)` —— 消毒 → `subtitle.layout_cues` →
  標點政策。**順序是重點**：`_subtitle_text` 要先跑（中和字面 `-->`、折掉內嵌
  換行，兩者都能偽造 cue 邊界），排版之後再消毒等於讓注入的文字先進斷行器。
- `transcript_fallback_segments(transcript, duration)` —— 沒有 `segments_json`
  時，把逐字稿各行平均分配到片長。這段邏輯原本存在三份，而且已經漂移過。

`routers/export.py` 的 srt/vtt 分支改走同一個 seam；CLI 的 fallback 也改用同一個
函式，所以兩邊在沒有 segments 的記錄上也逐字節相同（以前 CLI 給整片一個 cue、
HTTP 按行平均分）。

**同時修 `:185`**：`seg.get("start", 0)` 對「顯式 null」會回 None（default 只在
key 不存在時生效），後面的 trim 比較就 `TypeError` → 對真實舊庫回 500。同一支
函式裡 `:218`、`:622-623` 早就是 `or 0` 的防禦形式，只有這裡不是。

順帶：時間碼從 `_subtitle_ts`（截斷毫秒）換成 `subtitle._ts`（整體毫秒四捨五入
且進位），差距 ≤1ms，且不會再產生 `00:00:60,000`。

新增 12 支測試。哨兵測試把 `subtitle.layout_cues` 換掉，要求哨兵出現在
`/export/srt`、`/export/vtt`、batch zip —— 任何一條路以後又自己長出 emitter
就立刻紅。另外釘住：CLI/HTTP 逐字節相同（有 segments 與沒 segments 兩種）、
長 segment 真的被折行且每行 ≤14 單位、標點政策確實到得了下載檔（而 .txt 保留
完整標點）、null 時間碼不再 500。

mutation-check 四處全紅在該紅的位置：
  srt/vtt 繞過 seam      → 全檔紅
  VTT 退回 SRT renderer  → 全檔紅
  null 守衛還原          → 500 測試紅
  fallback 不按行切       → fallback 單元測試紅

一處誠實標註：`_subtitle_text` 這層目前**沒有**單獨的 mutation 證明 —— `wrap()`
自己會折掉換行，而標點政策自己會吃掉 `-->` 的兩個 dash。三層防守都在，注入測試
釘的是結果。但只要有呼叫端傳 `restrict_punct=False`，那一層就會變成唯一的防線。

全套 1465 passed / 7 skipped。

Co-authored-by: Penny <penny@users.noreply.github.com>
Co-authored-by: Claude Opus 5 <noreply@anthropic.com>