### PR TITLE
fix(export): timeline SRT 是第三份手寫 emitter

### DIFF
--- a/routers/export.py
+++ b/routers/export.py
@@ -576,8 +576,11 @@ def export_timeline(
 
     if fmt == "srt":
         import json as _json
-        srt = ""
-        idx = 1
+        # Build ONE segment list already positioned on the timeline, then hand it
+        # to the same seam the single-clip export uses. This was the third
+        # hand-written cue emitter; sequencing is this endpoint's job, layout is
+        # not.
+        timeline_segments = []
         offset = 0.0  # cumulative timeline position in seconds
         for rec in recs:
             win_in, dur = _clip_window(rec)  # D2: honor the clip's IN/OUT marks
@@ -588,6 +591,7 @@ def export_timeline(
                     segs = _json.loads(rec["segments_json"])
                 except Exception:
                     segs = []
+            segs = [s for s in segs if isinstance(s, dict)]
             if segs:
                 for seg in segs:
                     seg_s = seg.get("start", 0) or 0
@@ -598,28 +602,23 @@ def export_timeline(
                     hi = min(seg_e, win_out)
                     if hi <= lo:
                         continue  # caption falls entirely outside the trim
-                    text = _subtitle_text(seg.get("text") or "")
-                    if not text:
-                        continue
-                    s = offset + (lo - win_in)
-                    e = offset + (hi - win_in)
-                    srt += f"{idx}\n{_subtitle_ts(s)} --> {_subtitle_ts(e)}\n{text}\n\n"
-                    idx += 1
+                    # {**seg}: carry every other key through. A rebuilt {start,end,
+                    # text} dict would silently drop speaker_id today and a
+                    # translation tomorrow.
+                    timeline_segments.append({**seg,
+                                              "start": offset + (lo - win_in),
+                                              "end": offset + (hi - win_in)})
             else:
                 # No segment timestamps (legacy rows / segmentless transcription):
-                # mirror the single-clip /export/srt fallback and distribute the
-                # transcript lines evenly across the clip, offset onto the timeline
+                # same fallback as the single-clip export, offset onto the timeline
                 # (Codex review P2 — otherwise transcript-only clips vanish).
-                lines = [l.strip() for l in (rec.get("transcript") or "").split("\n") if l.strip()]
-                n = max(len(lines), 1)
-                for li, line in enumerate(lines):
-                    s = offset + li * (dur / n)
-                    e = offset + (li + 1) * (dur / n)
-                    srt += f"{idx}\n{_subtitle_ts(s)} --> {_subtitle_ts(e)}\n{_subtitle_text(line)}\n\n"
-                    idx += 1
+                for seg in transcript_fallback_segments(rec.get("transcript") or "", dur):
+                    timeline_segments.append({**seg,
+                                              "start": offset + seg["start"],
+                                              "end": offset + seg["end"]})
             offset += dur
         return HTMLResponse(
-            content=srt,
+            content=render_subtitle_cues(timeline_segments, "srt"),
             media_type="text/plain; charset=utf-8",
             headers={"Content-Disposition": 'attachment; filename="arkiv-timeline.srt"'},
         )

--- a/tests/test_export_subtitle_wiring.py
+++ b/tests/test_export_subtitle_wiring.py
@@ -194,3 +194,86 @@ def test_the_transcript_fallback_shares_the_clip_between_its_lines():
 def test_the_transcript_fallback_is_empty_for_an_empty_transcript():
     export_builders = importlib.import_module("export_builders")
     assert export_builders.transcript_fallback_segments("  \n\n ", 9.0) == []
+
+
+# ── the timeline export: the third hand-written emitter ──────────────────────
+
+def _seed_two(db):
+    """Two 10-second clips, each with one caption."""
+    for i, (name, text) in enumerate([("a.mp4", "甲段台詞"), ("b.mp4", "乙段台詞")], 1):
+        db.upsert({
+            "path": "/tmp/{0}".format(name), "filename": name, "ext": ".mp4",
+            "duration_s": 10.0, "size_mb": 5.0, "width": 1920, "height": 1080,
+            "fps": 30.0, "has_audio": 1, "transcript": text, "lang": "zh",
+            "frame_tags": "", "thumbnail_path": "",
+            "processed_at": "2026-05-0{0}T09:00:00".format(i),
+            "segments_json": json.dumps(
+                [{"start": 0.0, "end": 4.0, "text": text, "speaker_id": "SPEAKER_0{0}".format(i)}],
+                ensure_ascii=False),
+        })
+
+
+def test_timeline_srt_goes_through_the_layout_engine(
+    fastapi_client, server_module, monkeypatch
+):
+    _seed_two(importlib.import_module("db"))
+    monkeypatch.setattr(subtitle, "layout_cues", lambda *a, **k: [(1.0, 2.0, ["哨兵"])])
+
+    r = fastapi_client.get("/api/export/timeline/srt?ids=1,2")
+
+    assert r.status_code == 200
+    assert "哨兵" in r.text
+
+
+def test_timeline_srt_keeps_every_other_segment_key(
+    fastapi_client, server_module, monkeypatch
+):
+    """Sequencing rebases start/end. Rebuilding the dict from just those three
+    fields would drop `speaker_id` today and a `translation` tomorrow."""
+    _seed_two(importlib.import_module("db"))
+    seen = {}
+    real = subtitle.layout_cues
+
+    def spy(segments, *a, **k):
+        seen["segments"] = segments
+        return real(segments, *a, **k)
+
+    monkeypatch.setattr(subtitle, "layout_cues", spy)
+    fastapi_client.get("/api/export/timeline/srt?ids=1,2")
+
+    assert [s.get("speaker_id") for s in seen["segments"]] == ["SPEAKER_01", "SPEAKER_02"]
+
+
+def test_timeline_srt_wraps_long_lines_too(fastapi_client, server_module):
+    db = importlib.import_module("db")
+    db.upsert({
+        "path": "/tmp/long.mp4", "filename": "long.mp4", "ext": ".mp4",
+        "duration_s": 12.0, "size_mb": 5.0, "width": 1920, "height": 1080,
+        "fps": 30.0, "has_audio": 1, "transcript": LONG, "lang": "zh",
+        "frame_tags": "", "thumbnail_path": "", "processed_at": "2026-05-01T09:00:00",
+        "segments_json": json.dumps([{"start": 0.0, "end": 12.0, "text": LONG}],
+                                    ensure_ascii=False),
+    })
+
+    srt = fastapi_client.get("/api/export/timeline/srt?ids=1").text
+    body_lines = [ln for ln in srt.split("\n") if ln and "-->" not in ln and not ln.isdigit()]
+
+    assert len(body_lines) > 1
+    assert all(subtitle.display_units(ln) <= 14.0 for ln in body_lines), body_lines
+
+
+def test_timeline_srt_applies_the_punctuation_policy(fastapi_client, server_module):
+    db = importlib.import_module("db")
+    db.upsert({
+        "path": "/tmp/p.mp4", "filename": "p.mp4", "ext": ".mp4",
+        "duration_s": 12.0, "size_mb": 5.0, "width": 1920, "height": 1080,
+        "fps": 30.0, "has_audio": 1, "transcript": PUNCT, "lang": "zh",
+        "frame_tags": "", "thumbnail_path": "", "processed_at": "2026-05-01T09:00:00",
+        "segments_json": json.dumps([{"start": 0.0, "end": 12.0, "text": PUNCT}],
+                                    ensure_ascii=False),
+    })
+
+    srt = fastapi_client.get("/api/export/timeline/srt?ids=1").text
+
+    assert "。" not in srt and "「" not in srt
+    assert "，" in srt and "？" in srt


### PR DESCRIPTION
`/api/export/timeline/srt` 是最後一條還在自己拼 cue 字串的路。改成先把多支
clip 排成**一份已經落在時間軸座標上的 segment 清單**，再交給
`render_subtitle_cues` —— 排序是這個端點的工作，排版不是。

順帶修掉一個會靜默吃掉資料的寫法：rebase 時原本重建一個
`{start, end, text}` 新 dict。改成 `{**seg, ...}` —— 今天它會丟掉
`speaker_id`，明天會丟掉 `translation`。有一支 spy 測試盯著這件事。

沒有 `segments_json` 的 clip 改用共用的 `transcript_fallback_segments`（第三份
「平均分配」複本也一併收掉）。

行為保持：既有三支 timeline SRT 測試（累計位移、IN/OUT trim 後 rebase、
無 segment 的 clip 不被丟掉）原封不動通過 —— 那是「只換排版、沒動排序」最直接
的證據。使用者看得到的差別是行終於會折了、標點政策也到得了。

新增 4 支測試。mutation-check 四處全紅在該紅的位置：
  timeline 繞過 seam        → 全檔紅
  segment 重建而非展開       → speaker_id 測試紅
  clip 位移被拿掉            → 既有累計位移測試紅
  無 segment 的 clip 掉位移   → 既有 test_server 紅

全套 1469 passed / 7 skipped。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>