### PR TITLE
feat(settings): 一行幾個字不該硬編在四個地方

### DIFF
--- a/config.py
+++ b/config.py
@@ -185,6 +185,22 @@ def _read_vision_num_ctx() -> int:
 
 OLLAMA_VISION_NUM_CTX = _read_vision_num_ctx()
 
+
+# Caption line width, in CJK units (a Latin char counts as 1/3). 14 is the
+# Netflix zh-Hant spec and subtitle.wrap()'s own default. It used to be hard-coded
+# in four places — the engine's default, the CLI flag, and two call sites — which
+# is three chances to disagree.
+def _read_subtitle_max_cjk() -> int:
+    raw = os.getenv("ARKIV_SUBTITLE_MAX_CJK", "14")
+    try:
+        val = int(raw)
+    except (TypeError, ValueError):
+        return 14
+    return val if 8 <= val <= 40 else 14
+
+
+SUBTITLE_MAX_CJK = _read_subtitle_max_cjk()
+
 def _detect_exiftool() -> str:
     """Resolve ExifTool binary path via fallback chain.
 

--- a/export.py
+++ b/export.py
@@ -119,7 +119,7 @@ def export_txt(media_id: int) -> str:
     return (rec.get("transcript") or "").strip()
 
 
-def export_srt(media_id: int, max_units: float = 14.0) -> str:
+def export_srt(media_id: int, max_units=None) -> str:
     """Laid-out SRT for one clip, using the Phase 12.5 subtitle engine.
 
     Uses segment-aligned timestamps (segments_json) when present; falls back to
@@ -150,6 +150,11 @@ def export_srt(media_id: int, max_units: float = 14.0) -> str:
                                                 rec.get("duration_s") or 0.0)
         if not segments:
             return ""
+    if max_units is None:
+        # Same resolution the HTTP export uses, so the CLI can't disagree with the
+        # app about how wide a caption line is.
+        import settings as settings_store
+        max_units = float(settings_store.subtitle_max_cjk())
     return subtitle.segments_to_srt(segments, max_units=max_units)
 
 
@@ -281,7 +286,8 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     p_srt = sub.add_parser("srt", help="A single clip's laid-out SRT (Phase 12.5 engine)")
     p_srt.add_argument("media_id", type=int)
-    p_srt.add_argument("--max-cjk", type=float, default=14.0, help="Max CJK units per line (default 14)")
+    p_srt.add_argument("--max-cjk", type=float, default=None,
+                       help="Max CJK units per line (default: the export.subtitle_max_cjk setting)")
     p_srt.add_argument("--out", default=None, help="Output file (default: stdout)")
 
     p_ch = sub.add_parser("chapters", help="A single clip's chapter markers from scene frames")

--- a/export_builders.py
+++ b/export_builders.py
@@ -22,6 +22,7 @@ NOTE: `_attachment_headers` (Content-Disposition builder) and `_log_safe`
 import json
 
 import db
+import settings as settings_store
 import subtitle
 
 
@@ -258,7 +259,7 @@ def transcript_fallback_segments(transcript: str, duration: float) -> list:
             for i, line in enumerate(lines)]
 
 
-def render_subtitle_cues(segments, fmt: str = "srt", max_units: float = 14.0,
+def render_subtitle_cues(segments, fmt: str = "srt", max_units=None,
                          max_lines: int = 2) -> str:
     """Render segments as SRT or VTT **through the Phase 12.5 layout engine**.
 
@@ -274,6 +275,8 @@ def render_subtitle_cues(segments, fmt: str = "srt", max_units: float = 14.0,
     out, then apply the punctuation policy inside the renderer. Sanitising after
     layout would let injected text through the line-splitter first.
     """
+    if max_units is None:
+        max_units = float(settings_store.subtitle_max_cjk())
     safe = [{**seg, "text": _subtitle_text(seg.get("text") or "")}
             for seg in segments if isinstance(seg, dict)]
     render = subtitle.segments_to_vtt if fmt == "vtt" else subtitle.segments_to_srt

--- a/frontend/src/routes/SettingsLive.svelte
+++ b/frontend/src/routes/SettingsLive.svelte
@@ -48,13 +48,14 @@
   let settingsList = []     // describe() output
   let settingsBusy = false
   let settingsMsg = ''
-  let visModel = '', visNumCtx = 16384, expDir = ''  // local edit buffers
+  let visModel = '', visNumCtx = 16384, expDir = '', subMaxCjk = 14  // local edit buffers
   function settingMeta(key) { return settingsList.find((s) => s.key === key) || null }
   async function loadSettings() {
     try { settingsList = (await api.getSettings()).settings || [] } catch { settingsList = [] }
     const vm = settingMeta('vision.model'); if (vm) visModel = vm.value
     const vc = settingMeta('vision.num_ctx'); if (vc) visNumCtx = vc.value
     const ed = settingMeta('export.default_dir'); if (ed) expDir = ed.value
+    const sm = settingMeta('export.subtitle_max_cjk'); if (sm) subMaxCjk = sm.value
   }
   async function saveSetting(values) {
     settingsBusy = true; settingsMsg = ''
@@ -504,7 +505,7 @@
             <div class="fshead">
               <Eyebrow style="margin-bottom:4px;">EXPORT · DEFAULT DEST</Eyebrow>
               <div class="ak-display fstitle">Export defaults</div>
-              <div class="fsdesc">預設匯出資料夾。<strong>真實生效</strong>：server-write CSV 匯出（Tauri 存檔路徑）未指定時落這個目錄。EDL fps / proxy 解析度 / drop-frame 仍每次呼叫帶入、無持久預設（待後端）。</div>
+              <div class="fsdesc">預設匯出資料夾。<strong>真實生效</strong>：server-write CSV 匯出（Tauri 存檔路徑）未指定時落這個目錄。字幕行寬<strong>真實生效</strong>：SRT/VTT（單支、批次、時間軸）與 CLI 都讀這個值。EDL fps / proxy 解析度 / drop-frame 仍每次呼叫帶入、無持久預設（待後端）。</div>
             </div>
             <div class="frows">
               <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">Default export dir</Mono>
@@ -513,10 +514,17 @@
                   {#if settingMeta('export.default_dir')}<span class="srctag">{settingMeta('export.default_dir').source}</span>{/if}
                 </div>
               </div>
+              <div class="frow"><Mono dim style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;">字幕行寬 · CJK 單位</Mono>
+                <div class="setctl">
+                  <input class="ak-input" type="number" min="8" max="40" bind:value={subMaxCjk}
+                         title="一行字幕最多幾個中文字（拉丁字母算 1/3）。14 = Netflix 繁中規範" />
+                  {#if settingMeta('export.subtitle_max_cjk')}<span class="srctag">{settingMeta('export.subtitle_max_cjk').source}</span>{/if}
+                </div>
+              </div>
               <div class="frow"><span></span>
                 <div class="setctl">
-                  <button class="ak-btn" on:click={() => saveSetting({ 'export.default_dir': expDir })} disabled={settingsBusy}>儲存</button>
-                  <button class="ak-btn" on:click={() => resetSettingKey('export.default_dir')} disabled={settingsBusy}>重設</button>
+                  <button class="ak-btn" on:click={() => saveSetting({ 'export.default_dir': expDir, 'export.subtitle_max_cjk': Number(subMaxCjk) })} disabled={settingsBusy}>儲存</button>
+                  <button class="ak-btn" on:click={() => { resetSettingKey('export.default_dir'); resetSettingKey('export.subtitle_max_cjk') }} disabled={settingsBusy}>重設</button>
                   {#if settingsMsg}<span class="setmsg">{settingsMsg}</span>{/if}
                 </div>
               </div>

--- a/settings.py
+++ b/settings.py
@@ -72,6 +72,14 @@ def _schema() -> Dict[str, Dict[str, Any]]:
             "type": "str",
             "default": lambda: "",
         },
+        "export.subtitle_max_cjk": {
+            "group": "export",
+            "label": "Subtitle line width (CJK units per line)",
+            "type": "int",
+            "default": lambda: config.SUBTITLE_MAX_CJK,
+            "min": 8,
+            "max": 40,
+        },
         # --- Ingest defaults ---
         "ingest.recursive": {
             "group": "ingest",
@@ -161,6 +169,12 @@ def effective(key: str, project: Optional[str] = None) -> Any:
         if key in p and p[key] is not None:
             value = _stored_to_typed(key, p[key])
     return value
+
+
+def subtitle_max_cjk(project: Optional[str] = None) -> int:
+    """Effective caption line width. Equals config.SUBTITLE_MAX_CJK when unset, so
+    every subtitle export is unchanged until an operator actually moves it."""
+    return effective("export.subtitle_max_cjk", project=project)
 
 
 def vision_model(project: Optional[str] = None) -> str:

--- a/tests/test_subtitle_width_setting.py
+++ b/tests/test_subtitle_width_setting.py
@@ -1,0 +1,109 @@
+"""Caption line width lives in one place now.
+
+14 CJK units (the Netflix zh-Hant spec) was hard-coded in four: `subtitle.wrap`'s
+default, the CLI's `--max-cjk`, and each renderer's signature. Four copies of a
+number an operator might reasonably want to change — and three chances for the CLI
+and the app to disagree about how wide a line is.
+
+Deliberately NOT a query parameter: batch export calls the single-clip builder
+internally, so a per-request width would have to be threaded through every caller —
+the exact partial wiring this wave exists to undo.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+import config
+import subtitle
+
+
+def _seed(db, text):
+    db.upsert({
+        "path": "/tmp/w.mp4", "filename": "w.mp4", "ext": ".mp4",
+        "duration_s": 12.0, "size_mb": 5.0, "width": 1920, "height": 1080,
+        "fps": 30.0, "has_audio": 1, "transcript": text, "lang": "zh",
+        "frame_tags": "", "thumbnail_path": "", "processed_at": "2026-05-01T09:00:00",
+        "segments_json": json.dumps([{"start": 0.0, "end": 12.0, "text": text}],
+                                    ensure_ascii=False),
+    })
+
+
+LONG = "這是一段很長的旁白，長到一行字幕根本放不下，所以引擎會把它拆成好幾行才對。"
+
+
+def _body_lines(srt):
+    return [ln for ln in srt.split("\n") if ln and "-->" not in ln and not ln.isdigit()]
+
+
+def test_default_equals_the_engine_default(tmp_db):
+    """Adding the setting must change nothing until someone moves it."""
+    settings = importlib.reload(importlib.import_module("settings"))
+    assert settings.subtitle_max_cjk() == config.SUBTITLE_MAX_CJK == 14
+
+
+def test_the_setting_changes_what_the_http_export_produces(fastapi_client, server_module):
+    _seed(importlib.import_module("db"), LONG)
+
+    wide = _body_lines(fastapi_client.get("/api/media/1/export/srt").text)
+    r = fastapi_client.put("/api/settings", json={"scope": "global",
+                                                 "values": {"export.subtitle_max_cjk": 8}})
+    assert r.status_code == 200, r.text
+    narrow = _body_lines(fastapi_client.get("/api/media/1/export/srt").text)
+
+    assert all(subtitle.display_units(ln) <= 8.0 for ln in narrow), narrow
+    assert len(narrow) > len(wide), "a narrower line must produce more of them"
+
+
+def test_the_setting_reaches_the_timeline_export_too(fastapi_client, server_module):
+    """One seam, so this comes for free — asserted because 'for free' is how the
+    three hand-written emitters justified themselves too."""
+    _seed(importlib.import_module("db"), LONG)
+    fastapi_client.put("/api/settings", json={"scope": "global",
+                                              "values": {"export.subtitle_max_cjk": 8}})
+
+    lines = _body_lines(fastapi_client.get("/api/export/timeline/srt?ids=1").text)
+
+    assert lines and all(subtitle.display_units(ln) <= 8.0 for ln in lines)
+
+
+def test_the_cli_reads_the_same_setting(fastapi_client, server_module):
+    _seed(importlib.import_module("db"), LONG)
+    fastapi_client.put("/api/settings", json={"scope": "global",
+                                              "values": {"export.subtitle_max_cjk": 8}})
+    export = importlib.reload(importlib.import_module("export"))
+
+    assert _body_lines(export.export_srt(1)) == _body_lines(
+        fastapi_client.get("/api/media/1/export/srt").text)
+
+
+def test_an_explicit_width_still_wins(fastapi_client, server_module):
+    """`--max-cjk 20` must not be silently overridden by the stored setting."""
+    _seed(importlib.import_module("db"), LONG)
+    fastapi_client.put("/api/settings", json={"scope": "global",
+                                              "values": {"export.subtitle_max_cjk": 8}})
+    export = importlib.reload(importlib.import_module("export"))
+
+    lines = _body_lines(export.export_srt(1, max_units=20.0))
+
+    assert any(subtitle.display_units(ln) > 8.0 for ln in lines)
+
+
+@pytest.mark.parametrize("bad", [4, 100, "wide"])
+def test_an_unusable_width_is_rejected_not_stored(fastapi_client, server_module, bad):
+    """A 2-unit line would make every cue a column of single characters, and the
+    schema is the only thing standing between an operator and that."""
+    r = fastapi_client.put("/api/settings", json={"scope": "global",
+                                                 "values": {"export.subtitle_max_cjk": bad}})
+    assert r.status_code == 422, r.text
+
+
+def test_the_settings_ui_offers_the_control():
+    """A setting the UI never shows is an API-only knob. settings.py's own rule is
+    that a control must have a downstream effect; the converse matters as well."""
+    from pathlib import Path
+    src = (Path(__file__).resolve().parent.parent / "frontend" / "src" / "routes"
+           / "SettingsLive.svelte").read_text(encoding="utf-8")
+    assert "export.subtitle_max_cjk" in src


### PR DESCRIPTION
14 CJK 單位（Netflix 繁中規範）原本寫死在四處：`subtitle.wrap` 的預設、CLI 的
`--max-cjk`、兩個 renderer 的簽章。一個 operator 有正當理由想調的數字，散在四份
複本裡，等於三個「CLI 跟 app 對『一行多寬』意見不合」的機會。

新增 `export.subtitle_max_cjk`（預設 14，範圍 8–40）進 `SETTINGS_SCHEMA` 的
`export` 群組，並且**只在一個地方解析** —— `render_subtitle_cues(max_units=None)`
去讀它。單支、批次 zip、時間軸三條路都是同一個 seam，所以三條路一起跟著動。
CLI 的 `--max-cjk` 預設改成 `None`，落到同一個設定；明確傳值仍然優先。

`config.SUBTITLE_MAX_CJK` 走跟 `OLLAMA_VISION_NUM_CTX` 一樣的解析形式：壞掉的
env 值退回 14，不讓一個 typo 產生每行兩個字的字幕。

UI 也加上控制項。settings.py 自己的規矩是「沒有下游效果的設定不准加」；反過來
也成立 —— 只有 API 打得到的旋鈕，對使用者等於不存在。順手把 export 區塊那句
「只有預設資料夾真實生效」的說明補正。

**刻意不做 query param**：批次匯出內部呼叫單支 builder，per-request 的寬度得
一路穿過每個呼叫點 —— 那正是這一波在收拾的「接一半」。

新增 9 支測試。mutation-check 五處全紅在該紅的位置：
  seam 不讀設定       → 全檔紅
  CLI 不讀設定        → 對等測試紅
  明確傳值被蓋掉      → 覆寫測試紅
  拿掉 8–40 範圍守衛  → 422 測試紅
  預設從 14 挪開      → 預設測試紅

全套 1478 passed / 7 skipped。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>