### PR TITLE
fix(media): 單支重轉錄完全不拿 ingest 鎖

### DIFF
--- a/routers/media.py
+++ b/routers/media.py
@@ -36,6 +36,7 @@ from mediarecords import _get_light_records_by_ids, _get_tags_bulk
 from pathres import _display_path, _resolve_frame, _resolve_media_path, _resolve_record
 from reqopts import _parse_ids_query
 from scenes import _scenes_payload
+from state import _acquire_ingest_slot, _release_ingest_slot
 from webguard import _assert_same_site
 
 router = APIRouter()
@@ -810,6 +811,13 @@ def retranscribe_media(
         # fable-audit 2026-07-12: don't leak the resolved absolute path in the
         # error body — surface the PROJECT_ROOT-relative/basename form (Phase 16.2).
         raise HTTPException(400, f"找不到媒體檔案：{_display_path(rec.get('path') or '')}")
+    # The ingest slot (audit H3) exists to stop two whisper decodes running at
+    # once — that is the OOM guard on a 16 GB box. Every batch path takes it;
+    # this one never did. So starting a batch and then clicking one clip's
+    # retranscribe put two decodes side by side, which is precisely the case the
+    # slot was added for. The batch paths already answer 409 the other way round.
+    if not _acquire_ingest_slot():
+        raise HTTPException(409, "已有匯入或轉錄任務進行中，請稍候")
     try:
         import transcribe as tr
         text, lang, segments, words = tr.transcribe(media_path, language=body.language)
@@ -817,6 +825,11 @@ def retranscribe_media(
         # Extraction/transcription failed — leave the existing transcript untouched
         # rather than blanking it (audit H1/H2).
         raise HTTPException(500, "retranscribe 失敗：{0}".format(e))
+    finally:
+        # Released as soon as whisper is done: the DB writes below are milliseconds
+        # and hold no model in memory, and keeping the slot across them would make
+        # the queue wait on sqlite for no reason.
+        _release_ingest_slot()
     # An empty result means "no speech"; for a clip that already has a transcript
     # that's almost always a regression (transient decode failure), not intent —
     # refuse to overwrite a good transcript with nothing (audit H1).

--- a/tests/test_hardening_concurrency.py
+++ b/tests/test_hardening_concurrency.py
@@ -46,3 +46,70 @@ def test_retranscribe_all_no_audio_returns_early_without_taking_slot(fastapi_cli
     # slot untouched / free
     assert server._acquire_ingest_slot() is True
     server._release_ingest_slot()
+
+
+# ── #12: the single-clip retranscribe never took the slot at all ─────────────
+# The batch paths all take it; this one didn't. So the way to get two whisper
+# decodes running side by side on a 16 GB box was: start a batch, then click one
+# clip's "retranscribe" — which is not an exotic sequence, it's what you do when
+# you notice one clip came out wrong while the batch is still going.
+
+def _seed_playable(sample_record, tmp_path):
+    """A row whose media file actually exists — the route 400s before reaching the
+    slot otherwise, which would make these tests pass for the wrong reason."""
+    import importlib
+    db = importlib.import_module("db")
+    media = tmp_path / "clip.mp4"
+    media.write_bytes(b"\x00")
+    db.upsert(sample_record(path=str(media), filename="clip.mp4", ext=".mp4", has_audio=1))
+    return 1
+
+
+def test_single_clip_retranscribe_409s_while_the_slot_is_held(
+    fastapi_client, sample_record, tmp_path
+):
+    import server
+    mid = _seed_playable(sample_record, tmp_path)
+    assert server._acquire_ingest_slot() is True  # a batch is running
+    try:
+        r = fastapi_client.post("/api/media/%d/retranscribe" % mid, json={"language": "zh"})
+        assert r.status_code == 409, r.text
+    finally:
+        server._release_ingest_slot()
+
+
+def test_single_clip_retranscribe_releases_the_slot_even_when_it_fails(
+    fastapi_client, sample_record, tmp_path, monkeypatch
+):
+    """A leaked slot is worse than no slot: every later ingest 409s until restart.
+    The failure path is the one that leaks, so that is the one tested."""
+    import server
+    import transcribe
+
+    mid = _seed_playable(sample_record, tmp_path)
+    monkeypatch.setattr(transcribe, "transcribe",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("ffmpeg died")))
+
+    r = fastapi_client.post("/api/media/%d/retranscribe" % mid, json={"language": "zh"})
+
+    assert r.status_code == 500
+    assert server._acquire_ingest_slot() is True, "the slot leaked on the failure path"
+    server._release_ingest_slot()
+
+
+def test_single_clip_retranscribe_releases_the_slot_on_success(
+    fastapi_client, sample_record, tmp_path, monkeypatch
+):
+    import server
+    import transcribe
+
+    mid = _seed_playable(sample_record, tmp_path)
+    monkeypatch.setattr(transcribe, "transcribe",
+                        lambda *a, **k: ("新的逐字稿", "zh",
+                                         [{"start": 0.0, "end": 1.0, "text": "新的逐字稿"}], []))
+
+    r = fastapi_client.post("/api/media/%d/retranscribe" % mid, json={"language": "zh"})
+
+    assert r.status_code == 200, r.text
+    assert server._acquire_ingest_slot() is True
+    server._release_ingest_slot()


### PR DESCRIPTION
`_acquire_ingest_slot()`（audit H3）存在的唯一理由是**不讓兩個 whisper 同時解碼**
—— 那是 16GB 機器上的 OOM 守衛。批次的每一條路都會拿它（`/api/ingest`、reingest、
WS、bin-copy、`/api/retranscribe-all`），**只有單支重轉錄從來沒拿過**。

所以要製造兩個並行解碼的方法是：開始一個批次，然後點某一支的「重新轉錄」——
那不是什麼刁鑽操作，那就是你在批次跑到一半、發現某一支結果不對時會做的事。
而且方向是不對稱的：批次那邊早就會對這種情況回 409，只有這邊不會。

修法照既有 pattern：拿不到就 409，`finally` 釋放。**鎖只 hold 到 whisper 結束**
—— 後面那段 DB 寫入是毫秒級、不佔任何模型記憶體，把鎖抓過去只會讓佇列白等 sqlite。

新增 3 支測試，其中一支專門盯**失敗路徑**：漏放的鎖比沒有鎖更糟，之後每一個匯入
都會 409 直到重啟。三支都先確認媒體檔真的存在，否則 route 會在碰到鎖之前就 400
—— 那樣測試會因為錯的理由通過。

mutation-check 兩處全紅在該紅的位置：
  不拿鎖         → 409 測試紅
  失敗時不放鎖   → 失敗路徑測試紅

全套 1481 passed / 7 skipped。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>