### PR TITLE
feat(progress): 進度看得見，而合約一個字都沒動

### DIFF
--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -257,6 +257,9 @@
   // reprocess local state, reset when the selected clip changes
   let reBusy = null // action currently running, or null
   let reMsg = ''
+  // Live progress for the running action, e.g. '12/40'. Supplied by the parent,
+  // which polls the job's status endpoint while its own POST is still in flight.
+  export let reProgress = ''
   let reLang = 'zh'
   let lastMediaId = null
   $: if (media && media.id !== lastMediaId) {
@@ -543,7 +546,7 @@
       </div>
       <div class="reprow">
         <button class="ak-btn rebtn" disabled={!!reBusy} on:click={() => doReprocess('retry-vision')}>
-          {reBusy === 'retry-vision' ? '分析中…' : '重試視覺'}
+          {reBusy === 'retry-vision' ? (reProgress ? `分析中… ${reProgress}` : '分析中…') : '重試視覺'}
         </button>
         <button class="ak-btn rebtn" disabled={!!reBusy} on:click={() => doReprocess('reingest')}>
           {reBusy === 'reingest' ? '重建中…' : '完整重建'}

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -403,6 +403,10 @@ export const retranscribe = (id, language = 'zh', opts) =>
 // POST /api/media/{id}/retry-vision → {ok, patched, still_empty, total_frames, message?}
 export const retryVision = (id, opts) =>
   req(`/api/media/${id}/retry-vision`, { method: 'POST', ...opts })
+// GET .../retry-vision/status → {state:'running'|'done'|'error'|'idle', phase, done, total}
+// Polled WHILE the POST above is still open — the POST contract is unchanged.
+export const retryVisionStatus = (id, opts) =>
+  req(`/api/media/${id}/retry-vision/status`, opts)
 // POST /api/media/{id}/reingest → {ok, stdout, stderr}. 409 if an ingest is
 // already running (single-flight guard); 504 on the 10-min server timeout.
 export const reingest = (id, opts) =>

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -806,6 +806,33 @@
     }
   }
 
+  // Live progress label for the running per-clip action ('12/40'), '' when idle.
+  let reProgress = ''
+
+  // Returns a stop function. A failed poll is ignored on purpose: the job is the
+  // POST, not this, and a status blip must never turn a working run into an error.
+  function pollVisionProgress(id) {
+    let alive = true
+    let timer = null
+    const tick = async () => {
+      if (!alive) return
+      try {
+        const s = await api.retryVisionStatus(id)
+        if (alive && s && s.state === 'running' && s.total) {
+          const phase = s.phase === 'fallback' ? '備援 ' : ''
+          reProgress = `${phase}${s.done || 0}/${s.total}`
+        }
+      } catch (_) {}
+      if (alive) timer = setTimeout(tick, 1000)
+    }
+    timer = setTimeout(tick, 1000)
+    return () => {
+      alive = false
+      if (timer) clearTimeout(timer)
+      reProgress = ''
+    }
+  }
+
   // Per-clip re-processing. Returns {ok, message} for the inspector to surface;
   // throws bubble up to the inspector's catch. Refetch detail on success so the
   // transcript / vision / tags reflect the new run.
@@ -819,7 +846,15 @@
       return { ok: r.ok, message: `轉錄完成 · ${r.transcript_length} 字 · ${r.language}` }
     }
     if (action === 'retry-vision') {
-      const r = await api.retryVision(id)
+      // Poll for progress while the POST is still open. The request contract is
+      // untouched — this only makes the middle of a multi-minute call visible.
+      const stopPolling = pollVisionProgress(id)
+      let r
+      try {
+        r = await api.retryVision(id)
+      } finally {
+        stopPolling()
+      }
       if (detailId === id) await fetchDetail(id)
       return {
         ok: r.ok,
@@ -1072,6 +1107,7 @@
         onAddTag={selected ? addTag : null}
         onRemoveTag={selected ? removeTag : null}
         onReprocess={selected ? reprocess : null}
+        {reProgress}
         languages={engineLangs}
         mediaLang={detailLive ? detailLive.lang : null}
         onExport={selected ? (fmt, trim) => exportClip(selected.id, fmt, selected.name, trim) : null}

--- a/progress.py
+++ b/progress.py
@@ -1,0 +1,68 @@
+"""progress.py — a write-only progress sink, bound per context.
+
+The problem this solves: `retry-vision` and `retranscribe` are blocking POSTs that
+can run for minutes, and the UI has nothing to show while they do. The obvious fix
+is to thread a `progress_cb` argument down through `vision.describe_frames` and
+`transcribe.transcribe` — which changes both signatures, every existing call site,
+and every test that calls them.
+
+A context-bound sink avoids all of that. The worker calls `report(...)`; whether
+anyone is listening is not its problem. Nothing about the call site changes except
+that one line exists.
+
+Three properties that make this safe to sprinkle into hot paths:
+
+* **Write-only.** `report()` returns None and has no reader side. A worker can
+  never read progress back and branch on it, so progress cannot change behaviour.
+* **Default no-op.** With no sink bound — CLI, tests, ingest.py — `report()` costs
+  one ContextVar lookup and returns.
+* **Per context.** `contextvars` means two jobs running at once each see their own
+  sink, with no id threading and no cross-talk. FastAPI's sync endpoints run in a
+  threadpool that copies the caller's context, so a sink bound inside the endpoint
+  is visible to everything it calls.
+
+A failing sink must never break the work it describes, so `report()` swallows
+exceptions from it. That is the one place in this codebase where a bare catch is
+the correct answer: the alternative is a progress bar taking down a transcode.
+"""
+from __future__ import annotations
+
+import contextvars
+from typing import Any, Callable, Dict, Optional
+
+Sink = Callable[[Dict[str, Any]], None]
+
+_sink: contextvars.ContextVar[Optional[Sink]] = contextvars.ContextVar(
+    "arkiv_progress_sink", default=None
+)
+
+
+def report(**fields: Any) -> None:
+    """Report progress to whoever is listening in this context. Usually nobody."""
+    sink = _sink.get()
+    if sink is None:
+        return
+    try:
+        sink(dict(fields))
+    except Exception:
+        pass  # progress must never break the work it is describing
+
+
+class capture:
+    """Bind a sink for the duration of a block.
+
+        with progress.capture(lambda ev: registry.update(job_id, **ev)):
+            vision.describe_frames(paths)
+    """
+
+    def __init__(self, sink: Sink):
+        self._sink = sink
+        self._token = None
+
+    def __enter__(self) -> "capture":
+        self._token = _sink.set(self._sink)
+        return self
+
+    def __exit__(self, *exc_info) -> bool:
+        _sink.reset(self._token)
+        return False  # never swallow the block's own exception

--- a/routers/media.py
+++ b/routers/media.py
@@ -29,6 +29,7 @@ import config
 import corrections
 import db
 import mediatypes
+import progress
 import tag_quality
 from auth import require_scopes
 from config import BASE_DIR
@@ -36,7 +37,7 @@ from mediarecords import _get_light_records_by_ids, _get_tags_bulk
 from pathres import _display_path, _resolve_frame, _resolve_media_path, _resolve_record
 from reqopts import _parse_ids_query
 from scenes import _scenes_payload
-from state import _acquire_ingest_slot, _release_ingest_slot
+from state import _acquire_ingest_slot, _release_ingest_slot, vision_jobs
 from webguard import _assert_same_site
 
 router = APIRouter()
@@ -938,24 +939,41 @@ def retry_vision(
     import vision as vis
     frame_paths = [_resolve_media_path(f["thumbnail_path"]) for f in empty_frames]
 
-    # Phase 1: try primary vision model
-    results = vis.describe_frames(frame_paths)
-    failed = [i for i, r in enumerate(results) if r.get("error") or not r.get("description")]
+    # Per-clip claim, not a process-wide one: two different clips may legitimately
+    # be retried at once, but the same clip twice would have both runs writing the
+    # same frame rows. The coarse OOM guard is the ingest slot, a separate thing.
+    if not vision_jobs.start(media_id, phase="primary", done=0, total=len(empty_frames)):
+        raise HTTPException(409, "這支素材的視覺重試正在進行中")
+    try:
+        # The sink is bound here and nowhere else: `vision.describe_frames` reports
+        # into whatever context it happens to run in, and knows nothing about jobs,
+        # ids, or HTTP. That is what keeps its signature unchanged.
+        with progress.capture(lambda ev: vision_jobs.update(media_id, **ev)):
+            # Phase 1: try primary vision model
+            results = vis.describe_frames(frame_paths)
+            failed = [i for i, r in enumerate(results) if r.get("error") or not r.get("description")]
 
-    # Phase 2: fallback to lighter model for failed frames. Config-driven (unified
-    # with ingest.py) and skipped gracefully when the fallback model isn't
-    # installed, instead of 404-ing once per failed frame.
-    if failed and config.VISION_FALLBACK_MODEL and vis.model_available(config.VISION_FALLBACK_MODEL):
-        fallback_model = config.VISION_FALLBACK_MODEL
-        # round-5 #50: pass the fallback model straight through to _call_vision.
-        # The old vis.VISION_MODEL global-swap was dead (_call_vision re-read the
-        # model from settings) — and being a module global it also raced across
-        # concurrent retry-vision calls. Threading the arg fixes both.
-        retry_paths = [frame_paths[i] for i in failed]
-        retry_results = vis.describe_frames(retry_paths, model=fallback_model)
-        for idx, retry_r in zip(failed, retry_results):
-            if retry_r.get("description") and not retry_r.get("error"):
-                results[idx] = retry_r
+            # Phase 2: fallback to lighter model for failed frames. Config-driven
+            # (unified with ingest.py) and skipped gracefully when the fallback
+            # model isn't installed, instead of 404-ing once per failed frame.
+            if failed and config.VISION_FALLBACK_MODEL and vis.model_available(config.VISION_FALLBACK_MODEL):
+                fallback_model = config.VISION_FALLBACK_MODEL
+                vision_jobs.update(media_id, phase="fallback", done=0, total=len(failed))
+                # round-5 #50: pass the fallback model straight through to
+                # _call_vision. The old vis.VISION_MODEL global-swap was dead
+                # (_call_vision re-read the model from settings) — and being a
+                # module global it also raced across concurrent retry-vision calls.
+                # Threading the arg fixes both.
+                retry_paths = [frame_paths[i] for i in failed]
+                retry_results = vis.describe_frames(retry_paths, model=fallback_model)
+                for idx, retry_r in zip(failed, retry_results):
+                    if retry_r.get("description") and not retry_r.get("error"):
+                        results[idx] = retry_r
+    except Exception:
+        # A crash must clear the claim, or this clip can never be retried again
+        # without restarting the server.
+        vision_jobs.finish(media_id, state="error")
+        raise
 
     # Write results to DB
     patched = 0
@@ -1011,9 +1029,25 @@ def retry_vision(
         )
 
     still_empty = sum(1 for vr in results if not vr.get("description") or vr.get("error"))
+    vision_jobs.finish(media_id, patched=patched, still_empty=still_empty,
+                       total=len(empty_frames))
     return {
         "ok": still_empty == 0,
         "patched": patched,
         "still_empty": still_empty,
         "total_frames": len(empty_frames),
     }
+
+
+@router.get("/api/media/{media_id}/retry-vision/status")
+def retry_vision_status(
+    media_id: int,
+    _tok: dict = Depends(require_scopes("videos_read")),
+):
+    """Where a retry-vision run has got to. Polled while the POST is still open.
+
+    `idle` is a real answer, not an error: nothing is known about this id, either
+    because it never ran or because it finished long enough ago to be evicted.
+    """
+    rec = vision_jobs.get(media_id)
+    return rec if rec is not None else {"state": "idle"}

--- a/state.py
+++ b/state.py
@@ -170,3 +170,81 @@ class IngestBroadcaster:
 
 
 ingest_ws = IngestBroadcaster()
+
+
+# ── Per-job progress registry ─────────────────────────────────────────────────
+class JobRegistry:
+    """Progress records keyed by job id, for work that runs behind a blocking POST.
+
+    Deliberately NOT a queue or a task runner. The POST still runs the work and
+    still returns the result — this only makes the middle of it visible, so the UI
+    can poll `.../status` while its own request is in flight. Keeping the request
+    contract unchanged is the point: turning these into 202-and-poll would buy only
+    "survives a dropped connection", and the client is on loopback with no proxy.
+
+    Two things this has to get right:
+
+    * **`get` returns a copy.** The record is mutated by the worker thread while the
+      poller reads it; handing out the live dict would let a caller observe it
+      half-updated, or hold a reference that keeps changing under them.
+    * **Terminal records survive.** A job that finishes between two polls must still
+      be reportable, or the UI's last observation is "running" forever. They are
+      evicted oldest-first past `max_done` so a long session can't grow this
+      without bound.
+    """
+
+    def __init__(self, max_done: int = 32):
+        self._lock = _threading.Lock()
+        self._jobs = {}          # job_id -> record dict
+        self._done_order = []    # job_ids in completion order (eviction queue)
+        self._max_done = max_done
+
+    def start(self, job_id, **fields) -> bool:
+        """Claim `job_id`. False when it is already running — the caller answers 409.
+
+        Note this is per id, not global: two different clips may legitimately be
+        worked on at once. The process-wide OOM guard is the ingest slot, a
+        separate and coarser thing.
+        """
+        with self._lock:
+            rec = self._jobs.get(job_id)
+            if rec is not None and rec.get("state") == "running":
+                return False
+            self._jobs[job_id] = dict(fields, state="running")
+            if job_id in self._done_order:
+                self._done_order.remove(job_id)
+            return True
+
+    def update(self, job_id, **fields) -> None:
+        """Merge fields into a running record. Silently ignores unknown/finished
+        ids — a late report from a job nobody is tracking is not an error."""
+        with self._lock:
+            rec = self._jobs.get(job_id)
+            if rec is None or rec.get("state") != "running":
+                return
+            rec.update(fields)
+
+    def finish(self, job_id, state: str = "done", **fields) -> None:
+        with self._lock:
+            rec = self._jobs.get(job_id)
+            if rec is None:
+                rec = self._jobs[job_id] = {}
+            rec.update(fields)
+            rec["state"] = state
+            if job_id in self._done_order:
+                self._done_order.remove(job_id)
+            self._done_order.append(job_id)
+            while len(self._done_order) > self._max_done:
+                self._jobs.pop(self._done_order.pop(0), None)
+
+    def get(self, job_id):
+        """A snapshot, or None when nothing is known about this id."""
+        with self._lock:
+            rec = self._jobs.get(job_id)
+            return dict(rec) if rec is not None else None
+
+
+# One registry per kind of work, so a vision retry and a retranscribe on the same
+# clip don't collide on the same id.
+vision_jobs = JobRegistry()
+transcribe_jobs = JobRegistry()

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,291 @@
+"""Progress reporting: visible middle, unchanged contract.
+
+`retry-vision` and `retranscribe` are blocking POSTs that run for minutes with
+nothing to show. The obvious fix — thread a `progress_cb` down into
+`vision.describe_frames` and `transcribe.transcribe` — changes both signatures,
+every call site, and every test that calls them. A context-bound sink changes none
+of that: the worker reports, and whether anyone listens is not its problem.
+
+What these tests defend:
+
+* a worker with no listener behaves exactly as before (CLI, ingest.py, tests);
+* two concurrent jobs do not see each other's progress;
+* a broken sink cannot break the work it describes;
+* a job that finishes between two polls is still reportable;
+* the POST's request/response shape is untouched.
+"""
+from __future__ import annotations
+
+import importlib
+import threading
+
+import pytest
+
+import progress
+import state
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registries():
+    """`state.vision_jobs` is process-global and `routers.media` imported it BY NAME,
+    so rebinding `state.vision_jobs` would not reach the route. Clear it in place
+    instead — otherwise one test's finished record makes another's "idle" assertion
+    depend on file order."""
+    for reg in (state.vision_jobs, state.transcribe_jobs):
+        with reg._lock:
+            reg._jobs.clear()
+            reg._done_order.clear()
+    yield
+
+
+# ── the sink ─────────────────────────────────────────────────────────────────
+
+def test_reporting_with_no_listener_is_a_silent_no_op():
+    """The common case by far: CLI runs, ingest.py, every existing test."""
+    assert progress.report(stage="x", done=1) is None
+
+
+def test_a_bound_sink_receives_the_fields():
+    seen = []
+    with progress.capture(seen.append):
+        progress.report(stage="frames", done=3, total=10)
+
+    assert seen == [{"stage": "frames", "done": 3, "total": 10}]
+
+
+def test_the_sink_is_unbound_again_after_the_block():
+    seen = []
+    with progress.capture(seen.append):
+        progress.report(a=1)
+    progress.report(a=2)
+
+    assert seen == [{"a": 1}]
+
+
+def test_a_broken_sink_cannot_break_the_work():
+    """A progress bar must never take down a transcode."""
+    def explode(_ev):
+        raise RuntimeError("the UI went away")
+
+    with progress.capture(explode):
+        progress.report(stage="frames")  # must not raise
+
+
+def test_the_block_s_own_exception_still_propagates():
+    """Swallowing the worker's exception would be catastrophic and is easy to do
+    by accident when `__exit__` returns something truthy."""
+    with pytest.raises(ValueError):
+        with progress.capture(lambda _ev: None):
+            raise ValueError("real failure")
+
+
+def test_two_threads_do_not_see_each_other_s_sink():
+    """Two clips can be worked on at once. A module-global sink would cross-wire
+    their progress; contextvars is what makes id-threading unnecessary."""
+    a, b = [], []
+    barrier = threading.Barrier(2)
+
+    def work(sink, tag):
+        with progress.capture(sink.append):
+            barrier.wait(timeout=5)  # (1) both sinks bound before either reports
+            progress.report(tag=tag)
+            barrier.wait(timeout=5)  # (2) neither unbinds before both have reported
+    # Both barriers matter. Without (2) a module-global sink would still pass by
+    # luck: whichever thread finishes first restores the other's sink on the way
+    # out, so the slower thread reports into the right list anyway.
+
+    t1 = threading.Thread(target=work, args=(a, "A"))
+    t2 = threading.Thread(target=work, args=(b, "B"))
+    t1.start(); t2.start(); t1.join(5); t2.join(5)
+
+    assert a == [{"tag": "A"}] and b == [{"tag": "B"}]
+
+
+# ── the registry ─────────────────────────────────────────────────────────────
+
+def test_a_second_start_on_the_same_id_is_refused():
+    reg = state.JobRegistry()
+    assert reg.start(7) is True
+    assert reg.start(7) is False
+
+
+def test_different_ids_run_side_by_side():
+    """Per id, not global. The process-wide OOM guard is the ingest slot."""
+    reg = state.JobRegistry()
+    assert reg.start(1) is True and reg.start(2) is True
+
+
+def test_a_finished_id_can_start_again():
+    reg = state.JobRegistry()
+    reg.start(7); reg.finish(7)
+    assert reg.start(7) is True
+
+
+def test_get_returns_a_copy_not_the_live_record():
+    """The worker mutates the record while the poller reads it. Handing out the
+    live dict lets a caller observe it half-updated."""
+    reg = state.JobRegistry()
+    reg.start(1, done=0)
+    snap = reg.get(1)
+    reg.update(1, done=5)
+
+    assert snap["done"] == 0
+    assert reg.get(1)["done"] == 5
+
+
+def test_a_finished_job_is_still_reportable():
+    """If terminal records vanished, a job that finished between two polls would
+    leave the UI's last observation at 'running' forever."""
+    reg = state.JobRegistry()
+    reg.start(1, total=10)
+    reg.finish(1, patched=10)
+
+    assert reg.get(1) == {"state": "done", "total": 10, "patched": 10}
+
+
+def test_finished_records_are_evicted_oldest_first():
+    reg = state.JobRegistry(max_done=2)
+    for i in range(4):
+        reg.start(i); reg.finish(i)
+
+    assert reg.get(0) is None and reg.get(1) is None
+    assert reg.get(2) is not None and reg.get(3) is not None
+
+
+def test_an_unknown_id_is_none_not_an_error():
+    assert state.JobRegistry().get(999) is None
+
+
+def test_a_late_update_on_a_finished_job_is_ignored():
+    """Otherwise a straggler report resurrects a completed record as 'running'."""
+    reg = state.JobRegistry()
+    reg.start(1); reg.finish(1, patched=3)
+    reg.update(1, done=99)
+
+    assert reg.get(1)["state"] == "done"
+    assert "done" not in reg.get(1)
+
+
+# ── end to end through the route ─────────────────────────────────────────────
+
+def _seed_with_empty_frames(db, sample_record, tmp_path, n=4):
+    db.upsert(sample_record(path=str(tmp_path / "v.mp4"), filename="v.mp4"))
+    with db.get_conn() as conn:
+        for i in range(n):
+            thumb = tmp_path / "f{0}.jpg".format(i)
+            thumb.write_bytes(b"\xff\xd8\xff")
+            conn.execute(
+                "INSERT INTO frames (media_id, frame_index, timestamp_s, thumbnail_path, description)"
+                " VALUES (?,?,?,?,?)", (1, i, float(i), str(thumb), ""))
+    return 1
+
+
+def test_status_reports_idle_for_a_clip_that_never_ran(fastapi_client, server_module):
+    r = fastapi_client.get("/api/media/1/retry-vision/status")
+    assert r.status_code == 200
+    assert r.json() == {"state": "idle"}
+
+
+def test_the_route_reports_frame_progress_and_then_finishes(
+    fastapi_client, server_module, sample_record, tmp_path, monkeypatch
+):
+    db = importlib.import_module("db")
+    mid = _seed_with_empty_frames(db, sample_record, tmp_path, n=4)
+
+    seen = []
+    import vision as vis
+
+    def fake_describe(paths, model=None):
+        # Report the way the real loop does, and snapshot what a poller would see.
+        import progress as pr
+        out = []
+        for i, p in enumerate(paths):
+            pr.report(stage="frames", done=i, total=len(paths))
+            seen.append(fastapi_client.get(
+                "/api/media/%d/retry-vision/status" % mid).json())
+            out.append({"description": "描述 {0}".format(i), "tags": ["a"], "file": p})
+        return out
+
+    monkeypatch.setattr(vis, "describe_frames", fake_describe)
+
+    r = fastapi_client.post("/api/media/%d/retry-vision" % mid)
+
+    assert r.status_code == 200
+    # Contract unchanged: same keys the UI already reads.
+    assert set(r.json()) >= {"ok", "patched", "still_empty", "total_frames"}
+    # Mid-flight the poller saw real, advancing numbers.
+    running = [s for s in seen if s.get("state") == "running"]
+    assert running, seen
+    assert [s.get("done") for s in running] == [0, 1, 2, 3]
+    assert all(s.get("total") == 4 for s in running)
+    # And afterwards the record is terminal, not stuck at 'running'.
+    after = fastapi_client.get("/api/media/%d/retry-vision/status" % mid).json()
+    assert after["state"] == "done" and after["patched"] == 4
+
+
+def test_a_second_retry_on_the_same_clip_is_refused_while_one_runs(
+    fastapi_client, server_module, sample_record, tmp_path, monkeypatch
+):
+    db = importlib.import_module("db")
+    mid = _seed_with_empty_frames(db, sample_record, tmp_path, n=2)
+    import vision as vis
+
+    inner = {}
+
+    def fake_describe(paths, model=None):
+        # `reentered` stops the nested POST from calling this again: without the
+        # 409 guard the second run would recurse forever, and a test that hangs
+        # proves nothing about WHY it failed.
+        if not inner.get("reentered"):
+            inner["reentered"] = True
+            inner["status"] = fastapi_client.post(
+                "/api/media/%d/retry-vision" % mid).status_code
+        return [{"description": "d", "tags": [], "file": p} for p in paths]
+
+    monkeypatch.setattr(vis, "describe_frames", fake_describe)
+    fastapi_client.post("/api/media/%d/retry-vision" % mid)
+
+    assert inner["status"] == 409
+
+
+def test_a_crashed_run_does_not_wedge_the_clip_forever(
+    fastapi_client, server_module, sample_record, tmp_path, monkeypatch
+):
+    """A claim left behind by a crash would make this clip un-retryable until the
+    server restarts."""
+    db = importlib.import_module("db")
+    mid = _seed_with_empty_frames(db, sample_record, tmp_path, n=2)
+    import vision as vis
+    monkeypatch.setattr(vis, "describe_frames",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("ollama died")))
+
+    with pytest.raises(RuntimeError):
+        fastapi_client.post("/api/media/%d/retry-vision" % mid)
+
+    assert state.vision_jobs.get(mid)["state"] == "error"
+    assert state.vision_jobs.start(mid) is True
+    state.vision_jobs.finish(mid)
+
+
+def test_the_real_vision_loop_reports_each_frame(monkeypatch):
+    """Pins the `report()` calls inside `describe_frames` itself. The route-level
+    test above drives a fake `describe_frames`, so it cannot see these — remove the
+    reports from the real loop and it stays green."""
+    import vision as vis
+
+    monkeypatch.setattr(vis, "_describe_one",
+                        lambda p, model=None: {"description": "rep", "tags": []})
+    monkeypatch.setattr(vis, "_describe_one_light",
+                        lambda p, model=None: {"description": "light", "tags": []})
+    monkeypatch.setattr(vis, "_is_usable_frame", lambda p: True)
+
+    seen = []
+    with progress.capture(seen.append):
+        vis.describe_frames(["a.jpg", "b.jpg", "c.jpg"])
+
+    # The representative frame runs BEFORE the loop and is the slowest call, so it
+    # gets its own report — otherwise the UI sits at nothing through it.
+    assert seen[0] == {"stage": "representative", "done": 0, "total": 3}
+    frames = [e for e in seen if e.get("stage") == "frames"]
+    assert [e["done"] for e in frames] == [0, 1, 2, 3]
+    assert all(e["total"] == 3 for e in frames)

--- a/tests/test_r5_25_router_media.py
+++ b/tests/test_r5_25_router_media.py
@@ -39,6 +39,7 @@ _EXPECTED_ROUTES = {
     ("/api/media/{media_id}/transcripts", "GET"),
     ("/api/media/{media_id}/transcript/activate", "POST"),
     ("/api/media/{media_id}/retry-vision", "POST"),
+    ("/api/media/{media_id}/retry-vision/status", "GET"),
 }
 
 
@@ -48,7 +49,7 @@ def test_media_router_is_a_leaf_module():
     assert not re.search(r"^\s*from\s+server\b", src, re.M)
 
 
-def test_router_owns_exactly_the_20_media_routes():
+def test_router_owns_exactly_the_21_media_routes():
     import routers.media as rm
     pairs = {
         (r.path, m)

--- a/vision.py
+++ b/vision.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional
 import requests
 
 import config
+import progress
 import zh_convert
 from llm import vision
 
@@ -182,7 +183,11 @@ def describe_frames(frame_paths: List[str], model: Optional[str] = None) -> List
     if not frame_paths:
         return []
 
-    rep_idx = len(frame_paths) // 2
+    total = len(frame_paths)
+    rep_idx = total // 2
+    # The representative frame is the expensive one (12 fields vs 11) and it runs
+    # before the loop, so without this the UI sits at 0 through the slowest call.
+    progress.report(stage="representative", done=0, total=total)
     rep_result = _describe_one(frame_paths[rep_idx], model=model)
     rep_result["file"] = frame_paths[rep_idx]
 
@@ -190,6 +195,7 @@ def describe_frames(frame_paths: List[str], model: Optional[str] = None) -> List
 
     results = []
     for i, path in enumerate(frame_paths):
+        progress.report(stage="frames", done=i, total=total)
         if i == rep_idx:
             results.append(rep_result)
             continue
@@ -209,6 +215,7 @@ def describe_frames(frame_paths: List[str], model: Optional[str] = None) -> List
             light[k] = rep_result.get(k)
         results.append(light)
 
+    progress.report(stage="frames", done=total, total=total)
     return results
 
 


### PR DESCRIPTION
`retry-vision` 是一個會跑好幾分鐘的阻塞 POST，中間完全沒東西可看。顯而易見的
做法是把 `progress_cb` 一路穿進 `vision.describe_frames` —— 那會改掉它的簽章、
所有既有呼叫點、以及每一支呼叫它的測試。

改成 **context-bound sink**（新 leaf `progress.py`，~70 行）：worker 呼叫
`report(...)`，有沒有人在聽不是它的事。`vision.py` 只多七行 `report()`，
**簽章零變更**。

三個讓它敢撒進熱路徑的性質：
- **只寫不讀** —— `report()` 回 None、沒有讀端，所以進度不可能改變行為
- **預設 no-op** —— 沒 bind sink 時（CLI、ingest.py、所有既有測試）只花一次
  ContextVar 查詢
- **per context** —— 兩支同時跑的工作各看各的 sink，不必穿 id、不會串音。
  FastAPI 的同步 endpoint 跑在會複製 context 的 threadpool 裡，所以在 endpoint
  裡 bind 的 sink，它呼叫的東西都看得到

`state.JobRegistry`：per-id 記錄 + `GET /api/media/{id}/retry-vision/status`。
兩件必須做對的事——**`get` 回複本**（worker 在寫、poller 在讀，交出活的 dict 等於
讓對方讀到寫到一半的狀態）、**終態要留著**（兩次輪詢之間結束的工作若記錄消失，
UI 最後看到的永遠是 running），超過 `max_done` 才依完成順序淘汰。

**POST 合約不動。** UI 一邊送 POST 一邊每秒輪詢 status。改成 202-then-poll 唯一
買到的是「連線斷掉還能活」，而 client 在 loopback、無 proxy、無 timeout ——
不值得為它改一個公開合約。

409 是 **per id** 的：兩支不同的素材同時重試是合理的，同一支兩次則會有兩個 run
寫同一批 frame 列。process 級的 OOM 守衛是 ingest slot，那是另一件更粗的事。
crash 一定要清掉 claim，否則這支素材要重啟 server 才能再重試。

新增 19 支測試。mutation-check 十處全紅在該紅的位置：
  sink 改成 module global   → 雙執行緒測試紅
  sink 壞掉往外拋           → 「不能弄壞它描述的工作」紅
  capture 吞掉 block 的例外 → 例外傳遞測試紅
  get 交出活的記錄          → 快照測試紅
  終態被丟掉 / 不淘汰       → 兩支紅
  遲到的 update 復活完成的  → 狀態測試紅
  拿掉 per-id claim         → 409 測試紅
  crash 不清 claim          → 卡死測試紅
  vision 迴圈不再回報       → 真迴圈測試紅

**兩支測試是為了「紅得有意義」才改的**：① 雙執行緒測試加了第二個 barrier ——
沒有它的話 module-global 版本會靠運氣通過（先結束的執行緒在離開時把另一支的
sink 還原回去）；② 409 測試加了 re-entry 旗標 —— 沒有守衛時巢狀 POST 會無限
遞迴，而**會 hang 的測試證明不了它為什麼失敗**。

全套 1500 passed / 7 skipped。svelte-check 0 warnings。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>