### PR TITLE
feat(progress): 轉錄階段 —— 只有階段，沒有百分比

### DIFF
--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -541,7 +541,7 @@
           {/each}
         </select>
         <button class="ak-btn rebtn" disabled={!!reBusy} on:click={() => doReprocess('retranscribe')}>
-          {reBusy === 'retranscribe' ? '轉錄中…' : '重轉錄'}
+          {reBusy === 'retranscribe' ? (reProgress ? `轉錄中… ${reProgress}` : '轉錄中…') : '重轉錄'}
         </button>
       </div>
       <div class="reprow">

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -407,6 +407,10 @@ export const retryVision = (id, opts) =>
 // Polled WHILE the POST above is still open — the POST contract is unchanged.
 export const retryVisionStatus = (id, opts) =>
   req(`/api/media/${id}/retry-vision/status`, opts)
+// GET .../retranscribe/status → {state, stage:'extracting'|'vad'|'decoding'|…}
+// Stage only — whisper decoding is one opaque call, so there is no percentage.
+export const retranscribeStatus = (id, opts) =>
+  req(`/api/media/${id}/retranscribe/status`, opts)
 // POST /api/media/{id}/reingest → {ok, stdout, stderr}. 409 if an ingest is
 // already running (single-flight guard); 504 on the 10-min server timeout.
 export const reingest = (id, opts) =>

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -809,6 +809,34 @@
   // Live progress label for the running per-clip action ('12/40'), '' when idle.
   let reProgress = ''
 
+  // Stage labels, not a progress bar: whisper decoding is a single opaque call and
+  // a percentage would be invented. Naming the stage is the honest version.
+  const TRANSCRIBE_STAGES = {
+    queued: '排隊中', extracting: '抽音軌', vad: '偵測語音',
+    decoding: '辨識中', polishing: '潤稿中', diarizing: '分辨語者',
+  }
+
+  // Poll `endpoint` every second and show `labels[stage]`. Shared by the two
+  // per-clip jobs that report stages rather than counts.
+  function pollStage(id, endpoint, labels) {
+    let alive = true
+    let timer = null
+    const tick = async () => {
+      if (!alive) return
+      try {
+        const s = await endpoint(id)
+        if (alive && s && s.state === 'running' && labels[s.stage]) reProgress = labels[s.stage]
+      } catch (_) {}
+      if (alive) timer = setTimeout(tick, 1000)
+    }
+    timer = setTimeout(tick, 1000)
+    return () => {
+      alive = false
+      if (timer) clearTimeout(timer)
+      reProgress = ''
+    }
+  }
+
   // Returns a stop function. A failed poll is ignored on purpose: the job is the
   // POST, not this, and a status blip must never turn a working run into an error.
   function pollVisionProgress(id) {
@@ -840,7 +868,13 @@
     if (!selected) return { ok: false, message: '未選取素材' }
     const id = selected.id
     if (action === 'retranscribe') {
-      const r = await api.retranscribe(id, opts.language || 'zh')
+      const stopPolling = pollStage(id, api.retranscribeStatus, TRANSCRIBE_STAGES)
+      let r
+      try {
+        r = await api.retranscribe(id, opts.language || 'zh')
+      } finally {
+        stopPolling()
+      }
       if (detailId === id) await fetchDetail(id)
       await fetchTranscripts(id)  // G2: surface the (possibly new) language as a tab
       return { ok: r.ok, message: `轉錄完成 · ${r.transcript_length} 字 · ${r.language}` }

--- a/routers/media.py
+++ b/routers/media.py
@@ -37,7 +37,8 @@ from mediarecords import _get_light_records_by_ids, _get_tags_bulk
 from pathres import _display_path, _resolve_frame, _resolve_media_path, _resolve_record
 from reqopts import _parse_ids_query
 from scenes import _scenes_payload
-from state import _acquire_ingest_slot, _release_ingest_slot, vision_jobs
+from state import (_acquire_ingest_slot, _release_ingest_slot,
+                   transcribe_jobs, vision_jobs)
 from webguard import _assert_same_site
 
 router = APIRouter()
@@ -817,14 +818,23 @@ def retranscribe_media(
     # this one never did. So starting a batch and then clicking one clip's
     # retranscribe put two decodes side by side, which is precisely the case the
     # slot was added for. The batch paths already answer 409 the other way round.
+    # Two different guards, both needed. The ingest slot is process-wide and stops
+    # a second whisper loading at all; the per-id claim stops the SAME clip being
+    # retranscribed twice, which the slot would happily allow once the first one
+    # finished. The per-id one is also what gives the status endpoint an identity.
+    if not transcribe_jobs.start(media_id, stage="queued"):
+        raise HTTPException(409, "這支素材的轉錄正在進行中")
     if not _acquire_ingest_slot():
+        transcribe_jobs.finish(media_id, state="idle")
         raise HTTPException(409, "已有匯入或轉錄任務進行中，請稍候")
     try:
         import transcribe as tr
-        text, lang, segments, words = tr.transcribe(media_path, language=body.language)
+        with progress.capture(lambda ev: transcribe_jobs.update(media_id, **ev)):
+            text, lang, segments, words = tr.transcribe(media_path, language=body.language)
     except Exception as e:
         # Extraction/transcription failed — leave the existing transcript untouched
         # rather than blanking it (audit H1/H2).
+        transcribe_jobs.finish(media_id, state="error")
         raise HTTPException(500, "retranscribe 失敗：{0}".format(e))
     finally:
         # Released as soon as whisper is done: the DB writes below are milliseconds
@@ -835,6 +845,7 @@ def retranscribe_media(
     # that's almost always a regression (transient decode failure), not intent —
     # refuse to overwrite a good transcript with nothing (audit H1).
     if not (text or "").strip() and (rec.get("transcript") or "").strip():
+        transcribe_jobs.finish(media_id, state="error")
         raise HTTPException(422, "transcribe 回空，拒絕覆寫既有逐字稿（可能是音訊擷取失敗）")
     active_lang = lang or body.language
     seg_json = json.dumps(segments, ensure_ascii=False) if segments else None
@@ -865,7 +876,21 @@ def retranscribe_media(
         )
         # archive the new active language too (its row mirrors media.*).
         db.upsert_transcript(media_id, active_lang, text, seg_json, words_json, _conn=conn)
+    transcribe_jobs.finish(media_id, stage="done", transcript_length=len(text),
+                           language=active_lang)
     return {"ok": True, "transcript_length": len(text), "language": active_lang, "backup": backup_name}
+
+
+@router.get("/api/media/{media_id}/retranscribe/status")
+def retranscribe_status(
+    media_id: int,
+    _tok: dict = Depends(require_scopes("videos_read")),
+):
+    """Which stage a retranscribe is in: extracting / vad / decoding / polishing /
+    diarizing. **No percentage** — whisper decoding is a single opaque call, and
+    inventing a number for it would be a worse answer than naming the stage."""
+    rec = transcribe_jobs.get(media_id)
+    return rec if rec is not None else {"state": "idle"}
 
 
 @router.get("/api/media/{media_id}/transcripts")

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -289,3 +289,156 @@ def test_the_real_vision_loop_reports_each_frame(monkeypatch):
     frames = [e for e in seen if e.get("stage") == "frames"]
     assert [e["done"] for e in frames] == [0, 1, 2, 3]
     assert all(e["total"] == 3 for e in frames)
+
+
+# ── transcribe stages ────────────────────────────────────────────────────────
+# Stages, not a percentage. Whisper decoding is one opaque call per file, so
+# "decoding" for four minutes is the truth and a bar creeping to 90% is not.
+
+def _seed_playable(db, sample_record, tmp_path):
+    media = tmp_path / "clip.mp4"
+    media.write_bytes(b"\x00")
+    db.upsert(sample_record(path=str(media), filename="clip.mp4", ext=".mp4", has_audio=1))
+    return 1
+
+
+def test_transcribe_reports_each_stage_it_passes_through(monkeypatch, tmp_path):
+    """Pins the reports inside `transcribe.transcribe` itself, with the backend and
+    the wav extraction stubbed — the stage names are the contract the UI reads."""
+    import transcribe as tr
+
+    monkeypatch.setattr(tr, "_USE_MLX", False)
+    monkeypatch.setattr(tr, "_non_mac_backend", lambda: "faster-whisper")
+    monkeypatch.setattr(tr, "_to_wav", lambda p: str(tmp_path / "a.wav"))
+    monkeypatch.setattr(tr, "_vad_filter", lambda w: (w, None))
+    monkeypatch.setattr(tr, "_transcribe_faster_whisper",
+                        lambda w, lang: ("句子", "zh", [], []))
+
+    seen = []
+    with progress.capture(seen.append):
+        tr.transcribe("/clip.mp4", language="zh")
+
+    stages = [e["stage"] for e in seen if "stage" in e]
+    assert stages[:3] == ["extracting", "vad", "decoding"]
+
+
+def test_the_status_endpoint_shows_the_stage_mid_run(
+    fastapi_client, server_module, sample_record, tmp_path, monkeypatch
+):
+    db = importlib.import_module("db")
+    mid = _seed_playable(db, sample_record, tmp_path)
+    import transcribe as tr
+
+    seen = []
+
+    def fake_transcribe(path, language=None):
+        for stage in ("extracting", "decoding", "polishing"):
+            progress.report(stage=stage)
+            seen.append(fastapi_client.get(
+                "/api/media/%d/retranscribe/status" % mid).json())
+        return "新的逐字稿", "zh", [], []
+
+    monkeypatch.setattr(tr, "transcribe", fake_transcribe)
+
+    r = fastapi_client.post("/api/media/%d/retranscribe" % mid, json={"language": "zh"})
+
+    assert r.status_code == 200, r.text
+    assert [s.get("stage") for s in seen] == ["extracting", "decoding", "polishing"]
+    assert all(s.get("state") == "running" for s in seen)
+    # No percentage is claimed anywhere — the UI has stage names to show, not a bar.
+    assert not any("percent" in s for s in seen)
+    after = fastapi_client.get("/api/media/%d/retranscribe/status" % mid).json()
+    assert after["state"] == "done" and after["stage"] == "done"
+
+
+def test_a_second_retranscribe_is_refused_after_the_slot_is_already_free(
+    fastapi_client, server_module, sample_record, tmp_path, monkeypatch
+):
+    """The window the per-id claim actually covers, and the only one it covers.
+
+    While whisper runs, the process-wide ingest slot already refuses everything, so
+    the claim adds nothing there. But the slot is released the moment decoding ends
+    — deliberately, because the DB writes that follow hold no model — and during
+    those writes a second POST would sail past the slot and start overwriting the
+    same media row. The claim is what stops that, and this drives the request from
+    inside the write phase so the window is hit deterministically."""
+    db = importlib.import_module("db")
+    mid = _seed_playable(db, sample_record, tmp_path)
+    import transcribe as tr
+
+    monkeypatch.setattr(tr, "transcribe", lambda *a, **k: ("文字", "zh", [], []))
+
+    inner = {}
+    real_upsert = db.upsert_transcript
+
+    def spy_upsert(*a, **k):
+        if not inner.get("reentered"):
+            inner["reentered"] = True
+            import server
+            # The slot really is free at this point — that is the premise.
+            assert server._acquire_ingest_slot() is True
+            server._release_ingest_slot()
+            inner["status"] = fastapi_client.post(
+                "/api/media/%d/retranscribe" % mid, json={"language": "zh"}).status_code
+        return real_upsert(*a, **k)
+
+    monkeypatch.setattr(db, "upsert_transcript", spy_upsert)
+    fastapi_client.post("/api/media/%d/retranscribe" % mid, json={"language": "zh"})
+
+    assert inner["status"] == 409
+
+
+def test_losing_the_ingest_slot_does_not_leave_a_stale_claim(
+    fastapi_client, server_module, sample_record, tmp_path
+):
+    """The per-id claim is taken BEFORE the process-wide slot. If the slot is busy
+    the request 409s — and must hand the claim back, or this clip is wedged until
+    a restart even though it never ran."""
+    import server
+    db = importlib.import_module("db")
+    mid = _seed_playable(db, sample_record, tmp_path)
+
+    assert server._acquire_ingest_slot() is True
+    try:
+        r = fastapi_client.post("/api/media/%d/retranscribe" % mid, json={"language": "zh"})
+        assert r.status_code == 409
+    finally:
+        server._release_ingest_slot()
+
+    assert state.transcribe_jobs.get(mid)["state"] != "running"
+    assert state.transcribe_jobs.start(mid) is True
+    state.transcribe_jobs.finish(mid)
+
+
+def test_a_failed_retranscribe_clears_its_claim(
+    fastapi_client, server_module, sample_record, tmp_path, monkeypatch
+):
+    db = importlib.import_module("db")
+    mid = _seed_playable(db, sample_record, tmp_path)
+    import transcribe as tr
+    monkeypatch.setattr(tr, "transcribe",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    r = fastapi_client.post("/api/media/%d/retranscribe" % mid, json={"language": "zh"})
+
+    assert r.status_code == 500
+    assert state.transcribe_jobs.get(mid)["state"] == "error"
+    assert state.transcribe_jobs.start(mid) is True
+    state.transcribe_jobs.finish(mid)
+
+
+def test_a_refused_empty_result_also_clears_its_claim(
+    fastapi_client, server_module, sample_record, tmp_path, monkeypatch
+):
+    """The 422 path (transcribe returned nothing for a clip that already has a
+    transcript) is a third exit from the handler and leaks just as easily."""
+    db = importlib.import_module("db")
+    mid = _seed_playable(db, sample_record, tmp_path)
+    import transcribe as tr
+    monkeypatch.setattr(tr, "transcribe", lambda *a, **k: ("", "zh", [], []))
+
+    r = fastapi_client.post("/api/media/%d/retranscribe" % mid, json={"language": "zh"})
+
+    assert r.status_code == 422
+    assert state.transcribe_jobs.start(mid) is True
+    state.transcribe_jobs.finish(mid)

--- a/tests/test_r5_25_router_media.py
+++ b/tests/test_r5_25_router_media.py
@@ -40,6 +40,7 @@ _EXPECTED_ROUTES = {
     ("/api/media/{media_id}/transcript/activate", "POST"),
     ("/api/media/{media_id}/retry-vision", "POST"),
     ("/api/media/{media_id}/retry-vision/status", "GET"),
+    ("/api/media/{media_id}/retranscribe/status", "GET"),
 }
 
 
@@ -49,7 +50,7 @@ def test_media_router_is_a_leaf_module():
     assert not re.search(r"^\s*from\s+server\b", src, re.M)
 
 
-def test_router_owns_exactly_the_21_media_routes():
+def test_router_owns_exactly_the_22_media_routes():
     import routers.media as rm
     pairs = {
         (r.path, m)

--- a/transcribe.py
+++ b/transcribe.py
@@ -16,6 +16,7 @@ import soundfile as sf
 from silero_vad import load_silero_vad, get_speech_timestamps
 import torch
 
+import progress
 import subtitle
 import whisper_guard
 import zh_convert
@@ -327,6 +328,10 @@ def transcribe(media_path: str, language=None) -> tuple:
     """
     if language is None:
         language = WHISPER_LANGUAGE_HINT or DEFAULT_LANGUAGE
+    # Stages only, deliberately no percentage: whisper decoding is one opaque call
+    # per file and there is no honest number to put on it. "decoding" for four
+    # minutes is the truth; a bar creeping to 90% and sitting there is not.
+    progress.report(stage="extracting")
     wav = _to_wav(media_path)
     if not wav:
         return "", "", [], []
@@ -336,21 +341,26 @@ def transcribe(media_path: str, language=None) -> tuple:
     offset_map = None
     try:
         if _USE_MLX:
+            progress.report(stage="vad")
             vad_wav, offset_map = _vad_filter(wav)
             if vad_wav is None:
                 return "", "", [], []
             try:
+                progress.report(stage="decoding")
                 result = _transcribe_mlx(vad_wav, language)
             finally:
                 if vad_wav != wav:
                     Path(vad_wav).unlink(missing_ok=True)
         elif _non_mac_backend() == "whisperx":
+            progress.report(stage="decoding")
             result = _transcribe_whisperx(wav, language)
         else:
+            progress.report(stage="vad")
             vad_wav, offset_map = _vad_filter(wav)
             if vad_wav is None:
                 return "", "", [], []
             try:
+                progress.report(stage="decoding")
                 result = _transcribe_faster_whisper(vad_wav, language)
             finally:
                 if vad_wav != wav:
@@ -725,6 +735,7 @@ def _postprocess(text: str, lang: str, segments: list, language: str,
 
     # Step 5: LLM polish
     if LLM_POLISH and len(filtered_text) > 10:
+        progress.report(stage="polishing")
         filtered_text = _llm_polish_batched(filtered_text, language)
 
     # Step 6: words_json reconciliation. The per-segment filter above rebuilt
@@ -752,6 +763,7 @@ def _postprocess(text: str, lang: str, segments: list, language: str,
     # the same VAD-filtered wav the segments were timed against (passed by each
     # backend), so the labels line up with the timecodes.
     if wav_path and DIARIZATION_ENABLED:
+        progress.report(stage="diarizing")
         timed_segments = _attach_speaker_ids(timed_segments, wav_path)
 
     timed_segments = _split_long_segments(timed_segments)


### PR DESCRIPTION
`transcribe.py` 七行 `progress.report(stage=…)`：`extracting` / `vad` /
`decoding` / `polishing` / `diarizing`，加上 `GET .../retranscribe/status`。
簽章零變更，走 #361 的 context sink。

**刻意不做進度條。** whisper 解碼是一次不透明呼叫，中間沒有任何可靠的完成度可讀。
「decoding」掛四分鐘是實話；一條爬到 90% 然後停在那裡的進度條不是。UI 顯示的是
階段名稱（抽音軌／偵測語音／辨識中／潤稿中／分辨語者），測試也斷言回應裡**沒有**
任何 percent 欄位。

per-id claim 的定位這裡要講清楚，因為它跟 retry-vision 不同：whisper 在跑的時候
**process 級的 ingest slot 已經擋掉一切**，claim 在那段時間什麼也沒多做。它真正
覆蓋的是另一個窗口 —— slot 在解碼結束的當下就釋放（刻意的，後面那段 DB 寫入不佔
模型記憶體），而在那些寫入進行時，第二個 POST 會直接通過 slot、開始覆寫同一列。
測試從**寫入階段內部**發出那個請求（spy `db.upsert_transcript`），先斷言 slot 確實
是空的，再斷言第二個 POST 拿到 409 —— 那才是這個 claim 唯一擋得到的東西。

三條退出路徑都要交還 claim，否則這支素材要重啟 server 才能再轉錄：搶不到 slot
的 409、轉錄失敗的 500、以及「回空但既有逐字稿不為空」的 422。三條各有一支測試。

新增 6 支測試。mutation-check 六處全紅在該紅的位置：
  transcribe 不再報階段     → 階段測試紅
  sink 沒 bind 在呼叫外面   → status 測試紅
  拿掉 per-id claim         → 寫入窗口測試紅
  三條退出路徑各漏放 claim  → 三支各自紅

全套 1506 passed / 7 skipped。svelte-check 0 warnings。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>