### PR TITLE
fix(media): 畫一條波形要去解 4K 原檔

### DIFF
--- a/routers/media.py
+++ b/routers/media.py
@@ -34,7 +34,8 @@ import tag_quality
 from auth import require_scopes
 from config import BASE_DIR
 from mediarecords import _get_light_records_by_ids, _get_tags_bulk
-from pathres import _display_path, _resolve_frame, _resolve_media_path, _resolve_record
+from pathres import (_display_path, _proxy_ready, _resolve_frame,
+                     _resolve_media_path, _resolve_record)
 from reqopts import _parse_ids_query
 from scenes import _scenes_payload
 from state import (_acquire_ingest_slot, _release_ingest_slot,
@@ -501,7 +502,10 @@ def get_media_waveform(
     _tok: dict = Depends(require_scopes("media_read")),
 ):
     """Return pre-computed audio peaks (0..1) for the inspector waveform.
-    Cached per (id, bins) under waveforms/<id>_<bins>.json."""
+
+    Cached per (id, bins, source) under `waveforms/<id>_<bins>_<p|o>.json`, where
+    the last part records whether the peaks came from the arkiv proxy or the
+    original file."""
     rec = db.get_record_by_id(media_id)
     if not rec:
         raise HTTPException(404, "找不到")
@@ -510,15 +514,31 @@ def get_media_waveform(
     bins = max(8, min(500, bins))
     if not rec.get("has_audio"):
         return {"media_id": media_id, "bins": bins, "peaks": [0.0] * bins}
+    # Decode the proxy when there is one. /api/stream has done this since the
+    # proxy feature shipped; the waveform never did, so drawing the inspector's
+    # 60-bar strip meant a full ffmpeg decode of the 4K original — the single
+    # slowest thing the inspector does, on a file we already have a small H.264
+    # copy of. The proxy's AAC is a lossy re-encode, which moves a peak by less
+    # than one pixel at 60 bins.
+    resolved_src = _resolve_media_path(rec["path"])
+    proxy_path = config.proxy_path_for(media_id, resolved_src)
+    if _proxy_ready(proxy_path):
+        file_path, source_tag = proxy_path, "p"
+    else:
+        file_path, source_tag = Path(resolved_src), "o"
+
     cache_dir = BASE_DIR / "waveforms"
     cache_dir.mkdir(parents=True, exist_ok=True)
-    cache_path = cache_dir / f"{media_id}_{bins}.json"
+    # The source tag is part of the key on purpose. The old `{id}_{bins}.json`
+    # recorded nothing about WHERE the peaks came from, so the first cached answer
+    # would be served forever — a clip drawn from its original before a proxy
+    # existed would never be redrawn from the proxy, and vice versa.
+    cache_path = cache_dir / f"{media_id}_{bins}_{source_tag}.json"
     if cache_path.exists():
         try:
             return json.loads(cache_path.read_text(encoding="utf-8"))
         except Exception:
             cache_path.unlink(missing_ok=True)
-    file_path = Path(_resolve_media_path(rec["path"]))
     if not file_path.exists():
         raise HTTPException(404, "找不到檔案")
     peaks = _compute_waveform(str(file_path), bins)

--- a/tests/test_waveform_source.py
+++ b/tests/test_waveform_source.py
@@ -1,0 +1,182 @@
+"""The inspector's waveform decoded the 4K original every time.
+
+`/api/stream` has served the H.264 proxy since the proxy feature shipped. The
+waveform endpoint — which runs ffmpeg over the whole file to produce sixty numbers
+— never did. So drawing a 60-bar strip meant a full decode of the camera original,
+on a clip we already keep a small proxy of. It is the slowest thing the inspector
+does and the one with the least excuse.
+
+The second half of this is the cache key. `waveforms/{id}_{bins}.json` recorded
+nothing about where the peaks came from, so the first answer cached won a clip
+forever: draw it before its proxy exists and it is drawn from the original for
+good. The source is now part of the filename.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+import config
+import pathres
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cache(tmp_path, monkeypatch):
+    """The waveform cache lives under `BASE_DIR/waveforms` — the real repo
+    directory. Without this the tests write into the working tree AND read each
+    other's cached answers, which is how three of them first passed for the wrong
+    reason."""
+    import routers.media as rm
+    monkeypatch.setattr(rm, "BASE_DIR", tmp_path / "cache_root")
+    yield
+
+
+def _recording_waveform(seen, value=0.5):
+    def _compute(path, bins):
+        seen.append(path)
+        return [value] * bins
+    return _compute
+
+
+def _seed(db, sample_record, tmp_path):
+    src = tmp_path / "cam" / "A001.mov"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_bytes(b"\x00" * 16)
+    db.upsert(sample_record(path=str(src), filename="A001.mov", ext=".mov", has_audio=1))
+    return 1, src
+
+
+def _make_proxy(media_id, src):
+    p = config.proxy_path_for(media_id, str(src))
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"\x00" * 16)
+    return p
+
+
+def test_the_proxy_is_decoded_when_there_is_one(
+    fastapi_client, server_module, sample_record, tmp_path, monkeypatch
+):
+    db = importlib.import_module("db")
+    mid, src = _seed(db, sample_record, tmp_path)
+    proxy = _make_proxy(mid, src)
+
+    seen = []
+    import routers.media as rm
+    monkeypatch.setattr(rm, "_compute_waveform", _recording_waveform(seen))
+
+    r = fastapi_client.get("/api/media/%d/waveform?bins=8" % mid)
+
+    assert r.status_code == 200
+    assert seen == [str(proxy)], "decoded the original instead of the proxy"
+
+
+def test_the_original_is_decoded_when_there_is_no_proxy(
+    fastapi_client, server_module, sample_record, tmp_path, monkeypatch
+):
+    db = importlib.import_module("db")
+    mid, src = _seed(db, sample_record, tmp_path)
+
+    seen = []
+    import routers.media as rm
+    monkeypatch.setattr(rm, "_compute_waveform", _recording_waveform(seen))
+
+    fastapi_client.get("/api/media/%d/waveform?bins=8" % mid)
+
+    assert seen == [str(src)]
+
+
+def test_an_empty_proxy_file_is_not_treated_as_a_proxy(
+    fastapi_client, server_module, sample_record, tmp_path, monkeypatch
+):
+    """A killed encode leaves a zero-byte file. Decoding it yields no peaks at all,
+    and the clip would show a flat line forever — the same `_proxy_ready` rule
+    /api/stream uses."""
+    db = importlib.import_module("db")
+    mid, src = _seed(db, sample_record, tmp_path)
+    proxy = _make_proxy(mid, src)
+    proxy.write_bytes(b"")
+    assert pathres._proxy_ready(proxy) is False
+
+    seen = []
+    import routers.media as rm
+    monkeypatch.setattr(rm, "_compute_waveform", _recording_waveform(seen))
+
+    fastapi_client.get("/api/media/%d/waveform?bins=8" % mid)
+
+    assert seen == [str(src)]
+
+
+def test_the_cache_filename_records_the_source(
+    fastapi_client, server_module, sample_record, tmp_path, monkeypatch
+):
+    db = importlib.import_module("db")
+    mid, src = _seed(db, sample_record, tmp_path)
+    import routers.media as rm
+    monkeypatch.setattr(rm, "_compute_waveform", lambda path, bins: [0.25] * bins)
+
+    fastapi_client.get("/api/media/%d/waveform?bins=8" % mid)
+    _make_proxy(mid, src)
+    fastapi_client.get("/api/media/%d/waveform?bins=8" % mid)
+
+    import routers.media as rm2
+    names = sorted(p.name for p in (rm2.BASE_DIR / "waveforms").glob("*.json"))
+    assert names == ["%d_8_o.json" % mid, "%d_8_p.json" % mid]
+
+
+def test_gaining_a_proxy_redraws_instead_of_serving_the_old_picture(
+    fastapi_client, server_module, sample_record, tmp_path, monkeypatch
+):
+    """The bug the tag exists for. With one key per (id, bins) the answer computed
+    from the original is served for the rest of the library's life."""
+    db = importlib.import_module("db")
+    mid, src = _seed(db, sample_record, tmp_path)
+    import routers.media as rm
+
+    monkeypatch.setattr(rm, "_compute_waveform", lambda path, bins: [0.1] * bins)
+    first = fastapi_client.get("/api/media/%d/waveform?bins=8" % mid).json()
+
+    _make_proxy(mid, src)
+    monkeypatch.setattr(rm, "_compute_waveform", lambda path, bins: [0.9] * bins)
+    second = fastapi_client.get("/api/media/%d/waveform?bins=8" % mid).json()
+
+    assert first["peaks"][0] == 0.1
+    assert second["peaks"][0] == 0.9, "served the pre-proxy picture from cache"
+
+
+def test_the_cache_is_still_used_when_the_source_has_not_changed(
+    fastapi_client, server_module, sample_record, tmp_path, monkeypatch
+):
+    """Tagging must not accidentally turn the cache off — that would make every
+    inspector click re-decode."""
+    db = importlib.import_module("db")
+    mid, _src = _seed(db, sample_record, tmp_path)
+    import routers.media as rm
+
+    calls = []
+    monkeypatch.setattr(rm, "_compute_waveform", _recording_waveform(calls, 0.3))
+
+    fastapi_client.get("/api/media/%d/waveform?bins=8" % mid)
+    fastapi_client.get("/api/media/%d/waveform?bins=8" % mid)
+
+    assert len(calls) == 1
+
+
+def test_a_clip_whose_original_is_offline_still_draws_from_its_proxy(
+    fastapi_client, server_module, sample_record, tmp_path, monkeypatch
+):
+    """A side effect worth having: the NAS being unmounted no longer blanks the
+    waveform for clips that have a local proxy."""
+    db = importlib.import_module("db")
+    mid, src = _seed(db, sample_record, tmp_path)
+    _make_proxy(mid, src)
+    src.unlink()
+
+    import routers.media as rm
+    monkeypatch.setattr(rm, "_compute_waveform", lambda path, bins: [0.4] * bins)
+
+    r = fastapi_client.get("/api/media/%d/waveform?bins=8" % mid)
+
+    assert r.status_code == 200
+    assert r.json()["peaks"][0] == 0.4


### PR DESCRIPTION
`/api/stream` 從 proxy 功能上線那天就會優先送 H.264 proxy。**波形端點沒有。**
所以 inspector 那條 60 格的小波形，每次都是對攝影機原檔跑一次完整 ffmpeg 解碼
—— 為了六十個數字，解一支我們手上早就有小版本的 4K 檔。那是 inspector 裡最慢的
一件事，而且最沒有理由。

改成有 proxy 就解 proxy。proxy 的 AAC 是有損重編碼，但在 60 格的尺度下，一個峰值
的位移小於一個像素。用的是 `_proxy_ready` 而不是 `exists()` —— 被 kill 的編碼會
留下零位元組檔案，解它會得到「一條平線」而不是錯誤，那種假資料還會被寫進快取。

**第二半是快取鍵。** 舊的 `waveforms/{id}_{bins}.json` 完全沒記錄峰值是從哪裡來的，
所以第一次算出來的答案就贏得這支素材的餘生：在 proxy 生成之前畫過一次，之後永遠
拿原檔那張圖，反之亦然。現在檔名是 `{id}_{bins}_{p|o}.json`。

順帶得到一個值得有的副作用：**NAS 沒掛載時，有本機 proxy 的素材仍然畫得出波形**。

新增 7 支測試。其中三支一開始是**因為錯的理由通過的** —— 波形快取寫在
`BASE_DIR/waveforms`，也就是真實的 repo 目錄，測試互相讀到對方的快取、還在工作區
留下檔案。加了 autouse fixture 把 `BASE_DIR` 指到 tmp 才是真的在測東西。

mutation-check 四處全紅在該紅的位置：
  忽略 proxy 解原檔        → proxy 測試紅
  用 exists() 取代 _proxy_ready → 零位元組測試紅
  快取鍵拿掉來源標記        → 「換來源要重畫」測試紅
  完全不讀快取              → 快取命中測試紅

全套 1513 passed / 7 skipped。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>