### PR TITLE
feat(media): 剪接師手上已經有 proxy 了

### DIFF
--- a/pathres.py
+++ b/pathres.py
@@ -102,3 +102,72 @@ def _proxy_ready(p: Path) -> bool:
         return p.exists() and p.stat().st_size > 0
     except OSError:
         return False
+
+
+# ── editor-supplied proxies (Resolve/Premiere sidecar folders) ───────────────
+# Cutting rooms already make proxies. When the footage came from one, there is a
+# `Proxy/` folder next to the media holding a small H.264 of every clip — and
+# arkiv has been re-encoding its own copy of something that already exists.
+_EDITOR_PROXY_DIRS = ("Proxy", "proxy", "PROXY")
+_EDITOR_PROXY_EXTS = (".mp4", ".mov", ".mxf")
+
+
+def _probe_duration(path: str):
+    """Seconds, or None if ffprobe can't say. Deliberately its own tiny call
+    (`-show_entries format=duration`) rather than ingest.probe: this runs on a
+    request path and does not need the full stream dump."""
+    import json as _json
+    import subprocess
+
+    import config
+    try:
+        r = subprocess.run(
+            [config.FFPROBE_PATH, "-v", "error", "-print_format", "json",
+             "-show_entries", "format=duration", path],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=20,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if r.returncode != 0:
+        return None
+    try:
+        return float(_json.loads(r.stdout)["format"]["duration"])
+    except (ValueError, KeyError, TypeError):
+        return None
+
+
+def editor_proxy_for(src: str, duration_s, fps=None, exts=_EDITOR_PROXY_EXTS):
+    """A sidecar `Proxy/<stem>.<ext>` for `src`, ONLY if its duration matches.
+
+    The duration gate is not defensive padding — it is the whole reason this is
+    safe. A Resolve proxy routinely carries handles, a slate, or a different start
+    timecode, so "same stem, same folder" is not "same media". A proxy two seconds
+    longer would silently shift every trimmed SRT, every waveform bar, and every
+    IN/OUT derived from it, in a way that looks like a transcription bug rather
+    than a file-picking bug.
+
+    Tolerance is one frame, floored at 0.5 s: a proxy legitimately differs by up
+    to a frame from rounding, and below ~2 fps the frame-based bound gets silly.
+
+    Returns None — never a guess — when the duration is unknown on either side.
+    Not knowing is exactly the case where picking the wrong file is unrecoverable.
+    """
+    if not src or not duration_s or float(duration_s) <= 0:
+        return None
+    source = Path(src)
+    tolerance = max(0.5, 1.0 / float(fps)) if fps else 0.5
+    for dirname in _EDITOR_PROXY_DIRS:
+        folder = source.parent / dirname
+        if not folder.is_dir():
+            continue
+        for ext in exts:
+            candidate = folder / (source.stem + ext)
+            if not _proxy_ready(candidate):
+                continue
+            probed = _probe_duration(str(candidate))
+            if probed is None:
+                continue
+            if abs(probed - float(duration_s)) <= tolerance:
+                return candidate
+    return None

--- a/routers/media.py
+++ b/routers/media.py
@@ -35,7 +35,7 @@ from auth import require_scopes
 from config import BASE_DIR
 from mediarecords import _get_light_records_by_ids, _get_tags_bulk
 from pathres import (_display_path, _proxy_ready, _resolve_frame,
-                     _resolve_media_path, _resolve_record)
+                     _resolve_media_path, _resolve_record, editor_proxy_for)
 from reqopts import _parse_ids_query
 from scenes import _scenes_payload
 from state import (_acquire_ingest_slot, _release_ingest_slot,
@@ -504,8 +504,8 @@ def get_media_waveform(
     """Return pre-computed audio peaks (0..1) for the inspector waveform.
 
     Cached per (id, bins, source) under `waveforms/<id>_<bins>_<p|o>.json`, where
-    the last part records whether the peaks came from the arkiv proxy or the
-    original file."""
+    the last part records where the peaks came from: `p` arkiv proxy, `e` the
+    cutting room's own sidecar proxy, `o` the original file."""
     rec = db.get_record_by_id(media_id)
     if not rec:
         raise HTTPException(404, "找不到")
@@ -521,24 +521,43 @@ def get_media_waveform(
     # copy of. The proxy's AAC is a lossy re-encode, which moves a peak by less
     # than one pixel at 60 bins.
     resolved_src = _resolve_media_path(rec["path"])
-    proxy_path = config.proxy_path_for(media_id, resolved_src)
-    if _proxy_ready(proxy_path):
-        file_path, source_tag = proxy_path, "p"
-    else:
-        file_path, source_tag = Path(resolved_src), "o"
-
     cache_dir = BASE_DIR / "waveforms"
     cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _cache(tag):
+        return cache_dir / f"{media_id}_{bins}_{tag}.json"
+
+    arkiv_proxy = config.proxy_path_for(media_id, resolved_src)
+    if _proxy_ready(arkiv_proxy):
+        file_path, source_tag = arkiv_proxy, "p"
+    elif _cache("e").exists():
+        # An editor-proxy answer we already computed. Served without re-probing:
+        # finding that proxy costs an ffprobe, and paying it on every poll of an
+        # already-cached waveform would undo the point of caching.
+        file_path, source_tag = None, "e"
+    else:
+        editor = editor_proxy_for(resolved_src, rec.get("duration_s"), rec.get("fps"))
+        if editor is not None:
+            file_path, source_tag = editor, "e"
+        else:
+            file_path, source_tag = Path(resolved_src), "o"
+
     # The source tag is part of the key on purpose. The old `{id}_{bins}.json`
     # recorded nothing about WHERE the peaks came from, so the first cached answer
     # would be served forever — a clip drawn from its original before a proxy
     # existed would never be redrawn from the proxy, and vice versa.
-    cache_path = cache_dir / f"{media_id}_{bins}_{source_tag}.json"
+    cache_path = _cache(source_tag)
     if cache_path.exists():
         try:
             return json.loads(cache_path.read_text(encoding="utf-8"))
         except Exception:
             cache_path.unlink(missing_ok=True)
+    if file_path is None:
+        # The 'e' cache we were about to serve turned out to be unreadable; find
+        # the editor proxy again rather than 500 on a corrupt cache file.
+        file_path = editor_proxy_for(resolved_src, rec.get("duration_s"), rec.get("fps"))
+        if file_path is None:
+            file_path, cache_path = Path(resolved_src), _cache("o")
     if not file_path.exists():
         raise HTTPException(404, "找不到檔案")
     peaks = _compute_waveform(str(file_path), bins)

--- a/tests/test_editor_proxy.py
+++ b/tests/test_editor_proxy.py
@@ -1,0 +1,247 @@
+"""The cutting room already made proxies; arkiv re-encoded its own anyway.
+
+When footage comes from an edit, there is usually a `Proxy/` folder sitting next to
+the media with a small H.264 of every clip. arkiv ignored it and built a second
+copy — or, when it had built nothing yet, decoded the 4K original.
+
+**The duration gate is the whole reason this is safe to use**, not padding around
+it. A Resolve proxy routinely carries handles, a slate, or a different start
+timecode. "Same stem, same folder" is not "same media", and a proxy two seconds
+longer would shift every waveform bar and every trimmed export derived from it — a
+mis-picked file that looks like a transcription bug.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+import config
+import pathres
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cache(tmp_path, monkeypatch):
+    import routers.media as rm
+    monkeypatch.setattr(rm, "BASE_DIR", tmp_path / "cache_root")
+    yield
+
+
+@pytest.fixture
+def clip(tmp_path):
+    src = tmp_path / "cam" / "A001.mov"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_bytes(b"\x00" * 16)
+    return src
+
+
+def _sidecar(src, name="A001.mp4", dirname="Proxy"):
+    folder = src.parent / dirname
+    folder.mkdir(exist_ok=True)
+    p = folder / name
+    p.write_bytes(b"\x00" * 16)
+    return p
+
+
+def _probe(monkeypatch, seconds):
+    """Stand in for ffprobe. `seconds` may be a dict keyed by path."""
+    def _fake(path):
+        return seconds.get(path) if isinstance(seconds, dict) else seconds
+    monkeypatch.setattr(pathres, "_probe_duration", _fake)
+
+
+# ── the finder ───────────────────────────────────────────────────────────────
+
+def test_a_matching_sidecar_proxy_is_found(clip, monkeypatch):
+    proxy = _sidecar(clip)
+    _probe(monkeypatch, 12.0)
+
+    assert pathres.editor_proxy_for(str(clip), 12.0, 30.0) == proxy
+
+
+def test_a_proxy_with_handles_is_refused(clip, monkeypatch):
+    """Two seconds of handle. This is the case the gate exists for — and the one
+    that would be silently wrong everywhere downstream."""
+    _sidecar(clip)
+    _probe(monkeypatch, 14.0)
+
+    assert pathres.editor_proxy_for(str(clip), 12.0, 30.0) is None
+
+
+def test_one_frame_of_difference_is_tolerated(clip, monkeypatch):
+    """Rounding between containers legitimately moves the duration by a frame."""
+    proxy = _sidecar(clip)
+    _probe(monkeypatch, 12.0 + 1.0 / 30.0 - 0.001)
+
+    assert pathres.editor_proxy_for(str(clip), 12.0, 30.0) == proxy
+
+
+def test_the_tolerance_never_goes_below_half_a_second(clip, monkeypatch):
+    """At 120 fps one frame is 8 ms — tighter than container rounding, which would
+    reject perfectly good proxies."""
+    proxy = _sidecar(clip)
+    _probe(monkeypatch, 12.4)
+
+    assert pathres.editor_proxy_for(str(clip), 12.0, 120.0) == proxy
+
+
+def test_an_unknown_source_duration_refuses_rather_than_guesses(clip, monkeypatch):
+    _sidecar(clip)
+    _probe(monkeypatch, 12.0)
+
+    assert pathres.editor_proxy_for(str(clip), None, 30.0) is None
+    assert pathres.editor_proxy_for(str(clip), 0, 30.0) is None
+
+
+def test_an_unprobeable_candidate_refuses_rather_than_guesses(clip, monkeypatch):
+    _sidecar(clip)
+    _probe(monkeypatch, None)
+
+    assert pathres.editor_proxy_for(str(clip), 12.0, 30.0) is None
+
+
+def test_a_zero_byte_proxy_is_ignored(clip, monkeypatch):
+    p = _sidecar(clip)
+    p.write_bytes(b"")
+    _probe(monkeypatch, 12.0)
+
+    assert pathres.editor_proxy_for(str(clip), 12.0, 30.0) is None
+
+
+def test_no_proxy_folder_is_not_an_error(clip, monkeypatch):
+    _probe(monkeypatch, 12.0)
+    assert pathres.editor_proxy_for(str(clip), 12.0, 30.0) is None
+
+
+@pytest.mark.parametrize("dirname", ["Proxy", "proxy", "PROXY"])
+def test_the_folder_name_may_be_any_of_the_usual_spellings(clip, monkeypatch, dirname):
+    """macOS is case-insensitive so this looks like one name locally; on the NAS
+    the footage actually lives on, it is three."""
+    proxy = _sidecar(clip, dirname=dirname)
+    _probe(monkeypatch, 12.0)
+
+    found = pathres.editor_proxy_for(str(clip), 12.0, 30.0)
+    # samefile, not ==: on a case-insensitive filesystem the finder reports whichever
+    # spelling it tried first, which is the same file by a different name. On the
+    # NAS the footage actually lives on, these are three distinct directories.
+    assert found is not None and found.samefile(proxy)
+
+
+def test_a_mov_sidecar_is_accepted_too(clip, monkeypatch):
+    proxy = _sidecar(clip, name="A001.mov")
+    _probe(monkeypatch, 12.0)
+
+    assert pathres.editor_proxy_for(str(clip), 12.0, 30.0) == proxy
+
+
+# ── through the waveform endpoint ────────────────────────────────────────────
+
+def _seed(db, sample_record, src, duration=12.0, fps=30.0):
+    db.upsert(sample_record(path=str(src), filename=src.name, ext=src.suffix,
+                            has_audio=1, duration_s=duration, fps=fps))
+    return 1
+
+
+def test_the_waveform_decodes_the_editor_proxy(
+    fastapi_client, server_module, sample_record, clip, monkeypatch
+):
+    db = importlib.import_module("db")
+    mid = _seed(db, sample_record, clip)
+    proxy = _sidecar(clip)
+    _probe(monkeypatch, 12.0)
+
+    seen = []
+    import routers.media as rm
+    monkeypatch.setattr(rm, "_compute_waveform",
+                        lambda path, bins: seen.append(path) or [0.6] * bins)
+
+    r = fastapi_client.get("/api/media/%d/waveform?bins=8" % mid)
+
+    assert r.status_code == 200
+    assert seen == [str(proxy)]
+    assert (rm.BASE_DIR / "waveforms" / ("%d_8_e.json" % mid)).exists()
+
+
+def test_the_arkiv_proxy_still_wins_over_the_editor_one(
+    fastapi_client, server_module, sample_record, clip, monkeypatch
+):
+    """Ours is a known quantity — same duration by construction, H.264, made for
+    this. The sidecar is a fallback for clips we have not proxied yet."""
+    db = importlib.import_module("db")
+    mid = _seed(db, sample_record, clip)
+    _sidecar(clip)
+    _probe(monkeypatch, 12.0)
+    ours = config.proxy_path_for(mid, str(clip))
+    ours.parent.mkdir(parents=True, exist_ok=True)
+    ours.write_bytes(b"\x00" * 16)
+
+    seen = []
+    import routers.media as rm
+    monkeypatch.setattr(rm, "_compute_waveform",
+                        lambda path, bins: seen.append(path) or [0.6] * bins)
+
+    fastapi_client.get("/api/media/%d/waveform?bins=8" % mid)
+
+    assert seen == [str(ours)]
+
+
+def test_a_cached_editor_answer_is_served_without_probing_again(
+    fastapi_client, server_module, sample_record, clip, monkeypatch
+):
+    """Finding a sidecar costs an ffprobe. Paying it on every poll of an already
+    cached waveform would undo the point of the cache."""
+    db = importlib.import_module("db")
+    mid = _seed(db, sample_record, clip)
+    _sidecar(clip)
+
+    probes = []
+    monkeypatch.setattr(pathres, "_probe_duration",
+                        lambda path: probes.append(path) or 12.0)
+    import routers.media as rm
+    monkeypatch.setattr(rm, "_compute_waveform", lambda path, bins: [0.6] * bins)
+
+    fastapi_client.get("/api/media/%d/waveform?bins=8" % mid)
+    assert len(probes) == 1
+    fastapi_client.get("/api/media/%d/waveform?bins=8" % mid)
+    assert len(probes) == 1, "re-probed on a cache hit"
+
+
+def test_a_corrupt_editor_cache_falls_back_instead_of_500ing(
+    fastapi_client, server_module, sample_record, clip, monkeypatch
+):
+    db = importlib.import_module("db")
+    mid = _seed(db, sample_record, clip)
+    proxy = _sidecar(clip)
+    _probe(monkeypatch, 12.0)
+    import routers.media as rm
+    (rm.BASE_DIR / "waveforms").mkdir(parents=True, exist_ok=True)
+    (rm.BASE_DIR / "waveforms" / ("%d_8_e.json" % mid)).write_text("{not json", encoding="utf-8")
+
+    seen = []
+    monkeypatch.setattr(rm, "_compute_waveform",
+                        lambda path, bins: seen.append(path) or [0.7] * bins)
+
+    r = fastapi_client.get("/api/media/%d/waveform?bins=8" % mid)
+
+    assert r.status_code == 200
+    assert seen == [str(proxy)]
+
+
+def test_a_mismatched_sidecar_leaves_the_waveform_on_the_original(
+    fastapi_client, server_module, sample_record, clip, monkeypatch
+):
+    """End to end: the gate has to hold at the endpoint, not only in the helper."""
+    db = importlib.import_module("db")
+    mid = _seed(db, sample_record, clip)
+    _sidecar(clip)
+    _probe(monkeypatch, 14.0)  # two seconds of handles
+
+    seen = []
+    import routers.media as rm
+    monkeypatch.setattr(rm, "_compute_waveform",
+                        lambda path, bins: seen.append(path) or [0.6] * bins)
+
+    fastapi_client.get("/api/media/%d/waveform?bins=8" % mid)
+
+    assert seen == [str(clip)]


### PR DESCRIPTION
素材來自剪接室時，媒體旁邊通常就有一個 `Proxy/` 資料夾，裡面每一支都有一份小的
H.264。arkiv 完全無視它，自己再編一份 —— 或者在還沒編之前，直接去解 4K 原檔。

`pathres.editor_proxy_for()` 找 `<src.parent>/{Proxy,proxy,PROXY}/<stem>.{mp4,mov,mxf}`。

**時長閘不是防禦性的補丁，它是這件事能不能做的前提。** Resolve 的 proxy 帶
handle、帶 slate、起始 timecode 不同，全都是常態。「同一個檔名、同一個資料夾」
不等於「同一段媒體」，而一份長兩秒的 proxy 會讓每一格波形、每一份 trim 過的匯出
都位移 —— 那看起來會像轉錄有問題，不像挑錯檔案。

- 容差＝一格，最低 0.5 秒（120fps 一格是 8ms，比容器捨入還嚴，會誤殺好 proxy）
- 兩邊任一邊時長不明就**回 None，不猜**。不確定的時候正是「挑錯檔案無法挽回」
  的時候
- 資料夾三種拼法都找：macOS 大小寫不敏感所以本機看起來是同一個，但素材真正住的
  那台 NAS 上是三個不同目錄

先只給波形用。優先序是 **arkiv 自己的 proxy > 剪接室的 > 原檔**：我們自己那份是
已知量（時長由建構保證、H.264、就是為這件事做的），sidecar 是還沒 proxy 過的素材
的退路。

**快取不會為此變慢**：找 sidecar 要花一次 ffprobe，所以 `{id}_{bins}_e.json` 命中
時直接送，不重新探測；那份快取壞掉時退回重找，而不是 500。

新增 17 支測試。mutation-check 八處全紅在該紅的位置：
  拿掉時長閘             → handle 測試紅
  時長不明就猜           → 「不猜」測試紅
  探測不到就當通過       → 同上
  拿掉 0.5 秒下限        → 120fps 測試紅
  零位元組 sidecar 收下  → 空檔測試紅
  波形不看 sidecar       → 端到端測試紅
  sidecar 蓋過我們自己的 → 優先序測試紅
  每次命中都重新探測     → 快取測試紅

全套 1530 passed / 7 skipped。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>