### PR TITLE
fix(stream): ProRes 原檔配 ProRes proxy 不能當成「能播」

### DIFF
--- a/routers/misc.py
+++ b/routers/misc.py
@@ -24,7 +24,7 @@ import config
 import db
 import mediatypes
 from auth import require_scopes
-from pathres import _proxy_ready, _resolve_media_path
+from pathres import _proxy_ready, _resolve_media_path, editor_proxy_for
 from state import _rebuild_embeddings, embed_rebuild as _embed_guard
 from webguard import _assert_same_site
 
@@ -65,14 +65,29 @@ def stream_media(media_id: int, _tok: dict = Depends(require_scopes("videos_read
     # proxies/ directory copied between installations cannot serve another
     # user's content under the same media_id.
     resolved_src = _resolve_media_path(rec["path"])
-    proxy_path = config.proxy_path_for(media_id, resolved_src)
-    if _proxy_ready(proxy_path):
+
+    # Pick a candidate first, then put EVERY candidate through the same gate.
+    # The old shape returned arkiv's proxy early, which was fine while ours was
+    # the only alternative — it is H.264 by construction. It stops being fine the
+    # moment a second candidate exists: a ProRes original sitting next to a ProRes
+    # sidecar proxy would have been declared playable purely because a file was
+    # found, and the browser would show "cannot play" with no explanation.
+    arkiv_proxy = config.proxy_path_for(media_id, resolved_src)
+    if _proxy_ready(arkiv_proxy):
+        # Ours is H.264 by construction — the one candidate that needs no probe.
         return FileResponse(
-            path=str(proxy_path),
+            path=str(arkiv_proxy),
             media_type="video/mp4",
             filename=Path(resolved_src).stem + "_proxy.mp4",
         )
-    file_path = Path(resolved_src)
+
+    # A cutting-room sidecar. `.mxf` is excluded on purpose: a browser cannot demux
+    # it whatever the codec inside, so serving one is a guaranteed black player.
+    file_path = editor_proxy_for(resolved_src, rec.get("duration_s"), rec.get("fps"),
+                                 exts=(".mp4", ".mov"))
+    serving_editor_proxy = file_path is not None
+    if file_path is None:
+        file_path = Path(resolved_src)
     if not file_path.exists():
         raise HTTPException(404, "找不到檔案")
     # Only serve known media extensions
@@ -88,15 +103,23 @@ def stream_media(media_id: int, _tok: dict = Depends(require_scopes("videos_read
     # on EVERY playback; only probe when the column is NULL (legacy rows) and
     # backfill so the next play is probe-free. None (probe failed / audio-only)
     # keeps the UNKNOWN fall-through behavior.
-    stored_codec = (rec.get("codec") or "").strip().lower() or None
-    if stored_codec is None:
+    if serving_editor_proxy:
+        # Probe the CANDIDATE, never the record: `media.codec` describes the
+        # original, and a sidecar is frequently a different codec (that is the
+        # point of it). And do NOT write the answer back — backfilling
+        # `media.codec` from a proxy would make the library claim the camera
+        # original is H.264, which every later decision then acts on.
         stored_codec = codec.probe_codec(str(file_path))
-        if stored_codec:
-            try:
-                with db.get_conn() as conn:
-                    conn.execute("UPDATE media SET codec=? WHERE id=?", (stored_codec, media_id))
-            except Exception:
-                pass  # backfill is best-effort; playback must not fail on it
+    else:
+        stored_codec = (rec.get("codec") or "").strip().lower() or None
+        if stored_codec is None:
+            stored_codec = codec.probe_codec(str(file_path))
+            if stored_codec:
+                try:
+                    with db.get_conn() as conn:
+                        conn.execute("UPDATE media SET codec=? WHERE id=?", (stored_codec, media_id))
+                except Exception:
+                    pass  # backfill is best-effort; playback must not fail on it
     if stored_codec and stored_codec in codec.PROXY_CODECS:
         return JSONResponse(
             status_code=409,

--- a/tests/test_stream_candidates.py
+++ b/tests/test_stream_candidates.py
@@ -1,0 +1,189 @@
+"""`/api/stream` picks a file, then every candidate goes through the same gate.
+
+The old shape returned arkiv's own proxy early and only gated the original. That
+was fine while ours was the only alternative — it is H.264 by construction. It
+stops being fine the moment there is a second candidate: a ProRes original next to
+a ProRes sidecar proxy would be declared playable because a file was *found*, and
+the viewer gets a black player with no explanation.
+
+Two rules that are easy to get wrong and expensive when wrong:
+
+* **`.mxf` is not a candidate.** A browser cannot demux it whatever the codec
+  inside, so serving one is a guaranteed black player rather than a 409 the UI can
+  act on.
+* **Never write a proxy's codec back to `media.codec`.** That column describes the
+  camera original, and a sidecar being a different codec is the entire point of it.
+  Backfilling from the proxy makes the library claim the original is H.264, and
+  every later decision believes it.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import codec
+import config
+import pathres
+
+
+@pytest.fixture
+def clip(tmp_path):
+    src = tmp_path / "cam" / "A001.mov"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_bytes(b"\x00" * 16)
+    return src
+
+
+def _seed(db, sample_record, src, **over):
+    rec = dict(path=str(src), filename=src.name, ext=src.suffix,
+               duration_s=12.0, fps=30.0, has_audio=1)
+    rec.update(over)
+    db.upsert(sample_record(**rec))
+    return 1
+
+
+def _sidecar(src, name="A001.mp4"):
+    folder = src.parent / "Proxy"
+    folder.mkdir(exist_ok=True)
+    p = folder / name
+    p.write_bytes(b"\x00" * 16)
+    return p
+
+
+def _probe_duration(monkeypatch, seconds=12.0):
+    monkeypatch.setattr(pathres, "_probe_duration", lambda path: seconds)
+
+
+def test_a_playable_sidecar_is_served(
+    fastapi_client, server_module, sample_record, clip, monkeypatch
+):
+    db = importlib.import_module("db")
+    mid = _seed(db, sample_record, clip, codec="prores")
+    proxy = _sidecar(clip)
+    _probe_duration(monkeypatch)
+    monkeypatch.setattr(codec, "probe_codec", lambda path, **k: "h264")
+
+    r = fastapi_client.get("/api/stream/%d" % mid)
+
+    assert r.status_code == 200
+    assert r.headers["content-disposition"].endswith('A001.mp4"')
+
+
+def test_a_prores_sidecar_is_refused_like_any_other_prores(
+    fastapi_client, server_module, sample_record, clip, monkeypatch
+):
+    """The case the restructure exists for. Finding a file is not the same as
+    finding a playable one."""
+    db = importlib.import_module("db")
+    mid = _seed(db, sample_record, clip, codec="prores")
+    _sidecar(clip, name="A001.mov")
+    _probe_duration(monkeypatch)
+    monkeypatch.setattr(codec, "probe_codec", lambda path, **k: "prores")
+
+    r = fastapi_client.get("/api/stream/%d" % mid)
+
+    assert r.status_code == 409
+    assert r.json()["need_proxy"] is True
+
+
+def test_an_mxf_sidecar_is_never_a_candidate(
+    fastapi_client, server_module, sample_record, clip, monkeypatch
+):
+    """Even H.264 inside MXF: no browser demuxes the container."""
+    db = importlib.import_module("db")
+    mid = _seed(db, sample_record, clip, codec="prores")
+    _sidecar(clip, name="A001.mxf")
+    _probe_duration(monkeypatch)
+    probed = []
+    monkeypatch.setattr(codec, "probe_codec",
+                        lambda path, **k: probed.append(path) or "prores")
+
+    r = fastapi_client.get("/api/stream/%d" % mid)
+
+    assert r.status_code == 409  # fell through to the original, which is ProRes
+    assert all(not p.endswith(".mxf") for p in probed)
+
+
+def test_the_candidate_is_probed_not_the_stored_codec(
+    fastapi_client, server_module, sample_record, clip, monkeypatch
+):
+    """`media.codec` describes the ORIGINAL. Trusting it for a sidecar would
+    refuse a perfectly playable proxy because the camera shot ProRes."""
+    db = importlib.import_module("db")
+    mid = _seed(db, sample_record, clip, codec="prores")
+    proxy = _sidecar(clip)
+    _probe_duration(monkeypatch)
+    probed = []
+    monkeypatch.setattr(codec, "probe_codec", lambda path, **k: probed.append(path) or "h264")
+
+    r = fastapi_client.get("/api/stream/%d" % mid)
+
+    assert r.status_code == 200
+    assert probed == [str(proxy)]
+
+
+def test_the_proxy_codec_is_not_written_back_to_the_record(
+    fastapi_client, server_module, sample_record, clip, monkeypatch
+):
+    """The quiet, permanent version of the bug: after one playback the library
+    would believe the ProRes original is H.264."""
+    db = importlib.import_module("db")
+    mid = _seed(db, sample_record, clip, codec=None)
+    _sidecar(clip)
+    _probe_duration(monkeypatch)
+    monkeypatch.setattr(codec, "probe_codec", lambda path, **k: "h264")
+
+    fastapi_client.get("/api/stream/%d" % mid)
+
+    assert (db.get_record_by_id(mid).get("codec") or "") == ""
+
+
+def test_the_original_still_backfills_its_own_codec(
+    fastapi_client, server_module, sample_record, clip, monkeypatch
+):
+    """The existing behaviour for legacy rows must survive the restructure —
+    probing on every playback is what that backfill avoids."""
+    db = importlib.import_module("db")
+    mid = _seed(db, sample_record, clip, codec=None)
+    monkeypatch.setattr(codec, "probe_codec", lambda path, **k: "h264")
+
+    fastapi_client.get("/api/stream/%d" % mid)
+
+    assert db.get_record_by_id(mid).get("codec") == "h264"
+
+
+def test_our_own_proxy_still_wins_and_needs_no_probe(
+    fastapi_client, server_module, sample_record, clip, monkeypatch
+):
+    db = importlib.import_module("db")
+    mid = _seed(db, sample_record, clip, codec="prores")
+    _sidecar(clip)
+    _probe_duration(monkeypatch)
+    ours = config.proxy_path_for(mid, str(clip))
+    ours.parent.mkdir(parents=True, exist_ok=True)
+    ours.write_bytes(b"\x00" * 16)
+    probed = []
+    monkeypatch.setattr(codec, "probe_codec", lambda path, **k: probed.append(path) or "prores")
+
+    r = fastapi_client.get("/api/stream/%d" % mid)
+
+    assert r.status_code == 200
+    assert probed == [], "arkiv's own proxy is H.264 by construction"
+
+
+def test_a_mismatched_sidecar_is_not_served(
+    fastapi_client, server_module, sample_record, clip, monkeypatch
+):
+    """The duration gate applies here too: a proxy with handles would play, but
+    every seek the user makes would land in the wrong place."""
+    db = importlib.import_module("db")
+    mid = _seed(db, sample_record, clip, codec="h264")
+    _sidecar(clip)
+    _probe_duration(monkeypatch, 14.0)  # two seconds of handles
+    monkeypatch.setattr(codec, "probe_codec", lambda path, **k: "h264")
+
+    r = fastapi_client.get("/api/stream/%d" % mid)
+
+    assert r.status_code == 200
+    assert r.headers["content-disposition"].endswith('A001.mov"')  # the original


### PR DESCRIPTION
`/api/stream` 原本的形狀是「找到 arkiv 的 proxy 就直接送」，只對原檔做 codec 閘。
在我們自己那份是唯一替代品的時候那沒問題 —— 它按建構就是 H.264。**第二個候選一
出現就不成立了**：ProRes 原檔旁邊放一份 ProRes 的 sidecar proxy，會因為「找到檔案」
而被判定可播，使用者拿到的是一個黑掉的播放器、沒有任何說明。

改成「先挑候選 → 每個候選都過同一道閘」：
  arkiv proxy（H.264 by construction，唯一不必探測的）
  → 剪接室 sidecar（**只收 `.mp4`/`.mov`**）
  → 原檔
  → 既有的 409 need_proxy 閘

**`.mxf` 刻意排除**：不管裡面是什麼 codec，瀏覽器都 demux 不了它，送出去保證是
黑畫面，而不是一個 UI 可以拿來引導使用者的 409。

**探測候選本身，不要讀 `media.codec`。** 那個欄位描述的是原檔，而 sidecar 是不同
codec 正是它存在的理由；拿原檔的 codec 去判 sidecar，會把一份完全能播的 proxy 擋掉，
只因為攝影機拍的是 ProRes。

**而且探測結果不准寫回去。** 這是同一個 bug 安靜且永久的版本：回填一次之後，
資料庫就會宣稱那支 ProRes 原檔是 H.264，之後每一個決定都相信它。原檔自己的 codec
回填照舊（那是避免每次播放都探測的機制），只有 proxy 這條不寫。

新增 8 支測試。mutation-check 五處全紅在該紅的位置：
  完全不看 sidecar        → 播放測試紅
  .mxf 收進候選           → mxf 測試紅
  sidecar 不過閘直接送     → ProRes sidecar 測試紅
  sidecar 讀 media.codec  → 探測對象測試紅
  proxy 的 codec 寫回      → 汙染測試紅

全套 1538 passed / 7 skipped。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>