### PR TITLE
fix(misc): 舊 library 的「在 Finder 顯示」永遠 403

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -344,9 +344,16 @@ export const getChapters = (id, format = 'youtube', opts) =>
   req(`/api/media/${id}/chapters?format=${format}`, opts)
 // /api/media/{id}/remotion-props → word-level caption props (JSON)
 export const getRemotionProps = (id, opts) => req(`/api/media/${id}/remotion-props`, opts)
-// POST /api/open-file {path, reveal} → reveal in Finder/Explorer (reveal=true) or open
-export const openFile = (path, reveal = true, opts) =>
-  req('/api/open-file', { method: 'POST', body: { path, reveal }, ...opts })
+// POST /api/open-file {path?, media_id?, reveal} → reveal in Finder/Explorer or open.
+// Send media_id whenever it is known: a library indexed before the relative-path
+// migration reports only a basename as its path, which the server cannot match back
+// to a row — every reveal on such a library 403s.
+export const openFile = (path, reveal = true, opts, mediaId = null) =>
+  req('/api/open-file', {
+    method: 'POST',
+    body: mediaId != null ? { media_id: mediaId, reveal } : { path, reveal },
+    ...opts,
+  })
 // /api/cache/info → {caches:{...}}; POST /api/cache/clear?target=app|thumbnails|chromadb|waveforms|all
 export const cacheInfo = (opts) => req('/api/cache/info', opts)
 export const clearCache = (target = 'app', opts) =>

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -203,8 +203,8 @@
       pushToast(`Remotion props 已匯出 · ${_stem(id, name)}.remotion.json`)
     } catch (e) { pushToast(`Remotion 匯出失敗: ${e.message}`, 'error') }
   }
-  async function revealFile(path) {
-    try { await api.openFile(path, true) } catch (e) { pushToast(`在 Finder 顯示失敗: ${e.message}`, 'error') }
+  async function revealFile(path, mediaId = null) {
+    try { await api.openFile(path, true, undefined, mediaId) } catch (e) { pushToast(`在 Finder 顯示失敗: ${e.message}`, 'error') }
   }
 
   // Poll /api/health, distinguishing deps-missing (503, immediate) from a still-
@@ -1147,7 +1147,7 @@
         onExport={selected ? (fmt, trim) => exportClip(selected.id, fmt, selected.name, trim) : null}
         onChapters={selected ? (fmt) => exportChapters(selected.id, selected.name, fmt) : null}
         onRemotion={selected ? () => exportRemotion(selected.id, selected.name) : null}
-        onReveal={inspPath ? () => revealFile(inspPath) : null}
+        onReveal={inspPath ? () => revealFile(inspPath, selected && selected.id) : null}
         onRate={rate}
         inPoint={detailLive ? detailLive.in_point : null}
         outPoint={detailLive ? detailLive.out_point : null}

--- a/routers/misc.py
+++ b/routers/misc.py
@@ -13,7 +13,7 @@ _assert_same_site from webguard. No server import, no cycle.
 import mimetypes
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from fastapi.responses import FileResponse, JSONResponse
@@ -41,7 +41,14 @@ def _log_safe(text: str, limit: int) -> str:
 
 
 class OpenFileRequest(BaseModel):  # audit M22: malformed JSON → clean 422, not a raw 500
-    path: str
+    # `path` alone cannot identify a clip from a library indexed before the
+    # relative-path migration: `_display_path` reduces an absolute path outside
+    # PROJECT_ROOT to its basename so the response can't leak the operator's
+    # directory tree, the UI hands that basename back, and `is_processed
+    # ("clip.mp4")` matches nothing — every "Show in Finder" on such a library is
+    # a 403. `media_id` names the row directly and closes that gap.
+    path: str = ""
+    media_id: Optional[int] = None
     reveal: bool = False
 
 
@@ -169,12 +176,22 @@ def open_file(
     read-only browse token is correctly refused.
     """
     import subprocess, platform
-    file_path = body.path
     reveal = body.reveal
-    # Validate: only allow paths that exist in our database
-    if not db.is_processed(file_path):
-        raise HTTPException(403, "只能開啟已索引的媒體檔案")
-    resolved_path = _resolve_media_path(file_path)
+    # Prefer the id. Note the security direction is CONVERGENT, not relaxed: an id
+    # can only ever name a row that already exists, and the path it yields is the
+    # library's own stored path — there is no attacker-controlled path in this
+    # branch at all, which is strictly less than the `path` branch allows.
+    if body.media_id is not None:
+        rec = db.get_record_by_id(body.media_id)
+        if not rec or not rec.get("path"):
+            raise HTTPException(403, "只能開啟已索引的媒體檔案")
+        resolved_path = _resolve_media_path(rec["path"])
+    else:
+        file_path = body.path
+        # Validate: only allow paths that exist in our database
+        if not file_path or not db.is_processed(file_path):
+            raise HTTPException(403, "只能開啟已索引的媒體檔案")
+        resolved_path = _resolve_media_path(file_path)
     if not Path(resolved_path).exists():
         raise HTTPException(404, "找不到檔案")
     system = platform.system()

--- a/tests/test_open_file_media_id.py
+++ b/tests/test_open_file_media_id.py
@@ -1,0 +1,134 @@
+""""Show in Finder" was a guaranteed 403 on any library indexed before the
+relative-path migration.
+
+The chain: `_display_path` refuses to leak the operator's directory tree, so a row
+whose stored path is absolute and outside PROJECT_ROOT comes back as a bare
+basename. The UI shows that string and hands it straight back to `/api/open-file`.
+The server then asks `db.is_processed("clip.mp4")`, which matches nothing, and
+answers 403 — on a file it has indexed, is showing on screen, and is streaming.
+
+`media_id` names the row instead. The security direction is convergent, not
+relaxed: an id can only name a row that already exists, and the path it yields is
+the library's own stored path, so that branch has no attacker-controlled path in
+it at all.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture
+def no_launch(monkeypatch):
+    """Never actually open Finder/Explorer from a test."""
+    calls = []
+    fake = types.ModuleType("subprocess")
+    fake.Popen = lambda *a, **k: calls.append(a)
+    monkeypatch.setitem(sys.modules, "subprocess", fake)
+    return calls
+
+
+def _seed_legacy(db, sample_record, tmp_path):
+    """A row stored with an absolute path outside PROJECT_ROOT — the pre-migration
+    shape, and the one `_display_path` reduces to a basename."""
+    src = tmp_path / "外接硬碟" / "案件A" / "clip.mp4"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_bytes(b"\x00")
+    db.upsert(sample_record(path=str(src), filename="clip.mp4", ext=".mp4"))
+    return 1, src
+
+
+def test_the_basename_the_ui_receives_is_exactly_what_the_server_rejects(
+    fastapi_client, server_module, sample_record, tmp_path
+):
+    """The premise of this whole fix, asserted rather than assumed."""
+    db = importlib.import_module("db")
+    import pathres
+    mid, src = _seed_legacy(db, sample_record, tmp_path)
+
+    shown = pathres._display_path(str(src))
+
+    assert shown == "clip.mp4"
+    assert db.is_processed(shown) is False
+    r = fastapi_client.post("/api/open-file", json={"path": shown, "reveal": True})
+    assert r.status_code == 403
+
+
+def test_revealing_by_id_works_on_that_same_library(
+    fastapi_client, server_module, sample_record, tmp_path, no_launch
+):
+    db = importlib.import_module("db")
+    mid, _src = _seed_legacy(db, sample_record, tmp_path)
+
+    r = fastapi_client.post("/api/open-file", json={"media_id": mid, "reveal": True})
+
+    assert r.status_code == 200, r.text
+    assert no_launch, "nothing was launched"
+
+
+def test_an_unknown_id_is_refused(fastapi_client, server_module):
+    r = fastapi_client.post("/api/open-file", json={"media_id": 4242, "reveal": True})
+    assert r.status_code == 403
+
+
+def test_the_path_branch_still_works_for_a_migrated_library(
+    fastapi_client, server_module, sample_record, tmp_path, no_launch
+):
+    """Relative rows already round-tripped correctly; the id is an addition, not a
+    replacement."""
+    db = importlib.import_module("db")
+    src = tmp_path / "clip2.mp4"
+    src.write_bytes(b"\x00")
+    db.upsert(sample_record(path=str(src), filename="clip2.mp4", ext=".mp4"))
+
+    r = fastapi_client.post("/api/open-file", json={"path": str(src), "reveal": False})
+
+    assert r.status_code == 200, r.text
+
+
+def test_an_arbitrary_path_is_still_refused(fastapi_client, server_module, no_launch):
+    """The id branch must not have loosened the path branch."""
+    r = fastapi_client.post("/api/open-file",
+                            json={"path": "/etc/passwd", "reveal": False})
+    assert r.status_code == 403
+    assert no_launch == []
+
+
+def test_an_empty_body_is_refused_rather_than_opening_something(
+    fastapi_client, server_module, no_launch
+):
+    """`path` became optional to make room for `media_id`; neither given must not
+    fall through to resolving the empty string."""
+    r = fastapi_client.post("/api/open-file", json={"reveal": False})
+    assert r.status_code == 403
+    assert no_launch == []
+
+
+def test_an_indexed_row_whose_file_is_gone_is_a_404_not_a_403(
+    fastapi_client, server_module, sample_record, tmp_path
+):
+    """Different causes, different answers: 403 means "not yours to open", 404
+    means "the NAS is unplugged". Collapsing them sends the user hunting for a
+    permissions problem that doesn't exist."""
+    db = importlib.import_module("db")
+    mid, src = _seed_legacy(db, sample_record, tmp_path)
+    src.unlink()
+
+    r = fastapi_client.post("/api/open-file", json={"media_id": mid, "reveal": True})
+
+    assert r.status_code == 404
+
+
+def test_the_ui_sends_the_id_when_it_has_one():
+    """A server fix nobody reaches is not a fix. The Inspector's reveal button is
+    the only caller."""
+    from pathlib import Path
+    root = Path(__file__).resolve().parent.parent / "frontend" / "src"
+    api = (root / "lib" / "api.js").read_text(encoding="utf-8")
+    main = (root / "routes" / "MainLive.svelte").read_text(encoding="utf-8")
+
+    assert "media_id: mediaId" in api
+    assert "revealFile(inspPath, selected && selected.id)" in main


### PR DESCRIPTION
鏈條是這樣的：`_display_path` 為了不洩漏使用者的目錄樹，會把「絕對且在
PROJECT_ROOT 之外」的舊路徑砍成單純的檔名；UI 顯示那個字串，然後原封不動送回
`/api/open-file`；server 去問 `db.is_processed("clip.mp4")`，匹配不到任何一列，
回 403 —— 對一支它已經索引過、正顯示在畫面上、而且正在串流給你看的檔案。

**任何在 relative-path 遷移之前索引的 library，這顆按鈕百分之百不會動。**

`media_id` 直接指名那一列。**安全方向是收斂的，不是放寬**：id 只可能指到一列
已經存在的資料，而它拿到的路徑是 library 自己存的路徑 —— 這條分支裡**根本沒有
攻擊者可控的路徑**，比 `path` 分支允許的還少。

`path` 分支原封不動保留（已遷移的 library 本來就通），只補上「path 空字串」不准
落到 resolve —— 那是把 `path` 改成 optional 之後才出現的洞。

順帶把兩種失敗分開：403 是「這不是你能開的東西」，404 是「NAS 沒插」。混在一起
會讓使用者去查一個根本不存在的權限問題。

新增 8 支測試，第一支先斷言**前提本身**：`_display_path` 真的回 `clip.mp4`、
`is_processed` 真的匹配不到、走 path 真的 403 —— 不假設這條鏈存在，先證明它存在。

mutation-check 五處全紅在該紅的位置：
  拿掉 media_id 分支      → 舊庫測試紅
  不存在的 id 也放行      → 403 測試紅
  空 path 落到 resolve    → 空 body 測試紅
  path 分支拿掉 DB 檢查   → 任意路徑測試紅
  UI 不再送 id            → 前端接線測試紅

全套 1546 passed / 7 skipped。svelte-check 0 warnings。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>