### PR TITLE
feat(tauri): 打包的 app 從來不啟動 Ollama，也找不到 ffmpeg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,37 @@ jobs:
       - name: cargo check --locked
         run: cargo check --locked --manifest-path src-tauri/Cargo.toml
 
+  tauri-check-windows:
+    name: tauri-check-windows
+    runs-on: windows-latest
+    # The comment above says "the app ships macOS-only". That stopped being true
+    # when W1-W4 shipped the .exe/.msi, and main.rs now carries three
+    # `#[cfg(windows)]` blocks — the CREATE_NO_WINDOW flags, the LOCALAPPDATA
+    # Ollama lookup, and the PATH augmentation — that the macOS runner does not
+    # compile at all. Until this job existed, a Windows-only type error would
+    # first appear during a `v*` release build, i.e. after the tag was pushed.
+    # Deliberately a SEPARATE job rather than a matrix on tauri-check: turning
+    # that one into a matrix renames it to `tauri-check (macos-latest)`, and the
+    # required check named `tauri-check` would then never report at all.
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Build frontend (generate_context! embeds frontend/dist)
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+      - name: cargo check --locked
+        run: cargo check --locked --manifest-path src-tauri/Cargo.toml
+
   audit:
     name: dependency-audit
     runs-on: ubuntu-latest

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -25,6 +25,132 @@ use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
 /// Holds the spawned backend so we can kill it on exit.
 struct Backend(Mutex<Option<Child>>);
 
+/// Holds an Ollama we started ourselves. `None` when Ollama was already running —
+/// killing someone else's daemon on quit would be worse than not starting one.
+struct Ollama(Mutex<Option<Child>>);
+
+/// Ollama's fixed local port. Probed rather than configured: if the user already
+/// has it running (the normal case for anyone who installed it themselves), we
+/// must not start a second one.
+const OLLAMA_PORT: u16 = 11434;
+
+/// PATH for child processes.
+///
+/// A Finder-launched `.app` inherits a minimal PATH — roughly
+/// `/usr/bin:/bin:/usr/sbin:/sbin` — not the shell's. Homebrew is not on it. So
+/// `faster-whisper` calling a bare `ffmpeg`, and every `ollama` lookup, fail with
+/// `[Errno 2] No such file or directory` inside the packaged app while working
+/// perfectly from a terminal. That difference is invisible during development,
+/// which is exactly why it shipped.
+fn augmented_path() -> String {
+    let current = std::env::var("PATH").unwrap_or_default();
+    #[allow(unused_mut)]
+    let mut parts: Vec<String> = Vec::new();
+    #[cfg(unix)]
+    {
+        let home = std::env::var("HOME").unwrap_or_default();
+        #[cfg(target_os = "macos")]
+        {
+            parts.push("/opt/homebrew/bin".into()); // Apple Silicon Homebrew
+            parts.push("/usr/local/bin".into()); // Intel Homebrew / manual installs
+        }
+        #[cfg(target_os = "linux")]
+        parts.push("/usr/local/bin".into());
+        if !home.is_empty() {
+            parts.push(format!("{home}/.local/bin"));
+        }
+    }
+    #[cfg(windows)]
+    {
+        if let Ok(local) = std::env::var("LOCALAPPDATA") {
+            parts.push(format!("{local}\\Programs\\Ollama"));
+        }
+    }
+    let sep = if cfg!(windows) { ";" } else { ":" };
+    // Existing entries win: never shadow a binary the user has deliberately put
+    // earlier on their own PATH.
+    let mut out = current.clone();
+    for p in parts {
+        if !current.split(sep).any(|e| e == p) {
+            out.push_str(sep);
+            out.push_str(&p);
+        }
+    }
+    out
+}
+
+/// Is something listening on `port`?
+fn port_open(port: u16) -> bool {
+    format!("127.0.0.1:{port}")
+        .parse()
+        .ok()
+        .map(|addr| TcpStream::connect_timeout(&addr, Duration::from_millis(300)).is_ok())
+        .unwrap_or(false)
+}
+
+/// Start `ollama serve` if nothing is already serving, returning the child we own.
+///
+/// The packaged app never did this — `main.rs` contained the string "ollama" zero
+/// times — so vision tagging, chat and embeddings all silently degraded inside the
+/// bundle while working from a dev shell. Silently, because each of those paths
+/// soft-fails by design: the clip just comes back with no description.
+fn spawn_ollama_if_needed(log_dir: &std::path::Path) -> Option<Child> {
+    if port_open(OLLAMA_PORT) {
+        eprintln!("[arkiv-tauri] ollama already running on {OLLAMA_PORT}");
+        return None;
+    }
+    let home = std::env::var("HOME").unwrap_or_default();
+    let mut candidates: Vec<String> = vec![
+        "/opt/homebrew/bin/ollama".into(),
+        "/usr/local/bin/ollama".into(),
+        "/Applications/Ollama.app/Contents/Resources/ollama".into(),
+    ];
+    if !home.is_empty() {
+        candidates.push(format!("{home}/.local/bin/ollama"));
+    }
+    #[cfg(windows)]
+    {
+        if let Ok(local) = std::env::var("LOCALAPPDATA") {
+            candidates.push(format!("{local}\\Programs\\Ollama\\ollama.exe"));
+        }
+    }
+    // Last resort: whatever PATH resolves, using the augmented one.
+    candidates.push("ollama".into());
+
+    let log = std::fs::File::create(log_dir.join("ollama.log")).ok();
+    for bin in candidates {
+        if bin.contains(std::path::MAIN_SEPARATOR) && !std::path::Path::new(&bin).exists() {
+            continue;
+        }
+        let mut cmd = Command::new(&bin);
+        cmd.arg("serve").env("PATH", augmented_path());
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+            cmd.creation_flags(CREATE_NO_WINDOW);
+        }
+        if let Some(f) = log.as_ref().and_then(|f| f.try_clone().ok()) {
+            let err = f.try_clone().ok();
+            cmd.stdout(Stdio::from(f));
+            if let Some(e) = err {
+                cmd.stderr(Stdio::from(e));
+            }
+        }
+        match cmd.spawn() {
+            Ok(child) => {
+                eprintln!("[arkiv-tauri] started ollama: {bin}");
+                return Some(child);
+            }
+            Err(e) => eprintln!("[arkiv-tauri] ollama spawn failed ({bin}): {e}"),
+        }
+    }
+    // Not fatal. arkiv indexes, searches and transcribes without Ollama; only the
+    // LLM-backed features degrade, and they already say so.
+    eprintln!("[arkiv-tauri] no ollama binary found; vision/chat/embed will be unavailable");
+    None
+}
+
 /// Ask the OS for a free TCP port (bind :0, read the assigned port, drop).
 fn free_port() -> u16 {
     TcpListener::bind("127.0.0.1:0")
@@ -92,6 +218,7 @@ fn main() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .manage(Backend(Mutex::new(None)))
+        .manage(Ollama(Mutex::new(None)))
         .setup(|app| {
             let port = free_port();
 
@@ -162,7 +289,11 @@ fn main() {
             .env("PYTHONPATH", &pythonpath)
             .env("ARKIV_PROJECT_ROOT", &proj_root)
             .env("ARKIV_PORT", port.to_string())
-            .env("ARKIV_TRUST_LOOPBACK", "1");
+            .env("ARKIV_TRUST_LOOPBACK", "1")
+            // Without this the bundled app cannot find ffmpeg (Homebrew is not on
+            // a Finder-launched process's PATH), and faster-whisper's bare
+            // `ffmpeg` call takes the whole batch down with [Errno 2].
+            .env("PATH", augmented_path());
             // `windows_subsystem = "windows"` (top of this file) only silences OUR
             // console. Spawning python.exe from a GUI process still allocates a new
             // one, so without this flag every launch parks a black console window
@@ -179,6 +310,12 @@ fn main() {
             if let Some(err) = stderr_cfg {
                 cmd.stderr(err);
             }
+            // Ollama first: the backend probes it during startup, and starting it
+            // after would leave the first minute of a session with vision off.
+            if let Some(o) = spawn_ollama_if_needed(&log_dir) {
+                app.state::<Ollama>().0.lock().unwrap().replace(o);
+            }
+
             let child = cmd.spawn();
 
             let child = match child {
@@ -210,6 +347,14 @@ fn main() {
             // survives the window closing.
             if let tauri::RunEvent::ExitRequested { .. } = event {
                 if let Some(state) = app_handle.try_state::<Backend>() {
+                    if let Some(mut child) = state.0.lock().unwrap().take() {
+                        let _ = child.kill();
+                    }
+                }
+                // Only the Ollama we started. If it was already running when we
+                // launched, the state holds None and the user's daemon — very
+                // possibly serving something else — is left alone.
+                if let Some(state) = app_handle.try_state::<Ollama>() {
                     if let Some(mut child) = state.0.lock().unwrap().take() {
                         let _ = child.kill();
                     }

--- a/tests/test_tauri_ollama.py
+++ b/tests/test_tauri_ollama.py
@@ -1,0 +1,86 @@
+"""The packaged app never started Ollama, and could not find ffmpeg.
+
+Two failures with the same shape: both work perfectly from a dev shell and both
+are invisible until someone runs the actual `.app`.
+
+* `main.rs` contained the string "ollama" **zero times**. Vision tagging, chat and
+  embeddings each soft-fail by design — a clip simply comes back with no
+  description — so inside the bundle they all degraded silently.
+* A Finder-launched app inherits a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`),
+  not the shell's. Homebrew is not on it, so `faster-whisper` shelling out to a
+  bare `ffmpeg` dies with `[Errno 2]` and takes the whole batch with it.
+
+These are source assertions, not behaviour tests — the Rust shell has no test
+harness and the failure only reproduces inside a real bundle. They exist so the
+next person to touch `main.rs` cannot delete the fix without noticing. `cargo
+check` on both macOS and Windows runners is what proves it compiles.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_MAIN_RS = Path(__file__).resolve().parent.parent / "src-tauri" / "src" / "main.rs"
+_CI = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "ci.yml"
+
+
+def _src():
+    return _MAIN_RS.read_text(encoding="utf-8")
+
+
+def test_the_app_starts_ollama_when_nothing_is_serving():
+    src = _src()
+    assert "fn spawn_ollama_if_needed" in src
+    assert "spawn_ollama_if_needed(" in src.split("fn spawn_ollama_if_needed", 1)[1], (
+        "defined but never called"
+    )
+
+
+def test_it_probes_before_starting_one():
+    """Starting a second daemon on a machine that already runs Ollama would fight
+    the user's own install for the port."""
+    body = _src().split("fn spawn_ollama_if_needed", 1)[1]
+    assert "port_open(OLLAMA_PORT)" in body.split("\n}", 1)[0]
+
+
+def test_only_an_ollama_we_started_is_killed_on_exit():
+    """Killing a daemon we did not start would take down whatever else the user
+    has pointed at it."""
+    src = _src()
+    assert "struct Ollama(Mutex<Option<Child>>)" in src
+    assert "try_state::<Ollama>()" in src
+    # The probe returns None when one is already running, so the state holds
+    # nothing and the exit path has nothing to kill.
+    body = _src().split("fn spawn_ollama_if_needed", 1)[1].split("\n}", 1)[0]
+    assert "return None" in body
+
+
+def test_the_backend_is_given_an_augmented_path():
+    src = _src()
+    assert "fn augmented_path" in src
+    assert re.search(r'\.env\("PATH", augmented_path\(\)\)', src), (
+        "the backend still inherits the Finder PATH"
+    )
+
+
+def test_homebrew_is_on_that_path():
+    """The specific directory whose absence broke ffmpeg on every Apple Silicon
+    install of the packaged app."""
+    assert "/opt/homebrew/bin" in _src()
+
+
+def test_the_existing_path_still_wins():
+    """Prepending would shadow a binary the user deliberately put earlier on their
+    own PATH — e.g. a pinned ffmpeg build."""
+    body = _src().split("fn augmented_path", 1)[1].split("\n}", 1)[0]
+    assert "let mut out = current.clone();" in body
+
+
+def test_the_windows_only_code_is_actually_compiled_somewhere():
+    """main.rs carries `#[cfg(windows)]` blocks that the macOS runner does not
+    compile at all. Without a Windows job, a type error there first appears during
+    a release build — after the tag is pushed."""
+    assert "#[cfg(windows)]" in _src()
+    ci = _CI.read_text(encoding="utf-8")
+    assert "tauri-check-windows" in ci
+    assert "runs-on: windows-latest" in ci


### PR DESCRIPTION
兩個形狀一樣的失效：從開發用 shell 跑都完全正常，只有在真正的 `.app` 裡才會發生。

**① `main.rs` 裡「ollama」這個字串出現 0 次。** vision 標註、chat、embedding 三條
路都是設計成 soft-fail 的（片子就是回來沒有描述），所以在打包 app 裡它們一起**靜默
降級**，沒有任何錯誤訊息。加 `spawn_ollama_if_needed()`：先探 127.0.0.1:11434，
已經有人在服務就什麼都不做（自己另外開一個會跟使用者自己的安裝搶埠），沒有才依序
試四個候選路徑。**離開時只 kill 我們自己啟動的那個** —— 狀態是 `Option<Child>`，
已經在跑的情況存的是 None，使用者可能還接著別的東西的 daemon 不會被我們關掉。
找不到 ollama 不是致命錯誤：arkiv 沒有它照樣索引、搜尋、轉錄。

**② Finder 啟動的 app 繼承的是最小 PATH**（`/usr/bin:/bin:/usr/sbin:/sbin`），
不是 shell 的。Homebrew 不在上面，所以 `faster-whisper` 呼叫裸 `ffmpeg` 會
`[Errno 2] No such file or directory`，**整批掛掉**。加 `augmented_path()` 並傳給
backend。既有項目優先 —— 絕不遮蔽使用者自己刻意排在前面的 binary（例如釘版本的
ffmpeg）。

**同時補上一個我這支自己製造的盲點**：`main.rs` 現在有三個 `#[cfg(windows)]`
區塊（CREATE_NO_WINDOW、LOCALAPPDATA 的 Ollama 查找、PATH），而 `tauri-check`
只跑在 macOS runner 上 —— 那些程式碼**根本沒被編譯過**，Windows 專屬的型別錯誤
會等到推了 `v*` tag、release build 跑起來才第一次出現。新增 `tauri-check-windows`。
**刻意做成另一個 job 而不是把 tauri-check 改成 matrix**：改成 matrix 會讓它更名為
`tauri-check (macos-latest)`，而 branch protection 上那個叫 `tauri-check` 的必要
檢查就永遠不會回報了。

新增 7 支測試。它們是**原始碼層級的斷言、不是行為測試** —— Rust 這層沒有測試骨架，
而這個失效只在真正的 bundle 裡重現。它們存在的目的是讓下一個動 `main.rs` 的人沒辦法
在沒注意到的情況下刪掉這個修正；「編得過」由兩個平台的 `cargo check` 負責。

本機 `cargo check` 綠。全套 1553 passed / 7 skipped。

⚠️ **實機驗證還沒做**：這支要在打包後的 `.app`（Finder 啟動，不是 `cargo tauri dev`）
上確認 ollama 真的被拉起來、ffmpeg 真的找得到。列進 todo。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>