### PR TITLE
fix(codec): .mts 探測出來是 h264，而瀏覽器完全播不了它

### DIFF
--- a/codec.py
+++ b/codec.py
@@ -20,6 +20,14 @@ PROXY_CODECS = frozenset({
     "prores", "ap4h", "ap4x", "apch", "apcn", "apcs", "apco",
 })
 
+# Containers a browser cannot demux, whatever is inside them. AVCHD camcorder
+# footage (.mts/.m2ts) is almost always plain H.264 — so the codec check says
+# "playable", we hand over the original bytes labelled video/mp4, and the
+# demuxer fails without a word. The user sees a black player and no error.
+# The container has to be decided BEFORE the codec, because the codec answer is
+# the thing that misleads here.
+REMUX_CONTAINERS = frozenset({".mts", ".m2ts", ".m2t", ".ts", ".mxf"})
+
 # Tri-state verdict: distinguishes "ffprobe says H.264" from "ffprobe failed",
 # so callers (e.g. stream endpoint) can pick a different fallback for each.
 NEEDED = "needed"
@@ -68,13 +76,28 @@ def probe_codec(path: str, timeout: float = 10.0) -> Optional[str]:
     return codec
 
 
+def container_needs_remux(path: str) -> bool:
+    """True for containers no browser can demux, independent of the codec.
+
+    Extension-only on purpose: this must answer before (and without) a probe,
+    since the probe is what produces the misleading "h264, looks fine" verdict.
+    """
+    return os.path.splitext(str(path))[1].lower() in REMUX_CONTAINERS
+
+
 def needs_proxy(path: str, timeout: float = 10.0) -> str:
     """Tri-state proxy verdict.
 
-    - NEEDED: codec is HEVC/ProRes/etc, browser can't play original.
+    - NEEDED: the browser can't play the original — an unplayable codec
+      (HEVC/ProRes) OR an undemuxable container (AVCHD .mts, .ts, .mxf).
     - NOT_NEEDED: codec is browser-friendly (H.264 etc).
     - UNKNOWN: ffprobe failed or file unreachable; caller decides fallback.
+
+    The container is checked first and without probing: an .mts holding H.264
+    probes as perfectly playable, which is precisely how it slipped through.
     """
+    if container_needs_remux(path):
+        return NEEDED
     codec = probe_codec(path, timeout=timeout)
     if codec is None:
         return UNKNOWN

--- a/ingest.py
+++ b/ingest.py
@@ -607,6 +607,67 @@ def _build_proxy_cmd(src: str, dst: str, height: int, hwaccel: bool) -> list:
     return cmd
 
 
+def build_proxies() -> tuple:
+    """Generate proxies for every indexed clip that needs one. Returns (ok, skipped).
+
+    Lifted verbatim out of ingest Phase 3 so the decision can be tested. It has to
+    be: it is one half of a pair. `/api/stream` answers 409 "build a proxy" for
+    files this function decides about, and if the two halves disagree the user is
+    told to do something that then silently does nothing.
+    """
+    proxy_ok, proxy_skip = 0, 0
+    with db.get_conn() as conn:
+        all_media = conn.execute("SELECT id, path, codec FROM media").fetchall()
+    for mid, mpath, stored_codec in all_media:
+        resolved_path = db.resolve_path(mpath)
+        proxy_path = config.proxy_path_for(mid, resolved_path)
+        if proxy_path.exists():
+            proxy_skip += 1
+            continue
+        if not Path(resolved_path).suffix.lower() in VIDEO_EXT:
+            continue
+        # Decide proxy need from the stored codec (set at ingest time) instead of
+        # re-running ffprobe on every browser-compatible file each invocation
+        # (H1). Only legacy rows with NULL codec fall back to a one-time probe,
+        # whose result is then persisted so the next run skips it too.
+        if stored_codec:
+            # The stored codec cannot answer for the container. An AVCHD .mts is
+            # stored as "h264", so this branch used to skip it — and the stream
+            # endpoint now tells the user to build a proxy for exactly those
+            # files. Without this the two halves disagree and the 409 never clears.
+            want_proxy = (stored_codec.lower() in codec.PROXY_CODECS
+                          or codec.container_needs_remux(resolved_path))
+        else:
+            verdict = codec.needs_proxy(resolved_path)
+            want_proxy = verdict == codec.NEEDED
+            if verdict != codec.UNKNOWN:
+                probed = codec.probe_codec(resolved_path)
+                if probed:
+                    with db.get_conn() as conn:
+                        conn.execute(
+                            "UPDATE media SET codec=? WHERE id=?", (probed.lower(), mid)
+                        )
+        if want_proxy:
+            print(f"  [{mid}] {Path(resolved_path).name} >proxy", end="", flush=True)
+            result = generate_proxy(mid, resolved_path)
+            if result:
+                # B6: show original→proxy size delta so the compression win is
+                # visible per-clip (not just the proxy's absolute size).
+                mib = 1024 * 1024
+                proxy_sz = Path(result).stat().st_size
+                orig_sz = Path(resolved_path).stat().st_size
+                pct = (proxy_sz - orig_sz) / orig_sz * 100 if orig_sz else 0
+                print(f" [OK {proxy_sz / mib:.0f}MB ← {orig_sz / mib:.0f}MB, {pct:+.0f}%]")
+                proxy_ok += 1
+            else:
+                print(" [FAIL]")
+    if proxy_ok or proxy_skip:
+        print(f"Proxies: {proxy_ok} generated, {proxy_skip} already exist")
+    else:
+        print("No files need proxy (all browser-compatible)")
+    return proxy_ok, proxy_skip
+
+
 def generate_proxy(media_id: int, path: str, force: bool = False,
                    height: Optional[int] = None, hwaccel: Optional[bool] = None) -> Optional[str]:
     """Generate an H.264 proxy for browser playback. Returns proxy path or None.
@@ -2545,51 +2606,7 @@ def main():
     # ── Phase 3: Proxy generation (browser-incompatible codecs) ────────────
     print(f"\n{'─'*60}")
     print("Phase 3: Proxy generation for browser-incompatible codecs...")
-    proxy_ok, proxy_skip = 0, 0
-    with db.get_conn() as conn:
-        all_media = conn.execute("SELECT id, path, codec FROM media").fetchall()
-    for mid, mpath, stored_codec in all_media:
-        resolved_path = db.resolve_path(mpath)
-        proxy_path = config.proxy_path_for(mid, resolved_path)
-        if proxy_path.exists():
-            proxy_skip += 1
-            continue
-        if not Path(resolved_path).suffix.lower() in VIDEO_EXT:
-            continue
-        # Decide proxy need from the stored codec (set at ingest time) instead of
-        # re-running ffprobe on every browser-compatible file each invocation
-        # (H1). Only legacy rows with NULL codec fall back to a one-time probe,
-        # whose result is then persisted so the next run skips it too.
-        if stored_codec:
-            want_proxy = stored_codec.lower() in codec.PROXY_CODECS
-        else:
-            verdict = codec.needs_proxy(resolved_path)
-            want_proxy = verdict == codec.NEEDED
-            if verdict != codec.UNKNOWN:
-                probed = codec.probe_codec(resolved_path)
-                if probed:
-                    with db.get_conn() as conn:
-                        conn.execute(
-                            "UPDATE media SET codec=? WHERE id=?", (probed.lower(), mid)
-                        )
-        if want_proxy:
-            print(f"  [{mid}] {Path(resolved_path).name} >proxy", end="", flush=True)
-            result = generate_proxy(mid, resolved_path)
-            if result:
-                # B6: show original→proxy size delta so the compression win is
-                # visible per-clip (not just the proxy's absolute size).
-                mib = 1024 * 1024
-                proxy_sz = Path(result).stat().st_size
-                orig_sz = Path(resolved_path).stat().st_size
-                pct = (proxy_sz - orig_sz) / orig_sz * 100 if orig_sz else 0
-                print(f" [OK {proxy_sz / mib:.0f}MB ← {orig_sz / mib:.0f}MB, {pct:+.0f}%]")
-                proxy_ok += 1
-            else:
-                print(" [FAIL]")
-    if proxy_ok or proxy_skip:
-        print(f"Proxies: {proxy_ok} generated, {proxy_skip} already exist")
-    else:
-        print("No files need proxy (all browser-compatible)")
+    build_proxies()
 
     batch_elapsed = _time.time() - batch_start
     total_dur = sum(b["duration_s"] for b in bench_log)

--- a/routers/misc.py
+++ b/routers/misc.py
@@ -110,6 +110,23 @@ def stream_media(media_id: int, _tok: dict = Depends(require_scopes("videos_read
     # on EVERY playback; only probe when the column is NULL (legacy rows) and
     # backfill so the next play is probe-free. None (probe failed / audio-only)
     # keeps the UNKNOWN fall-through behavior.
+    # The container decides first, and without a probe: an AVCHD .mts holds plain
+    # H.264, so the codec check says "playable" and we hand over bytes the browser
+    # cannot demux. That is a black player with no error rather than a 409 the UI
+    # can turn into "build a proxy".
+    if codec.container_needs_remux(str(file_path)):
+        return JSONResponse(
+            status_code=409,
+            content={
+                "need_proxy": True,
+                "media_id": media_id,
+                "filename": rec.get("filename"),
+                "reason": "container cannot be demuxed in a browser ({0}); proxy required".format(
+                    file_path.suffix.lower()),
+                "hint": "POST /api/proxy/build to queue proxy generation",
+            },
+        )
+
     if serving_editor_proxy:
         # Probe the CANDIDATE, never the record: `media.codec` describes the
         # original, and a sidecar is frequently a different codec (that is the

--- a/tests/test_container_remux.py
+++ b/tests/test_container_remux.py
@@ -1,0 +1,106 @@
+""".mts probes as H.264, and no browser can play it.
+
+AVCHD camcorder footage is plain H.264 inside an MPEG-TS container. The codec
+check therefore says "browser-friendly", arkiv hands over the original bytes
+labelled `video/mp4`, and the demuxer fails silently. The user sees a black player
+and no error — the worst version of this failure, because every diagnostic
+available to them says the file is fine.
+
+So the container has to be decided BEFORE the codec, and without probing: the
+probe's answer is the thing that misleads.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import codec
+
+
+@pytest.mark.parametrize("name", ["A.mts", "A.M2TS", "A.m2t", "A.ts", "A.mxf"])
+def test_undemuxable_containers_are_recognised_by_extension(name):
+    assert codec.container_needs_remux(name) is True
+
+
+@pytest.mark.parametrize("name", ["A.mp4", "A.mov", "A.mkv", "A.webm"])
+def test_ordinary_containers_are_not(name):
+    assert codec.container_needs_remux(name) is False
+
+
+def test_the_verdict_does_not_wait_for_a_probe(monkeypatch):
+    """If the container check ran after probing, a missing/slow ffprobe would turn
+    a known-bad container into UNKNOWN — which the stream endpoint falls through
+    on, i.e. straight back to serving the unplayable bytes."""
+    probed = []
+    monkeypatch.setattr(codec, "probe_codec", lambda p, **k: probed.append(p) or "h264")
+
+    assert codec.needs_proxy("/x/A001.mts") == codec.NEEDED
+    assert probed == [], "probed a file whose container already settled it"
+
+
+def test_h264_in_an_ordinary_container_is_still_fine(monkeypatch):
+    monkeypatch.setattr(codec, "probe_codec", lambda p, **k: "h264")
+    assert codec.needs_proxy("/x/A001.mp4") == codec.NOT_NEEDED
+
+
+def _seed(db, sample_record, tmp_path, name, **over):
+    src = tmp_path / name
+    src.write_bytes(b"\x00" * 16)
+    rec = dict(path=str(src), filename=name, ext=src.suffix, duration_s=12.0, fps=30.0)
+    rec.update(over)
+    db.upsert(sample_record(**rec))
+    return 1, src
+
+
+def test_streaming_an_mts_asks_for_a_proxy_instead_of_sending_it(
+    fastapi_client, server_module, sample_record, tmp_path, monkeypatch
+):
+    db = importlib.import_module("db")
+    mid, _src = _seed(db, sample_record, tmp_path, "A001.mts", codec="h264")
+
+    r = fastapi_client.get("/api/stream/%d" % mid)
+
+    assert r.status_code == 409
+    body = r.json()
+    assert body["need_proxy"] is True
+    assert ".mts" in body["reason"]
+
+
+def test_the_proxy_builder_agrees_that_an_mts_needs_one(
+    fastapi_client, server_module, sample_record, tmp_path, monkeypatch
+):
+    """The two halves have to agree. The batch builder decides from the STORED
+    codec, which for an .mts is "h264" — so it would skip the very files the
+    stream endpoint has just told the user to build proxies for, and the 409 would
+    never clear."""
+    db = importlib.import_module("db")
+    mid, src = _seed(db, sample_record, tmp_path, "A001.mts", codec="h264")
+    ingest = importlib.import_module("ingest")
+
+    built = []
+    fake_out = tmp_path / "proxy.mp4"
+    fake_out.write_bytes(b"\x00" * 8)  # the reporter stats it for the size delta
+
+    monkeypatch.setattr(ingest, "generate_proxy",
+                        lambda media_id, path, **k: built.append(path) or str(fake_out))
+
+    ingest.build_proxies()
+
+    assert built == [str(src)]
+
+
+def test_the_proxy_builder_still_skips_an_ordinary_h264_mp4(
+    fastapi_client, server_module, sample_record, tmp_path, monkeypatch
+):
+    db = importlib.import_module("db")
+    _seed(db, sample_record, tmp_path, "B001.mp4", codec="h264")
+    ingest = importlib.import_module("ingest")
+
+    built = []
+    monkeypatch.setattr(ingest, "generate_proxy",
+                        lambda media_id, path, **k: built.append(path) or "/fake/proxy.mp4")
+
+    ingest.build_proxies()
+
+    assert built == []


### PR DESCRIPTION
AVCHD 攝影機拍出來的 `.mts` 裡面是純 H.264，只是裝在 MPEG-TS 容器裡。所以 codec
檢查說「瀏覽器友善」，arkiv 把原始 bytes 標成 `video/mp4` 送出去，demuxer 靜默失敗。
使用者看到的是**黑掉的播放器加上零錯誤訊息** —— 這是這類失效最糟的版本，因為他手上
每一個診斷資訊都說這個檔案沒問題。

`codec.container_needs_remux()`：`.mts` / `.m2ts` / `.m2t` / `.ts` / `.mxf`，
**在探測之前、而且不需要探測**就判定。順序是重點 —— 探測的答案正是誤導人的那個
東西；而且如果容器檢查排在探測之後，ffprobe 缺席或逾時會把一個「已知不能播」的
容器變成 UNKNOWN，而 stream 端點對 UNKNOWN 的處理正是「照送原檔」。

**同時修掉會讓這個修正變成死路的另一半**：批次 proxy 產生器是用**存下來的 codec**
判斷的，而 `.mts` 存的是 "h264" → 它會跳過那些檔案。也就是 stream 端點告訴使用者
「去建 proxy」，而建 proxy 的那一端根本不會替這些檔案建 —— 409 永遠清不掉。

為了測得到這件事，把 Phase 3 逐字搬成 `ingest.build_proxies()`。**它必須被測到**：
它是一對東西的其中一半，兩半不同意的時候，使用者被叫去做一件做了也沒用的事。

新增 14 支測試。mutation-check 五處全紅在該紅的位置：
  容器清單清空              → 全檔紅
  容器檢查移到探測之後      → 「不等探測」測試紅
  stream 端點不再檢查容器   → 409 測試紅
  建構器不看容器            → 兩半一致測試紅
  建構器一律建 proxy        → 跳過測試紅

全套 1567 passed / 7 skipped。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>