### PR TITLE
fix(vision): 標籤與結構化欄位仍然把簡體漏進索引

### DIFF
--- a/tests/test_vision_traditional.py
+++ b/tests/test_vision_traditional.py
@@ -20,6 +20,15 @@ import json
 import pytest
 
 import vision as vis
+import zh_convert
+
+# opencc has no cp39 arm64 wheel, so `zh_convert` degrades to identity on the 3.9
+# CI leg — the same guard the Phase 9.8b tests use. Skipping is right: identity is
+# a deliberate, tested degradation, and asserting conversion there would be
+# asserting that opencc is installed, which is a packaging question, not this one.
+_needs_opencc = pytest.mark.skipif(
+    zh_convert._converter("s2twp") is None, reason="opencc not installed"
+)
 
 
 SIMPLIFIED = {
@@ -41,6 +50,7 @@ def _vision_returns(monkeypatch, raw):
     monkeypatch.setattr(vis, "_call_vision", lambda *a, **k: raw)
 
 
+@_needs_opencc
 def test_tags_are_traditionalised(monkeypatch):
     """The one that costs recall: a Simplified tag can never be searched for."""
     _vision_returns(monkeypatch, json.dumps(SIMPLIFIED, ensure_ascii=False))
@@ -50,6 +60,7 @@ def test_tags_are_traditionalised(monkeypatch):
     assert result["tags"] == ["訪談", "場景", "人物"]
 
 
+@_needs_opencc
 def test_the_structured_fields_are_traditionalised(monkeypatch):
     _vision_returns(monkeypatch, json.dumps(SIMPLIFIED, ensure_ascii=False))
 
@@ -61,6 +72,7 @@ def test_the_structured_fields_are_traditionalised(monkeypatch):
     assert result["edit_reason"] == "適合作為開場"
 
 
+@_needs_opencc
 def test_the_description_still_is_too(monkeypatch):
     """The one field that already worked — a regression here would be silent."""
     _vision_returns(monkeypatch, json.dumps(SIMPLIFIED, ensure_ascii=False))
@@ -94,6 +106,7 @@ def test_a_missing_field_stays_none(monkeypatch):
     assert result["focus_score"] is None
 
 
+@_needs_opencc
 def test_the_light_path_converts_the_same_things(monkeypatch):
     """Every frame except the representative one goes through this path — it is
     the majority of what lands in the index."""
@@ -105,6 +118,7 @@ def test_the_light_path_converts_the_same_things(monkeypatch):
     assert result["content_type"] == "訪談"
 
 
+@_needs_opencc
 def test_the_non_json_fallback_path_converts_too(monkeypatch):
     """When the model answers in prose instead of JSON, the tags come off the last
     line. Same index, same requirement."""
@@ -116,6 +130,7 @@ def test_the_non_json_fallback_path_converts_too(monkeypatch):
     assert "這" in result["description"]
 
 
+@_needs_opencc
 def test_the_light_non_json_fallback_converts_too(monkeypatch):
     _vision_returns(monkeypatch, "这是访谈画面\n访谈, 场景")
 
@@ -124,6 +139,7 @@ def test_the_light_non_json_fallback_converts_too(monkeypatch):
     assert result["tags"] == ["訪談", "場景"]
 
 
+@_needs_opencc
 def test_text_that_is_already_traditional_is_untouched(monkeypatch):
     """Conversion must be idempotent — re-running vision on an existing library
     must not churn its tags."""

--- a/tests/test_vision_traditional.py
+++ b/tests/test_vision_traditional.py
@@ -1,0 +1,137 @@
+"""Vision tags and structured fields still leaked Simplified into the index.
+
+Phase 9.8b routed the frame *description* through `zh_convert` because qwen3-vl
+ignores the "繁體中文" instruction and emits Simplified anyway. It converted one
+field out of eleven.
+
+Tags are the expensive omission, because **tags are index keys**. A Simplified tag
+is a permanently unfindable one: the user searches 場景 and the library holds 场景.
+Worse, once both spellings exist they are two separate tags and the pool splits.
+The structured fields (`content_type`, `atmosphere`, `energy`, `edit_position`,
+`edit_reason`) are Chinese phrases too, and they are displayed and filtered on.
+
+The fix is one normalisation of the whole result at each return, rather than four
+per-field assignments — four assignments is how one came to be missing.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import vision as vis
+
+
+SIMPLIFIED = {
+    "description": "这是一个访谈场景，人物在讲话。",
+    "tags": ["访谈", "场景", "人物"],
+    "content_type": "访谈",
+    "focus_score": 5,
+    "exposure": "正常",
+    "stability": "稳定",
+    "audio_quality": "清晰",
+    "atmosphere": "严肃",
+    "energy": "中",
+    "edit_position": "中段",
+    "edit_reason": "适合作为开场",
+}
+
+
+def _vision_returns(monkeypatch, raw):
+    monkeypatch.setattr(vis, "_call_vision", lambda *a, **k: raw)
+
+
+def test_tags_are_traditionalised(monkeypatch):
+    """The one that costs recall: a Simplified tag can never be searched for."""
+    _vision_returns(monkeypatch, json.dumps(SIMPLIFIED, ensure_ascii=False))
+
+    result = vis._describe_one("/fake.jpg")
+
+    assert result["tags"] == ["訪談", "場景", "人物"]
+
+
+def test_the_structured_fields_are_traditionalised(monkeypatch):
+    _vision_returns(monkeypatch, json.dumps(SIMPLIFIED, ensure_ascii=False))
+
+    result = vis._describe_one("/fake.jpg")
+
+    assert result["content_type"] == "訪談"
+    assert result["stability"] == "穩定"
+    assert result["atmosphere"] == "嚴肅"
+    assert result["edit_reason"] == "適合作為開場"
+
+
+def test_the_description_still_is_too(monkeypatch):
+    """The one field that already worked — a regression here would be silent."""
+    _vision_returns(monkeypatch, json.dumps(SIMPLIFIED, ensure_ascii=False))
+
+    assert "訪談" in vis._describe_one("/fake.jpg")["description"]
+    assert "这" not in vis._describe_one("/fake.jpg")["description"]
+
+
+def test_a_numeric_field_survives_conversion(monkeypatch):
+    """`focus_score` is an int, and opencc raises on one (`'int' object has no
+    attribute 'encode'`).
+
+    Two things stop that reaching anyone: the `isinstance(value, str)` guard here,
+    and `zh_convert._convert` swallowing converter exceptions and returning its
+    input. So no single mutation makes this red — it pins the outcome, which is
+    what a stored `focus_score` of 5 depends on."""
+    _vision_returns(monkeypatch, json.dumps(SIMPLIFIED, ensure_ascii=False))
+
+    assert vis._describe_one("/fake.jpg")["focus_score"] == 5
+
+
+def test_a_missing_field_stays_none(monkeypatch):
+    """Absent is not the same as empty: a NULL column means "the model did not
+    say", and "" would claim it answered with nothing."""
+    _vision_returns(monkeypatch, json.dumps(
+        {"description": "简单", "tags": []}, ensure_ascii=False))
+
+    result = vis._describe_one("/fake.jpg")
+
+    assert result["content_type"] is None
+    assert result["focus_score"] is None
+
+
+def test_the_light_path_converts_the_same_things(monkeypatch):
+    """Every frame except the representative one goes through this path — it is
+    the majority of what lands in the index."""
+    _vision_returns(monkeypatch, json.dumps(SIMPLIFIED, ensure_ascii=False))
+
+    result = vis._describe_one_light("/fake.jpg")
+
+    assert result["tags"] == ["訪談", "場景", "人物"]
+    assert result["content_type"] == "訪談"
+
+
+def test_the_non_json_fallback_path_converts_too(monkeypatch):
+    """When the model answers in prose instead of JSON, the tags come off the last
+    line. Same index, same requirement."""
+    _vision_returns(monkeypatch, "这是访谈画面\n访谈, 场景, 人物")
+
+    result = vis._describe_one("/fake.jpg")
+
+    assert result["tags"] == ["訪談", "場景", "人物"]
+    assert "這" in result["description"]
+
+
+def test_the_light_non_json_fallback_converts_too(monkeypatch):
+    _vision_returns(monkeypatch, "这是访谈画面\n访谈, 场景")
+
+    result = vis._describe_one_light("/fake.jpg")
+
+    assert result["tags"] == ["訪談", "場景"]
+
+
+def test_text_that_is_already_traditional_is_untouched(monkeypatch):
+    """Conversion must be idempotent — re-running vision on an existing library
+    must not churn its tags."""
+    _vision_returns(monkeypatch, json.dumps(
+        {"description": "訪談畫面", "tags": ["訪談", "場景"], "content_type": "訪談"},
+        ensure_ascii=False))
+
+    result = vis._describe_one("/fake.jpg")
+
+    assert result["tags"] == ["訪談", "場景"]
+    assert result["description"] == "訪談畫面"

--- a/vision.py
+++ b/vision.py
@@ -162,6 +162,28 @@ _VISION_FIELDS = (
 )
 
 
+def _to_taiwan_result(result: Dict) -> Dict:
+    """Traditionalise every human-readable field of a vision result, in place.
+
+    Only `description` was converted before, and the reason that mattered is not
+    cosmetic: **tags are index keys**. A Simplified tag is a permanently
+    unfindable one — the user searches 场景 and the library has 場景, or worse,
+    both exist as separate tags and the pool splits in two. The structured fields
+    (`content_type`, `atmosphere`, `energy`, `edit_position`, `edit_reason`) are
+    Chinese phrases too, and they are displayed and filtered on.
+
+    One place instead of four assignments, because four was how one of them came
+    to be missing.
+    """
+    result["description"] = zh_convert.to_taiwan(result.get("description") or "")
+    result["tags"] = [zh_convert.to_taiwan(t) for t in (result.get("tags") or [])]
+    for field in _VISION_FIELDS:
+        value = result.get(field)
+        if isinstance(value, str):  # focus_score is an int — leave it alone
+            result[field] = zh_convert.to_taiwan(value)
+    return result
+
+
 def _empty_result() -> Dict:
     result = {"description": "", "tags": []}
     for field in _VISION_FIELDS:
@@ -237,7 +259,7 @@ def _normalize_result(parsed: Dict) -> Dict:
     # description through zh_convert (s2twp), mirroring transcribe.py's write-path,
     # so frame descriptions honor the Traditional-Chinese contract (audit: 175 frames
     # / 159 clips had Simplified vision text because this path never converted).
-    result["description"] = zh_convert.to_taiwan(parsed.get("description", ""))
+    result["description"] = parsed.get("description", "")
     # Sanitize at the source: drop empty / pure-punctuation tags (e.g. the bare
     # "}" the JSON-fallback parser leaks) so they never enter the DB. Read-side
     # filtering (tag_quality.is_noise) also screens them, this just keeps storage clean.
@@ -247,7 +269,7 @@ def _normalize_result(parsed: Dict) -> Dict:
     ]
     for field in _VISION_FIELDS:
         result[field] = parsed.get(field)
-    return result
+    return _to_taiwan_result(result)
 
 
 def _call_vision(img_path, prompt, max_retries=2, model=None):
@@ -305,9 +327,9 @@ def _describe_one(img_path, max_retries=2, model=None):
         return result
     tags = [t.strip() for t in lines[-1].split(",")] if len(lines) > 1 else []
     result = _empty_result()
-    result["description"] = zh_convert.to_taiwan(description)
+    result["description"] = description
     result["tags"] = tags
-    return result
+    return _to_taiwan_result(result)
 
 
 def _describe_one_light(img_path, max_retries=2, model=None):
@@ -322,20 +344,20 @@ def _describe_one_light(img_path, max_retries=2, model=None):
         if not isinstance(parsed, dict):
             return _empty_result()  # non-object payload → empty desc → flagged failed
         result = _empty_result()
-        result["description"] = zh_convert.to_taiwan(parsed.get("description", ""))
+        result["description"] = parsed.get("description", "")
         result["tags"] = parsed.get("tags", []) or []
         for field in _LIGHT_FIELDS:
             result[field] = parsed.get(field)
-        return result
+        return _to_taiwan_result(result)
     except json.JSONDecodeError:
         lines = [ln.strip() for ln in raw.splitlines() if ln.strip() and not ln.strip().startswith("```")]
         description = lines[0] if lines else ""
         if raw.lstrip().startswith(("{", "[")) or _is_degenerate_desc(description):
             return _empty_result()  # broken-JSON fragment → empty desc → flagged failed
         result = _empty_result()
-        result["description"] = zh_convert.to_taiwan(description)
+        result["description"] = description
         result["tags"] = [t.strip() for t in lines[-1].split(",")] if len(lines) > 1 else []
-        return result
+        return _to_taiwan_result(result)
 
 
 def _is_usable_frame(img_path):


### PR DESCRIPTION
Phase 9.8b 把 frame **description** 導進 `zh_convert`，因為 qwen3-vl 無視提示裡的
「繁體中文」照樣吐簡體。它轉了十一個欄位裡的**一個**。

**tags 是最貴的那個遺漏，因為 tags 是索引鍵。** 一個簡體標籤是一個永遠搜不到的
標籤：使用者搜「場景」，庫裡存的是「场景」。更糟的是兩種寫法一旦都存在，它們就是
兩個不同的標籤，tag pool 直接裂成兩半。結構化欄位（`content_type`／`atmosphere`／
`energy`／`edit_position`／`edit_reason`）同樣是中文詞，而且會顯示、會被拿來篩選。

修法是在每個 return 之前把**整個 result** 正規化一次，而不是四個 per-field 賦值
—— 四個賦值正是其中一個會漏掉的原因。

新增 9 支測試，涵蓋四條回傳路徑（JSON／散文 fallback × 完整／light）。light 那條
特別重要：**除了代表幀以外的每一幀都走它**，那是進索引的大多數。另外釘住「已經是
繁體的文字不會被動到」—— 轉換必須冪等，否則對既有庫重跑 vision 會把標籤攪一遍。

mutation-check 五處全紅在該紅的位置：
  tags 不轉                → 標籤測試紅
  結構化欄位不轉           → 欄位測試紅
  缺席欄位被填成空字串     → None 測試紅
  light 路徑跳過正規化     → light 測試紅
  散文 fallback 跳過正規化 → fallback 測試紅

一處誠實標註：`isinstance(value, str)`（擋住 int 的 `focus_score`）**沒有單獨的
mutation 證明** —— opencc 對 int 會拋 `'int' object has no attribute 'encode'`，
而 `zh_convert._convert` 自己就把轉換器的例外吞掉並原樣回傳。兩層都在，測試釘的是
結果。

全套 1576 passed / 7 skipped。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>