### PR TITLE
chore(ops): backfill_creation_date.py —— 沒有 exiftool 那次 ingest 的洞

### DIFF
--- a/backfill_creation_date.py
+++ b/backfill_creation_date.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Re-read EXIF for rows whose camera metadata was never captured.
+
+`exiftool_extract` returns `{}` when the binary is missing — a whole ingest run
+then writes `creation_date`, `camera_make`, `camera_model`, `lens_model` and the
+rest as NULL, with one banner line as the only signal. Installing exiftool
+afterwards fixes nothing: `db._backfill_shot_date` derives `shot_date` FROM
+`creation_date`, so a NULL stays NULL, and nothing anywhere goes back to the file
+to read the EXIF a second time.
+
+Visible cost: those clips sit in the `unknown` bucket of the shoot-date facet
+forever, and the camera columns the DIT views depend on are empty.
+
+This is the pass that goes back. It reads the file again, writes only fields that
+are currently NULL, and never overwrites something already there — a hand-edited
+value must survive a repair run.
+
+    python backfill_creation_date.py --dry-run     # what would change
+    python backfill_creation_date.py               # do it
+    python backfill_creation_date.py --limit 20    # a taste first
+
+Exit status is 0 even when nothing needed doing; a repair that finds nothing to
+repair is a success, not an error.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import db
+
+# Only these are backfilled. Everything here comes from the file itself and is
+# therefore re-derivable; anything a human can edit (tags, ratings, in/out
+# points, camera_id) is deliberately absent.
+_EXIF_FIELDS = (
+    "creation_date",
+    "camera_make",
+    "camera_model",
+    "lens_model",
+    "gps_lat",
+    "gps_lon",
+    "color_space",
+    "iso",
+    "shutter_speed",
+    "aperture",
+    "focal_length",
+    "reel_name",
+    "white_balance",
+)
+
+
+def rows_needing_backfill(conn, limit=None):
+    """Rows with no `creation_date`. That single column is the marker: it is the
+    one field essentially every camera writes, so its absence means the read
+    failed rather than the camera being quiet."""
+    sql = ("SELECT id, path, filename FROM media "
+           "WHERE creation_date IS NULL OR creation_date = '' ORDER BY id")
+    if limit:
+        sql += " LIMIT {0}".format(int(limit))
+    return conn.execute(sql).fetchall()
+
+
+def backfill_row(conn, row, dry_run=False):
+    """Returns (status, fields_written). status ∈ missing / no_exif / ok."""
+    import ingest
+
+    resolved = db.resolve_path(row["path"])
+    if not Path(resolved).exists():
+        # The NAS is unplugged, or the file moved. Not an error worth failing on:
+        # run it again when the volume is back.
+        return "missing", {}
+
+    meta = ingest.exiftool_extract(resolved)
+    if not meta:
+        return "no_exif", {}
+
+    current = conn.execute(
+        "SELECT {0} FROM media WHERE id = ?".format(", ".join(_EXIF_FIELDS)),
+        (row["id"],),
+    ).fetchone()
+
+    writes = {}
+    for field in _EXIF_FIELDS:
+        value = meta.get(field)
+        if value in (None, ""):
+            continue
+        if current[field] not in (None, ""):
+            continue  # never overwrite what is already there
+        writes[field] = value
+    if not writes:
+        return "no_exif", {}
+
+    if not dry_run:
+        # shot_date is DERIVED, so it has to be recomputed here — writing
+        # creation_date alone would leave the facet still showing `unknown`,
+        # which is the symptom this script exists to clear.
+        if "creation_date" in writes:
+            writes["shot_date"] = db.normalise_shot_date(writes["creation_date"])
+        assignments = ", ".join("{0} = ?".format(k) for k in writes)
+        conn.execute(
+            "UPDATE media SET {0} WHERE id = ?".format(assignments),
+            list(writes.values()) + [row["id"]],
+        )
+    return "ok", writes
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--dry-run", action="store_true",
+                    help="report what would be written, change nothing")
+    ap.add_argument("--limit", type=int, default=None,
+                    help="only look at the first N candidate rows")
+    args = ap.parse_args(argv)
+
+    db.init_db()
+    counts = {"ok": 0, "missing": 0, "no_exif": 0}
+    with db.get_conn() as conn:
+        rows = rows_needing_backfill(conn, args.limit)
+        print("{0} row(s) with no creation_date".format(len(rows)))
+        for row in rows:
+            status, writes = backfill_row(conn, row, dry_run=args.dry_run)
+            counts[status] += 1
+            if status == "ok":
+                print("  [{0}] {1}: {2}".format(
+                    row["id"], row["filename"],
+                    ", ".join("{0}={1}".format(k, v) for k, v in writes.items())))
+            elif status == "missing":
+                print("  [{0}] {1}: file not reachable — skipped".format(
+                    row["id"], row["filename"]))
+    verb = "would write" if args.dry_run else "wrote"
+    print("{0} {1}; {2} without EXIF; {3} unreachable".format(
+        verb, counts["ok"], counts["no_exif"], counts["missing"]))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_backfill_creation_date.py
+++ b/tests/test_backfill_creation_date.py
@@ -1,0 +1,168 @@
+"""Rows ingested without exiftool stay dateless forever.
+
+`exiftool_extract` returns `{}` when the binary is missing, so a whole ingest run
+writes `creation_date` and every camera column as NULL — one banner line is the
+only signal. Installing exiftool afterwards fixes nothing: `db._backfill_shot_date`
+derives `shot_date` FROM `creation_date`, so NULL stays NULL, and nothing goes back
+to the file to read the EXIF again.
+
+What the user sees: those clips are stuck in the `unknown` bucket of the shoot-date
+facet, permanently, and the DIT columns are empty.
+
+Two rules this pass must not break:
+
+* **Never overwrite.** A value already in the column — including one a human
+  typed — outranks anything re-read from the file.
+* **Recompute the derived column.** Writing `creation_date` alone leaves
+  `shot_date` NULL and the facet still saying `unknown`, i.e. the symptom
+  survives the repair.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import db
+
+
+@pytest.fixture
+def script(tmp_db):
+    mod = importlib.import_module("backfill_creation_date")
+    return importlib.reload(mod)
+
+
+@pytest.fixture
+def exif(monkeypatch):
+    """Stand in for exiftool. Pass a dict, or {} for "no exiftool / no EXIF"."""
+    import ingest
+
+    def _install(payload):
+        monkeypatch.setattr(ingest, "exiftool_extract", lambda p, fps=None: payload)
+    return _install
+
+
+def _seed(sample_record, tmp_path, name="A001.mp4", **over):
+    src = tmp_path / name
+    src.write_bytes(b"\x00")
+    rec = dict(path=str(src), filename=name, ext=".mp4")
+    rec.update(over)
+    rec.setdefault("creation_date", None)
+    db.upsert(sample_record(**rec))
+    return src
+
+
+def _row(mid=1):
+    with db.get_conn() as conn:
+        return dict(conn.execute("SELECT * FROM media WHERE id=?", (mid,)).fetchone())
+
+
+def test_a_dateless_row_gets_its_date_back(script, exif, sample_record, tmp_path):
+    _seed(sample_record, tmp_path)
+    exif({"creation_date": "2026:03:14 09:30:00", "camera_make": "Sony"})
+
+    script.main([])
+
+    row = _row()
+    assert row["creation_date"] == "2026:03:14 09:30:00"
+    assert row["camera_make"] == "Sony"
+
+
+def test_the_derived_shot_date_is_recomputed(script, exif, sample_record, tmp_path):
+    """Without this the clip is still in the `unknown` facet bucket — the symptom
+    the whole script exists to clear."""
+    _seed(sample_record, tmp_path)
+    exif({"creation_date": "2026:03:14 09:30:00"})
+
+    script.main([])
+
+    assert _row()["shot_date"] == "2026-03-14"
+
+
+def test_an_existing_value_is_never_overwritten(script, exif, sample_record, tmp_path):
+    """It might have been typed by a human. A repair pass that overwrites is a
+    repair pass that destroys work."""
+    _seed(sample_record, tmp_path, camera_make="手動填的")
+    exif({"creation_date": "2026:03:14 09:30:00", "camera_make": "Sony"})
+
+    script.main([])
+
+    assert _row()["camera_make"] == "手動填的"
+
+
+def test_rows_that_already_have_a_date_are_not_even_considered(
+    script, exif, sample_record, tmp_path
+):
+    _seed(sample_record, tmp_path, creation_date="2026:01:01 00:00:00")
+    with db.get_conn() as conn:
+        assert script.rows_needing_backfill(conn) == []
+
+
+def test_dry_run_changes_nothing(script, exif, sample_record, tmp_path, capsys):
+    _seed(sample_record, tmp_path)
+    exif({"creation_date": "2026:03:14 09:30:00"})
+
+    script.main(["--dry-run"])
+
+    assert _row()["creation_date"] is None
+    assert "would write 1" in capsys.readouterr().out
+
+
+def test_an_unreachable_file_is_skipped_not_failed(
+    script, exif, sample_record, tmp_path, capsys
+):
+    """The NAS being unplugged is a "run it again later", not an error."""
+    src = _seed(sample_record, tmp_path)
+    src.unlink()
+    exif({"creation_date": "2026:03:14 09:30:00"})
+
+    assert script.main([]) == 0
+    assert "1 unreachable" in capsys.readouterr().out
+
+
+def test_a_file_with_genuinely_no_exif_is_reported_separately(
+    script, exif, sample_record, tmp_path, capsys
+):
+    """"exiftool is missing" and "this file has no metadata" look identical from
+    here — both return {} — but the count tells the user which run to repeat."""
+    _seed(sample_record, tmp_path)
+    exif({})
+
+    script.main([])
+
+    assert "1 without EXIF" in capsys.readouterr().out
+    assert _row()["creation_date"] is None
+
+
+def test_an_unparseable_date_still_writes_the_raw_value(
+    script, exif, sample_record, tmp_path
+):
+    """`creation_date` is stored raw on purpose (cameras disagree about format);
+    only the derived column is allowed to be NULL when it can't be read."""
+    _seed(sample_record, tmp_path)
+    exif({"creation_date": "not a date"})
+
+    script.main([])
+
+    row = _row()
+    assert row["creation_date"] == "not a date"
+    assert row["shot_date"] is None
+
+
+def test_limit_stops_early(script, exif, sample_record, tmp_path):
+    for i in range(3):
+        _seed(sample_record, tmp_path, name="A00{0}.mp4".format(i))
+    exif({"creation_date": "2026:03:14 09:30:00"})
+
+    script.main(["--limit", "1"])
+
+    dated = [r for r in (_row(i) for i in (1, 2, 3)) if r["creation_date"]]
+    assert len(dated) == 1
+
+
+def test_editorial_fields_are_out_of_scope(script):
+    """Only file-derived fields are re-read. Anything a human sets — tags, rating,
+    in/out, camera_id — must never be touched by a repair pass."""
+    for human in ("tags", "rating", "in_point", "out_point", "camera_id", "angle",
+                  "transcript"):
+        assert human not in script._EXIF_FIELDS


### PR DESCRIPTION
`exiftool_extract` 在 binary 不存在時回 `{}`，於是那一整輪 ingest 把
`creation_date`、`camera_make`、`camera_model`、鏡頭、ISO、光圈…… 全部寫成 NULL，
唯一的訊號是一行 banner。**事後裝上 exiftool 也救不回來**：`db._backfill_shot_date`
是**從** `creation_date` 推導 `shot_date` 的，NULL 進 NULL 出，而全樹沒有任何東西
會回頭再讀一次那個檔案的 EXIF。

使用者看得到的後果：那些片子永遠卡在拍攝日期 facet 的 `unknown` 桶裡，而 DIT 檢視
依賴的相機欄位是空的。

這支就是那個「回頭再讀一次」。兩條它不能破的規則：

- **絕不覆寫。** 欄位裡已經有的值 —— 包含人手打的 —— 永遠贏過重讀出來的。
  重寫式的修復是會摧毀工作成果的修復。
- **推導欄位要一起重算。** 只寫 `creation_date` 會讓 `shot_date` 還是 NULL、
  facet 還是說 `unknown` —— 症狀原封不動活過這次修復。

只回填**檔案本身推得出來的**欄位。人設定的東西（tags、評分、in/out、camera_id）
刻意不在清單裡，而且有一支測試盯著這份清單。

`--dry-run` / `--limit N`。找不到檔案（NAS 沒插）算 skip 不算失敗 —— 那是「等下次
再跑」。「沒有 exiftool」和「這個檔案真的沒有 metadata」從這裡看起來一模一樣
（都回 `{}`），所以分開計數，讓使用者知道該重跑哪一種。

新增 10 支測試。mutation-check 六處全紅在該紅的位置：
  覆寫既有值          → 手打值測試紅
  不重算 shot_date    → facet 測試紅
  dry-run 照樣寫      → dry-run 測試紅
  候選查詢不篩選      → 候選測試紅
  檔案不在也照寫      → 不可達測試紅
  忽略 --limit        → limit 測試紅

全套 1586 passed / 7 skipped。**這是這一波計畫 22 支的最後一支。**

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>