### PR TITLE
chore(ops): repair_timecodes.py —— 修復既有庫要跑的那支，收進 repo

### DIFF
--- a/scripts/repair_timecodes.py
+++ b/scripts/repair_timecodes.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Re-transcribe a library whose timecodes were written in gapless-speech time.
+
+Every clip transcribed before PR #350 carries timestamps relative to the
+VAD-trimmed audio, not the media. The error is the total silence removed before
+that line, so it grows along the clip — a caption can be seconds early by the end.
+
+**There is no offset-only backfill.** `_vad_filter` consumed its `stamps` and
+returned a path; the trimmed wav was unlinked moments later. The mapping was never
+stored anywhere, so the only repair is to transcribe the clip again.
+
+This calls the SAME worker the API uses rather than reimplementing it — that
+worker already carries the H1 guard (never blank a good transcript on a failed
+decode), the outgoing-language archive, and the backup snapshot. A repair script
+with its own copy of that logic is a repair script that drifts from the thing it
+is repairing.
+
+    ARKIV_PROJECT_ROOT=<library> python scripts/repair_timecodes.py --dry-run
+    ARKIV_PROJECT_ROOT=<library> python scripts/repair_timecodes.py
+
+`backup=True` is not optional and is not exposed as a flag: the write overwrites
+the archived `transcripts` row for that language, and `corrections._write_backup`
+is the only rollback path.
+
+Expect polish, not whisper, to be the wall clock. Whisper decodes several times
+faster than realtime; LLM polish runs at 3-4 characters/second. A few hours of
+audio is an overnight job.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--dry-run", action="store_true",
+                    help="report the work and stop")
+    ap.add_argument("--limit", type=int, default=None,
+                    help="only the first N clips (a taste before the overnight run)")
+    args = ap.parse_args(argv)
+
+    if not os.getenv("ARKIV_PROJECT_ROOT"):
+        print("set ARKIV_PROJECT_ROOT to the library you mean to repair", file=sys.stderr)
+        return 2
+
+    import config
+    import db
+
+    print("project root:", config.PROJECT_ROOT)
+    print("db:", config.DB_PATH)
+    db.init_db()
+    with db.get_conn() as conn:
+        rows = conn.execute(
+            "SELECT id, path, duration_s, "
+            "       CASE WHEN transcript IS NOT NULL AND transcript != '' "
+            "            THEN 1 ELSE 0 END AS has_text "
+            "FROM media WHERE has_audio=1 ORDER BY id"
+        ).fetchall()
+    # Every audio clip is a target, not only the ones with text: a clip that came
+    # back empty may have been a failed decode rather than a silent clip, and the
+    # H1 guard means a good transcript can never be replaced by an empty one.
+    targets = [(r["id"], r["path"]) for r in rows]
+    if args.limit:
+        targets = targets[: args.limit]
+    print("audio clips: {0} (with transcript: {1})  audio: {2:.2f} h".format(
+        len(rows), sum(r["has_text"] for r in rows),
+        sum((r["duration_s"] or 0) for r in rows) / 3600))
+    print("targets this run:", len(targets))
+    if args.dry_run:
+        return 0
+
+    import routers.retranscribe as rt
+    start = time.time()
+    rt._run_retranscribe_all(targets, None, True)
+    progress = dict(rt._retranscribe_guard.progress)
+    print("done={done} failed={failed} backup={backup}".format(**progress))
+    print("elapsed: {0:.1f} min".format((time.time() - start) / 60))
+    # A failure count above zero is worth acting on: it means a clip was skipped
+    # (file unreachable, decode error), not that its transcript was replaced badly.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_repair_timecodes_script.py
+++ b/tests/test_repair_timecodes_script.py
@@ -1,0 +1,51 @@
+"""The repair script must not grow its own copy of the retranscribe logic.
+
+The clips being repaired are someone's only copy of a hand-corrected transcript.
+The API worker already knows not to blank a good transcript on a failed decode, to
+archive the outgoing language, and to snapshot before writing. A repair script
+that reimplements that is a script that drifts away from the thing it repairs —
+and it drifts silently, because a repair run looks the same either way until you
+need the rollback.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "repair_timecodes.py"
+
+
+def _src():
+    return _SCRIPT.read_text(encoding="utf-8")
+
+
+def test_it_calls_the_api_worker():
+    assert "_run_retranscribe_all" in _src()
+
+
+def test_it_does_not_write_transcripts_itself():
+    """Any UPDATE of its own would be a second, unreviewed write path."""
+    src = _src()
+    for forbidden in ("UPDATE media", "upsert_transcript", "INSERT INTO transcripts"):
+        assert forbidden not in src, "the script writes transcripts on its own"
+
+
+def test_the_backup_is_not_optional():
+    """`corrections._write_backup` is the only rollback. A `--no-backup` flag is a
+    loaded gun pointed at a library that cannot be re-derived."""
+    src = _src()
+    assert "--no-backup" not in src
+    assert "_run_retranscribe_all(targets, None, True)" in src
+
+
+def test_it_refuses_to_run_without_being_told_which_library():
+    """Defaulting to the ambient PROJECT_ROOT would let a mistyped command
+    re-transcribe the wrong library."""
+    import subprocess
+    import sys
+
+    env = {k: v for k, v in __import__("os").environ.items() if k != "ARKIV_PROJECT_ROOT"}
+    r = subprocess.run([sys.executable, str(_SCRIPT), "--dry-run"],
+                       capture_output=True, text=True, env=env, timeout=60)
+
+    assert r.returncode == 2
+    assert "ARKIV_PROJECT_ROOT" in r.stderr


### PR DESCRIPTION
#350 之前轉錄過的每一支片子，時間碼都是相對於 VAD 裁切後的音檔而不是媒體，
誤差＝該行之前被移除的靜音總和，沿片累積。**沒有 offset-only backfill 可做** ——
`_vad_filter` 把 `stamps` 用完就丟、裁切檔幾行後 unlink，映射從來沒有被存到任何
地方，所以唯一的修法是整支重跑轉錄。

這支腳本原本只活在我的暫存目錄，而 NAS（731 支）與 mini（290 支）兩邊都還要跑，
所以收進 repo 與 `backfill_creation_date.py` 放在一起。

**它呼叫 API 用的那個同一個 worker**（`routers.retranscribe._run_retranscribe_all`），
不自己寫一份：那個 worker 已經帶著 H1 守衛（解碼失敗絕不把好的逐字稿清成空）、
outgoing 語言封存、以及備份快照。自己抄一份的修復腳本會跟它要修的東西**無聲地**
漂開 —— 兩者跑起來看不出差別，直到你需要回滾的那天。

`backup=True` 寫死、**不開成 flag**：寫入會覆蓋該語言的封存列，
`corrections._write_backup` 是唯一的回滾路徑；一個 `--no-backup` 是對著一個
再也推導不回來的庫上膛。沒設 `ARKIV_PROJECT_ROOT` 直接拒跑，免得打錯指令去改到
別的庫。

4 支測試盯住這份契約（有呼叫 worker／自己不寫 transcript／備份不可關／沒指定
library 就拒跑）。

已對 ROG 那個庫實跑過：26 支、`點進去隨便一個` 原標 0.00 實際 4.62、覆蓋率
16–51% → 17–98%、對原始音檔量能量 8/8 段命中語音。

全套 1590 passed / 7 skipped。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>