### PR TITLE
fix(tauri): ⌘Q 離開時，backend 與我們啟動的 ollama 都沒被收掉

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -343,22 +343,35 @@ fn main() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(|app_handle, event| {
-            // Kill the backend child when the app is exiting, so no orphan uvicorn
-            // survives the window closing.
-            if let tauri::RunEvent::ExitRequested { .. } = event {
-                if let Some(state) = app_handle.try_state::<Backend>() {
-                    if let Some(mut child) = state.0.lock().unwrap().take() {
-                        let _ = child.kill();
+            // Kill our children when the app is exiting, so no orphan uvicorn (or
+            // Ollama) survives the window closing.
+            //
+            // BOTH events, and that is the fix rather than a belt-and-braces: with
+            // only `ExitRequested`, quitting through an Apple Event — which is what
+            // ⌘Q and `osascript -e 'quit app "arkiv"'` send — never reached this
+            // code at all, and every such quit left a uvicorn holding its port.
+            // Measured: quit the packaged app, `pgrep` still finds the backend.
+            // `Exit` is the last event before the process ends and fires on every
+            // path. `take()` makes the pair idempotent when both fire.
+            match event {
+                tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit => {
+                    if let Some(state) = app_handle.try_state::<Backend>() {
+                        if let Some(mut child) = state.0.lock().unwrap().take() {
+                            let _ = child.kill();
+                            let _ = child.wait(); // reap, don't leave a zombie
+                        }
+                    }
+                    // Only the Ollama we started. If it was already running when we
+                    // launched, the state holds None and the user's daemon — very
+                    // possibly serving something else — is left alone.
+                    if let Some(state) = app_handle.try_state::<Ollama>() {
+                        if let Some(mut child) = state.0.lock().unwrap().take() {
+                            let _ = child.kill();
+                            let _ = child.wait();
+                        }
                     }
                 }
-                // Only the Ollama we started. If it was already running when we
-                // launched, the state holds None and the user's daemon — very
-                // possibly serving something else — is left alone.
-                if let Some(state) = app_handle.try_state::<Ollama>() {
-                    if let Some(mut child) = state.0.lock().unwrap().take() {
-                        let _ = child.kill();
-                    }
-                }
+                _ => {}
             }
         });
 }

--- a/tests/test_tauri_ollama.py
+++ b/tests/test_tauri_ollama.py
@@ -84,3 +84,33 @@ def test_the_windows_only_code_is_actually_compiled_somewhere():
     ci = _CI.read_text(encoding="utf-8")
     assert "tauri-check-windows" in ci
     assert "runs-on: windows-latest" in ci
+
+
+# ── exit cleanup ─────────────────────────────────────────────────────────────
+# Found by actually quitting the packaged app rather than reading the code: with
+# only `ExitRequested`, an Apple Event quit (⌘Q, `osascript -e 'quit app "arkiv"'`)
+# never reached the cleanup at all, and every such quit left a uvicorn holding its
+# port. Measured before the fix: `pgrep` finds the backend after the app is gone.
+
+
+def test_cleanup_runs_on_both_exit_events():
+    """`Exit` is the last event before the process ends and fires on every path;
+    `ExitRequested` alone misses the Apple Event route."""
+    src = _src()
+    assert "RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit" in src, (
+        "the quit path that leaves orphans is the one not handled"
+    )
+
+
+def test_the_children_are_reaped_not_just_signalled():
+    """kill() without wait() leaves a zombie for the life of the parent."""
+    src = _src()
+    tail = src.split(".run(|app_handle, event|", 1)[1]
+    assert tail.count("child.kill()") == 2
+    assert tail.count("child.wait()") == 2
+
+
+def test_taking_the_child_out_of_state_keeps_it_idempotent():
+    """Both events can fire on one quit; the second must find nothing to kill."""
+    tail = _src().split(".run(|app_handle, event|", 1)[1]
+    assert tail.count(".lock().unwrap().take()") == 2


### PR DESCRIPTION
驗 #367 的時候發現的，而且是**實際去 quit 那個打包好的 app** 才看得到 ——
讀 code 讀不出來。

`RunEvent::ExitRequested` 不涵蓋 Apple Event 那條離開路徑，而 **⌘Q 與
`osascript -e 'quit app "arkiv"'` 送的正是 Apple Event**。所以那段清理程式碼
從來沒有在正常關閉時跑過：每一次 ⌘Q 都留下一個還佔著 port 的 uvicorn。

實測（修正前）：

    啟動後 backend: 1
    quit 之後  app: 0   backend: 1     ← 孤兒

修法是同時處理 `RunEvent::Exit` —— 它是 process 結束前的最後一個事件，每條路徑
都會發。`take()` 讓兩個事件都發時第二次找不到東西可殺，天然冪等。順手補
`child.wait()` 把子行程收屍，否則會在 parent 的生命週期裡留一個 zombie。

實測（修正後）：

    啟動後 backend: 1
    quit 之後  app: 0   backend: 0     ← 乾淨
    ollama: 1（使用者 launchd 的那個，沒被動到）

**backend 那段 kill 比這次的 ollama 更早就存在**，所以這是一個既有的孤兒 bug，
只是 #367 讓 ollama 也繼承了同一個缺陷。

新增 3 支測試（兩個事件都要處理／要 reap 不能只送訊號／`take()` 保持冪等）。
`cargo check` 綠，重建 `.app` 後用最小 PATH 啟動 + ⌘Q 實測通過。

全套 1593 passed / 7 skipped。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>