### PR TITLE
ci: chromadb 今天多三個 CVE，全部是 server 模式的，具名忽略

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,10 +278,27 @@ jobs:
           # PYSEC id and its GHSA alias, so a pip-audit id switch can't red the gate
           # on the very advisory it means to skip — the gate still blocks on any
           # other/new advisory. Revisit when a fix ships or chromadb is dropped.
+          #
+          # 2026-08-25: three MORE from the same disclosure batch (consecutive CVE
+          # ids, same package, same "no fixed version" state) — and the same
+          # reasoning applies unchanged, so they get the same explicit treatment:
+          #   CVE-2026-45830  cross-tenant read/write by any authenticated user
+          #   CVE-2026-45831  SimpleRBACAuthorizationProvider ignores tenant scope
+          #   CVE-2026-45833  RCE via trust_remote_code, needs UPDATE_COLLECTION
+          # All three require a RUNNING ChromaDB server with authenticated users
+          # (two of them additionally require multiple tenants). arkiv calls
+          # `chromadb.PersistentClient(path=...)` and nothing else — verified: no
+          # HttpClient, no server process, no tenants, no auth provider anywhere in
+          # the tree. None of the three is reachable, and there is no fixed version
+          # to move to. Both the CVE id and its GHSA alias are listed for each, for
+          # the same id-switch reason as above.
           # NOTE: this only gates MERGES if `dependency-audit` (and `test-windows`)
           # are set as REQUIRED checks in branch protection — verify in repo settings.
           pip-audit -r requirements.txt -r requirements-dev.txt \
-            --ignore-vuln PYSEC-2026-311 --ignore-vuln GHSA-f4j7-r4q5-qw2c
+            --ignore-vuln PYSEC-2026-311 --ignore-vuln GHSA-f4j7-r4q5-qw2c \
+            --ignore-vuln CVE-2026-45830 --ignore-vuln GHSA-2wm9-hf6c-p5cr \
+            --ignore-vuln CVE-2026-45831 --ignore-vuln GHSA-xph7-9rjv-w5fr \
+            --ignore-vuln CVE-2026-45833 --ignore-vuln GHSA-36p7-vc44-83pf
       - uses: actions/setup-node@v7
         with:
           node-version: "20"

--- a/tests/test_assemble_no_secrets.py
+++ b/tests/test_assemble_no_secrets.py
@@ -140,3 +140,50 @@ def test_macos_script_is_valid_bash() -> None:
     """
     proc = subprocess.run(["bash", "-n"], input=SH.read_bytes(), capture_output=True)
     assert proc.returncode == 0, f"bash -n failed:\n{proc.stderr.decode(errors='replace')}"
+
+
+# ── the chromadb advisory ignores must stay honest ───────────────────────────
+# `dependency-audit` is a real gate, and the only sanctioned way past it is an
+# EXPLICIT per-advisory ignore with a reason. That is safe exactly as long as the
+# reason stays true: arkiv embeds chromadb in-process and never runs its server.
+# The day someone adds an HttpClient, every one of those ignores silently becomes
+# a live vulnerability with a stale excuse next to it.
+
+def test_no_chromadb_server_client_anywhere():
+    """The premise behind every chromadb `--ignore-vuln` in ci.yml."""
+    import re
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parent.parent
+    offenders = []
+    for py in root.rglob("*.py"):
+        parts = set(py.parts)
+        if parts & {"tests", ".venv", "node_modules", "temp", "src-tauri"}:
+            continue
+        text = py.read_text(encoding="utf-8", errors="replace")
+        if re.search(r"chromadb\.HttpClient|chromadb\.AsyncHttpClient", text):
+            offenders.append(str(py.relative_to(root)))
+    assert offenders == [], (
+        "ci.yml ignores chromadb server-mode CVEs because arkiv never runs the "
+        "server. These files break that premise: {0}".format(offenders)
+    )
+
+
+def test_every_ignored_advisory_carries_a_reason():
+    """A bare `--ignore-vuln` with no comment is indistinguishable from `|| true`."""
+    from pathlib import Path
+    import re
+
+    ci = (Path(__file__).resolve().parent.parent / ".github" / "workflows"
+          / "ci.yml").read_text(encoding="utf-8")
+    block = ci.split("- name: pip-audit", 1)[1].split("- uses:", 1)[0]
+    ids = re.findall(r"--ignore-vuln (\S+)", block)
+    assert ids, "no ignores found — did the step move?"
+    for advisory in ids:
+        assert advisory in block, advisory
+    # Each ignored CVE id must also appear in a comment line explaining it.
+    commented = {m for m in re.findall(r"#.*?(CVE-\d{4}-\d+|PYSEC-\d{4}-\d+)", block)}
+    for advisory in ids:
+        if advisory.startswith("GHSA-"):
+            continue  # aliases ride along with their CVE/PYSEC id
+        assert advisory in commented, "{0} is ignored with no stated reason".format(advisory)


### PR DESCRIPTION
`dependency-audit` 從今天起紅在每一支 PR 上，而且跟改動內容無關：chromadb 1.5.9
多了三個新 advisory，**三個都沒有修復版本**。

    CVE-2026-45830  任何已認證使用者可跨租戶讀寫
    CVE-2026-45831  SimpleRBACAuthorizationProvider 不檢查租戶範圍
    CVE-2026-45833  帶 UPDATE_COLLECTION 權限者可用 trust_remote_code RCE

**三個都要有「跑起來的 ChromaDB server + 已認證使用者」才觸發**（其中兩個還要多
租戶）。arkiv 只呼叫 `chromadb.PersistentClient(path=...)` —— 實查全樹沒有
`HttpClient`、沒有 server process、沒有租戶、沒有 auth provider。都到不了。

而且這不是新的資安判斷：`CVE-2026-45829`（同一批、連號、同樣 server-mode、同樣
無修復版本）**早就用一模一樣的理由具名忽略**了。這支只是把同一個已拍板的處置
延伸到同批的另外三個。

照 workflow 自己寫的程序：具名忽略、寫明理由、絕不用 `|| true`；CVE id 與 GHSA
alias 兩個都列，免得 pip-audit 換 id 的時候，這個閘門紅在它本來就要跳過的那條上。

**加兩支守衛，因為這個忽略只在它的理由為真的時候才安全**：
- 任何 `.py` 出現 `chromadb.HttpClient` 就紅 —— 那天到來時，這些忽略會在一行過期
  的藉口旁邊靜靜地變成真的漏洞
- 每個被忽略的 CVE/PYSEC id 都必須在註解裡有對應的說明 —— 沒寫理由的
  `--ignore-vuln` 跟 `|| true` 分不出來

mutation-check 兩處全紅在該紅的位置。全套 1592 passed / 7 skipped。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>