### PR TITLE
docs: 更正一個把別人的工作歸給陌生人的署名，並鳴謝 pen

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -1,0 +1,62 @@
+# Acknowledgements
+
+## pen — the VAD timestamp defect, and the fix
+
+In August 2026 `pen` reported that clicking a transcript timecode in the Inspector
+seeked to the wrong place, or jumped back to 00:00, and sent a 20-patch series.
+
+It was not a bug in their setup. `_vad_filter()` ran Silero VAD, concatenated the
+speech it kept into a gapless WAV, and returned only the path — the `stamps` that
+said where that speech came from went out of scope, and the trimmed file was
+unlinked moments later. Every timestamp Whisper reported was therefore in
+gapless-speech time while every other clock in arkiv (frames, waveform,
+`<video>.currentTime`, EDL source TC) is media time. The error equals the silence
+removed before that line, so it grows along the clip.
+
+Measured on a real library after the fix: a caption labelled 0.00 s was actually
+at 4.62 s on an 8-second clip; on a 2m48s clip the last line was labelled 60.7 s
+and belonged at 167.0 s.
+
+**pen had already fixed it.** Patch 0019 in that series arrived on 2026-08-22 with
+the same design arkiv shipped two days later — an offset map returned from
+`_vad_filter`, remapping applied to segments *and* words before anything
+downstream sees them, `ARKIV_VAD_THRESHOLD` exposed, and oversized segments
+re-wrapped through `subtitle.wrap()`'s 14-CJK-unit budget with each line's span
+sized **proportionally to its display width rather than an equal 1/n split**,
+because an equal split puts a click's seek target at the segment's geometric
+midpoint. arkiv reached the same conclusions independently and rebuilt them
+test-first; the convergence is the strongest evidence the diagnosis was right.
+
+Work in this repository that implements what pen had already written and sent:
+
+| pen's patch | shipped as |
+|---|---|
+| 0019 VAD timestamp drift, oversized-segment re-wrap | #350, #353 |
+| 0011 chunked LLM punctuation polish | #352 |
+| 0004 waveform prefers the H.264 proxy | #363 |
+| 0016 prefer an editor-made proxy beside the source | #364, #365 |
+| 0005 auto-start Ollama on app launch | #367 |
+| 0008–0010, 0013, 0014 transcript / punctuation output | #354, #356, #357 |
+
+### Correction
+
+PRs #349, #350, #351, #356 and #357 carry a
+`Co-authored-by: Penny <penny@users.noreply.github.com>` trailer. **That address
+was invented and is wrong.** `penny@users.noreply.github.com` resolves to
+[github.com/Penny](https://github.com/Penny), an unrelated account with no
+connection to this project or to the work described above. The trailers cannot be
+removed from merged history without rewriting `main`, so the correction lives
+here.
+
+pen's own Git identity is on the patches they sent. It is deliberately not
+reproduced here: per this project's practice, a contributor is asked before being
+named, and that question is outstanding. If pen tells us how they would like to be
+credited — a GitHub account, a different name, or not at all — this page and the
+project's public credits will follow it.
+
+---
+
+*Attribution rule that came out of this: never construct a
+`<something>@users.noreply.github.com` address. Those resolve to whoever holds
+that account. Use the contributor's own Git author line, or credit them by name
+here.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,3 +263,10 @@ confirm that:
 You keep the copyright to what you wrote — point 3 is a license you grant, not a transfer of
 ownership. Merged contributions are credited in the repository's contributor list; if you'd
 like to be credited under a different name than your Git identity, just say so in the PR.
+
+**Crediting someone who did not open the PR themselves** (a patch sent by mail, a bug report
+that turned into a fix): use their own Git author line from the patch, or name them in
+[ACKNOWLEDGEMENTS.md](ACKNOWLEDGEMENTS.md). **Never construct a
+`<name>@users.noreply.github.com` address** — GitHub resolves those to whoever actually holds
+that account, so a guessed one credits a stranger. That has happened here once; see the
+correction in ACKNOWLEDGEMENTS.md.

--- a/tests/test_acknowledgements.py
+++ b/tests/test_acknowledgements.py
@@ -1,0 +1,54 @@
+"""The attribution correction has to stay findable.
+
+Five merged commits credit `Co-authored-by: Penny <penny@users.noreply.github.com>`.
+That address was invented, and GitHub resolves it to a real, unrelated account — so
+the repository's own history currently credits a stranger for another person's work.
+Merged history cannot be rewritten (this project never force-pushes `main`), which
+makes the correction a document rather than a commit, and a document is exactly the
+kind of thing that gets tidied away later by someone who does not know why it exists.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_ACK = _ROOT / "ACKNOWLEDGEMENTS.md"
+
+
+def test_the_acknowledgement_exists():
+    assert _ACK.exists()
+
+
+def test_it_states_the_wrong_trailer_and_why_it_is_wrong():
+    text = _ACK.read_text(encoding="utf-8")
+    assert "penny@users.noreply.github.com" in text
+    assert "invented" in text
+    # The point that makes it urgent rather than cosmetic: it lands on a real person.
+    assert "github.com/Penny" in text
+
+
+def test_it_names_the_affected_prs():
+    """Someone auditing the history needs to know which commits are affected."""
+    text = _ACK.read_text(encoding="utf-8")
+    for pr in ("#349", "#350", "#351", "#356", "#357"):
+        assert pr in text, "affected PR {0} not listed".format(pr)
+
+
+def test_it_does_not_publish_the_contributor_s_private_address():
+    """This project asks before naming a contributor, and that question is still
+    open. Correcting one over-share by committing a personal email would be a
+    second one."""
+    text = _ACK.read_text(encoding="utf-8")
+    emails = re.findall(r"[\w.+-]+@[\w-]+\.[\w.]+", text)
+    allowed = {"penny@users.noreply.github.com"}  # quoted precisely to disown it
+    assert set(emails) <= allowed, "unexpected address published: {0}".format(
+        set(emails) - allowed)
+
+
+def test_the_rule_is_written_where_the_next_person_will_look():
+    """An acknowledgement explains one incident; CONTRIBUTING is what someone reads
+    before crediting the next mailed-in patch."""
+    contributing = (_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    assert "users.noreply.github.com" in contributing
+    assert "ACKNOWLEDGEMENTS.md" in contributing


### PR DESCRIPTION
**#349/#350/#351/#356/#357 帶的 `Co-authored-by: Penny
<penny@users.noreply.github.com>` 是我編出來的位址。** 而
`penny@users.noreply.github.com` 在 GitHub 上會解析到
[github.com/Penny](https://github.com/Penny) —— 一個跟這個專案、跟這件工作
毫無關係的真實帳號。也就是說，這個 repo 的歷史目前正把 pen 的工作歸給一個陌生人。

merged 的歷史不能重寫（本專案不 force-push main），所以更正只能是一份文件 ——
`ACKNOWLEDGEMENTS.md`。

同時把該講的講清楚：**pen 早就自己修好了。** 那 20 支 patch 裡的 0019 在
2026-08-22 就送到，設計跟 arkiv 兩天後出的 #350/#353 一樣 —— `_vad_filter` 回
offset map、remap 套在 segment **與 words** 上、開出 `ARKIV_VAD_THRESHOLD`、
過長 segment 用 `subtitle.wrap()` 的 14 單位預算重排，而且**跨度按顯示寬度比例分
而不是等分**，理由同樣是「等分會讓點擊落在 segment 的幾何中點」。我們是各自獨立
走到同一個結論再重寫的；這種收斂本身就是「她的診斷是對的」最強的證據。

另外六支實作她已寫過並交給我們的東西：#352（潤稿切塊）、#363（波形走 proxy）、
#364/#365（剪接室 proxy）、#367（Ollama 自動啟動）。表列在鳴謝檔裡。

**刻意不放她的 email。** 本專案的做法是具名前先問，而那個問題還沒得到回覆 ——
用公開一個私人信箱去更正另一個過度公開，是第二次犯同樣的錯。她要怎麼被署名
（GitHub 帳號、別的名字、或不要）由她決定，這頁跟對外的鳴謝都跟著改。

`CONTRIBUTING.md` 補上規則：**絕不自己造
`<name>@users.noreply.github.com`** —— 那種位址會解析到真正持有該帳號的人。

新增 5 支測試盯住這份更正（存在、寫明錯在哪、列出受影響的 PR、**不得包含她的
私人信箱**、規則寫在下一個人會看的地方）。

全套 1597 passed / 7 skipped。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>