### PR TITLE
feat(transcribe): 電平太低的素材，語音在 whisper 看到之前就沒了

### DIFF
--- a/config.py
+++ b/config.py
@@ -201,6 +201,18 @@ def _read_subtitle_max_cjk() -> int:
 
 SUBTITLE_MAX_CJK = _read_subtitle_max_cjk()
 
+
+# Quiet recordings lose whole passages before whisper ever sees them: VAD reads a
+# low-level track as silence and drops it. Normalising fixes that — but only for
+# tracks that need it. Running dynaudnorm over already well-levelled audio pulls
+# the noise floor up in the quiet passages, which is where hallucinations come
+# from, so this is GATED on a measured level rather than applied to everything.
+#
+# -30 dB mean is well below normal dialogue (a healthy mix sits around -20 to
+# -26) and comfortably above the level at which VAD starts eating speech.
+AUDIO_NORMALISE = os.getenv("ARKIV_AUDIO_NORMALISE", "1").strip().lower() not in ("0", "false", "no", "off")
+AUDIO_NORMALISE_BELOW_DB = float(os.getenv("ARKIV_AUDIO_NORMALISE_BELOW_DB", "-30"))
+
 def _detect_exiftool() -> str:
     """Resolve ExifTool binary path via fallback chain.
 

--- a/tests/test_audio_normalise.py
+++ b/tests/test_audio_normalise.py
@@ -1,0 +1,139 @@
+"""Quiet recordings lose whole passages before whisper ever sees them.
+
+VAD reads a low-level track as silence and drops it, so the transcript comes back
+with holes — and the holes land disproportionately on relaxed, quietly-spoken
+passages, which in mixed Mandarin/Taiwanese material is exactly where the Taiwanese
+tends to be. Normalising the audio recovers them.
+
+**But only for tracks that need it**, and that gate is the whole design. Running
+`dynaudnorm` over an already well-levelled track pulls the noise floor up in the
+quiet stretches — which is where hallucinations come from. So the level is measured
+first and the filter is applied only below a threshold.
+"""
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+import transcribe as tr
+
+
+class _FakeRun:
+    """Capture the ffmpeg argv, and answer volumedetect with a scripted level."""
+
+    def __init__(self, mean_db=None, fail_probe=False):
+        self.mean_db = mean_db
+        self.fail_probe = fail_probe
+        self.calls = []
+
+    def __call__(self, cmd, **kw):
+        self.calls.append(cmd)
+        if "volumedetect" in " ".join(cmd):
+            if self.fail_probe:
+                raise OSError("ffmpeg missing")
+            body = ("" if self.mean_db is None
+                    else "[Parsed_volumedetect_0 @ 0x0] mean_volume: {0} dB\n".format(self.mean_db))
+            return subprocess.CompletedProcess(cmd, 0, b"", body.encode())
+        # the extract call: pretend it wrote the output file
+        out = cmd[-2]
+        with open(out, "wb") as fh:
+            fh.write(b"\x00" * 64)
+        return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+
+def _extract_cmd(fake):
+    return next(c for c in fake.calls if "volumedetect" not in " ".join(c))
+
+
+def test_a_quiet_track_is_normalised(monkeypatch):
+    fake = _FakeRun(mean_db=-46.8)
+    monkeypatch.setattr(subprocess, "run", fake)
+    monkeypatch.setattr(tr, "AUDIO_NORMALISE", True)
+
+    tr._to_wav("/clip.mp4")
+
+    assert "dynaudnorm" in " ".join(_extract_cmd(fake))
+
+
+def test_a_healthy_track_is_left_alone(monkeypatch):
+    """The half that protects existing libraries: normalising good audio raises the
+    noise floor in the quiet parts, and that is where hallucinations start."""
+    fake = _FakeRun(mean_db=-22.0)
+    monkeypatch.setattr(subprocess, "run", fake)
+    monkeypatch.setattr(tr, "AUDIO_NORMALISE", True)
+
+    tr._to_wav("/clip.mp4")
+
+    assert "dynaudnorm" not in " ".join(_extract_cmd(fake))
+    assert "-af" not in _extract_cmd(fake)
+
+
+def test_an_unmeasurable_track_is_left_alone(monkeypatch):
+    """No reading means no evidence the track needs help. Guessing 'probably quiet'
+    would apply the filter to everything ffmpeg can't probe."""
+    fake = _FakeRun(mean_db=None)
+    monkeypatch.setattr(subprocess, "run", fake)
+    monkeypatch.setattr(tr, "AUDIO_NORMALISE", True)
+
+    tr._to_wav("/clip.mp4")
+
+    assert "dynaudnorm" not in " ".join(_extract_cmd(fake))
+
+
+def test_a_failed_probe_does_not_break_extraction(monkeypatch):
+    """The probe is an optimisation. If it throws, transcription must still run —
+    losing the whole clip to a level check would be a far worse trade."""
+    fake = _FakeRun(fail_probe=True)
+    monkeypatch.setattr(subprocess, "run", fake)
+    monkeypatch.setattr(tr, "AUDIO_NORMALISE", True)
+
+    out = tr._to_wav("/clip.mp4")
+
+    assert out
+    assert "dynaudnorm" not in " ".join(_extract_cmd(fake))
+
+
+def test_the_feature_can_be_turned_off_entirely(monkeypatch):
+    """Off means off — including the probe, so a library that doesn't want this
+    doesn't pay an extra ffmpeg pass per clip either."""
+    fake = _FakeRun(mean_db=-46.8)
+    monkeypatch.setattr(subprocess, "run", fake)
+    monkeypatch.setattr(tr, "AUDIO_NORMALISE", False)
+
+    tr._to_wav("/clip.mp4")
+
+    assert not any("volumedetect" in " ".join(c) for c in fake.calls)
+    assert "dynaudnorm" not in " ".join(_extract_cmd(fake))
+
+
+def test_the_probe_writes_nothing(monkeypatch):
+    """`-f null -` decodes to nowhere. A probe that re-encoded would double the
+    cost of every ingest."""
+    fake = _FakeRun(mean_db=-40.0)
+    monkeypatch.setattr(subprocess, "run", fake)
+    monkeypatch.setattr(tr, "AUDIO_NORMALISE", True)
+
+    tr._to_wav("/clip.mp4")
+
+    probe = next(c for c in fake.calls if "volumedetect" in " ".join(c))
+    assert probe[-2:] == ["-f", "null"] or probe[-3:-1] == ["-f", "null"]
+
+
+@pytest.mark.parametrize("db,expected", [(-30.1, True), (-29.9, False)])
+def test_the_threshold_is_where_it_says_it_is(monkeypatch, db, expected):
+    fake = _FakeRun(mean_db=db)
+    monkeypatch.setattr(subprocess, "run", fake)
+    monkeypatch.setattr(tr, "AUDIO_NORMALISE", True)
+    monkeypatch.setattr(tr, "AUDIO_NORMALISE_BELOW_DB", -30.0)
+
+    tr._to_wav("/clip.mp4")
+
+    assert ("dynaudnorm" in " ".join(_extract_cmd(fake))) is expected
+
+
+def test_the_level_is_parsed_from_ffmpeg_stderr(monkeypatch):
+    fake = _FakeRun(mean_db=-33.8)
+    monkeypatch.setattr(subprocess, "run", fake)
+
+    assert tr._mean_volume_db("/clip.mp4") == pytest.approx(-33.8)

--- a/transcribe.py
+++ b/transcribe.py
@@ -9,6 +9,7 @@ import tempfile
 import threading
 import time
 import platform
+import re
 from pathlib import Path
 
 import numpy as np
@@ -31,6 +32,8 @@ from config import (
     OLLAMA_CHAT_MODEL,
     FFMPEG_PATH,
     DIARIZATION_ENABLED,
+    AUDIO_NORMALISE,
+    AUDIO_NORMALISE_BELOW_DB,
     PYANNOTE_TOKEN,
     VAD_THRESHOLD,
 )
@@ -892,12 +895,46 @@ def _llm_polish_batched(text: str, language: str = "zh") -> str:
     return " ".join(out)
 
 
+def _mean_volume_db(media_path: str):
+    """Mean audio level in dBFS, or None when ffmpeg can't say.
+
+    One cheap pass — `volumedetect` decodes to null, so nothing is written and no
+    re-encode happens. Cheap enough to run per clip, and the alternative is
+    guessing whether a track needs help.
+    """
+    cmd = [FFMPEG_PATH, "-i", media_path, "-map", "a:0",
+           "-af", "volumedetect", "-f", "null", "-"]
+    try:
+        r = subprocess.run(cmd, capture_output=True, timeout=300)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    err = (r.stderr or b"").decode("utf-8", "replace")
+    match = re.search(r"mean_volume:\s*(-?\d+(?:\.\d+)?) dB", err)
+    return float(match.group(1)) if match else None
+
+
 def _to_wav(media_path: str):
     _fd, out = tempfile.mkstemp(suffix=".wav"); os.close(_fd)
+    filters = []
+    if AUDIO_NORMALISE:
+        # Gated, not unconditional. A quiet track loses whole passages before
+        # whisper sees them — VAD reads low level as silence and drops it, and the
+        # holes land disproportionately on relaxed, quietly-spoken passages. But
+        # normalising an already healthy track raises its noise floor in exactly
+        # the quiet stretches where hallucinations start, so measure first.
+        mean_db = _mean_volume_db(media_path)
+        if mean_db is not None and mean_db < AUDIO_NORMALISE_BELOW_DB:
+            print("  [audio] mean {0:.1f} dB < {1:.0f} dB — normalising".format(
+                mean_db, AUDIO_NORMALISE_BELOW_DB), flush=True)
+            filters.append("dynaudnorm")
     cmd = [
         FFMPEG_PATH, "-i", media_path,
         "-ac", "1", "-ar", "16000",
         "-map", "a:0",
+    ]
+    if filters:
+        cmd += ["-af", ",".join(filters)]
+    cmd += [
         "-loglevel", "error",
         out, "-y"
     ]


### PR DESCRIPTION
低電平的收音會被 VAD 讀成靜音直接丟掉，所以逐字稿回來是有洞的 —— 而那些洞
**不平均分布**：講話放鬆、音量比較小的段落最容易整段消失，在國台語夾雜的素材裡，
那通常也正是台語密集的地方。正規化就能把它們救回來。

**但只對需要的素材做，這個閘門才是這支的設計重點。** 對本來就收得好的音軌硬套
`dynaudnorm`，會把安靜段的底噪一起拉上來 —— 而那正是幻覺的來源。所以先量再決定：

- `_mean_volume_db()` 用 `volumedetect` 量一次。`-f null -` 解碼到空，不寫檔、
  不重編碼，便宜到可以每支跑
- 低於 `ARKIV_AUDIO_NORMALISE_BELOW_DB`（預設 −30 dB）才加 `dynaudnorm`。健康的
  對白大約落在 −20 ～ −26，所以這個門檻在正常素材之下、又在「VAD 開始吃掉語音」
  之上
- **量不到就不套** —— 沒有讀數就沒有證據說這支需要幫忙，猜「大概很小聲」等於對
  每一支 ffmpeg 探測不到的素材都套下去
- **探測失敗不能弄壞抽音軌** —— 那只是最佳化，為了一次電平檢查賠掉整支片子是更
  糟的交換
- `ARKIV_AUDIO_NORMALISE=0` 整個關掉，連探測都不跑

新增 9 支測試。mutation-check 五處全紅在該紅的位置：
  無條件套           → 健康音軌測試紅
  量不到就當要正規化   → 未知音軌測試紅
  探測失敗往外拋      → 抽音軌測試紅
  關掉了還是探測      → 開關測試紅
  完全不套           → 低電平測試紅

全套 1609 passed / 7 skipped。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>