### PR TITLE
feat(transcribe): 跑兩次 ASR，把「兩邊不一致的地方」變成產出

### DIFF
--- a/tests/test_transcript_compare.py
+++ b/tests/test_transcript_compare.py
@@ -1,0 +1,195 @@
+"""Running ASR twice is only useful if the disagreements are the output.
+
+Two engines fail differently: Whisper flattens Taiwanese into Mandarin but gets
+proper nouns right; Qwen3-ASR keeps the Taiwanese but writes proper nouns
+phonetically. So agreement is shippable and disagreement is a short list worth a
+human ear — which means the alignment has to survive the fact that the two engines
+don't segment the same way at all.
+"""
+from __future__ import annotations
+
+import pytest
+
+import transcript_compare as tc
+
+
+def seg(start, end, text):
+    return {"start": start, "end": end, "text": text}
+
+
+# ── alignment ────────────────────────────────────────────────────────────────
+
+def test_segments_pair_by_time_not_by_index():
+    """The engines emit different segment counts for the same speech. Pairing by
+    index would misalign everything after the first difference — and the result
+    would look like disagreement everywhere, burying the real ones."""
+    a = [seg(0, 5, "一整句話講完")]
+    b = [seg(0, 2, "一整句"), seg(2, 5, "話講完")]
+
+    pairs = tc.align(a, b)
+
+    assert len(pairs) == 2
+    matched = [p for p in pairs if p[0] and p[1]]
+    assert len(matched) == 1
+
+
+def test_a_segment_pairs_with_the_one_it_overlaps_not_the_first_available():
+    """The sharper version of the above. `a` sits at 10-12s; the first candidate in
+    `b` is at 0-2s and shares nothing with it. Pairing greedily by availability
+    rather than by overlap would marry those two and report a disagreement between
+    sentences that were never spoken at the same time."""
+    a = [seg(10, 12, "後半的話")]
+    b = [seg(0, 2, "開頭的話"), seg(10, 12, "後半的話")]
+
+    pairs = tc.align(a, b)
+    matched = [(x, y) for x, y in pairs if x and y]
+
+    assert len(matched) == 1
+    assert matched[0][1]["text"] == "後半的話"
+
+
+def test_a_segment_with_no_counterpart_pairs_with_none():
+    """That is what makes a coverage hole visible, instead of silently shifting
+    every later pair by one."""
+    a = [seg(0, 2, "第一句"), seg(10, 12, "只有這邊有")]
+    b = [seg(0, 2, "第一句")]
+
+    pairs = tc.align(a, b)
+
+    assert (None in [p[1] for p in pairs])
+    assert len(pairs) == 2
+
+
+def test_pairs_come_back_in_time_order():
+    a = [seg(10, 12, "後面"), seg(0, 2, "前面")]
+    b = [seg(0, 2, "前面")]
+
+    starts = [float((p[0] or p[1])["start"]) for p in tc.align(a, b)]
+
+    assert starts == sorted(starts)
+
+
+def test_a_b_side_extra_segment_is_not_dropped():
+    a = [seg(0, 2, "有")]
+    b = [seg(0, 2, "有"), seg(5, 7, "b 多出來的")]
+
+    pairs = tc.align(a, b)
+
+    assert any(p[0] is None and p[1] is not None for p in pairs)
+
+
+def test_barely_touching_segments_are_not_paired():
+    """A 50 ms brush is two different utterances, not the same one."""
+    a = [seg(0, 2.0, "甲")]
+    b = [seg(1.95, 4.0, "乙")]
+
+    pairs = tc.align(a, b, min_overlap_s=0.2)
+
+    assert all(not (p[0] and p[1]) for p in pairs)
+
+
+# ── classification ───────────────────────────────────────────────────────────
+
+def test_identical_text_agrees():
+    assert tc.classify(seg(0, 1, "一樣的字"), seg(0, 1, "一樣的字")) == tc.AGREE
+
+
+def test_punctuation_and_spacing_are_not_disagreements():
+    """The two engines punctuate differently by nature. Reporting that as something
+    to review would bury the differences that matter."""
+    assert tc.classify(seg(0, 1, "好，那我們開始。"), seg(0, 1, "好 那我們開始")) == tc.AGREE
+
+
+def test_one_side_empty_is_a_coverage_hole():
+    assert tc.classify(seg(0, 1, "有講話"), seg(0, 1, "")) == tc.COVERAGE
+    assert tc.classify(None, seg(0, 1, "只有一邊聽到")) == tc.COVERAGE
+
+
+def test_one_side_catching_a_fraction_is_also_coverage():
+    """Not empty, but two words out of a sentence — same failure, and calling it a
+    wording difference would send someone hunting for a nuance that isn't there."""
+    assert tc.classify(seg(0, 3, "這一整句話都有被聽到而且很長"),
+                       seg(0, 3, "這一整")) == tc.COVERAGE
+
+
+def test_taiwanese_kept_on_one_side_only_is_flagged_as_taigi():
+    """The failure this whole exercise exists for: one engine wrote the Taiwanese,
+    the other flattened it into fluent Mandarin — which reads fine, so nothing else
+    would ever catch it."""
+    assert tc.classify(seg(0, 2, "我們今天來看"), seg(0, 2, "阮今仔日來看")) == tc.TAIGI
+
+
+def test_taiwanese_on_both_sides_is_not_a_taigi_flag():
+    """Both kept it — whatever they disagree about, it isn't the flattening."""
+    kind = tc.classify(seg(0, 2, "阮遮有問題"), seg(0, 2, "阮遐有問題"))
+    assert kind != tc.TAIGI
+
+
+def test_markers_shared_with_mandarin_are_not_in_the_set():
+    """伊 / 講 / 較 / 欲 are ordinary Mandarin too. A marker that fires on Mandarin
+    makes the category cry wolf, and a category that cries wolf gets ignored —
+    taking the real ones with it."""
+    for ch in "伊講較欲":
+        assert ch not in tc.TAIGI_MARKERS
+
+
+def test_a_plain_wording_difference_is_other():
+    """No evidence of either known failure. `other` means 'a person has to listen',
+    not 'we classified it'."""
+    assert tc.classify(seg(0, 2, "這個沒有問題"), seg(0, 2, "這個不是問題")) == tc.OTHER
+
+
+def test_no_phonetic_category_is_invented():
+    """Classifying 'proper noun written phonetically' needs a pronunciation table,
+    and arkiv has none — opencc converts script, not sound. Anything that would
+    require guessing at pronunciation must land in `other`."""
+    kind = tc.classify(seg(0, 2, "富田的產品"), seg(0, 2, "福田的產品"))
+    assert kind == tc.OTHER
+
+
+# ── the whole thing ──────────────────────────────────────────────────────────
+
+def test_compare_separates_shippable_from_reviewable():
+    a = [seg(0, 2, "第一句一樣"), seg(2, 4, "我們今天"), seg(4, 6, "有講到東西")]
+    b = [seg(0, 2, "第一句一樣"), seg(2, 4, "阮今仔日"), seg(4, 6, "")]
+
+    out = tc.compare(a, b)
+
+    assert out["agreed"] == 1
+    assert out["by_kind"] == {tc.TAIGI: 1, tc.COVERAGE: 1}
+    assert {r["kind"] for r in out["review"]} == {tc.TAIGI, tc.COVERAGE}
+
+
+def test_review_items_carry_both_readings_and_a_timestamp():
+    """The point is to jump to the audio and listen. An item without a window, or
+    with only one side, cannot be acted on."""
+    out = tc.compare([seg(3, 5, "我們今天")], [seg(3, 5, "阮今仔日")])
+
+    item = out["review"][0]
+    assert item["start"] == 3 and item["end"] == 5
+    assert item["a"] == "我們今天" and item["b"] == "阮今仔日"
+
+
+def test_two_identical_transcripts_produce_no_review():
+    a = [seg(0, 2, "完全一樣"), seg(2, 4, "第二句")]
+    assert tc.compare(a, list(a))["review"] == []
+
+
+def test_empty_inputs_do_not_raise():
+    assert tc.compare([], [])["review"] == []
+    assert tc.compare([seg(0, 1, "只有一邊")], [])["by_kind"] == {tc.COVERAGE: 1}
+
+
+def test_segments_without_timestamps_go_to_review_rather_than_claim_agreement():
+    """Legacy rows carry explicit nulls, and alignment is done by time — so with no
+    timestamps there is nothing to align on.
+
+    They are reported as needing review, not as agreeing. Matching them up by
+    position instead would be a guess, and a guess that says "these agree" is the
+    one failure mode this module must not have: it would mark unverified text as
+    shippable."""
+    out = tc.compare([{"start": None, "end": None, "text": "沒有時間"}],
+                     [{"start": None, "end": None, "text": "沒有時間"}])
+
+    assert out["agreed"] == 0
+    assert out["review"], "silently dropped instead of flagged"

--- a/transcript_compare.py
+++ b/transcript_compare.py
@@ -1,0 +1,143 @@
+"""transcript_compare.py — align two transcripts of the same audio and say where
+they disagree.
+
+Running ASR twice and diffing is not about picking a winner. Two engines fail in
+different, recognisable ways, so the disagreements are worth more than either
+transcript alone:
+
+* Whisper flattens Taiwanese into Mandarin — the sentence reads fluently and the
+  Taiwanese is simply gone. It is also the one that honours a term dictionary, so
+  proper nouns and model numbers come out right.
+* Qwen3-ASR keeps Taiwanese far more faithfully, but tends to write the sound
+  rather than the word, so proper nouns drift.
+
+Where they agree, you can ship it. Where they don't, you have a short list that is
+worth a human ear — and usually you can see at a glance which failure it is,
+because the two look nothing alike.
+
+**What this module deliberately does NOT do**: decide which side is right, and
+classify "proper noun written phonetically". The latter needs a pronunciation
+table, and arkiv has none — opencc converts script, not sound. Guessing would
+manufacture a confident-looking category out of nothing, so a difference that
+isn't demonstrably one of the known kinds is returned as `other`, meaning
+"a person has to listen".
+
+Alignment is by TIME, so segments without usable timestamps cannot be aligned and
+are reported as needing review. Pairing them by position instead would be a guess,
+and a guess that comes out as "these agree" is the one failure this module must not
+have — it would mark unverified text as shippable.
+
+Pure functions, stdlib only. No I/O, no model, no engine assumptions — it takes
+two segment lists in arkiv's usual `{"start", "end", "text"}` shape.
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+# Characters that are written Taiwanese and effectively do not appear in written
+# Mandarin. Deliberately conservative: 伊 / 講 / 較 / 欲 are common in both and are
+# NOT here, because a marker that fires on Mandarin makes the whole category
+# meaningless. Missing a few Taiwanese lines is recoverable; a category that cries
+# wolf gets ignored, and then so does the real one.
+TAIGI_MARKERS = "毋袂佇阮恁遮遐蹛媠囡爸母囝孫兜箍焦鬧熱歹勢多謝按怎啥物"
+
+AGREE = "agree"
+COVERAGE = "coverage"   # one side has text the other simply doesn't
+TAIGI = "taigi"         # one side kept Taiwanese, the other flattened it
+OTHER = "other"         # different wording — needs a human ear
+
+
+def _overlap(a: Dict, b: Dict) -> float:
+    """Seconds the two segments share."""
+    lo = max(float(a.get("start") or 0.0), float(b.get("start") or 0.0))
+    hi = min(float(a.get("end") or 0.0), float(b.get("end") or 0.0))
+    return max(0.0, hi - lo)
+
+
+def _norm(text: str) -> str:
+    """Compare content, not layout: whitespace and the punctuation the two engines
+    disagree about anyway are not differences worth a human's time."""
+    drop = " \t\n，。、！？；：「」『』（）,.!?;:\"'"
+    return "".join(ch for ch in (text or "") if ch not in drop)
+
+
+def _taigi_count(text: str) -> int:
+    return sum(1 for ch in (text or "") if ch in TAIGI_MARKERS)
+
+
+def align(a_segments: List[Dict], b_segments: List[Dict],
+          min_overlap_s: float = 0.2) -> List[Tuple[Optional[Dict], Optional[Dict]]]:
+    """Pair segments by time overlap, in order.
+
+    Time, not text — the two engines segment differently (one may emit twice as
+    many segments for the same speech), so pairing by index would misalign
+    everything after the first disagreement. A segment with no counterpart pairs
+    with None, which is what makes a coverage hole visible instead of silently
+    shifting every later pair.
+    """
+    pairs: List[Tuple[Optional[Dict], Optional[Dict]]] = []
+    used_b = set()
+    for a in a_segments:
+        best, best_overlap = None, 0.0
+        for i, b in enumerate(b_segments):
+            if i in used_b:
+                continue
+            ov = _overlap(a, b)
+            if ov > best_overlap:
+                best, best_overlap, best_i = b, ov, i
+        if best is not None and best_overlap >= min_overlap_s:
+            used_b.add(best_i)
+            pairs.append((a, best))
+        else:
+            pairs.append((a, None))
+    for i, b in enumerate(b_segments):
+        if i not in used_b:
+            pairs.append((None, b))
+    pairs.sort(key=lambda p: float((p[0] or p[1]).get("start") or 0.0))
+    return pairs
+
+
+def classify(a: Optional[Dict], b: Optional[Dict]) -> str:
+    """What KIND of difference this is — or AGREE."""
+    ta, tb = _norm((a or {}).get("text", "")), _norm((b or {}).get("text", ""))
+    if ta == tb:
+        return AGREE
+    if not ta or not tb:
+        return COVERAGE
+    # A large length gap in the same window is a coverage hole too: one engine
+    # heard a sentence, the other caught two words of it.
+    longer, shorter = max(len(ta), len(tb)), min(len(ta), len(tb))
+    if shorter * 2 <= longer:
+        return COVERAGE
+    if (_taigi_count(ta) > 0) != (_taigi_count(tb) > 0):
+        return TAIGI
+    return OTHER
+
+
+def compare(a_segments: List[Dict], b_segments: List[Dict],
+            min_overlap_s: float = 0.2) -> Dict:
+    """Two transcripts in, one review list out.
+
+    Returns `{"agreed": n, "review": [...], "by_kind": {...}}` where each review
+    item carries both readings and the window they cover, so a person can jump
+    straight to the audio.
+    """
+    review = []
+    agreed = 0
+    for a, b in align(a_segments, b_segments, min_overlap_s):
+        kind = classify(a, b)
+        if kind == AGREE:
+            agreed += 1
+            continue
+        anchor = a or b
+        review.append({
+            "start": float(anchor.get("start") or 0.0),
+            "end": float(anchor.get("end") or 0.0),
+            "kind": kind,
+            "a": (a or {}).get("text", ""),
+            "b": (b or {}).get("text", ""),
+        })
+    by_kind: Dict[str, int] = {}
+    for item in review:
+        by_kind[item["kind"]] = by_kind.get(item["kind"], 0) + 1
+    return {"agreed": agreed, "review": review, "by_kind": by_kind}


### PR DESCRIPTION
新 leaf `transcript_compare.py`（純函式、只用標準函式庫）。

跑兩次 ASR 再 diff，重點不是挑贏家 —— 是**兩個引擎的失敗模式不一樣而且認得出來**，
所以分歧本身比任何一份稿都值錢：

- Whisper 會把台語抹平成國語 —— 句子讀起來很順，台語就這樣不見了。而它吃 term
  dictionary，專有名詞與型號反而最準
- Qwen3-ASR 對台語忠實得多，但傾向寫音不寫字，專有名詞會走音

一致的地方可以直接出，不一致的地方就是一份**值得人耳的短名單**。

**按時間配對，不按索引。** 兩個引擎的斷句方式根本不同（同一段語音可能一邊出兩倍
的 segment），照索引配會讓第一個分歧之後的東西全部錯位 —— 結果是「到處都不一致」，
把真正的分歧埋掉。配不到的就跟 `None` 配，那正是讓覆蓋率破洞看得見的方式。

分類只做**證據支持得起的三類**：
- `coverage` 一邊有、另一邊沒有（或只抓到一小截）
- `taigi` 一邊留了台語、另一邊抹平了
- `other` 需要人耳

**刻意不做「專有名詞寫音不寫字」的自動判別** —— 那需要發音表，而 arkiv 沒有
（opencc 轉的是字不是音）。硬猜等於憑空造出一個看起來很有把握的分類，所以判不出來
的一律回 `other`，意思是「請人去聽」。

台語 marker 也刻意保守：`伊`／`講`／`較`／`欲` **不在名單裡**，因為它們在國語裡也
很常見。一個會對國語誤報的 marker 會讓整個分類失去意義 —— 漏掉幾句台語還救得回來，
但一個常喊狼來了的分類會被忽略，然後真的那次也一起被忽略。

無時間碼的 segment 回報成「需要複查」而不是「一致」：按位置猜著配是猜，而猜出來
的「這兩個一致」正是這個模組唯一不能有的失效 —— 那會把沒驗過的文字標成可以出。

新增 20 支測試。mutation-check 八處全紅在該紅的位置。其中**兩支測試是重寫過的**：
原本的「按時間配對」測試在「先到先配」的 mutation 下照樣綠（案例分不出兩者），
補了一個 `a` 在 10-12 秒、而 `b` 的第一個候選在 0-2 秒的案例才真的紅。

全套 1620 passed / 7 skipped。

⚠️ **第二條引擎還沒接** —— 這支是引擎無關的對齊層。Qwen3-ASR 的模型在 PC 上
（`QwenASR_1.0.9`），不在這台 Mac，所以接線與實跑要在有模型的機器上做。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>