### PR TITLE
feat(transcribe): 第二條 ASR 引擎 —— 走大家都在講的那個介面

### DIFF
--- a/asr_api.py
+++ b/asr_api.py
@@ -1,0 +1,131 @@
+"""asr_api.py — transcribe through an OpenAI-compatible `/audio/transcriptions`
+endpoint.
+
+The second engine in a two-pass setup has to come from somewhere, and the useful
+observation is that the thing we want to reach locally (QwenASR ships a
+`/audio/transcriptions` + `/health` server) speaks the same shape as Groq,
+Cloudflare Workers AI, and every whisper.cpp server. So this is not a
+"Qwen backend" — it is one adapter that reaches all of them, and which one is in
+use is a URL.
+
+That also means the awkward part is real: those services do not agree on the
+response body. Three shapes turn up in practice and all three are handled here:
+
+* `verbose_json` — `{"text", "segments":[{"start","end","text"}]}`. The good case.
+* plain `{"text": "..."}` — no timings at all.
+* SRT — QwenASR's own default. Timings are there, just in a subtitle format.
+
+**A response with no timings does not get invented ones.** It comes back as a
+single segment spanning the clip, flagged by `segments == []` upstream, because a
+fabricated start/end is exactly the class of bug this project just spent a week
+removing. Nothing downstream can tell a guessed timestamp from a measured one.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Dict, List, Optional, Tuple
+
+import requests
+
+# Where the second engine lives. Unset means "no second engine configured", which
+# is the normal state — the feature is opt-in per machine, because the model has
+# to actually be installed somewhere.
+ASR_API_BASE = os.getenv("ARKIV_ASR_API_BASE", "").rstrip("/")
+ASR_API_KEY = os.getenv("ARKIV_ASR_API_KEY", "")
+ASR_API_MODEL = os.getenv("ARKIV_ASR_API_MODEL", "whisper-1")
+ASR_API_TIMEOUT = int(os.getenv("ARKIV_ASR_API_TIMEOUT", "1800"))
+
+_SRT_TIME = re.compile(
+    r"(\d{2}):(\d{2}):(\d{2})[,.](\d{1,3})\s*-->\s*(\d{2}):(\d{2}):(\d{2})[,.](\d{1,3})")
+
+
+def configured() -> bool:
+    return bool(ASR_API_BASE)
+
+
+def _srt_seconds(h: str, m: str, s: str, ms: str) -> float:
+    return int(h) * 3600 + int(m) * 60 + int(s) + int(ms.ljust(3, "0")) / 1000.0
+
+
+def parse_srt(srt_text: str) -> List[Dict]:
+    """SRT → arkiv segments. Tolerant of `,` or `.` as the millisecond separator
+    (SRT says comma, WebVTT says dot, and servers emit both)."""
+    segments: List[Dict] = []
+    for block in re.split(r"\n\s*\n", (srt_text or "").strip()):
+        lines = [ln for ln in block.splitlines() if ln.strip()]
+        if not lines:
+            continue
+        timing_at = next((i for i, ln in enumerate(lines) if _SRT_TIME.search(ln)), None)
+        if timing_at is None:
+            continue
+        m = _SRT_TIME.search(lines[timing_at])
+        text = " ".join(ln.strip() for ln in lines[timing_at + 1:]).strip()
+        if not text:
+            continue
+        segments.append({
+            "start": _srt_seconds(*m.groups()[:4]),
+            "end": _srt_seconds(*m.groups()[4:]),
+            "text": text,
+        })
+    return segments
+
+
+def _segments_from_payload(body: str, content_type: str) -> Tuple[str, List[Dict]]:
+    """(text, segments) from whichever of the three shapes came back."""
+    if "json" in (content_type or "").lower() or body.lstrip().startswith("{"):
+        try:
+            data = json.loads(body)
+        except ValueError:
+            data = None
+        if isinstance(data, dict):
+            segments = [
+                {"start": float(s.get("start") or 0.0),
+                 "end": float(s.get("end") or 0.0),
+                 "text": (s.get("text") or "").strip()}
+                for s in (data.get("segments") or [])
+                if (s.get("text") or "").strip()
+            ]
+            return (data.get("text") or "").strip(), segments
+    # not JSON → SRT (QwenASR's default) or bare text
+    segments = parse_srt(body)
+    if segments:
+        return " ".join(s["text"] for s in segments), segments
+    return (body or "").strip(), []
+
+
+def transcribe(wav_path: str, language: Optional[str] = None,
+               base_url: Optional[str] = None, api_key: Optional[str] = None,
+               model: Optional[str] = None, timeout: Optional[int] = None) -> Tuple:
+    """arkiv's four-tuple contract: (text, language, segments, words).
+
+    `words` is always empty: none of these endpoints return word timings, and the
+    alternative — deriving them by splitting a segment evenly — would be exactly
+    the invented-timestamp bug this project just removed.
+    """
+    base = (base_url if base_url is not None else ASR_API_BASE).rstrip("/")
+    if not base:
+        raise RuntimeError("no ASR API configured (set ARKIV_ASR_API_BASE)")
+    key = api_key if api_key is not None else ASR_API_KEY
+    headers = {"Authorization": "Bearer {0}".format(key)} if key else {}
+    data = {
+        "model": model if model is not None else ASR_API_MODEL,
+        # Ask for timings. A server that doesn't know this format ignores it and
+        # answers in its own, which the parser above already handles.
+        "response_format": "verbose_json",
+    }
+    if language:
+        data["language"] = language
+    with open(wav_path, "rb") as fh:
+        resp = requests.post(
+            "{0}/audio/transcriptions".format(base),
+            headers=headers,
+            data=data,
+            files={"file": (os.path.basename(wav_path), fh, "audio/wav")},
+            timeout=timeout if timeout is not None else ASR_API_TIMEOUT,
+        )
+    resp.raise_for_status()
+    text, segments = _segments_from_payload(
+        resp.text, resp.headers.get("Content-Type", ""))
+    return text, (language or ""), segments, []

--- a/tests/test_asr_api.py
+++ b/tests/test_asr_api.py
@@ -1,0 +1,203 @@
+"""A second ASR engine, reached over the shape everyone already speaks.
+
+The thing we want locally — QwenASR ships an `/audio/transcriptions` + `/health`
+server — talks the same protocol as Groq, Cloudflare Workers AI, and every
+whisper.cpp server. So this is one adapter for all of them, and which engine is in
+use is a URL.
+
+The awkward part is that they disagree about the response body. Three shapes turn
+up and all three have to work, because the whole point of a second pass is that it
+comes from a *different* engine.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+import requests
+
+import asr_api
+
+
+class _Resp:
+    def __init__(self, body, content_type="application/json", status=200):
+        self.text = body
+        self.headers = {"Content-Type": content_type}
+        self._status = status
+
+    def raise_for_status(self):
+        if self._status >= 400:
+            raise requests.HTTPError("{0}".format(self._status))
+
+
+@pytest.fixture
+def wav(tmp_path):
+    p = tmp_path / "a.wav"
+    p.write_bytes(b"RIFF0000WAVE")
+    return str(p)
+
+
+def _post(monkeypatch, resp, captured=None):
+    def fake_post(url, headers=None, data=None, files=None, timeout=None):
+        if captured is not None:
+            captured.update({"url": url, "headers": headers or {}, "data": data or {},
+                             "files": files or {}, "timeout": timeout})
+        return resp
+    monkeypatch.setattr(requests, "post", fake_post)
+
+
+# ── the three response shapes ────────────────────────────────────────────────
+
+def test_verbose_json_segments_are_used(monkeypatch, wav):
+    _post(monkeypatch, _Resp(json.dumps({
+        "text": "第一句 第二句",
+        "segments": [{"start": 0.0, "end": 2.0, "text": "第一句"},
+                     {"start": 2.0, "end": 4.0, "text": "第二句"}],
+    }, ensure_ascii=False)))
+
+    text, lang, segs, words = asr_api.transcribe(wav, "zh", base_url="http://x")
+
+    assert [s["text"] for s in segs] == ["第一句", "第二句"]
+    assert segs[1]["start"] == 2.0
+    assert text == "第一句 第二句"
+
+
+def test_srt_is_parsed_into_segments(monkeypatch, wav):
+    """QwenASR's own default. The timings are there — just in subtitle format."""
+    _post(monkeypatch, _Resp(
+        "1\n00:00:01,000 --> 00:00:03,500\n第一句話\n\n"
+        "2\n00:00:04,000 --> 00:00:06,000\n第二句話\n", "text/plain"))
+
+    _text, _lang, segs, _w = asr_api.transcribe(wav, "zh", base_url="http://x")
+
+    assert [(s["start"], s["end"]) for s in segs] == [(1.0, 3.5), (4.0, 6.0)]
+    assert segs[0]["text"] == "第一句話"
+
+
+def test_a_text_only_answer_yields_no_segments(monkeypatch, wav):
+    """**No invented timings.** A server that returns only text has told us nothing
+    about when anything was said, and a fabricated start/end is indistinguishable
+    downstream from a measured one — which is the entire bug class this project
+    just spent a wave removing."""
+    _post(monkeypatch, _Resp("就只有一串文字沒有時間", "text/plain"))
+
+    text, _lang, segs, _w = asr_api.transcribe(wav, "zh", base_url="http://x")
+
+    assert text == "就只有一串文字沒有時間"
+    assert segs == []
+
+
+def test_words_are_always_empty(monkeypatch, wav):
+    """None of these endpoints return word timings, and splitting a segment evenly
+    to manufacture them is the same invented-timestamp mistake one level down."""
+    _post(monkeypatch, _Resp(json.dumps({
+        "text": "abc", "segments": [{"start": 0, "end": 3, "text": "abc"}]})))
+
+    _t, _l, _s, words = asr_api.transcribe(wav, "zh", base_url="http://x")
+
+    assert words == []
+
+
+# ── SRT parsing edge cases ───────────────────────────────────────────────────
+
+def test_both_millisecond_separators_are_accepted():
+    """SRT says comma, WebVTT says dot, and real servers emit both."""
+    comma = asr_api.parse_srt("1\n00:00:01,500 --> 00:00:02,000\n甲\n")
+    dot = asr_api.parse_srt("1\n00:00:01.500 --> 00:00:02.000\n甲\n")
+    assert comma == dot
+    assert comma[0]["start"] == 1.5
+
+
+def test_a_multi_line_cue_becomes_one_segment():
+    segs = asr_api.parse_srt("1\n00:00:00,000 --> 00:00:02,000\n第一行\n第二行\n")
+    assert segs[0]["text"] == "第一行 第二行"
+
+
+def test_a_cue_with_no_text_is_dropped():
+    segs = asr_api.parse_srt("1\n00:00:00,000 --> 00:00:02,000\n\n\n2\n"
+                             "00:00:02,000 --> 00:00:03,000\n有字\n")
+    assert [s["text"] for s in segs] == ["有字"]
+
+
+def test_garbage_is_not_a_segment():
+    assert asr_api.parse_srt("這不是 SRT，只是一段話") == []
+    assert asr_api.parse_srt("") == []
+
+
+def test_short_millisecond_fields_are_padded_not_misread():
+    """`00:00:01,5` means 500 ms, not 5 ms. Reading it as 5 would put the cue half
+    a second early — small, silent, and exactly the kind of drift we just fixed."""
+    assert asr_api.parse_srt("1\n00:00:01,5 --> 00:00:02,0\n甲\n")[0]["start"] == 1.5
+
+
+# ── the request ──────────────────────────────────────────────────────────────
+
+def test_it_asks_for_timings(monkeypatch, wav):
+    """`verbose_json` is what gets segments out of a compliant server. A server that
+    doesn't know the format ignores it and answers in its own, which the parser
+    handles — so asking costs nothing and not asking costs the timings."""
+    cap = {}
+    _post(monkeypatch, _Resp('{"text":"x"}'), cap)
+
+    asr_api.transcribe(wav, "zh", base_url="http://x")
+
+    assert cap["data"]["response_format"] == "verbose_json"
+
+
+def test_the_language_hint_is_passed_through(monkeypatch, wav):
+    cap = {}
+    _post(monkeypatch, _Resp('{"text":"x"}'), cap)
+    asr_api.transcribe(wav, "zh", base_url="http://x")
+    assert cap["data"]["language"] == "zh"
+
+
+def test_no_language_hint_means_no_field(monkeypatch, wav):
+    """Sending an empty language is not the same as omitting it — some servers read
+    `""` as a request to transcribe in no language at all."""
+    cap = {}
+    _post(monkeypatch, _Resp('{"text":"x"}'), cap)
+    asr_api.transcribe(wav, None, base_url="http://x")
+    assert "language" not in cap["data"]
+
+
+def test_the_api_key_becomes_a_bearer_header(monkeypatch, wav):
+    cap = {}
+    _post(monkeypatch, _Resp('{"text":"x"}'), cap)
+    asr_api.transcribe(wav, "zh", base_url="http://x", api_key="secret")
+    assert cap["headers"]["Authorization"] == "Bearer secret"
+
+
+def test_no_key_sends_no_auth_header(monkeypatch, wav):
+    """A local QwenASR with auth off would reject `Bearer ` on some builds."""
+    cap = {}
+    _post(monkeypatch, _Resp('{"text":"x"}'), cap)
+    asr_api.transcribe(wav, "zh", base_url="http://x", api_key="")
+    assert "Authorization" not in cap["headers"]
+
+
+def test_a_trailing_slash_in_the_base_url_does_not_double_up(monkeypatch, wav):
+    cap = {}
+    _post(monkeypatch, _Resp('{"text":"x"}'), cap)
+    asr_api.transcribe(wav, "zh", base_url="http://x:8000/")
+    assert cap["url"] == "http://x:8000/audio/transcriptions"
+
+
+def test_an_unconfigured_endpoint_is_a_clear_error(monkeypatch, wav):
+    """Silently returning nothing would look exactly like 'this clip has no speech'
+    — the failure this project has now been bitten by twice."""
+    monkeypatch.setattr(asr_api, "ASR_API_BASE", "")
+    with pytest.raises(RuntimeError, match="ARKIV_ASR_API_BASE"):
+        asr_api.transcribe(wav, "zh")
+
+
+def test_an_http_error_propagates(monkeypatch, wav):
+    _post(monkeypatch, _Resp("nope", "text/plain", status=500))
+    with pytest.raises(requests.HTTPError):
+        asr_api.transcribe(wav, "zh", base_url="http://x")
+
+
+def test_configured_reflects_the_env(monkeypatch):
+    monkeypatch.setattr(asr_api, "ASR_API_BASE", "")
+    assert asr_api.configured() is False
+    monkeypatch.setattr(asr_api, "ASR_API_BASE", "http://x")
+    assert asr_api.configured() is True


### PR DESCRIPTION
雙稿對齊（#377）做好了，但第二條引擎要從哪來。有用的觀察是：我們想在本機接的
QwenASR 自己就開 `/audio/transcriptions` + `/health` —— **跟 Groq、Cloudflare
Workers AI、以及每一個 whisper.cpp server 是同一個協定**。

所以這支不是「Qwen 後端」，是**一個轉接層通到全部**，用哪個引擎是一個 URL 的事。
todo 裡那條「whisper-guard × 雲端 Whisper 免費額度」也一併有解了。

麻煩的地方是這些服務**對回應格式並不一致**，而雙稿的重點正是第二條來自「不同的」
引擎，所以三種形狀都得吃：

- `verbose_json` —— `{"text", "segments":[{"start","end","text"}]}`，最好的情況
- 只有 `{"text": ...}` —— 完全沒有時間
- SRT —— QwenASR 自己的預設，時間在，只是包成字幕格式

**沒有時間的回應，不會被補上編出來的時間。** 它就是回 `segments == []`。編出來的
start/end 在下游跟量到的長得一模一樣 —— 那正是這一波花了整整一輪在拔掉的 bug
類別。`words` 永遠是空的，理由同上：把 segment 平均切開來製造逐字時間，是同一個
錯誤往下一層。

SRT 解析上兩件容易錯的：逗號與句點兩種毫秒分隔都收（SRT 規範是逗號、WebVTT 是
句點，真實 server 兩種都吐）；`00:00:01,5` 是 500 毫秒不是 5 毫秒，讀錯會讓 cue
早半秒 —— 小、無聲、而且正是我們剛修完的那種漂移。

新增 18 支測試。mutation-check 八處全紅在該紅的位置：
  沒時間就自己編一個 / 毫秒不補零 / 不要求 verbose_json / 沒設定就靜默回空 /
  空 key 也送 Bearer / language 空字串也送 / SRT 不解析 / base url 尾斜線重複

全套 1638 passed / 7 skipped。

⚠️ **還沒對真的 QwenASR server 打過** —— 那台 PC 只有 12GB VRAM，而它現在正在跑
既有庫的修復（faster-whisper 佔著 GPU）。bench 明確記過兩條線不可同跑會 OOM，
所以實測排在修復跑完之後。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>