### PR TITLE
fix(transcribe): 雙稿對齊按文字，不按 segment 邊界

### DIFF
--- a/tests/test_transcript_compare.py
+++ b/tests/test_transcript_compare.py
@@ -150,15 +150,15 @@ def test_no_phonetic_category_is_invented():
 # ── the whole thing ──────────────────────────────────────────────────────────
 
 def test_compare_separates_shippable_from_reviewable():
-    a = [seg(0, 2, "第一句一樣"), seg(2, 4, "我們今天"), seg(4, 6, "有講到東西")]
-    b = [seg(0, 2, "第一句一樣"), seg(2, 4, "阮今仔日"), seg(4, 6, "")]
+    """A long shared passage, then a stretch only one side heard."""
+    shared = "這一段兩邊都有而且完全一樣所以不需要任何人去聽"
+    a = [seg(0, 6, shared), seg(6, 12, "這一長段只有其中一邊聽到完全沒有出現在另一份稿裡")]
+    b = [seg(0, 6, shared)]
 
     out = tc.compare(a, b)
 
-    assert out["agreed"] == 1
-    assert out["by_kind"] == {tc.TAIGI: 1, tc.COVERAGE: 1}
-    assert {r["kind"] for r in out["review"]} == {tc.TAIGI, tc.COVERAGE}
-
+    assert out["agreed_chars"] >= len(shared) - 2
+    assert out["by_kind"] == {tc.COVERAGE: 1}
 
 def test_review_items_carry_both_readings_and_a_timestamp():
     """The point is to jump to the audio and listen. An item without a window, or
@@ -166,13 +166,17 @@ def test_review_items_carry_both_readings_and_a_timestamp():
     out = tc.compare([seg(3, 5, "我們今天")], [seg(3, 5, "阮今仔日")])
 
     item = out["review"][0]
-    assert item["start"] == 3 and item["end"] == 5
-    assert item["a"] == "我們今天" and item["b"] == "阮今仔日"
+    # The window is the DIFFERING run, not the whole segment — that is the point:
+    # it points at the part worth listening to, not at everything around it.
+    assert 3 <= item["start"] <= item["end"] <= 5
+    assert item["a"] and item["b"]
 
 
 def test_two_identical_transcripts_produce_no_review():
     a = [seg(0, 2, "完全一樣"), seg(2, 4, "第二句")]
-    assert tc.compare(a, list(a))["review"] == []
+    out = tc.compare(a, list(a))
+    assert out["review"] == []
+    assert out["agreed_chars"] == out["total_chars"]
 
 
 def test_empty_inputs_do_not_raise():
@@ -180,16 +184,98 @@ def test_empty_inputs_do_not_raise():
     assert tc.compare([seg(0, 1, "只有一邊")], [])["by_kind"] == {tc.COVERAGE: 1}
 
 
-def test_segments_without_timestamps_go_to_review_rather_than_claim_agreement():
-    """Legacy rows carry explicit nulls, and alignment is done by time — so with no
-    timestamps there is nothing to align on.
+def test_identical_text_agrees_even_without_timestamps():
+    """Changed deliberately when alignment moved from time to text.
 
-    They are reported as needing review, not as agreeing. Matching them up by
-    position instead would be a guess, and a guess that says "these agree" is the
-    one failure mode this module must not have: it would mark unverified text as
-    shippable."""
+    Agreement is a property of the TEXT; timestamps only exist to point a human at
+    the audio. Two identical transcripts agree whether or not they carry timings —
+    the earlier "no timestamps means we cannot judge" rule belonged to segment
+    pairing, where matching by position really would have been a guess."""
     out = tc.compare([{"start": None, "end": None, "text": "沒有時間"}],
                      [{"start": None, "end": None, "text": "沒有時間"}])
 
-    assert out["agreed"] == 0
-    assert out["review"], "silently dropped instead of flagged"
+    assert out["agreed_chars"] > 0
+    assert out["review"] == []
+
+
+# ── the failure that only real data showed ───────────────────────────────────
+
+def test_the_same_sentence_one_window_apart_is_not_two_coverage_holes():
+    """Measured on a real 199 s clip (49 vs 64 segments): segment-to-segment
+    pairing reported **1 agreement and 68 items to review**, and most of the
+    "coverage holes" were text BOTH sides had, sitting one window apart because the
+    two engines cut the speech differently.
+
+        whisper  25.5-27.0  還是全部都夾好再調
+        qwen     27.0-28.0  還是全部都夾好再調
+
+    Aligning on text instead of boundaries is what fixes it — boundaries are an
+    artefact of the engine, not of the speech."""
+    a = [seg(25.5, 27.0, "還是全部都夾好再調"), seg(27.0, 28.0, "夾好再調")]
+    b = [seg(27.0, 28.0, "還是全部都夾好再調")]
+
+    out = tc.compare(a, b)
+
+    assert out["agreed_chars"] >= len("還是全部都夾好再調") - 1
+    assert len(out["review"]) <= 1, out["review"]
+
+
+def test_a_short_word_swap_is_not_called_a_coverage_hole():
+    """`我們` vs `阮` is a 2:1 length ratio, and the ratio rule was firing on it —
+    swallowing the Taiwanese category it exists alongside. The rule only means
+    something when the longer side is long enough to be 'a sentence vs a
+    fragment'."""
+    out = tc.compare([seg(0, 2, "我們今天")], [seg(0, 2, "阮今仔日")])
+
+    assert tc.COVERAGE not in out["by_kind"]
+    assert tc.TAIGI in out["by_kind"]
+
+
+def test_agreement_is_counted_in_characters_not_runs():
+    """"12 equal runs" is not something a person can act on; "1,180 of 1,240
+    characters matched" says how much is left to listen to."""
+    a = [seg(0, 4, "完全相同的一整句話")]
+    out = tc.compare(a, list(a))
+
+    assert out["agreed_chars"] == out["total_chars"] == len("完全相同的一整句話")
+
+
+def test_a_run_of_one_word_disagreements_becomes_one_listening_window():
+    """On messy audio the two engines argue continuously, and character-level diffs
+    produce a stream of one-word entries. Six entries is six trips to the timeline
+    for one thing to listen to."""
+    a = [seg(30.0, 36.0, "到夾有頭夾到夾去這個他夾到夾")]
+    b = [seg(30.0, 36.0, "的話可以可以得它插不進")]
+
+    out = tc.compare(a, b)
+
+    assert len(out["review"]) <= 2, out["review"]
+    assert out["review"][0]["end"] - out["review"][0]["start"] > 1.0
+
+
+def test_merging_keeps_both_sides_text():
+    merged = tc._merge_nearby([
+        {"start": 1.0, "end": 1.4, "kind": tc.OTHER, "a": "甲", "b": "乙"},
+        {"start": 1.6, "end": 2.0, "kind": tc.OTHER, "a": "丙", "b": "丁"},
+    ])
+    assert len(merged) == 1
+    assert merged[0]["a"] == "甲 丙" and merged[0]["b"] == "乙 丁"
+
+
+def test_a_taigi_finding_is_not_buried_by_what_it_sits_next_to():
+    """"the Taiwanese was flattened here" is the finding worth surfacing; merging it
+    into a neighbour labelled `other` would hide the only category that names a
+    known, fixable failure."""
+    merged = tc._merge_nearby([
+        {"start": 1.0, "end": 1.4, "kind": tc.OTHER, "a": "x", "b": "y"},
+        {"start": 1.5, "end": 2.0, "kind": tc.TAIGI, "a": "我們", "b": "阮"},
+    ])
+    assert len(merged) == 1 and merged[0]["kind"] == tc.TAIGI
+
+
+def test_distant_disagreements_stay_separate():
+    merged = tc._merge_nearby([
+        {"start": 1.0, "end": 1.4, "kind": tc.OTHER, "a": "甲", "b": "乙"},
+        {"start": 40.0, "end": 41.0, "kind": tc.OTHER, "a": "丙", "b": "丁"},
+    ])
+    assert len(merged) == 2

--- a/transcript_compare.py
+++ b/transcript_compare.py
@@ -41,6 +41,10 @@ from typing import Dict, List, Optional, Tuple
 # wolf gets ignored, and then so does the real one.
 TAIGI_MARKERS = "毋袂佇阮恁遮遐蹛媠囡爸母囝孫兜箍焦鬧熱歹勢多謝按怎啥物"
 
+# Below this, a length ratio says nothing: short diff runs are word swaps, not
+# missing speech.
+_COVERAGE_MIN_CHARS = 8
+
 AGREE = "agree"
 COVERAGE = "coverage"   # one side has text the other simply doesn't
 TAIGI = "taigi"         # one side kept Taiwanese, the other flattened it
@@ -69,16 +73,13 @@ def align(a_segments: List[Dict], b_segments: List[Dict],
           min_overlap_s: float = 0.2) -> List[Tuple[Optional[Dict], Optional[Dict]]]:
     """Pair segments by time overlap, in order.
 
-    Time, not text — the two engines segment differently (one may emit twice as
-    many segments for the same speech), so pairing by index would misalign
-    everything after the first disagreement. A segment with no counterpart pairs
-    with None, which is what makes a coverage hole visible instead of silently
-    shifting every later pair.
+    Kept for callers that want raw pairs. `compare()` no longer uses it — see
+    `cluster()` for why one-to-one pairing is the wrong shape for two engines.
     """
     pairs: List[Tuple[Optional[Dict], Optional[Dict]]] = []
     used_b = set()
     for a in a_segments:
-        best, best_overlap = None, 0.0
+        best, best_overlap, best_i = None, 0.0, -1
         for i, b in enumerate(b_segments):
             if i in used_b:
                 continue
@@ -104,40 +105,124 @@ def classify(a: Optional[Dict], b: Optional[Dict]) -> str:
         return AGREE
     if not ta or not tb:
         return COVERAGE
-    # A large length gap in the same window is a coverage hole too: one engine
-    # heard a sentence, the other caught two words of it.
+    # A large length gap is a coverage hole too: one engine heard a sentence, the
+    # other caught two words of it. Only for runs long enough for "a sentence vs a
+    # fragment" to mean anything — on a two-character difference the ratio fires on
+    # everything (`我們` vs `阮` is 2:1) and swallows the categories that matter.
     longer, shorter = max(len(ta), len(tb)), min(len(ta), len(tb))
-    if shorter * 2 <= longer:
+    if longer >= _COVERAGE_MIN_CHARS and shorter * 2 <= longer:
         return COVERAGE
     if (_taigi_count(ta) > 0) != (_taigi_count(tb) > 0):
         return TAIGI
     return OTHER
 
 
+def _char_timeline(segments: List[Dict]) -> Tuple[str, List[Tuple[float, float]]]:
+    """Flatten segments into one normalised character stream, keeping each
+    character's (start, end) so a difference can be pointed back at the audio."""
+    chars: List[str] = []
+    times: List[Tuple[float, float]] = []
+    for seg in segments:
+        text = _norm(seg.get("text") or "")
+        if not text:
+            continue
+        start = float(seg.get("start") or 0.0)
+        end = float(seg.get("end") or 0.0)
+        span = max(0.0, end - start)
+        for k, ch in enumerate(text):
+            # Within a segment the per-character time is interpolated. That is an
+            # estimate and only ever used to LOCATE a difference for a human, never
+            # written anywhere — the moment it were stored it would be the invented
+            # timestamp problem again.
+            frac = k / len(text)
+            nxt = (k + 1) / len(text)
+            chars.append(ch)
+            times.append((start + span * frac, start + span * nxt))
+    return "".join(chars), times
+
+
+# Two engines arguing across a messy passage produce a run of one-word
+# disagreements. Six entries of a single character each are six trips to the
+# timeline for what is one thing to listen to, so runs closer together than this
+# are reported as one window.
+_MERGE_GAP_S = 1.5
+
+
+def _merge_nearby(review: List[Dict], gap_s: float = _MERGE_GAP_S) -> List[Dict]:
+    """Collapse review items separated by less than `gap_s` into one window.
+
+    The merged item keeps both sides' text joined in order, so nothing is lost —
+    only the number of places a person has to visit changes. A merged run takes the
+    kind of its most specific member: `taigi` outranks `other` outranks `coverage`,
+    because "the Taiwanese was flattened here" is the finding worth surfacing and it
+    would otherwise be buried by whatever it sits next to.
+    """
+    if not review:
+        return []
+    priority = {TAIGI: 3, OTHER: 2, COVERAGE: 1}
+    ordered = sorted(review, key=lambda r: (r["start"], r["end"]))
+    out = [dict(ordered[0])]
+    for item in ordered[1:]:
+        last = out[-1]
+        if item["start"] - last["end"] <= gap_s:
+            last["end"] = max(last["end"], item["end"])
+            last["a"] = (last["a"] + " " + item["a"]).strip()
+            last["b"] = (last["b"] + " " + item["b"]).strip()
+            if priority.get(item["kind"], 0) > priority.get(last["kind"], 0):
+                last["kind"] = item["kind"]
+        else:
+            out.append(dict(item))
+    return out
+
+
 def compare(a_segments: List[Dict], b_segments: List[Dict],
             min_overlap_s: float = 0.2) -> Dict:
     """Two transcripts in, one review list out.
 
-    Returns `{"agreed": n, "review": [...], "by_kind": {...}}` where each review
-    item carries both readings and the window they cover, so a person can jump
-    straight to the audio.
+    **Aligned on text, not on segment boundaries.** Boundaries are an artefact of
+    the engine, not of the speech, and the two engines cut differently — so pairing
+    segment-to-segment marries the same sentence to the wrong neighbour. Measured on
+    a real 199 s clip (49 vs 64 segments), pairing produced **1 agreement and 68
+    review items**, most of them phantom coverage holes for text that both sides
+    had. That is the same as telling someone to listen to the whole clip.
+
+    `difflib` over the normalised character stream ignores boundaries entirely.
+    Equal runs are agreement; each differing run becomes one review item, located
+    back on the timeline by the character it starts and ends at.
     """
+    import difflib
+
+    a_text, a_times = _char_timeline(a_segments)
+    b_text, b_times = _char_timeline(b_segments)
+    if not a_text and not b_text:
+        return {"agreed_chars": 0, "total_chars": 0, "review": [], "by_kind": {}}
+
     review = []
-    agreed = 0
-    for a, b in align(a_segments, b_segments, min_overlap_s):
-        kind = classify(a, b)
-        if kind == AGREE:
-            agreed += 1
+    agreed_chars = 0
+    matcher = difflib.SequenceMatcher(None, a_text, b_text, autojunk=False)
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            agreed_chars += (i2 - i1)
             continue
-        anchor = a or b
+        a_part, b_part = a_text[i1:i2], b_text[j1:j2]
+        kind = classify({"text": a_part} if a_part else None,
+                        {"text": b_part} if b_part else None)
+        if kind == AGREE:
+            agreed_chars += (i2 - i1)
+            continue
+        spans = a_times[i1:i2] + b_times[j1:j2]
         review.append({
-            "start": float(anchor.get("start") or 0.0),
-            "end": float(anchor.get("end") or 0.0),
+            "start": min(s for s, _e in spans) if spans else 0.0,
+            "end": max(e for _s, e in spans) if spans else 0.0,
             "kind": kind,
-            "a": (a or {}).get("text", ""),
-            "b": (b or {}).get("text", ""),
+            "a": a_part,
+            "b": b_part,
         })
+    review = _merge_nearby(review)
     by_kind: Dict[str, int] = {}
     for item in review:
         by_kind[item["kind"]] = by_kind.get(item["kind"], 0) + 1
-    return {"agreed": agreed, "review": review, "by_kind": by_kind}
+    # Characters, not runs: "12 equal runs" says nothing a person can act on,
+    # "1,180 of 1,240 characters matched" says how much is left to listen to.
+    return {"agreed_chars": agreed_chars, "total_chars": max(len(a_text), len(b_text)),
+            "review": review, "by_kind": by_kind}


### PR DESCRIPTION
#377 出去之後拿真實素材跑了一次，結果**它幾乎沒有用**。

199 秒的片子、whisper 49 段 vs Qwen3-ASR 64 段：**一致 1 處、需複查 68 處**。
那等於叫人把整支重聽一遍。

原因不是分類錯，是**配對錯**。兩個引擎切點不同，所以同一句話常常落在相鄰的窗口：

    whisper  25.5-27.0  還是全部都夾好再調
    qwen     27.0-28.0  還是全部都夾好再調

「時間重疊貪婪配對」把它們各自嫁給錯的鄰居，然後回報兩個**根本不存在的覆蓋率
破洞**。34 個 coverage 裡有相當比例是這樣來的。

**segment 邊界是引擎的產物，不是語音的性質** —— 所以改成對**正規化後的字元流**做
`difflib` 序列對齊，完全不看邊界。相等的區間算一致，每個相異區間變成一筆待複查，
再用字元的時間把它指回時間軸（那個插值只用來**定位**給人聽，永遠不寫進任何地方 ——
一寫下去就又是這一波剛拔掉的「編出來的時間碼」）。

**兩個真實資料逼出來的修正：**

1. **「長度懸殊算 coverage」對短片段誤判。** `我們` vs `阮` 是 2:1，規則直接觸發，
   把它旁邊的台語分類整個吞掉。那條規則只在「一整句 vs 一個殘片」時才有意義 →
   加下限 8 字。
2. **相鄰的小分歧要合併成一個聆聽視窗。** 髒音檔上兩個引擎會連續吵架，字元級 diff
   產出一串「一個字」的條目 —— 六筆一個字等於為同一件事跑六趟時間軸。1.5 秒內的
   合併成一筆，**合併時 `taigi` 優先於 `other` 優先於 `coverage`**，因為「台語在
   這裡被抹平」是唯一指名了已知且可修的失效，不能被旁邊的東西埋掉。

`agreed` 也從「相等的 run 數」改成 **`agreed_chars` / `total_chars`** —— 「12 個
相等區間」不是人能拿來行動的東西，「365 字裡對得上 209 字」才是。

**同一支素材，修正後：對得上 209/365 字、需複查 5 處**（other 4、taigi 1）。
從「重聽整支」變成「聽 5 個地方」，而且台語那筆活著出來了。

一個刻意的行為變更：無時間碼的相同文字現在**算一致**。一致是文字的性質，時間碼
只是用來把人帶到音檔；原本「沒時間碼就不能判斷」那條規則屬於 segment 配對 ——
在那裡按位置配才真的是用猜的。

新增 7 支測試（含三支直接記錄上面那個真實案例）。全套 1654 passed / 7 skipped。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>