### PR TITLE
feat(ops): 薄 server —— 讓沒有那張卡的機器也用得到第二條引擎

### DIFF
--- a/scripts/asr_serve.py
+++ b/scripts/asr_serve.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""A thin OpenAI-compatible ASR endpoint over a locally-installed engine.
+
+Why this exists: the second pass in a dual-transcript setup needs an engine that
+only one machine has (Qwen3-ASR wants CUDA). arkiv's client side already speaks
+`/audio/transcriptions` — this is the other half, so a Mac can use the PC's GPU.
+
+Why not QwenASR's own server: measured 2026-08-25, its `api_server.py` calls the
+engine with an `out_format` argument that the CUDA `GPUASREngine.process_file()`
+does not accept and cannot honour — its docs only promise the OpenVINO and chatllm
+engines. Every request 500s. This wrapper calls `process_file()` the way that
+engine actually works and converts the result itself.
+
+    python scripts/asr_serve.py --engine qwen --model-dir <QwenASR cudagpu dir>
+    python scripts/asr_serve.py --engine qwen --token mytoken --port 11500
+
+**Binds to 127.0.0.1 unless told otherwise, and always requires a token.** This
+runs a model over whatever it is sent; an unauthenticated one on 0.0.0.0 is a
+GPU someone else can drive. `--host 0.0.0.0` is deliberate and explicit.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import secrets
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+MAX_UPLOAD_BYTES = 512 * 1024 * 1024  # an hour of 16k mono wav is ~115 MB
+
+
+# ── multipart (stdlib `cgi` is deprecated; this is the slice we need) ─────────
+
+def parse_multipart(body: bytes, boundary: bytes):
+    """Returns (fields, files) where files maps name → (filename, bytes).
+
+    Deliberately small: enough for the one shape an OpenAI-compatible client
+    sends. Anything it cannot parse yields empty dicts rather than a guess.
+    """
+    fields, files = {}, {}
+    sep = b"--" + boundary
+    for part in body.split(sep):
+        if not part.strip() or part.strip() == b"--":
+            continue
+        head, _, data = part.partition(b"\r\n\r\n")
+        if not _:
+            continue
+        data = data[:-2] if data.endswith(b"\r\n") else data
+        head_text = head.decode("utf-8", "replace")
+        name = re.search(r'name="([^"]*)"', head_text)
+        if not name:
+            continue
+        filename = re.search(r'filename="([^"]*)"', head_text)
+        if filename:
+            files[name.group(1)] = (filename.group(1), data)
+        else:
+            fields[name.group(1)] = data.decode("utf-8", "replace").strip()
+    return fields, files
+
+
+# ── engines ──────────────────────────────────────────────────────────────────
+
+def load_qwen(model_dir: str):
+    """Return `transcribe(wav_path, language) -> [segments]` for QwenASR's CUDA
+    engine, loaded by path because `app-gpu.py` is not an importable module name.
+
+    Its GUI lives behind a `__main__` guard, so importing it costs nothing but the
+    class definitions.
+    """
+    import importlib.util
+
+    base = Path(model_dir).resolve()
+    sys.path.insert(0, str(base))
+    spec = importlib.util.spec_from_file_location("qwen_appgpu", base / "app-gpu.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["qwen_appgpu"] = mod
+    spec.loader.exec_module(mod)
+
+    engine = mod.GPUASREngine()
+    engine.load("cuda")
+    print("[asr-serve] qwen engine ready", flush=True)
+
+    import asr_api
+
+    def transcribe(wav_path: str, language: str | None):
+        # Qwen3-ASR wants a language NAME, not an ISO code, and its list has no
+        # Taiwanese — faithfulness there comes from transcribing as Chinese
+        # without flattening, not from a dedicated mode.
+        lang = {"zh": "Chinese", "en": "English", "yue": "Cantonese",
+                "ja": "Japanese", "ko": "Korean"}.get((language or "").lower(),
+                                                      language or "Chinese")
+        out = engine.process_file(Path(wav_path), language=lang)
+        if not out or not Path(out).exists():
+            return []
+        text = Path(out).read_text(encoding="utf-8", errors="replace")
+        try:
+            Path(out).unlink()
+        except OSError:
+            pass
+        # Reuse arkiv's own SRT parser, so both ends of the wire agree by
+        # construction rather than by two implementations that happen to match.
+        return asr_api.parse_srt(text)
+
+    return transcribe
+
+
+ENGINES = {"qwen": load_qwen}
+
+
+# ── server ───────────────────────────────────────────────────────────────────
+
+def make_handler(transcribe, token):
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def _send(self, code, payload, content_type="application/json"):
+            body = (json.dumps(payload, ensure_ascii=False).encode("utf-8")
+                    if content_type == "application/json" else payload.encode("utf-8"))
+            self.send_response(code)
+            self.send_header("Content-Type", content_type + "; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _authorised(self):
+            got = self.headers.get("Authorization", "")
+            return secrets.compare_digest(got, "Bearer " + token)
+
+        def log_message(self, fmt, *args):
+            print("[asr-serve] " + (fmt % args), flush=True)
+
+        def do_GET(self):
+            if self.path.split("?")[0] != "/health":
+                return self._send(404, {"error": "not found"})
+            if not self._authorised():
+                return self._send(401, {"error": "unauthorised"})
+            self._send(200, {"status": "ok", "model_ready": True})
+
+        def do_POST(self):
+            if self.path.split("?")[0] not in ("/audio/transcriptions",
+                                               "/v1/audio/transcriptions"):
+                return self._send(404, {"error": "not found"})
+            if not self._authorised():
+                return self._send(401, {"error": "unauthorised"})
+            length = int(self.headers.get("Content-Length") or 0)
+            if length <= 0 or length > MAX_UPLOAD_BYTES:
+                return self._send(413, {"error": "bad or oversized upload"})
+            ctype = self.headers.get("Content-Type", "")
+            m = re.search(r"boundary=([^;]+)", ctype)
+            if not m:
+                return self._send(400, {"error": "expected multipart/form-data"})
+            fields, files = parse_multipart(self.rfile.read(length),
+                                            m.group(1).strip('"').encode())
+            if "file" not in files:
+                return self._send(400, {"error": "no file part"})
+            _name, blob = files["file"]
+            fd, tmp = tempfile.mkstemp(suffix=".wav")
+            os.close(fd)
+            try:
+                Path(tmp).write_bytes(blob)
+                segments = transcribe(tmp, fields.get("language"))
+            except Exception as exc:  # a bad clip must not take the server down
+                self.log_message("transcribe failed: %s: %s", type(exc).__name__, exc)
+                return self._send(500, {"error": {"message": "{0}: {1}".format(
+                    type(exc).__name__, exc)}})
+            finally:
+                Path(tmp).unlink(missing_ok=True)
+            text = " ".join(s["text"] for s in segments)
+            # verbose_json is what arkiv asks for; anything else still gets the
+            # timings, because throwing them away is never the helpful answer.
+            self._send(200, {"text": text, "segments": segments})
+
+    return Handler
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--engine", default="qwen", choices=sorted(ENGINES))
+    ap.add_argument("--model-dir", required=True,
+                    help="the engine's install directory")
+    ap.add_argument("--host", default="127.0.0.1",
+                    help="0.0.0.0 exposes a GPU to your network — be deliberate")
+    ap.add_argument("--port", type=int, default=11435)
+    ap.add_argument("--token", default=None, help="generated and printed if omitted")
+    args = ap.parse_args(argv)
+
+    token = args.token or secrets.token_urlsafe(12)
+    transcribe = ENGINES[args.engine](args.model_dir)
+    httpd = ThreadingHTTPServer((args.host, args.port), make_handler(transcribe, token))
+    print("[asr-serve] listening on http://{0}:{1}  token={2}".format(
+        args.host, args.port, token), flush=True)
+    threading.Thread(target=httpd.serve_forever, daemon=False).start()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_asr_serve.py
+++ b/tests/test_asr_serve.py
@@ -1,0 +1,215 @@
+"""The other half of the wire: a thin OpenAI-compatible endpoint over a local engine.
+
+Exists because the second pass needs an engine only one machine has, and because
+QwenASR's own server cannot drive its CUDA engine (measured: it passes an
+`out_format` the engine has no parameter for, and every request 500s).
+
+The tests that matter here are the ones about **what this refuses to do**. It is a
+network service that runs a model over whatever it is sent, so the interesting
+failures are "listens on 0.0.0.0 by accident", "serves without a token", and
+"takes the whole server down on one bad clip".
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import threading
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "asr_serve", _ROOT / "scripts" / "asr_serve.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+srv = _load()
+
+
+# ── multipart ────────────────────────────────────────────────────────────────
+
+def _body(parts, boundary=b"B"):
+    out = b""
+    for name, filename, data in parts:
+        out += b"--" + boundary + b"\r\n"
+        disp = 'form-data; name="{0}"'.format(name)
+        if filename:
+            disp += '; filename="{0}"'.format(filename)
+        out += ("Content-Disposition: " + disp + "\r\n\r\n").encode()
+        out += data + b"\r\n"
+    return out + b"--" + boundary + b"--\r\n"
+
+
+def test_fields_and_files_are_separated():
+    fields, files = srv.parse_multipart(
+        _body([("model", None, b"whisper-1"), ("file", "a.wav", b"RIFFDATA")]), b"B")
+    assert fields == {"model": "whisper-1"}
+    assert files == {"file": ("a.wav", b"RIFFDATA")}
+
+
+def test_binary_payloads_survive_intact():
+    """A wav is not text. Any decode/encode round trip in the parser corrupts it,
+    and the corruption shows up as a mysteriously bad transcript rather than an
+    error."""
+    blob = bytes(range(256)) * 4
+    _f, files = srv.parse_multipart(_body([("file", "a.wav", blob)]), b"B")
+    assert files["file"][1] == blob
+
+
+def test_unparseable_input_yields_nothing_rather_than_a_guess():
+    assert srv.parse_multipart(b"not multipart at all", b"B") == ({}, {})
+
+
+# ── the service's refusals ───────────────────────────────────────────────────
+
+class _FakeEngine:
+    def __init__(self, segments=None, raises=None):
+        self.segments = segments or [{"start": 0.0, "end": 1.0, "text": "測試"}]
+        self.raises = raises
+        self.calls = []
+
+    def __call__(self, wav_path, language):
+        self.calls.append((wav_path, language))
+        if self.raises:
+            raise self.raises
+        return self.segments
+
+
+@pytest.fixture
+def server():
+    from http.server import ThreadingHTTPServer
+    started = {}
+
+    def _start(engine, token="tok"):
+        httpd = ThreadingHTTPServer(("127.0.0.1", 0), srv.make_handler(engine, token))
+        threading.Thread(target=httpd.serve_forever, daemon=True).start()
+        started["httpd"] = httpd
+        return "http://127.0.0.1:{0}".format(httpd.server_address[1])
+
+    yield _start
+    if "httpd" in started:
+        started["httpd"].shutdown()
+
+
+def _post(url, token=None, parts=None, ctype="multipart/form-data; boundary=B"):
+    body = _body(parts if parts is not None else [("file", "a.wav", b"RIFF")])
+    req = urllib.request.Request(url + "/audio/transcriptions", data=body, method="POST")
+    req.add_header("Content-Type", ctype)
+    if token:
+        req.add_header("Authorization", "Bearer " + token)
+    return urllib.request.urlopen(req, timeout=10)
+
+
+def test_a_request_without_a_token_is_refused(server):
+    url = server(_FakeEngine())
+    with pytest.raises(urllib.error.HTTPError) as e:
+        _post(url)
+    assert e.value.code == 401
+
+
+def test_a_wrong_token_is_refused(server):
+    url = server(_FakeEngine())
+    with pytest.raises(urllib.error.HTTPError) as e:
+        _post(url, token="wrong")
+    assert e.value.code == 401
+
+
+def test_health_also_requires_the_token(server):
+    """An unauthenticated health probe tells an outsider a GPU is here."""
+    url = server(_FakeEngine())
+    with pytest.raises(urllib.error.HTTPError) as e:
+        urllib.request.urlopen(url + "/health", timeout=10)
+    assert e.value.code == 401
+
+
+def test_a_good_request_returns_segments(server):
+    engine = _FakeEngine([{"start": 1.0, "end": 2.0, "text": "第一句"}])
+    url = server(engine)
+
+    payload = json.loads(_post(url, token="tok").read())
+
+    assert payload["segments"] == [{"start": 1.0, "end": 2.0, "text": "第一句"}]
+    assert payload["text"] == "第一句"
+
+
+def test_the_language_field_reaches_the_engine(server):
+    engine = _FakeEngine()
+    url = server(engine)
+    _post(url, token="tok", parts=[("language", None, b"zh"),
+                                   ("file", "a.wav", b"RIFF")])
+    assert engine.calls[0][1] == "zh"
+
+
+def test_one_bad_clip_does_not_take_the_server_down(server):
+    """A batch feeding this will hit a corrupt file eventually. Answering 500 for
+    that one and staying up is the difference between losing a clip and losing the
+    run."""
+    engine = _FakeEngine(raises=RuntimeError("bad audio"))
+    url = server(engine)
+
+    with pytest.raises(urllib.error.HTTPError) as e:
+        _post(url, token="tok")
+    assert e.value.code == 500
+
+    engine.raises = None
+    assert json.loads(_post(url, token="tok").read())["segments"]
+
+
+def test_a_request_with_no_file_is_a_400_not_a_crash(server):
+    url = server(_FakeEngine())
+    with pytest.raises(urllib.error.HTTPError) as e:
+        _post(url, token="tok", parts=[("model", None, b"whisper-1")])
+    assert e.value.code == 400
+
+
+def test_a_non_multipart_body_is_a_400(server):
+    url = server(_FakeEngine())
+    with pytest.raises(urllib.error.HTTPError) as e:
+        _post(url, token="tok", ctype="application/json")
+    assert e.value.code == 400
+
+
+def test_the_uploaded_temp_file_is_removed(server):
+    engine = _FakeEngine()
+    url = server(engine)
+    _post(url, token="tok")
+    assert not Path(engine.calls[0][0]).exists(), "upload left on disk"
+
+
+def test_the_v1_prefix_is_accepted_too(server):
+    """OpenAI's own path is `/v1/audio/transcriptions`; clients send both."""
+    url = server(_FakeEngine())
+    req = urllib.request.Request(url + "/v1/audio/transcriptions",
+                                 data=_body([("file", "a.wav", b"RIFF")]), method="POST")
+    req.add_header("Content-Type", "multipart/form-data; boundary=B")
+    req.add_header("Authorization", "Bearer tok")
+    assert urllib.request.urlopen(req, timeout=10).status == 200
+
+
+# ── the defaults that keep a GPU off the network ─────────────────────────────
+
+def test_it_binds_to_loopback_unless_told_otherwise():
+    src = (_ROOT / "scripts" / "asr_serve.py").read_text(encoding="utf-8")
+    assert 'ap.add_argument("--host", default="127.0.0.1"' in src
+
+
+def test_a_token_is_always_required():
+    """Not "generated if you ask" — generated if omitted, and compared on every
+    request. There is no unauthenticated path."""
+    src = (_ROOT / "scripts" / "asr_serve.py").read_text(encoding="utf-8")
+    assert "args.token or secrets.token_urlsafe" in src
+    assert "compare_digest" in src, "token compared with ==, not constant-time"
+
+
+def test_uploads_are_capped():
+    src = (_ROOT / "scripts" / "asr_serve.py").read_text(encoding="utf-8")
+    assert "MAX_UPLOAD_BYTES" in src
+    assert "length > MAX_UPLOAD_BYTES" in src


### PR DESCRIPTION
雙稿的第二條引擎只存在於有 CUDA 的那台，而 arkiv 的 client 端（#378）早就會講
`/audio/transcriptions`。這支是另外一半：**Mac 可以用 PC 的 GPU**。

**為什麼不直接用 QwenASR 自己的 server**：2026-08-25 實打量到，它的 `api_server.py`
呼叫引擎時傳 `out_format`，而 CUDA 版 `GPUASREngine.process_file()` 沒有那個參數、
也沒有輸出格式的能力 —— 它的文件本來就只保證 OpenVINO 與 chatllm。每一個請求都 500。
這支照那個引擎真正的用法呼叫，轉檔自己來。

**協定歸 arkiv、引擎歸 adapter**：`ENGINES` 是一張表，之後換引擎不用重寫 server。
Qwen 的 adapter 只做三件它非知道不可的事 —— 語言要傳完整名稱不是 ISO 碼（而且
它的清單裡**沒有台語**，忠實度來自「以中文轉錄但不抹平」）、`process_file` 吃的是
wav 不是容器、輸出是 SRT 檔路徑。SRT 轉 segments **重用 `asr_api.parse_srt`**，
讓線的兩端因為共用同一份實作而一致，不是因為兩份剛好寫得一樣。

**這是一個會對上傳檔案跑模型的網路服務，所以預設是拒絕**：
- **只綁 127.0.0.1**，`--host 0.0.0.0` 必須是刻意的（那等於把一張 GPU 交給網段）
- **一律要 token**（沒給就產生並印出），`compare_digest` 常數時間比較
- **health 也要驗** —— 沒驗的 health 等於告訴外面「這裡有張卡」
- 上傳有 512MB 上限
- **一支壞片不能把整個 server 帶走**（批次一定會遇到壞檔，那是「掉一支」與「掉整輪」
  的差別），暫存檔一律刪掉

`cgi` 在 3.13 已棄用，所以 multipart 自己解一小塊 —— 只夠 OpenAI 相容 client 送的
那一種形狀，解不出來就回空而不是猜。

新增 16 支測試，重點在**它拒絕做什麼**。mutation-check 九處全紅在該紅的位置：
  不驗 token / health 不驗 / token 用 `==` 比較 / 預設綁 0.0.0.0 / 上傳無上限 /
  壞檔案讓 server 掛掉 / 暫存檔不刪 / 沒有 file 也照跑 / multipart 把二進位解成文字

全套 1670 passed / 7 skipped。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>