### PR TITLE
fix(transcribe): 台語 marker 量過之後，它一直在對雜訊貼標籤

### DIFF
--- a/tests/test_transcript_compare.py
+++ b/tests/test_transcript_compare.py
@@ -279,3 +279,36 @@ def test_distant_disagreements_stay_separate():
         {"start": 40.0, "end": 41.0, "kind": tc.OTHER, "a": "丙", "b": "丁"},
     ])
     assert len(merged) == 2
+
+
+# ── the marker set, after measuring it ───────────────────────────────────────
+
+def test_only_unambiguous_characters_are_markers():
+    """Measured across 541 real transcripts (22,799 chars): 19 of the original 24
+    markers never appeared, and the 5 that did are ordinary Mandarin. The category
+    was labelling noise.
+
+    Anything that also occurs in written Mandarin must stay out — a marker that
+    fires on Mandarin does not make the category noisy, it makes it wrong."""
+    for ch in "怎焦物啥按爸母孫熱歹勢多謝鬧囝兜箍伊講較欲":
+        assert ch not in tc.TAIGI_MARKERS, "{0} occurs in ordinary Mandarin".format(ch)
+
+
+def test_the_markers_that_remain_are_the_ones_that_only_exist_in_taiwanese():
+    for ch in "毋袂佇阮恁遮遐蹛媠囡":
+        assert ch in tc.TAIGI_MARKERS
+
+
+def test_ordinary_mandarin_never_looks_like_taiwanese():
+    """The regression the measurement exposed: two plain Mandarin readings that
+    happen to differ must not come back labelled `taigi`."""
+    out = tc.compare([seg(0, 3, "他說這個怎麼按下去物件就不見了")],
+                     [seg(0, 3, "他說這個怎麼按下去東西就不見了")])
+    assert tc.TAIGI not in out["by_kind"], out
+
+
+def test_real_written_taiwanese_still_registers():
+    """Narrowing must not silence the category entirely — when an engine does write
+    Taiwanese, this is what has to fire."""
+    out = tc.compare([seg(0, 3, "我們不會在這裡")], [seg(0, 3, "阮袂佇遮")])
+    assert tc.TAIGI in out["by_kind"], out

--- a/transcript_compare.py
+++ b/transcript_compare.py
@@ -34,12 +34,25 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional, Tuple
 
-# Characters that are written Taiwanese and effectively do not appear in written
-# Mandarin. Deliberately conservative: 伊 / 講 / 較 / 欲 are common in both and are
-# NOT here, because a marker that fires on Mandarin makes the whole category
-# meaningless. Missing a few Taiwanese lines is recoverable; a category that cries
-# wolf gets ignored, and then so does the real one.
-TAIGI_MARKERS = "毋袂佇阮恁遮遐蹛媠囡爸母囝孫兜箍焦鬧熱歹勢多謝按怎啥物"
+# Characters that only appear in written Taiwanese.
+#
+# **Measured 2026-08-26 and the result matters more than the list:** across 541
+# real transcripts (22,799 characters) not one of 毋 袂 佇 阮 恁 遮 遐 蹛 媠 囡
+# appeared — **zero**. Nineteen of the original twenty-four markers never fired at
+# all, and the five that did (怎 焦 物 啥 按) are ordinary Mandarin characters, so
+# what the category was actually reporting was noise.
+#
+# The reason is structural, not a tuning problem: **neither engine writes Taiwanese
+# orthography.** Whisper flattens Taiwanese into Mandarin by design, and
+# Qwen3-ASR has no Taiwanese in its supported-language list at all — it transcribes
+# Taiwanese speech AS Chinese. The two differ by writing different Mandarin
+# characters for the same sound, not by one of them writing 台語漢字.
+#
+# So the list is now only the unambiguous characters. It will almost never fire on
+# these two engines, and that is the correct behaviour: a category that names a
+# specific failure must stay silent when it cannot see that failure. It becomes
+# useful the day an engine that actually writes Taiwanese is added.
+TAIGI_MARKERS = "毋袂佇阮恁遮遐蹛媠囡"
 
 # Below this, a length ratio says nothing: short diff runs are word swaps, not
 # missing speech.


### PR DESCRIPTION
照拍板做 (1)：驗這個 marker 集合到底有沒有鑑別力。**沒有。**

跨 541 份真實逐字稿（22,799 字）：

- **明確只屬於書面台語的字 —— 毋 袂 佇 阮 恁 遮 遐 蹛 媠 囡 —— 出現 0 次**
- 原本 24 個 marker 裡 **19 個從未觸發**
- 有觸發的 5 個（怎 焦 物 啥 按）**全都是國語裡也常用的字**

所以那個分類實際在回報的是**雜訊**。會議素材那次 `taigi: 6` 個視窗，幾乎確定就是
怎/敢/傷 這種模稜兩可的字剛好只出現在一邊，不是偵測到台語。

**原因是結構性的，不是調參數能解決的：兩個引擎都不寫台語漢字。** whisper 依設計
把台語抹平成國語；而 **Qwen3-ASR 的支援語言清單裡根本沒有台語** —— 它是把台語
當中文轉錄。兩者的差別是「同一個音挑了不同的國語字」，不是「一邊寫台語漢字」。

改法：**集合只留明確無歧義的字**。它在這兩個引擎上幾乎永遠不會觸發 —— 而那正是
對的行為。**一個指名了特定失效的分類，在看不見那個失效的時候就應該閉嘴。** 哪天
接了真的會寫台語的引擎，它才開始有意義。

一個指名失效卻在對雜訊貼標籤的分類，比沒有這個分類更糟：它讓人相信一個不存在的
訊號。

⚠️ 這也表示 bench 當時的「台語 marker 114 vs 77」量的東西跟我假設的不一樣。
**我不知道它實際量了什麼，不猜。** 要用那個結論就得先回去看它的定義。

新增 4 支測試：模稜兩可的字不得在集合內、無歧義的字必須在、**兩份普通國語稿不得
被標成 taigi**（量測暴露出來的那個回歸）、而真的書面台語仍然要觸發。

全套 1674 passed / 7 skipped。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>