### PR TITLE
feat(transcribe): 兩個引擎真正的差別是語氣，不是字

### DIFF
--- a/tests/test_transcript_compare.py
+++ b/tests/test_transcript_compare.py
@@ -283,6 +283,47 @@ def test_distant_disagreements_stay_separate():
 
 # ── the marker set, after measuring it ───────────────────────────────────────
 
+def test_particles_are_what_actually_carries_the_signal():
+    """Two measurements got us here. Written-Taiwanese characters fired **zero**
+    times across 541 real transcripts, because neither engine writes Taiwanese
+    orthography. The 3-way bench measured the same property successfully because its
+    set is mostly sentence-final PARTICLES — re-measured on the same 22,799
+    characters: **134 hits against zero**."""
+    for ch in "啦齁嘛蛤欸咧吼唷呴":
+        assert ch in tc.PARTICLE_MARKERS
+
+
+def test_a_particle_smoothed_away_is_not_reported_as_a_missing_sentence():
+    """`做` vs `做啦` is one engine tidying the speech away. With the empty-side rule
+    checked first it came back as `coverage` — "the other engine missed something" —
+    which is the opposite of what happened."""
+    out = tc.compare([seg(0, 3, "那我們就這樣做")], [seg(0, 3, "那我們就這樣做啦")])
+    assert out["by_kind"] == {tc.TAIGI: 1}, out
+
+
+def test_a_genuinely_missing_sentence_is_still_a_hole():
+    """The rule above must not swallow real coverage: a hole contains real words,
+    not just particles."""
+    out = tc.compare([seg(0, 5, "這一整句話都有被聽到而且很長")], [seg(0, 5, "")])
+    assert out["by_kind"] == {tc.COVERAGE: 1}, out
+
+
+def test_particles_on_both_sides_is_not_a_texture_finding():
+    """Both engines kept the texture — whatever they disagree about, it is not
+    that."""
+    out = tc.compare([seg(0, 3, "這樣做啦")], [seg(0, 3, "這樣用啦")])
+    assert tc.TAIGI not in out["by_kind"], out
+
+
+def test_ambiguous_members_of_the_bench_set_are_excluded():
+    """敢 (dare) and 乎 (classical particle) are ordinary Mandarin. Harmless in a
+    density metric where they add the same background to both sides; not harmless
+    when classifying one window, which is where the first version of this category
+    went wrong."""
+    assert "敢" not in tc.PARTICLE_MARKERS and "敢" not in tc.TAIGI_MARKERS
+    assert "乎" not in tc.PARTICLE_MARKERS and "乎" not in tc.TAIGI_MARKERS
+
+
 def test_only_unambiguous_characters_are_markers():
     """Measured across 541 real transcripts (22,799 chars): 19 of the original 24
     markers never appeared, and the 5 that did are ordinary Mandarin. The category
@@ -292,6 +333,7 @@ def test_only_unambiguous_characters_are_markers():
     fires on Mandarin does not make the category noisy, it makes it wrong."""
     for ch in "怎焦物啥按爸母孫熱歹勢多謝鬧囝兜箍伊講較欲":
         assert ch not in tc.TAIGI_MARKERS, "{0} occurs in ordinary Mandarin".format(ch)
+        assert ch not in tc.PARTICLE_MARKERS, "{0} occurs in ordinary Mandarin".format(ch)
 
 
 def test_the_markers_that_remain_are_the_ones_that_only_exist_in_taiwanese():
@@ -312,3 +354,11 @@ def test_real_written_taiwanese_still_registers():
     Taiwanese, this is what has to fire."""
     out = tc.compare([seg(0, 3, "我們不會在這裡")], [seg(0, 3, "阮袂佇遮")])
     assert tc.TAIGI in out["by_kind"], out
+
+
+def test_a_particle_buried_in_real_words_still_counts():
+    """The other branch: both sides carry real content, so `particles_only` does not
+    apply — the finding has to come from the marker COUNT. Without particles in that
+    count, "one engine kept the 啦 and the other didn't" is invisible."""
+    assert tc.classify({"text": "甲啦乙丙"}, {"text": "甲乙丙丁"}) == tc.TAIGI
+    assert tc.classify({"text": "甲乙丙戊"}, {"text": "甲乙丙丁"}) == tc.OTHER

--- a/transcript_compare.py
+++ b/transcript_compare.py
@@ -34,25 +34,38 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional, Tuple
 
-# Characters that only appear in written Taiwanese.
+# What actually distinguishes these two engines is **spoken texture**, not
+# orthography — and that took two measurements to establish.
 #
-# **Measured 2026-08-26 and the result matters more than the list:** across 541
-# real transcripts (22,799 characters) not one of 毋 袂 佇 阮 恁 遮 遐 蹛 媠 囡
-# appeared — **zero**. Nineteen of the original twenty-four markers never fired at
-# all, and the five that did (怎 焦 物 啥 按) are ordinary Mandarin characters, so
-# what the category was actually reporting was noise.
+# First attempt used written-Taiwanese characters (毋 袂 佇 阮 恁 遮 遐 蹛 媠 囡).
+# Across 541 real transcripts (22,799 characters) they fired **zero** times, because
+# neither engine writes Taiwanese orthography: Whisper flattens Taiwanese into
+# Mandarin by design, and Qwen3-ASR has no Taiwanese in its supported languages at
+# all — it transcribes Taiwanese speech AS Chinese. Both write Mandarin characters;
+# they differ in WHICH ones.
 #
-# The reason is structural, not a tuning problem: **neither engine writes Taiwanese
-# orthography.** Whisper flattens Taiwanese into Mandarin by design, and
-# Qwen3-ASR has no Taiwanese in its supported-language list at all — it transcribes
-# Taiwanese speech AS Chinese. The two differ by writing different Mandarin
-# characters for the same sound, not by one of them writing 台語漢字.
+# The 3-way meeting bench (2026-07-16) measured the same thing successfully, and
+# looking at its definition explains why: its set is mostly sentence-final
+# PARTICLES — 啦 齁 乎 嘛 蛤 欸 咧 吼 唷 呴 — plus a few Taiwanese words. Those are
+# what survives when someone speaks Mandarin with Taiwanese speech habits, and an
+# engine either keeps them or smooths them into tidy prose. Re-measured on the same
+# 22,799 characters: **134 hits (0.59%) against zero** for the orthographic set.
 #
-# So the list is now only the unambiguous characters. It will almost never fire on
-# these two engines, and that is the correct behaviour: a category that names a
-# specific failure must stay silent when it cannot see that failure. It becomes
-# useful the day an engine that actually writes Taiwanese is added.
-TAIGI_MARKERS = "毋袂佇阮恁遮遐蹛媠囡"
+# So the category detects "one engine kept the spoken texture, the other tidied it
+# away". It is a PROXY for Taiwanese fidelity — the bench used it as one and said so
+# — not a detector of Taiwanese, and the bench's own note applies here too: the
+# robust signal is the ordering between engines, not the absolute count.
+#
+# 敢 and 乎 are in the bench's set but NOT here: both are ordinary Mandarin (敢 =
+# dare, 乎 = classical particle). They are harmless in a density metric, where they
+# add the same background to both sides, but this classifies individual windows —
+# and there an ambiguous member produces exactly the false label that the first
+# version of this category was producing.
+PARTICLE_MARKERS = "啦齁嘛蛤欸咧吼唷呴"
+# Written Taiwanese proper. Effectively never fires on these two engines, and that
+# is correct — it becomes meaningful the day an engine that writes 台語漢字 is added.
+TAIGI_MARKERS = "毋袂佇阮恁遮遐蹛媠囡攏矣"
+TAIGI_WORDS = ("按呢", "這馬")
 
 # Below this, a length ratio says nothing: short diff runs are word swaps, not
 # missing speech.
@@ -60,7 +73,7 @@ _COVERAGE_MIN_CHARS = 8
 
 AGREE = "agree"
 COVERAGE = "coverage"   # one side has text the other simply doesn't
-TAIGI = "taigi"         # one side kept Taiwanese, the other flattened it
+TAIGI = "taigi"         # one side kept the spoken texture, the other tidied it
 OTHER = "other"         # different wording — needs a human ear
 
 
@@ -78,8 +91,20 @@ def _norm(text: str) -> str:
     return "".join(ch for ch in (text or "") if ch not in drop)
 
 
+def _particles_only(text: str) -> bool:
+    """Every character present is a spoken-texture marker (and there is at least
+    one). An empty side is not "particles only" — that is a hole."""
+    stripped = "".join((text or "").split())
+    if not stripped:
+        return False
+    return all(ch in PARTICLE_MARKERS or ch in TAIGI_MARKERS for ch in stripped)
+
+
 def _taigi_count(text: str) -> int:
-    return sum(1 for ch in (text or "") if ch in TAIGI_MARKERS)
+    """Spoken-texture markers: particles, plus written Taiwanese if it ever shows up."""
+    text = text or ""
+    n = sum(1 for ch in text if ch in PARTICLE_MARKERS or ch in TAIGI_MARKERS)
+    return n + sum(text.count(w) for w in TAIGI_WORDS)
 
 
 def align(a_segments: List[Dict], b_segments: List[Dict],
@@ -116,6 +141,12 @@ def classify(a: Optional[Dict], b: Optional[Dict]) -> str:
     ta, tb = _norm((a or {}).get("text", "")), _norm((b or {}).get("text", ""))
     if ta == tb:
         return AGREE
+    # BEFORE the coverage check: a difference that is nothing but particles is the
+    # smoothing case, not a hole. `做` vs `做啦` is one engine tidying the speech
+    # away — and with the empty-side rule first it came back as "the other engine
+    # missed something", which is the opposite of what happened.
+    if _particles_only(ta) or _particles_only(tb):
+        return TAIGI
     if not ta or not tb:
         return COVERAGE
     # A large length gap is a coverage hole too: one engine heard a sentence, the


### PR DESCRIPTION
回去看 bench 的 marker 定義，整件事就通了。它的集合是
｛啦 齁 乎 嘛 蛤 欸 咧 吼 唷 呴 按呢 這馬 袂 毋 敢 攏 矣｝—— **大多數是句尾語氣詞**，
不是台語漢字。它量的是「講話的口氣有沒有被磨平」，跟我做的是兩件不同的事。

同一批語料（541 份、22,799 字）重算：

| 集合 | 命中 | 密度 |
|---|---|---|
| bench 的（語氣詞為主） | **134** | 0.588% |
| 台語漢字（#381 收窄後） | **0** | 0.000% |

訊號全部來自 `啦 78`、`欸 30`、`嘛 9`、`齁 5`、`唷 4`、`蛤 3`。書面台語詞
（按呢、這馬、袂、毋、攏、矣）**全部 0** —— 跟 #381 的發現一致：引擎不寫台語漢字。

所以這個分類**可以成立，只是我量錯東西**。它偵測的是「一邊留住了口語的質感、
另一邊把它整理掉了」，那是 bench 拿來當台語忠實度**代理指標**的東西 —— 而 bench
自己就標註了「絕對值依集合而定，穩健訊號是引擎之間的排序」，那句話對這裡一樣成立。

**`敢` 與 `乎` 不收**（bench 的集合裡有）：兩個都是普通國語（敢＝dare、乎＝文言
語氣）。在密度指標裡無害 —— 它們對兩邊加同樣的背景值；但這裡是**逐個視窗分類**，
那正是這個分類第一版出錯的地方。

**順序也修了**：語氣詞判斷要排在 coverage 之前。`做` vs `做啦` 是一邊把語氣整理掉，
但「有一邊是空的就算破洞」先攔下來，結論會變成「另一邊漏聽了」—— 剛好相反。

新增 6 支測試。mutation-check 五處全紅在該紅的位置：
  語氣詞檢查排到 coverage 之後 / 空字串也算 particles_only / 語氣詞不算進 marker /
  把 敢乎 收回集合 / 台語漢字集合清空

全套 1680 passed / 7 skipped。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>