### PR TITLE
feat(transcribe): 語氣詞密度 —— 不用對齊、不用人耳的那個訊號

### DIFF
--- a/tests/test_transcript_compare.py
+++ b/tests/test_transcript_compare.py
@@ -362,3 +362,54 @@ def test_a_particle_buried_in_real_words_still_counts():
     count, "one engine kept the 啦 and the other didn't" is invisible."""
     assert tc.classify({"text": "甲啦乙丙"}, {"text": "甲乙丙丁"}) == tc.TAIGI
     assert tc.classify({"text": "甲乙丙戊"}, {"text": "甲乙丙丁"}) == tc.OTHER
+
+
+# ── particle density: the half that works when the diff doesn't ──────────────
+# Measured on a 10-minute Taiwanese talk-show slice: Whisper 0.90%, Qwen3-ASR
+# 1.46% — the same ordering the 3-way bench found. On that SAME material the
+# transcripts agreed on 49% of characters and the review list covered 94% of the
+# timeline, because the two engines disagree systematically on Taiwanese rather
+# than occasionally. A diff is the wrong instrument for a systematic difference;
+# one number per transcript is the right one.
+
+def test_density_is_markers_per_hundred_characters():
+    assert tc.particle_density("甲乙丙丁啦") == pytest.approx(20.0)
+    assert tc.particle_density("") == 0.0
+    assert tc.particle_density("完全沒有語氣的一句話") == 0.0
+
+
+def test_density_needs_no_alignment_or_second_transcript():
+    """The point of separating it out: it answers "how much texture is in this
+    transcript" from the transcript alone."""
+    assert tc.particle_count("那我們就這樣做啦齁") == 2
+
+
+def test_compare_reports_which_side_kept_more_texture():
+    out = tc.compare([seg(0, 5, "那我們就這樣做欸對啦")], [seg(0, 5, "那我們就這樣做")])
+
+    assert out["texture"]["kept_more"] == "a"
+    assert out["texture"]["a"] > out["texture"]["b"]
+
+
+def test_texture_is_reported_even_when_the_review_list_is_useless():
+    """The measured case: 49% agreement, review covering 94% of the timeline — the
+    diff had nothing to offer and the densities still did."""
+    a = [seg(0, 5, "這馬按呢講啦欸對齁")]
+    b = [seg(0, 5, "現在這樣說對")]
+
+    out = tc.compare(a, b)
+
+    assert out["review"], "premise: these disagree heavily"
+    assert out["texture"]["kept_more"] == "a"
+
+
+def test_a_small_difference_names_no_winner():
+    """Below a fifth apart, the marker set's own arbitrariness is doing the talking
+    — claiming a winner there would be reading noise as a result."""
+    out = tc.compare([seg(0, 5, "甲乙丙丁啦戊己")], [seg(0, 5, "甲乙丙丁齁戊己")])
+    assert out["texture"]["kept_more"] is None
+
+
+def test_two_transcripts_with_no_texture_name_no_winner():
+    out = tc.compare([seg(0, 5, "完全沒有語氣詞")], [seg(0, 5, "完全沒有語氣字")])
+    assert out["texture"]["kept_more"] is None

--- a/transcript_compare.py
+++ b/transcript_compare.py
@@ -91,6 +91,36 @@ def _norm(text: str) -> str:
     return "".join(ch for ch in (text or "") if ch not in drop)
 
 
+def particle_count(text: str) -> int:
+    """How many spoken-texture markers a transcript carries."""
+    return _taigi_count(text)
+
+
+def particle_density(text: str) -> float:
+    """Markers per 100 characters.
+
+    **This is the cheap half of the whole exercise, and on Taiwanese-heavy material
+    it is the useful half.** Measured on a 10-minute Taiwanese talk-show slice:
+    Whisper 0.90%, Qwen3-ASR 1.46% — the same ordering the 3-way bench found, and
+    it needs no alignment, no second opinion, and no human ear. One number per
+    transcript answers "which engine kept more of how these people actually spoke".
+
+    Why it matters that this is separate from `compare()`: on that same material the
+    two transcripts agreed on only 49% of characters and the review list covered 94%
+    of the timeline — because the engines disagree SYSTEMATICALLY on Taiwanese
+    (one flattens it to Mandarin, the other writes it phonetically), not
+    occasionally. A diff is the wrong instrument for a systematic difference. This
+    number is the right one.
+
+    It is a PROXY and a relative one — the absolute value depends on the marker set,
+    and the robust signal is the ordering between two transcripts of the SAME audio.
+    Comparing densities across different clips says more about the speakers than
+    about the engine.
+    """
+    text = text or ""
+    return 100.0 * particle_count(text) / len(text) if text else 0.0
+
+
 def _particles_only(text: str) -> bool:
     """Every character present is a spoken-texture marker (and there is at least
     one). An empty side is not "particles only" — that is a hole."""
@@ -192,6 +222,20 @@ def _char_timeline(segments: List[Dict]) -> Tuple[str, List[Tuple[float, float]]
 _MERGE_GAP_S = 1.5
 
 
+def _kept_more(a_text: str, b_text: str):
+    """"a" / "b" / None — which transcript kept more spoken texture.
+
+    None when the difference is under a fifth, because below that the marker set's
+    own arbitrariness is doing the talking, not the engines.
+    """
+    da, db = particle_density(a_text), particle_density(b_text)
+    if max(da, db) <= 0:
+        return None
+    if abs(da - db) / max(da, db) < 0.2:
+        return None
+    return "a" if da > db else "b"
+
+
 def _merge_nearby(review: List[Dict], gap_s: float = _MERGE_GAP_S) -> List[Dict]:
     """Collapse review items separated by less than `gap_s` into one window.
 
@@ -268,5 +312,14 @@ def compare(a_segments: List[Dict], b_segments: List[Dict],
         by_kind[item["kind"]] = by_kind.get(item["kind"], 0) + 1
     # Characters, not runs: "12 equal runs" says nothing a person can act on,
     # "1,180 of 1,240 characters matched" says how much is left to listen to.
+    #
+    # `texture` is reported even when the review list is useless, and on
+    # Taiwanese-heavy audio that is exactly the case: measured 49% agreement and a
+    # review list covering 94% of the timeline, while the densities (0.90 vs 1.46)
+    # cleanly said which engine kept more. When the two disagree systematically the
+    # diff has nothing to offer and this still does.
     return {"agreed_chars": agreed_chars, "total_chars": max(len(a_text), len(b_text)),
-            "review": review, "by_kind": by_kind}
+            "review": review, "by_kind": by_kind,
+            "texture": {"a": round(particle_density(a_text), 3),
+                        "b": round(particle_density(b_text), 3),
+                        "kept_more": _kept_more(a_text, b_text)}}


### PR DESCRIPTION
拿台語談話節目實跑（10 分鐘切片，只抓音軌）之後，這一段的結論翻過來了：

| | 字元一致率 | 需要人耳 | 語氣詞密度 |
|---|---|---|---|
| whisper | | | 0.90% |
| Qwen3-ASR | | | **1.46%** |
| 對齊結果 | **49%** | **94%** | |

**假設第一次成立**：Qwen 保住的語氣詞是 whisper 的兩倍，跟 bench 的排序一致，
文字量也多 18%。

**但同一份素材上，diff 完全沒用**：一致率 49%、複查視窗蓋掉 94% 的時間軸。原因不是
音質（這支比會議乾淨得多），是**內容** —— 台語濃的素材上兩個引擎是**系統性**分歧
（一個抹平成國語、一個寫音近字），不是偶發錯誤。**對系統性差異用 diff 是拿錯工具。**

而那個便宜的訊號一直都在，只是被埋在沒用的複查清單裡：`particle_density()`
**一份逐字稿一個數字，不需要對齊、不需要第二份稿、不需要人耳。**

- `particle_count()` / `particle_density()` 公開出來
- `compare()` 的回傳加 `texture: {a, b, kept_more}` —— **即使複查清單毫無價值也照報**，
  因為那正是台語素材的情況
- `kept_more` 差距不到五分之一就回 `None`：低於那個幅度是 marker 集合本身的隨意性在
  說話，不是引擎。宣告贏家等於把雜訊讀成結果

它是**代理指標而且是相對的** —— 絕對值依集合而定，穩健的是「同一段音訊的兩份稿」
之間的排序。跨不同片子比密度，講的是講話的人不是引擎。

新增 6 支測試。mutation-check 五處全紅在該紅的位置：
  density 不除以長度 / compare 不報 texture / 微小差異也宣告贏家 /
  兩邊都沒語氣也宣告贏家 / 贏家判反

全套 1686 passed / 7 skipped。

⚠️ **順帶推翻我自己上一個猜測**：我原本預期「換乾淨素材會讓複查視窗降到個位數」。
跑出來是相反的（會議 73% → 談話節目 94%）。決定複查量的不是音質，是兩個引擎對
這種語言的處理差多少 —— 而那正是我們想利用的東西本身。

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>