### PR TITLE
fix(transcribe): 我排除了敢和乎，卻把攏和矣留在裡面

### DIFF
--- a/tests/test_transcript_compare.py
+++ b/tests/test_transcript_compare.py
@@ -413,3 +413,88 @@ def test_a_small_difference_names_no_winner():
 def test_two_transcripts_with_no_texture_name_no_winner():
     out = tc.compare([seg(0, 5, "完全沒有語氣詞")], [seg(0, 5, "完全沒有語氣字")])
     assert out["texture"]["kept_more"] is None
+
+
+# ── the audit round: what the first pass of the marker rule missed ────────────
+
+def test_the_bench_members_that_are_also_mandarin_stay_out():
+    """攏 and 矣 came in with the bench's set and were never held to the rule that
+    threw out 敢 and 乎 — 攏 is 靠攏/拉攏/合攏, 矣 is 足矣. Measured cost before this
+    was fixed: a plain-Mandarin sentence scoring 18.75% density."""
+    for ch in "敢乎攏矣":
+        assert ch not in tc.TAIGI_MARKERS and ch not in tc.PARTICLE_MARKERS
+
+
+def test_plain_mandarin_does_not_register_as_texture():
+    assert tc.particle_count("他拉攏了對手也靠攏了盟友最後合攏") == 0
+    assert tc.compare([seg(0, 3, "如此足矣")], [seg(0, 3, "如此足够")])["by_kind"] == {tc.OTHER: 1}
+
+
+def test_a_particle_against_a_whole_sentence_is_still_a_hole():
+    """The particles-only rule exists for `做` vs `做啦`. It must not reach the case
+    where the other side is a sentence — labelling that `taigi` says "one engine
+    tidied the texture away" about fourteen characters of missing speech, and sends
+    nobody to listen to it."""
+    out = tc.compare([seg(0, 3, "齁")], [seg(0, 3, "我們今天討論的重點是預算分配")])
+
+    assert out["by_kind"] == {tc.COVERAGE: 1}
+
+
+def test_smoothing_of_a_short_run_is_still_texture():
+    """The other side of that guard: the case it was written for still works.
+
+    Written against the shape `compare` actually produces — a diff run, not two
+    whole segments. `做` vs `做啦` reaches `classify` as `""` vs `"啦"`, and it is
+    only the particles-only branch that stops the empty side reading as a hole. The
+    first version of this test passed `做啦`/`做` in whole and was green with the
+    branch disabled, because the later marker rule caught it anyway: a test that
+    could not fail.
+    """
+    out = tc.compare([seg(0, 3, "做")], [seg(0, 3, "做啦")])
+
+    assert out["by_kind"] == {tc.TAIGI: 1}
+
+
+def test_layout_characters_are_not_differences():
+    """A CJK engine emits U+3000, not a space, and the drop-list spelled out only
+    ASCII whitespace — so identical speech came back as a coverage hole."""
+    assert tc.compare([seg(0, 3, "你好　嗎")], [seg(0, 3, "你好嗎")])["review"] == []
+    assert tc.compare([seg(0, 3, "是的…")], [seg(0, 3, "是的")])["review"] == []
+
+
+def test_a_segment_with_neither_text_nor_timing_still_sorts():
+    """`p[0] or p[1]` reads `{}` as absent and dereferences None."""
+    assert tc.align([{}], []) == [({}, None)]
+
+
+# ── wiring and thresholds that no test was holding ───────────────────────────
+
+def test_compare_merges_its_own_review_list():
+    """`_merge_nearby` had unit tests, but nothing asserted `compare` calls it —
+    the line could be deleted and the whole suite stayed green."""
+    a = [seg(0, 2, "甲乙丙丁戊己庚辛")]
+    b = [seg(0, 2, "甲子丙丁戊丑庚辛")]
+
+    out = tc.compare(a, b)
+
+    assert len(out["review"]) == 1, out["review"]
+    assert out["review"][0]["a"] == "乙 己"
+    assert out["review"][0]["b"] == "子 丑"
+
+
+def test_the_fifth_is_the_actual_threshold():
+    """Both sides of it, because the two texture tests sat at ratio 0 and ratio 1
+    — everything in between was free to move."""
+    hundred = "啦" + "甲" * 99          # 1.000%
+    assert tc._kept_more(hundred, "啦" + "甲" * 132) == "a"   # 0.752% — 25% apart
+    assert tc._kept_more(hundred, "啦" + "甲" * 109) is None  # 0.909% —  9% apart
+
+
+def test_the_denominator_is_the_longer_transcript():
+    """`agreed / total` has to be readable as "how much is left to listen to". With
+    the shorter side as the denominator, an engine that dropped half the clip scores
+    100% agreement."""
+    out = tc.compare([seg(0, 3, "甲乙丙")], [seg(0, 3, "甲乙丙丁戊己庚辛")])
+
+    assert out["agreed_chars"] == 3
+    assert out["total_chars"] == 8

--- a/transcript_compare.py
+++ b/transcript_compare.py
@@ -22,10 +22,16 @@ manufacture a confident-looking category out of nothing, so a difference that
 isn't demonstrably one of the known kinds is returned as `other`, meaning
 "a person has to listen".
 
-Alignment is by TIME, so segments without usable timestamps cannot be aligned and
-are reported as needing review. Pairing them by position instead would be a guess,
-and a guess that comes out as "these agree" is the one failure this module must not
-have — it would mark unverified text as shippable.
+Alignment is by TEXT: `difflib` over the two normalised character streams. Segment
+boundaries are an artefact of the engine, not of the speech, and the two engines cut
+differently — pairing segment-to-segment marries the same sentence to the wrong
+neighbour, which on a real clip produced 1 agreement and 68 mostly-phantom review
+items. Timestamps are used only to point a difference back at the audio, never to
+decide what pairs with what.
+
+(`align()` is the earlier time-overlap pairing. `compare()` does not use it, and
+nothing else in the repo does either — it survives as a public helper for callers
+that genuinely want segment pairs, and its tests pin it.)
 
 Pure functions, stdlib only. No I/O, no model, no engine assumptions — it takes
 two segment lists in arkiv's usual `{"start", "end", "text"}` shape.
@@ -45,8 +51,9 @@ from typing import Dict, List, Optional, Tuple
 # they differ in WHICH ones.
 #
 # The 3-way meeting bench (2026-07-16) measured the same thing successfully, and
-# looking at its definition explains why: its set is mostly sentence-final
-# PARTICLES — 啦 齁 乎 嘛 蛤 欸 咧 吼 唷 呴 — plus a few Taiwanese words. Those are
+# looking at its definition explains why. Its set in full is
+#   啦 齁 乎 嘛 蛤 欸 咧 吼 唷 呴 · 按呢 這馬 · 袂 毋 敢 攏 矣
+# — mostly sentence-final PARTICLES, plus a few Taiwanese words. Those are
 # what survives when someone speaks Mandarin with Taiwanese speech habits, and an
 # engine either keeps them or smooths them into tidy prose. Re-measured on the same
 # 22,799 characters: **134 hits (0.59%) against zero** for the orthographic set.
@@ -56,15 +63,22 @@ from typing import Dict, List, Optional, Tuple
 # — not a detector of Taiwanese, and the bench's own note applies here too: the
 # robust signal is the ordering between engines, not the absolute count.
 #
-# 敢 and 乎 are in the bench's set but NOT here: both are ordinary Mandarin (敢 =
-# dare, 乎 = classical particle). They are harmless in a density metric, where they
-# add the same background to both sides, but this classifies individual windows —
-# and there an ambiguous member produces exactly the false label that the first
-# version of this category was producing.
+# **Four of the bench's members are dropped here: 敢 乎 攏 矣.** All four are also
+# ordinary Mandarin — 敢 = dare, 乎 = classical particle, 攏 = gather (靠攏/拉攏/
+# 合攏), 矣 = classical final particle (足矣). They are harmless in a density metric
+# over a whole corpus, where they add the same background to both sides, but this
+# module also classifies individual windows — and there an ambiguous member produces
+# exactly the false label the first version of this category was producing.
+#
+# 攏 and 矣 shipped anyway in the first pass of this rule, because they came in with
+# the bench's set while only 敢 and 乎 were tested against the rule. The cost was
+# measured afterwards: `他拉攏了對手也靠攏了盟友最後合攏` — plain Mandarin, no
+# Taiwanese in it — scored 18.75%, and `如此足矣` vs `如此足够` came back `taigi`.
+# The rule was right; it just was not applied to everything it was written for.
 PARTICLE_MARKERS = "啦齁嘛蛤欸咧吼唷呴"
 # Written Taiwanese proper. Effectively never fires on these two engines, and that
 # is correct — it becomes meaningful the day an engine that writes 台語漢字 is added.
-TAIGI_MARKERS = "毋袂佇阮恁遮遐蹛媠囡攏矣"
+TAIGI_MARKERS = "毋袂佇阮恁遮遐蹛媠囡"
 TAIGI_WORDS = ("按呢", "這馬")
 
 # Below this, a length ratio says nothing: short diff runs are word swaps, not
@@ -86,9 +100,14 @@ def _overlap(a: Dict, b: Dict) -> float:
 
 def _norm(text: str) -> str:
     """Compare content, not layout: whitespace and the punctuation the two engines
-    disagree about anyway are not differences worth a human's time."""
-    drop = " \t\n，。、！？；：「」『』（）,.!?;:\"'"
-    return "".join(ch for ch in (text or "") if ch not in drop)
+    disagree about anyway are not differences worth a human's time.
+
+    `str.isspace` rather than a list of space characters — the ideographic space
+    U+3000 is what a CJK engine actually emits, and spelling out `" \t\n"` missed
+    it, so `你好　嗎` and `你好嗎` came back as a coverage hole on identical speech.
+    """
+    drop = "，。、！？；：「」『』（）…,.!?;:\"'"
+    return "".join(ch for ch in (text or "") if not ch.isspace() and ch not in drop)
 
 
 def particle_count(text: str) -> int:
@@ -162,7 +181,10 @@ def align(a_segments: List[Dict], b_segments: List[Dict],
     for i, b in enumerate(b_segments):
         if i not in used_b:
             pairs.append((None, b))
-    pairs.sort(key=lambda p: float((p[0] or p[1]).get("start") or 0.0))
+    # `p[0] or p[1]` reads an empty dict as absent and then dereferences None —
+    # a segment can legitimately be `{}` (no text, no timing) and must still sort.
+    pairs.sort(key=lambda p: float(
+        (p[0] if p[0] is not None else p[1]).get("start") or 0.0))
     return pairs
 
 
@@ -175,7 +197,12 @@ def classify(a: Optional[Dict], b: Optional[Dict]) -> str:
     # smoothing case, not a hole. `做` vs `做啦` is one engine tidying the speech
     # away — and with the empty-side rule first it came back as "the other engine
     # missed something", which is the opposite of what happened.
-    if _particles_only(ta) or _particles_only(tb):
+    longer, shorter = max(len(ta), len(tb)), min(len(ta), len(tb))
+    _lopsided = longer >= _COVERAGE_MIN_CHARS and shorter * 2 <= longer
+    if (_particles_only(ta) or _particles_only(tb)) and not _lopsided:
+        # ...but only when the particle IS the difference. A lone 齁 against a full
+        # sentence is a hole with a particle sitting in it, and calling that
+        # "smoothed texture" hides the one thing a person needed to be sent to.
         return TAIGI
     if not ta or not tb:
         return COVERAGE
@@ -183,8 +210,7 @@ def classify(a: Optional[Dict], b: Optional[Dict]) -> str:
     # other caught two words of it. Only for runs long enough for "a sentence vs a
     # fragment" to mean anything — on a two-character difference the ratio fires on
     # everything (`我們` vs `阮` is 2:1) and swallows the categories that matter.
-    longer, shorter = max(len(ta), len(tb)), min(len(ta), len(tb))
-    if longer >= _COVERAGE_MIN_CHARS and shorter * 2 <= longer:
+    if _lopsided:
         return COVERAGE
     if (_taigi_count(ta) > 0) != (_taigi_count(tb) > 0):
         return TAIGI


### PR DESCRIPTION
#381 立的規則是「同時也是普通國語的字不能當 marker」，並據此把 bench 集合裡的
敢 和 乎 拿掉。但 bench 集合是 ｛啦 齁 乎 嘛 蛤 欸 咧 吼 唷 呴 · 按呢 這馬 ·
袂 毋 敢 攏 矣｝ —— 攏 和 矣 跟著抄了進來，而它們通過不了同一個判準：
攏 是靠攏／拉攏／合攏，矣 是足矣。規則沒錯，只是沒套在自己抄進來的每個字上。

量到的代價：
- 「他拉攏了對手也靠攏了盟友最後合攏」—— 整句國語 —— 密度 18.75%
- 「如此足矣」vs「如此足够」回 taigi

同一輪對抗式審計還抓到三個 classify/compare 的邊界，一併修：

- **一個語氣詞對上一整句話，被標成 taigi 而不是 coverage。** particles-only
  分支是為「做」vs「做啦」寫的，但它跑在 coverage 檢查之前、且不看另一邊多長。
  `齁` vs `我們今天討論的重點是預算分配` 於是變成「一邊把語氣抹平了」——
  十四個字的漏聽就沒有人被派去聽。加長度閘。
- **`_norm` 只列了 ASCII 空白**，而 CJK 引擎吐的是 U+3000。`你好　嗎` 對
  `你好嗎` 回一個幻影 coverage。改成 `str.isspace()`，並補上 `…`。
- **`align([{}], [])` 炸掉** —— `p[0] or p[1]` 把空 dict 讀成不存在。

以及三處「拿掉也不會紅」的接線，補測試釘住：`compare()` 有沒有真的呼叫
`_merge_nearby`（刪掉那一行，43 支全綠）、`_kept_more` 的五分之一門檻
（0.2 改成 0.99，全綠）、`total_chars` 取兩邊較長者（改成 `len(a_text)`，全綠）。

模組 docstring 還寫著「Alignment is by TIME」—— 那是 #379 之前的設計，
現在按文字對齊，一併改正。

10 個 mutation 全紅在該紅的那支。其中一支我第一版寫錯：`做啦`/`做` 整段送進
classify 時，就算關掉守衛也會被後面的 marker 規則接住 —— 綠得但不是因為守衛。
改寫成 compare 真正產生的形狀（`""` vs `"啦"` 的 diff run）才咬得到。

全套 1695 passed / 7 skipped。