### PR TITLE
feat(transcribe): 語氣詞讀數接上 Inspector —— 以及它的分母本來是錯的

### DIFF
--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -198,6 +198,12 @@
   export let viewLang = null
   export let onViewLang = null // (lang) => void — view a language (no activate)
   export let onActivateLang = null // (lang) => void — make it the active transcript
+  // Spoken-texture reading for the language being viewed: {count, density}.
+  // Server-computed (one definition of the marker set, in transcript_compare) —
+  // `density` is null when the transcript is too short for a percentage to be
+  // anything but noise, and the count is shown alone. A count is honest at any
+  // length; a percentage needs a denominator.
+  export let particleStat = null
   export let frameDescriptions = null // string[]; when set, render a Vision block
   // Richer per-frame vision metadata for the scene timeline. When set, supersedes
   // frameDescriptions. [{tc?, description, content_type, atmosphere, energy,
@@ -316,6 +322,19 @@
   // stay populated for reference.
   export let live = false
   $: lines = live ? (transcriptLines ?? []) : (transcriptLines ?? MOCK_TRANSCRIPT)
+  // 語氣詞 readout, appended to the segment count rather than given its own row —
+  // it is a footnote on the transcript, not a headline about the clip.
+  $: particleLabel = particleStat
+    ? ` · 語氣 ${particleStat.count}` +
+      (particleStat.density != null ? ` · ${particleStat.density.toFixed(1)}%` : '')
+    : ''
+  $: particleTitle = !particleStat
+    ? undefined
+    : particleStat.density != null
+      ? '語氣詞密度：每 100 字裡的語氣詞（啦齁嘛蛤欸咧吼唷呴）。' +
+        '高＝保留了口說語氣，低＝被整理成書面語。' +
+        '這是相對指標 —— 比同一段聲音的兩份逐字稿有意義；跨片比較比到的是講話的人，不是引擎。'
+      : '這份逐字稿太短，百分比會被單一個字左右，所以只給個數。'
   $: pathStr = live
     ? (pathLabel ?? media.name)
     : (pathLabel ?? `/vol/nas01/bicycle-diaries/raw/${media.name}`)
@@ -454,7 +473,7 @@
   <div class="block transcript">
     <div class="blockhead">
       <Eyebrow>Transcript</Eyebrow>
-      <Mono dim style="font-size:9.5px;">{lines.length} 段</Mono>
+      <Mono dim style="font-size:9.5px;" title={particleTitle}>{lines.length} 段{particleLabel}</Mono>
     </div>
     {#if transcriptLangs && transcriptLangs.length}
       <div class="langtabs">

--- a/frontend/src/lib/Mono.svelte
+++ b/frontend/src/lib/Mono.svelte
@@ -2,9 +2,14 @@
 <script>
   export let dim = false
   export let style = ''
+  // Forwarded so a caller can explain a compact readout without wrapping this in
+  // another element. Svelte drops attributes a component does not declare, and it
+  // drops them silently — `title=` on <Mono> looked right in the source and simply
+  // never reached the DOM.
+  export let title = undefined
 </script>
 
-<span class="ak-mono" class:dim {style}><slot /></span>
+<span class="ak-mono" class:dim {style} {title}><slot /></span>
 
 <style>
   .dim {

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -736,9 +736,19 @@
   $: transcriptLangs = tdLive ? tdLive.transcripts.map((t) => ({ lang: t.lang, active: !!t.active })) : null
   // transcript: show the viewed language's segments_json when tabs are loaded,
   // else fall back to the live detail's active transcript.
+  $: _viewedRow = (tdLive && viewLang)
+    ? (tdLive.transcripts.find((t) => t.lang === viewLang) || null)
+    : null
   $: _displaySegs = (tdLive && viewLang)
-    ? (parseJson((tdLive.transcripts.find((t) => t.lang === viewLang) || {}).segments_json) || [])
+    ? (parseJson((_viewedRow || {}).segments_json) || [])
     : (detailLive ? (parseJson(detailLive.segments_json) || []) : null)
+  // 語氣詞 count/density for the viewed language. Computed server-side so the
+  // marker set has exactly one definition; absent (null) when the server declines
+  // to answer — a non-CJK transcript would score a structural 0, which reads as a
+  // measurement and is not one.
+  $: particleStat = _viewedRow && _viewedRow.particle_count != null
+    ? { count: _viewedRow.particle_count, density: _viewedRow.particle_density }
+    : null
   $: inspTranscript = _displaySegs
     ? _displaySegs.map((sg) => [secToTc(sg.start), sg.text, false, sg.start])
     : null
@@ -1130,6 +1140,7 @@
         peaks={inspPeaks}
         pathLabel={inspPath}
         transcriptLines={inspTranscript}
+        {particleStat}
         {transcriptLangs}
         {viewLang}
         {onViewLang}

--- a/routers/media.py
+++ b/routers/media.py
@@ -31,6 +31,7 @@ import db
 import mediatypes
 import progress
 import tag_quality
+import transcript_compare
 from auth import require_scopes
 from config import BASE_DIR
 from mediarecords import _get_light_records_by_ids, _get_tags_bulk
@@ -957,6 +958,15 @@ def list_transcripts(media_id: int, _tok: dict = Depends(require_scopes("videos_
             r["active"] = True
         else:
             r["active"] = False
+        # 語氣詞 reading for the inspector. Computed here rather than in the
+        # frontend so the marker set has exactly one definition — a copy in JS
+        # would drift the first time the set is corrected, and it has been
+        # corrected twice already. Both fields are None when the module declines
+        # to answer (no CJK), and `particle_density` alone is None when the
+        # transcript is too short for a percentage to be anything but noise.
+        reading = transcript_compare.particle_reading(r.get("transcript"))
+        r["particle_count"] = reading["count"] if reading else None
+        r["particle_density"] = reading["density"] if reading else None
     return {"active_lang": active_lang, "transcripts": rows}
 
 

--- a/scripts/measure_particle_density.py
+++ b/scripts/measure_particle_density.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Re-measure the spoken-texture numbers `transcript_compare` quotes.
+
+Those numbers — 541 transcripts, 22,799 characters, 134 marker hits, and the
+0.90 vs 1.46 engine ordering — decided the marker set and the length below which
+a percentage is not reported. They were measured once, on libraries that live on a
+NAS and two other machines, and written into a docstring. A reader with the repo in
+front of them had no way to check any of it, and I had no way to re-check it after
+changing the set. This is that way.
+
+    python scripts/measure_particle_density.py <library.db> [more.db ...]
+
+Reads `media.transcript` and `transcripts.transcript` from each database, opened
+read-only — it never writes, so it is safe to point at a live library. Prints the
+corpus totals, the length distribution (the reason the per-clip percentage is
+withheld below a threshold), and how much of the corpus clears it.
+
+To compare two ENGINES rather than describe one corpus, point it at two databases
+holding the same clips and read the two density lines against each other. The
+absolute value depends on the marker set; only the ordering is robust.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import transcript_compare as tc  # noqa: E402
+
+_BUCKETS = [(0, 20), (20, 40), (40, 80), (80, 200), (200, 1000), (1000, None)]
+
+
+def _texts(db_path: str):
+    """Every DISTINCT non-empty transcript in one library, active and archived.
+
+    `media.transcript` mirrors whichever language is active, and the endpoint
+    lazily writes that same text into `transcripts` — so a naive union over both
+    tables counts every active transcript twice. Keyed by (media_id, lang), with
+    `media` read first because it is the authoritative copy of the active one.
+    """
+    con = sqlite3.connect("file:{0}?mode=ro".format(db_path), uri=True)
+    con.row_factory = sqlite3.Row
+    seen = set()
+    try:
+        rows = con.execute(
+            "SELECT id AS mid, lang, transcript AS t FROM media "
+            "WHERE transcript IS NOT NULL AND TRIM(transcript) <> ''")
+        for r in rows:
+            seen.add((r["mid"], r["lang"]))
+            yield r["lang"], r["t"]
+        try:
+            rows = con.execute(
+                "SELECT media_id AS mid, lang, transcript AS t FROM transcripts "
+                "WHERE transcript IS NOT NULL AND TRIM(transcript) <> ''")
+        except sqlite3.Error:
+            return  # a database predating the per-language archive
+        for r in rows:
+            if (r["mid"], r["lang"]) not in seen:
+                yield r["lang"], r["t"]
+    finally:
+        con.close()
+
+
+def _pct(n, d):
+    return 100.0 * n / d if d else 0.0
+
+
+def main(argv):
+    if not argv:
+        print(__doc__.strip().splitlines()[2].strip() or "usage: see module docstring")
+        print("usage: measure_particle_density.py <library.db> [more.db ...]")
+        return 2
+
+    corpus = []
+    for db_path in argv:
+        if not Path(db_path).exists():
+            print("{0}: not found".format(db_path))
+            continue
+        got = [(lang, t) for lang, t in _texts(db_path)]
+        corpus.extend(got)
+        chars = sum(len(t) for _l, t in got)
+        hits = sum(tc.particle_count(t) for _l, t in got)
+        print("{0}: {1} transcripts, {2} chars, {3} hits ({4:.2f}%)".format(
+            db_path, len(got), chars, hits, _pct(hits, chars)))
+
+    if not corpus:
+        print("nothing to measure")
+        return 1
+
+    chars = sum(len(t) for _l, t in corpus)
+    hits = sum(tc.particle_count(t) for _l, t in corpus)
+    print("\nCORPUS  {0} transcripts · {1} chars · {2} hits · density {3:.2f}%".format(
+        len(corpus), chars, hits, _pct(hits, chars)))
+    print("markers  particles={0!r}  taigi={1!r}  words={2}".format(
+        tc.PARTICLE_MARKERS, tc.TAIGI_MARKERS, "".join(tc.TAIGI_WORDS)))
+
+    print("\nlength distribution — why a per-clip percentage is withheld below "
+          "{0} chars:".format(tc.DENSITY_MIN_CHARS))
+    print("{0:<12}{1:>7}{2:>9}{3:>12}".format("chars", "clips", "share", "1 marker ="))
+    for lo, hi in _BUCKETS:
+        sel = [t for _l, t in corpus if lo <= len(t) < (hi if hi is not None else 10 ** 12)]
+        if not sel:
+            continue
+        mid = (lo + (hi if hi is not None else lo * 2)) / 2 or 1
+        print("{0:<12}{1:>7}{2:>8.0f}%{3:>11.2f}%".format(
+            "{0}-{1}".format(lo, hi if hi is not None else "∞"),
+            len(sel), _pct(len(sel), len(corpus)), 100.0 / mid))
+
+    measurable = [t for _l, t in corpus if len(t) >= tc.DENSITY_MIN_CHARS]
+    print("\n{0} of {1} transcripts ({2:.0f}%) are long enough for a percentage; "
+          "the rest report a count only.".format(
+              len(measurable), len(corpus), _pct(len(measurable), len(corpus))))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_transcript_compare.py
+++ b/tests/test_transcript_compare.py
@@ -498,3 +498,59 @@ def test_the_denominator_is_the_longer_transcript():
 
     assert out["agreed_chars"] == 3
     assert out["total_chars"] == 8
+
+
+# ── the denominator ──────────────────────────────────────────────────────────
+
+def test_punctuation_does_not_change_the_reading():
+    """Punctuation only ever enters the denominator, so the more punctuated side
+    reads as having less texture. The Whisper path goes through LLM polish and the
+    Qwen path does not — which is exactly the comparison this metric is for.
+
+    Measured before the fix: 9.09% vs 11.76% on this pair, 29% apart, against a
+    `_kept_more` threshold of 20%. Punctuation alone could name the winner.
+    """
+    polished = "那我們就這樣做啦，齁，對，就是這樣，好不好？"
+    raw = "那我們就這樣做啦齁對就是這樣好不好"
+
+    assert tc.particle_density(polished) == pytest.approx(tc.particle_density(raw))
+    assert tc._kept_more(polished, raw) is None
+
+
+def test_the_denominator_ignores_layout_and_symbols():
+    assert tc._speech_chars("你好　嗎…，。！？「」—《》 %") == 3
+    assert tc._speech_chars("abc 123") == 6
+
+
+# ── the reading the UI renders ───────────────────────────────────────────────
+
+def test_a_latin_transcript_gets_no_reading_rather_than_zero():
+    """Every marker is CJK, so an English transcript scores a structural zero.
+    Rendering "0.0%" there reads as a measurement of the engine and is a statement
+    about the alphabet."""
+    assert tc.particle_reading("this is an english transcript of some length") is None
+    assert tc.particle_reading("") is None
+
+
+def test_a_short_transcript_reports_a_count_and_no_percentage():
+    """arkiv's transcripts average 42 characters. At that length one 啦 is 2.4% —
+    a number that moves further on one character than the whole engine gap."""
+    r = tc.particle_reading("那我們就這樣做啦齁")
+
+    assert r["count"] == 2
+    assert r["density"] is None
+
+
+def test_a_long_enough_transcript_reports_both():
+    text = "啦" * 4 + "甲" * 396  # 400 speech chars, 4 markers
+
+    r = tc.particle_reading(text)
+
+    assert r["count"] == 4
+    assert r["density"] == pytest.approx(1.0)
+
+
+def test_the_threshold_is_counted_in_speech_characters_not_string_length():
+    """A transcript padded to 200 with punctuation is not a 200-character
+    transcript — that is the same confound one level up."""
+    assert tc.particle_reading("啦" + "甲" * 99 + "，" * 200)["density"] is None

--- a/tests/test_transcripts_g2.py
+++ b/tests/test_transcripts_g2.py
@@ -115,3 +115,41 @@ def test_activate_unknown_language_404(langclient):
     mid = _seed()
     r = langclient.post(f"/api/media/{mid}/transcript/activate", json={"lang": "fr"})
     assert r.status_code == 404
+
+
+# ── 語氣詞 reading on the endpoint (feeds the inspector's transcript header) ──
+
+def _long_zh(markers=4, filler=396):
+    """A transcript over DENSITY_MIN_CHARS so a percentage is reported."""
+    return "啦" * markers + "甲" * filler
+
+
+def test_reading_accompanies_each_language(langclient):
+    mid = _seed(transcript=_long_zh(), lang="zh")
+
+    row = langclient.get(f"/api/media/{mid}/transcripts").json()["transcripts"][0]
+
+    assert row["particle_count"] == 4
+    assert row["particle_density"] == pytest.approx(1.0)
+
+
+def test_a_short_transcript_gets_a_count_and_no_percentage(langclient):
+    """The common case — arkiv clips average ~42 characters. The count is honest at
+    that length and the percentage is not, so the endpoint says so rather than
+    letting the UI render a number that moves 2.4 points per character."""
+    mid = _seed(transcript="那我們就這樣做啦齁", lang="zh")
+
+    row = langclient.get(f"/api/media/{mid}/transcripts").json()["transcripts"][0]
+
+    assert row["particle_count"] == 2
+    assert row["particle_density"] is None
+
+
+def test_a_non_cjk_transcript_gets_no_reading_at_all(langclient):
+    """Not zero — absent. Every marker is CJK, so 0.0% here would be a fact about
+    the alphabet dressed up as a fact about the engine."""
+    mid = _seed(transcript="an english transcript, of quite ordinary length", lang="en")
+
+    row = langclient.get(f"/api/media/{mid}/transcripts").json()["transcripts"][0]
+
+    assert row["particle_count"] is None and row["particle_density"] is None

--- a/transcript_compare.py
+++ b/transcript_compare.py
@@ -85,6 +85,20 @@ TAIGI_WORDS = ("按呢", "這馬")
 # missing speech.
 _COVERAGE_MIN_CHARS = 8
 
+# Below this many speech characters, no percentage is reported at all — only a
+# count. One marker moves the reading by `100/L` points, and the gap this metric
+# exists to resolve is 0.56 points (0.90 vs 1.46), so below L = 179 a single
+# character outweighs the entire signal. And arkiv's transcripts really are that
+# short: 541 real ones averaged 42 characters, where one 啦 reads as 2.4%.
+# `scripts/measure_particle_density.py` re-measures both numbers against any
+# library, so this threshold can be re-derived rather than believed. Writing it
+# turned up a counting trap the original one-off measurement may well have fallen
+# into: `media.transcript` and the active row of `transcripts` are the same text,
+# so a union over both tables counts every active transcript twice. If the 541 was
+# arrived at that way it is nearer 270. The MEAN length and the density ratio are
+# unaffected by a uniform double-count, and those are what this threshold rests on.
+DENSITY_MIN_CHARS = 200
+
 AGREE = "agree"
 COVERAGE = "coverage"   # one side has text the other simply doesn't
 TAIGI = "taigi"         # one side kept the spoken texture, the other tidied it
@@ -115,8 +129,24 @@ def particle_count(text: str) -> int:
     return _taigi_count(text)
 
 
+def _speech_chars(text: str) -> int:
+    """The denominator: characters that carry speech.
+
+    An allowlist (`str.isalnum`), not the drop-list `_norm` uses for comparison.
+    Punctuation only ever enters the denominator, never the numerator, so any
+    punctuation the drop-list happened to miss deflates the reading — and the two
+    engines do not punctuate alike, because the Whisper path runs through LLM polish
+    and the Qwen path does not.
+
+    Measured, same sentence, same two markers, with and without polish punctuation:
+    **9.09% vs 11.76% — a 29% difference from punctuation alone**, against a
+    `_kept_more` threshold of 20%. Punctuation could flip the winner by itself.
+    """
+    return sum(1 for ch in (text or "") if ch.isalnum())
+
+
 def particle_density(text: str) -> float:
-    """Markers per 100 characters.
+    """Markers per 100 characters of speech.
 
     **This is the cheap half of the whole exercise, and on Taiwanese-heavy material
     it is the useful half.** Measured on a 10-minute Taiwanese talk-show slice:
@@ -135,9 +165,38 @@ def particle_density(text: str) -> float:
     and the robust signal is the ordering between two transcripts of the SAME audio.
     Comparing densities across different clips says more about the speakers than
     about the engine.
+
+    The 0.90/1.46 pair above was measured with raw string length as the denominator,
+    before `_speech_chars` existed. That confound deflates whichever side carries
+    more punctuation — the Whisper side, which is the lower of the two — so the real
+    gap is if anything wider than 0.56 points, not narrower. The ordering stands;
+    the digits are stale. `scripts/measure_particle_density.py` replaces them with
+    clean ones the day those libraries are mounted again.
+    """
+    n = _speech_chars(text)
+    return 100.0 * particle_count(text) / n if n else 0.0
+
+
+def particle_reading(text: str) -> Optional[Dict]:
+    """One transcript's texture reading — `{"count", "density"}` — or None.
+
+    **None entirely when the text carries no CJK.** Every marker is a CJK character,
+    so an English transcript scores a structural zero. Rendering "0.0%" there looks
+    like a measurement and is a category error: the honest answer is that this
+    instrument does not apply, and None is how you say that.
+
+    **`density` is None below `DENSITY_MIN_CHARS`**, and the count is returned
+    alone. A count is honest at any length; a percentage needs a denominator. This
+    is the shape the UI renders, so the decision not to answer lives here, next to
+    the reasons for it, rather than in a component that would have to re-derive it.
     """
     text = text or ""
-    return 100.0 * particle_count(text) / len(text) if text else 0.0
+    if not any("\u4e00" <= ch <= "\u9fff" for ch in text):
+        return None
+    count = particle_count(text)
+    n = _speech_chars(text)
+    return {"count": count,
+            "density": round(100.0 * count / n, 2) if n >= DENSITY_MIN_CHARS else None}
 
 
 def _particles_only(text: str) -> bool:


### PR DESCRIPTION
「接 UI」這件事逼出一個比接線更重要的問題：**`particle_density()` 的分母是
`len(text)`，含標點。** 而 Whisper 那條走 `_llm_polish`（會補標點），Qwen 那條
不走。標點只進分母不進分子 —— 所以標點多的那一邊，密度被系統性稀釋。

量了：同一句話、同樣兩個語氣詞，一邊有標點一邊沒有 —— **9.09% vs 11.76%，
差 29%**，而 `_kept_more` 判勝負的門檻是 20%。**光是標點就足以翻轉勝負。**
`compare()` 內部算在正規化過的字流上，沒中；只有單獨呼叫 `particle_density()`
會中 —— 而那正是 UI 要呼叫的那一個。

改用 `_speech_chars()`（`str.isalnum` 白名單）當分母，不是 `_norm` 的黑名單：
標點永遠只進分母，所以黑名單漏掉的任何一個符號都會壓低讀數。

文中引的 0.90/1.46 是用舊分母量的，一併註明：confound 壓低的是標點較多的那邊，
也就是本來就比較低的 Whisper —— 所以真實差距只會更大，不會更小。排序成立，數字過期。

**UI 的形狀來自量測，不是來自品味。** 一個語氣詞在長度 L 的稿子上貢獻 `100/L`
個百分點；這個指標存在的理由是解析 0.56 個百分點的引擎差距；`100/L < 0.56`
需要 `L ≥ 179`。而 arkiv 的逐字稿真的就那麼短（平均 42 字，一個「啦」＝2.4%）。
所以：

- **個數永遠給**（任何長度都誠實），**百分比只在 ≥200 個「說話字元」時給**
- **完全沒有 CJK 就整個不給** —— 英文稿結構上必然是 0%，把它畫成 0.0%
  是把「字母系統」的事實裝成「引擎」的事實
- 讀數在後端算（`particle_reading()`），不在前端 —— marker 集合只能有一份定義，
  而它已經被修正過兩次了

`GET /api/media/{id}/transcripts` 每列多兩個欄位；Inspector 的 Transcript 標頭
接在「N 段」後面 —— `19 段 · 語氣 25 · 9.7%`。它是逐字稿的註腳，不是這支片的標題。

實際跑起來看畫面（無頭 Chrome，四種狀態各一支種好的片）才發現：
**`<Mono>` 沒有宣告 `title` prop，Svelte 靜默丟掉了整個 tooltip。** 原始碼看起來
完全正確，DOM 裡什麼都沒有。Mono 補上轉發。

順帶：`scripts/measure_particle_density.py` —— 那些量測數字（541 筆／22,799 字／
134 hits／0.90 vs 1.46）在 repo 裡沒有任何東西支撐，只能相信我寫的。現在可以重跑。
寫它的時候撞到一個計數陷阱：`media.transcript` 和 `transcripts` 的 active 那列
是同一份文字，union 兩張表會把每份 active 稿算兩次 —— 當初那次很可能就是這樣算的，
若是則 541 其實接近 270。平均長度與密度比值不受均勻重複計數影響，而門檻靠的正是那兩個。

9 個 mutation 全紅在該紅的那支。全套 1704 passed / 7 skipped，前端 build + test 綠。