### PR TITLE
fix(asr): 200 不等於這份 body 讀得懂

### DIFF
--- a/asr_api.py
+++ b/asr_api.py
@@ -15,10 +15,19 @@ response body. Three shapes turn up in practice and all three are handled here:
 * plain `{"text": "..."}` — no timings at all.
 * SRT — QwenASR's own default. Timings are there, just in a subtitle format.
 
-**A response with no timings does not get invented ones.** It comes back as a
-single segment spanning the clip, flagged by `segments == []` upstream, because a
-fabricated start/end is exactly the class of bug this project just spent a week
-removing. Nothing downstream can tell a guessed timestamp from a measured one.
+**A response with no timings does not get invented ones.** It comes back as
+`(text, [])` — the words, and an empty segment list saying plainly that nothing
+here is placed on a timeline. A fabricated start/end is the class of bug this
+project just spent a week removing, and nothing downstream can tell a guessed
+timestamp from a measured one.
+
+**A 200 is not a promise that the body is readable.** Every shape here comes from
+someone else's server, so each is parsed defensively: a segment that is not an
+object, or whose timing is not a number, is left out of the timed list while its
+words still reach `text`. The one thing that is never done is returning an
+unparsed body as the transcript — a failed SRT parse used to come back with its
+own index numbers and `-->` lines as the spoken words, which is worse than an
+error because nothing about it looks wrong.
 """
 from __future__ import annotations
 
@@ -37,8 +46,17 @@ ASR_API_KEY = os.getenv("ARKIV_ASR_API_KEY", "")
 ASR_API_MODEL = os.getenv("ARKIV_ASR_API_MODEL", "whisper-1")
 ASR_API_TIMEOUT = int(os.getenv("ARKIV_ASR_API_TIMEOUT", "1800"))
 
+# Hours are `\d+`, not `\d{2}`: plenty of emitters write `0:00:01,000`, and the
+# consequence of missing one was not "no segments" but the whole raw SRT coming
+# back as the transcript text. Minutes and seconds are `\d{1,2}` for the same
+# reason. `-->` is the anchor; everything around it is written more loosely than
+# the format implies.
 _SRT_TIME = re.compile(
-    r"(\d{2}):(\d{2}):(\d{2})[,.](\d{1,3})\s*-->\s*(\d{2}):(\d{2}):(\d{2})[,.](\d{1,3})")
+    r"(\d+):(\d{1,2}):(\d{1,2})[,.](\d{1,3})\s*-->\s*(\d+):(\d{1,2}):(\d{1,2})[,.](\d{1,3})")
+
+# What a subtitle body looks like even when it will not parse. Used only to tell
+# "this was meant to be SRT and I failed" apart from "this is plain text".
+_LOOKS_LIKE_SRT = "-->"
 
 
 def configured() -> bool:
@@ -72,27 +90,82 @@ def parse_srt(srt_text: str) -> List[Dict]:
     return segments
 
 
+def _seg_text(seg) -> str:
+    """A segment's words, or "" if this object has none we can use."""
+    if not isinstance(seg, dict):
+        return ""
+    text = seg.get("text")
+    return text.strip() if isinstance(text, str) else ""
+
+
+def _timing(seg) -> Optional[Tuple[float, float]]:
+    """(start, end) if both are numbers, else None — never a substitute value.
+
+    `float(s.get("start") or 0.0)` used to raise on a string and, worse, would
+    silently place a segment at 0.0 for a `null`. Both are the invented-timestamp
+    failure wearing different clothes: a caller cannot tell either one from a
+    measurement.
+    """
+    start, end = seg.get("start"), seg.get("end")
+    if isinstance(start, bool) or isinstance(end, bool):
+        return None  # bool is an int; a True start is not a time
+    if not isinstance(start, (int, float)) or not isinstance(end, (int, float)):
+        return None
+    return float(start), float(end)
+
+
+def _from_json(data: Dict) -> Tuple[str, List[Dict]]:
+    """(text, segments) from a decoded JSON object, tolerating a hostile shape.
+
+    A segment that is not an object, or whose timing is unusable, is dropped from
+    the TIMED list — but its words are not lost, because they are still part of
+    the transcript: either the server's own top-level `text` (which every
+    OpenAI-compatible response carries) or, absent that, the join of every
+    segment's words including the dropped ones.
+    """
+    raw = data.get("segments")
+    raw = raw if isinstance(raw, list) else []
+    segments = []
+    for seg in raw:
+        text = _seg_text(seg)
+        if not text:
+            continue
+        span = _timing(seg)
+        if span is None:
+            continue
+        segments.append({"start": span[0], "end": span[1], "text": text})
+
+    text = data.get("text")
+    if not isinstance(text, str) or not text.strip():
+        # No usable top-level transcript: rebuild it from every segment that had
+        # words, timed or not, so a bad timing never costs a sentence.
+        text = " ".join(t for t in (_seg_text(seg) for seg in raw) if t)
+    return text.strip(), segments
+
+
 def _segments_from_payload(body: str, content_type: str) -> Tuple[str, List[Dict]]:
     """(text, segments) from whichever of the three shapes came back."""
+    body = body or ""
     if "json" in (content_type or "").lower() or body.lstrip().startswith("{"):
         try:
             data = json.loads(body)
         except ValueError:
             data = None
         if isinstance(data, dict):
-            segments = [
-                {"start": float(s.get("start") or 0.0),
-                 "end": float(s.get("end") or 0.0),
-                 "text": (s.get("text") or "").strip()}
-                for s in (data.get("segments") or [])
-                if (s.get("text") or "").strip()
-            ]
-            return (data.get("text") or "").strip(), segments
+            return _from_json(data)
     # not JSON → SRT (QwenASR's default) or bare text
     segments = parse_srt(body)
     if segments:
         return " ".join(s["text"] for s in segments), segments
-    return (body or "").strip(), []
+    if _LOOKS_LIKE_SRT in body:
+        # It was meant to be a subtitle file and we could not read it. Returning
+        # the body would put index numbers and `--> ` lines into the transcript
+        # and call them speech — silent, plausible-looking garbage. An error is
+        # the smaller harm: the caller can log it, and nobody ships it by mistake.
+        raise ValueError(
+            "response looks like a subtitle file but no cue parsed "
+            "(first 80 chars: {0!r})".format(body.strip()[:80]))
+    return body.strip(), []
 
 
 def transcribe(wav_path: str, language: Optional[str] = None,

--- a/tests/test_asr_api.py
+++ b/tests/test_asr_api.py
@@ -201,3 +201,99 @@ def test_configured_reflects_the_env(monkeypatch):
     assert asr_api.configured() is False
     monkeypatch.setattr(asr_api, "ASR_API_BASE", "http://x")
     assert asr_api.configured() is True
+
+
+# ── a 200 is not a promise that the body is readable ─────────────────────────
+
+def test_a_subtitle_body_that_will_not_parse_is_an_error_not_a_transcript():
+    """The worst outcome this module can have. A failed SRT parse used to fall
+    through and return the raw body — index numbers and `-->` lines and all — as
+    the spoken words. Nothing about that looks wrong downstream."""
+    body = "1\n00:00:0X,000 --> 呃\n你好\n"
+
+    with pytest.raises(ValueError, match="subtitle"):
+        asr_api._segments_from_payload(body, "text/plain")
+
+
+def test_a_single_digit_hour_is_still_a_timestamp():
+    """`0:00:01,000` is what several emitters write, and the hour field was
+    `\\d{2}` — so the whole file failed to parse and came back as transcript text."""
+    segs = asr_api.parse_srt("1\n0:00:01,000 --> 0:00:02,000\n甲\n")
+
+    assert segs == [{"start": 1.0, "end": 2.0, "text": "甲"}]
+
+
+def test_the_timing_line_is_searched_for_not_assumed():
+    """A cue index is optional, so the timing is not always the second line."""
+    assert asr_api.parse_srt("00:00:01,000 --> 00:00:02,000\n甲\n")[0]["text"] == "甲"
+
+
+def test_plain_text_is_still_plain_text():
+    """The subtitle guard must not swallow the shape it sits next to."""
+    assert asr_api._segments_from_payload("就是一段話", "text/plain") == ("就是一段話", [])
+
+
+# ── malformed JSON that still arrives with a 200 ─────────────────────────────
+
+def test_a_segment_that_is_not_an_object_does_not_take_down_the_caller():
+    text, segs = asr_api._segments_from_payload(
+        json.dumps({"text": "完整逐字稿", "segments": ["not a dict"]}), "application/json")
+
+    assert text == "完整逐字稿" and segs == []
+
+
+def test_a_segments_field_that_is_not_a_list_does_not_take_down_the_caller():
+    """Written with a NUMBER, not a dict. The first version used `{"a": 1}` and
+    could not fail: iterating a dict yields its keys, which are strings, which the
+    per-segment guard already drops — so the list check it claimed to pin could be
+    deleted with the test still green. A non-iterable is what that check is for."""
+    text, segs = asr_api._segments_from_payload(
+        json.dumps({"text": "甲", "segments": 5}), "application/json")
+
+    assert text == "甲" and segs == []
+    # and the shapes that merely iterate to nothing still come back clean
+    assert asr_api._segments_from_payload(
+        json.dumps({"text": "乙", "segments": {"a": 1}}), "application/json") == ("乙", [])
+
+
+def test_a_non_string_transcript_falls_back_to_the_segments():
+    """`{"text": 5}` used to raise on `.strip()`. The words are in the segments
+    either way, so there is no reason for the caller to see an exception."""
+    text, segs = asr_api._segments_from_payload(
+        json.dumps({"text": 5, "segments": [{"start": 0, "end": 1, "text": "甲"}]}),
+        "application/json")
+
+    assert text == "甲" and len(segs) == 1
+
+
+def test_an_unusable_timing_costs_the_placement_not_the_words():
+    """`float("abc")` used to raise. Dropping the line instead would lose speech,
+    and keeping it at 0.0 would be the invented-timestamp bug — so the segment
+    leaves the timed list while its words stay in the transcript."""
+    text, segs = asr_api._segments_from_payload(json.dumps({"segments": [
+        {"start": "abc", "end": 1, "text": "甲"},
+        {"start": 1, "end": 2, "text": "乙"},
+    ]}), "application/json")
+
+    assert text == "甲 乙"
+    assert [s["text"] for s in segs] == ["乙"]
+
+
+def test_a_null_start_is_not_the_head_of_the_clip():
+    """`s.get("start") or 0.0` read a missing timing as "zero seconds in" — a
+    silent, confident, wrong placement."""
+    _text, segs = asr_api._segments_from_payload(
+        json.dumps({"segments": [{"start": None, "end": 1, "text": "甲"}]}),
+        "application/json")
+
+    assert segs == []
+
+
+def test_a_boolean_is_not_a_timestamp():
+    """`isinstance(True, int)` is True, so a bare numeric check lets `start: true`
+    through as 1.0 second."""
+    _text, segs = asr_api._segments_from_payload(
+        json.dumps({"segments": [{"start": True, "end": 2, "text": "甲"}]}),
+        "application/json")
+
+    assert segs == []


### PR DESCRIPTION
對抗式審計抓到的，全部實際重現過。最難看的是**靜默垃圾**那條：

`_SRT_TIME` 的小時欄位寫死 `\d{2}`，而 `0:00:01,000` 是不少 emitter 的寫法。
解析不出任何 cue 之後，程式碼會 fall through 到「那就當純文字吧」——
於是 `text` 變成 `'1\n0:00:01,000 --> 0:00:02,000\nhi'`，
**序號和時間碼被當成講出來的話**。它不會報錯、看起來也不像壞掉。

- 小時改 `\d+`、分秒改 `\d{1,2}`（`-->` 才是錨點，周圍寫得比格式規定鬆）
- **body 含 `-->` 但一個 cue 都解不出來 → 丟 `ValueError`**，不再回傳原始 body。
  拿到 200 卻讀不懂，報錯是比較小的傷害：呼叫端可以 log，沒有人會不小心出貨它

其餘四條都是「200 但格式怪 → 直接爆例外」：
- segment 不是物件（`'str' object has no attribute 'get'`）
- `segments` 根本不是 list（給個數字就 `TypeError`）
- 頂層 `text` 不是字串（`{"text": 5}` 在 `.strip()` 炸掉）
- `start` 不是數字（`float("abc")` → `ValueError`）

處理原則：**壞掉的時間碼付出的代價是「位置」，不是「那句話」**。
timing 不可用的 segment 離開有時間軸的清單，但它的字仍然進 `text` ——
丟掉整段會漏掉語音，留在 0.0 則正是這一波剛清掉的「發明時間碼」。
另外 `s.get("start") or 0.0` 把 null 讀成「開頭那一秒」，也是同一個 bug 換件衣服；
`isinstance(True, int)` 為真，所以 `start: true` 會變成 1.0 秒，一併擋掉。

docstring 那句「comes back as a single segment spanning the clip, flagged by
`segments == []` upstream」自相矛盾（回的是 `(text, [])`，沒有那個 segment），
而且沒有 upstream —— 改成描述實際行為。

11 個 mutation。**其中一支我第一版寫的測試不會紅**：`{"segments": {"a": 1}}`
迭代 dict 得到的是 key（字串），逐段守衛本來就會丟掉，所以那個 list 檢查刪掉也全綠。
改用非可迭代的數字才咬得到 —— 這是這一波第二次「測試綠得但不是因為守衛」。

全套 1714 passed / 7 skipped。