### PR TITLE
fix(asr-serve): 早退不讀 body，把下一個請求也毀掉

### DIFF
--- a/scripts/asr_serve.py
+++ b/scripts/asr_serve.py
@@ -181,9 +181,18 @@ def make_handler(transcribe, token):
             connection is the part it can live without.
             """
             length = self._content_length()
-            drainable = length is not None and 0 < length <= DRAIN_LIMIT_BYTES
-            if not drainable and length:
+            if length is None:
+                # An unreadable Content-Length means we cannot know where this
+                # body ends, so the stream can never be resynced — the only safe
+                # answer is to end the connection. `if not drainable and length:`
+                # missed this, because None is falsy: the desync this method
+                # exists to prevent, through a different door.
                 self.close_connection = True
+                drainable = False
+            else:
+                drainable = 0 < length <= DRAIN_LIMIT_BYTES
+                if length > DRAIN_LIMIT_BYTES:
+                    self.close_connection = True
             self._send(code, payload)
             if not drainable:
                 return

--- a/scripts/asr_serve.py
+++ b/scripts/asr_serve.py
@@ -17,6 +17,7 @@ engine actually works and converts the result itself.
 **Binds to 127.0.0.1 unless told otherwise, and always requires a token.** This
 runs a model over whatever it is sent; an unauthenticated one on 0.0.0.0 is a
 GPU someone else can drive. `--host 0.0.0.0` is deliberate and explicit.
+Prefer `ARKIV_ASR_SERVE_TOKEN` over `--token`: argv shows up in `ps`.
 """
 from __future__ import annotations
 
@@ -34,6 +35,15 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 MAX_UPLOAD_BYTES = 512 * 1024 * 1024  # an hour of 16k mono wav is ~115 MB
+
+# How much of a body we will read purely to keep a connection usable after
+# refusing the request. Draining is a courtesy; reading half a gigabyte we have
+# already said no to is not.
+DRAIN_LIMIT_BYTES = 1024 * 1024
+
+# Per-connection socket timeout. Without one, a client that opens a connection and
+# sends a byte an hour holds a thread forever, and it does so BEFORE authenticating.
+REQUEST_TIMEOUT_S = 60
 
 
 # ── multipart (stdlib `cgi` is deprecated; this is the slice we need) ─────────
@@ -117,8 +127,16 @@ ENGINES = {"qwen": load_qwen}
 # ── server ───────────────────────────────────────────────────────────────────
 
 def make_handler(transcribe, token):
+    # One engine, one GPU. `ThreadingHTTPServer` runs `do_POST` concurrently, so
+    # without this two uploads call `process_file()` on the same engine object at
+    # the same time. Serialising is not a compromise here — it is what a single
+    # card wants — and the alternative is a class of failure that shows up as a
+    # garbled transcript rather than an error.
+    engine_lock = threading.Lock()
+
     class Handler(BaseHTTPRequestHandler):
         protocol_version = "HTTP/1.1"
+        timeout = REQUEST_TIMEOUT_S
 
         def _send(self, code, payload, content_type="application/json"):
             body = (json.dumps(payload, ensure_ascii=False).encode("utf-8")
@@ -126,8 +144,45 @@ def make_handler(transcribe, token):
             self.send_response(code)
             self.send_header("Content-Type", content_type + "; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))
+            if self.close_connection:
+                self.send_header("Connection", "close")
             self.end_headers()
             self.wfile.write(body)
+
+        def _content_length(self):
+            """The declared body size, or None if the header is not a number."""
+            raw = self.headers.get("Content-Length")
+            if raw is None:
+                return 0
+            try:
+                return int(raw)
+            except ValueError:
+                return None
+
+        def _refuse(self, code, payload):
+            """Answer a request whose body we never read.
+
+            HTTP/1.1 keep-alive means the next request comes off the same socket,
+            so an early return that leaves the body in the stream desyncs it: the
+            server parses `--B` as a request line and answers the client's NEXT
+            request with a 400 it did not cause, then stops answering entirely.
+            Reproduced with a raw socket — arkiv's own client escapes it only
+            because `requests.post` opens a fresh connection every call.
+
+            Small bodies are drained so the connection survives; anything larger
+            (or a length we cannot read) closes it instead.
+            """
+            length = self._content_length()
+            if length is None or length > DRAIN_LIMIT_BYTES:
+                self.close_connection = True
+            else:
+                remaining = length
+                while remaining > 0:
+                    chunk = self.rfile.read(min(remaining, 65536))
+                    if not chunk:
+                        break
+                    remaining -= len(chunk)
+            return self._send(code, payload)
 
         def _authorised(self):
             got = self.headers.get("Authorization", "")
@@ -138,24 +193,28 @@ def make_handler(transcribe, token):
 
         def do_GET(self):
             if self.path.split("?")[0] != "/health":
-                return self._send(404, {"error": "not found"})
+                return self._refuse(404, {"error": "not found"})
             if not self._authorised():
-                return self._send(401, {"error": "unauthorised"})
+                return self._refuse(401, {"error": "unauthorised"})
             self._send(200, {"status": "ok", "model_ready": True})
 
         def do_POST(self):
             if self.path.split("?")[0] not in ("/audio/transcriptions",
                                                "/v1/audio/transcriptions"):
-                return self._send(404, {"error": "not found"})
+                return self._refuse(404, {"error": "not found"})
             if not self._authorised():
-                return self._send(401, {"error": "unauthorised"})
-            length = int(self.headers.get("Content-Length") or 0)
+                return self._refuse(401, {"error": "unauthorised"})
+            length = self._content_length()
+            if length is None:
+                # `int("abc")` used to raise here, unhandled: the connection was
+                # dropped with no response at all and a traceback per request.
+                return self._refuse(400, {"error": "bad Content-Length"})
             if length <= 0 or length > MAX_UPLOAD_BYTES:
-                return self._send(413, {"error": "bad or oversized upload"})
+                return self._refuse(413, {"error": "bad or oversized upload"})
             ctype = self.headers.get("Content-Type", "")
             m = re.search(r"boundary=([^;]+)", ctype)
             if not m:
-                return self._send(400, {"error": "expected multipart/form-data"})
+                return self._refuse(400, {"error": "expected multipart/form-data"})
             fields, files = parse_multipart(self.rfile.read(length),
                                             m.group(1).strip('"').encode())
             if "file" not in files:
@@ -165,11 +224,14 @@ def make_handler(transcribe, token):
             os.close(fd)
             try:
                 Path(tmp).write_bytes(blob)
-                segments = transcribe(tmp, fields.get("language"))
+                with engine_lock:
+                    segments = transcribe(tmp, fields.get("language"))
             except Exception as exc:  # a bad clip must not take the server down
+                # The detail goes to the operator's log, not down the wire: the
+                # exception text carries local paths and model internals, and the
+                # client can do nothing with either.
                 self.log_message("transcribe failed: %s: %s", type(exc).__name__, exc)
-                return self._send(500, {"error": {"message": "{0}: {1}".format(
-                    type(exc).__name__, exc)}})
+                return self._send(500, {"error": {"message": "transcription failed"}})
             finally:
                 Path(tmp).unlink(missing_ok=True)
             text = " ".join(s["text"] for s in segments)
@@ -189,15 +251,30 @@ def main(argv=None):
     ap.add_argument("--host", default="127.0.0.1",
                     help="0.0.0.0 exposes a GPU to your network — be deliberate")
     ap.add_argument("--port", type=int, default=11435)
-    ap.add_argument("--token", default=None, help="generated and printed if omitted")
+    ap.add_argument("--token", default=None,
+                    help="generated and printed if omitted; ARKIV_ASR_SERVE_TOKEN "
+                         "is read first and keeps it out of `ps`")
     args = ap.parse_args(argv)
 
-    token = args.token or secrets.token_urlsafe(12)
+    # argv is world-readable in `ps` on every machine this is likely to run on.
+    # The env var is the way to supply a token that a colleague on the same box
+    # cannot simply read; `--token` stays for convenience on a private machine.
+    token = os.getenv("ARKIV_ASR_SERVE_TOKEN") or args.token or secrets.token_urlsafe(12)
     transcribe = ENGINES[args.engine](args.model_dir)
     httpd = ThreadingHTTPServer((args.host, args.port), make_handler(transcribe, token))
     print("[asr-serve] listening on http://{0}:{1}  token={2}".format(
         args.host, args.port, token), flush=True)
-    threading.Thread(target=httpd.serve_forever, daemon=False).start()
+    # In the MAIN thread, not a spawned one. The previous version started a
+    # non-daemon thread and returned, so `main` was finished before the first
+    # request arrived: there was no shutdown path at all, and Ctrl-C was
+    # delivered to a thread that had already exited.
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("[asr-serve] stopping", flush=True)
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
     return 0
 
 

--- a/scripts/asr_serve.py
+++ b/scripts/asr_serve.py
@@ -171,18 +171,33 @@ def make_handler(transcribe, token):
 
             Small bodies are drained so the connection survives; anything larger
             (or a length we cannot read) closes it instead.
+
+            **The answer goes out BEFORE the drain**, which is not the obvious
+            order. Draining first looks tidier and reintroduces the very symptom
+            this method exists to remove: a client that declares 1000 bytes, sends
+            10, and stalls makes the drain block until the socket timeout, and the
+            refusal is never sent — measured, and indistinguishable from the server
+            being down. The response is the part the client is owed; reusing the
+            connection is the part it can live without.
             """
             length = self._content_length()
-            if length is None or length > DRAIN_LIMIT_BYTES:
+            drainable = length is not None and 0 < length <= DRAIN_LIMIT_BYTES
+            if not drainable and length:
                 self.close_connection = True
-            else:
-                remaining = length
+            self._send(code, payload)
+            if not drainable:
+                return
+            remaining = length
+            try:
                 while remaining > 0:
                     chunk = self.rfile.read(min(remaining, 65536))
                     if not chunk:
                         break
                     remaining -= len(chunk)
-            return self._send(code, payload)
+            except OSError:  # stalled or reset mid-drain
+                remaining = -1
+            if remaining != 0:
+                self.close_connection = True
 
         def _authorised(self):
             got = self.headers.get("Authorization", "")

--- a/tests/test_asr_serve.py
+++ b/tests/test_asr_serve.py
@@ -205,11 +205,171 @@ def test_a_token_is_always_required():
     """Not "generated if you ask" — generated if omitted, and compared on every
     request. There is no unauthenticated path."""
     src = (_ROOT / "scripts" / "asr_serve.py").read_text(encoding="utf-8")
-    assert "args.token or secrets.token_urlsafe" in src
+    assert "secrets.token_urlsafe" in src
     assert "compare_digest" in src, "token compared with ==, not constant-time"
 
 
-def test_uploads_are_capped():
-    src = (_ROOT / "scripts" / "asr_serve.py").read_text(encoding="utf-8")
-    assert "MAX_UPLOAD_BYTES" in src
-    assert "length > MAX_UPLOAD_BYTES" in src
+def test_an_oversized_upload_is_refused_without_being_read(server, monkeypatch):
+    """This replaces a test that grepped the source for `length > MAX_UPLOAD_BYTES`.
+
+    That one passed with the cap multiplied by 1024² — 512 TB — because the string
+    it looked for was still there. The cap could have regressed to nothing and the
+    suite would have stayed green, which is the same as having no test.
+
+    The cap is lowered rather than sending half a gigabyte: what is under test is
+    the comparison, not the number.
+    """
+    monkeypatch.setattr(srv, "MAX_UPLOAD_BYTES", 64)
+    engine = _FakeEngine()
+    url = server(engine)
+
+    with pytest.raises(urllib.error.HTTPError) as e:
+        _post(url, token="tok", parts=[("file", "a.wav", b"R" * 200)])
+
+    assert e.value.code == 413
+    assert engine.calls == [], "the engine must not see a body we refused"
+
+
+def test_an_upload_under_the_cap_still_goes_through(server, monkeypatch):
+    """The other half — a cap that refuses everything would also pass the test
+    above."""
+    monkeypatch.setattr(srv, "MAX_UPLOAD_BYTES", 4096)
+    engine = _FakeEngine()
+    url = server(engine)
+
+    assert _post(url, token="tok").status == 200
+    assert len(engine.calls) == 1
+
+
+# ── the HTTP layer, which is where a thin server gets its bugs ───────────────
+
+def _port(url):
+    return int(url.rsplit(":", 1)[1])
+
+
+def _statuses(raw):
+    """Status codes in the order they came back.
+
+    By regex over the whole stream, not `splitlines()`: a JSON body carries no
+    trailing newline, so the next response's status line is glued to the end of
+    the previous body (`{"error": "unauthorised"}HTTP/1.1 200 OK`) and a
+    line-oriented reader sees one response where there are two.
+    """
+    import re as _re
+    return _re.findall(r"HTTP/1\.[01] (\d{3})", raw)
+
+
+def _raw(url, payload, want=1, timeout=5):
+    """Speak HTTP by hand — `requests`/`urllib` open a fresh connection per call,
+    which is exactly what hides a keep-alive bug."""
+    import socket
+    s = socket.create_connection(("127.0.0.1", _port(url)), timeout=timeout)
+    try:
+        s.sendall(payload)
+        out = b""
+        while out.count(b"HTTP/1.") < want and len(out) < 65536:
+            chunk = s.recv(4096)
+            if not chunk:
+                break
+            out += chunk
+        return out.decode("utf-8", "replace")
+    finally:
+        s.close()
+
+
+def _raw_post(body=None, token=None, length=None, ctype="multipart/form-data; boundary=B"):
+    body = _body([("file", "a.wav", b"RIFF")]) if body is None else body
+    head = ("POST /audio/transcriptions HTTP/1.1\r\nHost: x\r\n"
+            "Content-Type: {0}\r\nContent-Length: {1}\r\n".format(
+                ctype, len(body) if length is None else length))
+    if token:
+        head += "Authorization: Bearer {0}\r\n".format(token)
+    return head.encode() + b"\r\n" + body
+
+
+def test_a_refused_request_does_not_desync_the_connection(server):
+    """The bug: an early return that never reads the body leaves those bytes in
+    the stream. The server then reads `--B` as the next request line, so the
+    client's NEXT request is answered with a 400 it did not cause — and the one
+    after that is never answered at all.
+
+    arkiv's own client escapes it only because `requests.post` opens a fresh
+    connection every time. Any `requests.Session` or curl keep-alive hits it.
+    """
+    url = server(_FakeEngine())
+
+    out = _raw(url, _raw_post() + _raw_post(token="tok"), want=2)
+
+    assert _statuses(out) == ["401", "200"], out[:400]
+
+
+def test_a_body_too_large_to_drain_closes_the_connection_instead(server):
+    """Draining is a courtesy. Reading half a gigabyte we already refused is not,
+    so the other honest answer is to tell the client the connection is over."""
+    url = server(_FakeEngine())
+    huge = srv.DRAIN_LIMIT_BYTES + 1
+
+    out = _raw(url, _raw_post(token="wrong", length=huge))
+
+    assert _statuses(out) == ["401"]
+    assert "connection: close" in out.lower()
+
+
+def test_a_non_numeric_content_length_is_a_400_not_a_dropped_connection(server):
+    """`int("abc")` raised inside the handler: no response at all, one traceback
+    per request. A client cannot tell that apart from the server being down."""
+    url = server(_FakeEngine())
+
+    out = _raw(url, _raw_post(token="tok", length="abc"))
+
+    assert _statuses(out) == ["400"], out[:200]
+
+
+def test_the_engine_is_never_called_by_two_requests_at_once(server):
+    """`ThreadingHTTPServer` handles requests concurrently and there is one engine
+    object holding one GPU. Overlapping `process_file()` calls on a single CUDA
+    engine produce a garbled transcript rather than an error, which is the worst
+    way for this to fail."""
+    import time
+
+    state = {"now": 0, "peak": 0}
+    guard = threading.Lock()
+
+    def engine(wav_path, language):
+        with guard:
+            state["now"] += 1
+            state["peak"] = max(state["peak"], state["now"])
+        time.sleep(0.15)
+        with guard:
+            state["now"] -= 1
+        return [{"start": 0.0, "end": 1.0, "text": "x"}]
+
+    url = server(engine)
+    threads = [threading.Thread(target=lambda: _post(url, token="tok")) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=20)
+
+    assert state["peak"] == 1, "engine saw {0} concurrent calls".format(state["peak"])
+
+
+def test_a_failed_transcription_does_not_send_its_exception_text_to_the_client(server):
+    """The exception carries local paths and model internals, and the client can
+    do nothing with either. The operator's log gets the detail."""
+    url = server(_FakeEngine(raises=RuntimeError("/Users/someone/models/secret.bin missing")))
+
+    with pytest.raises(urllib.error.HTTPError) as e:
+        _post(url, token="tok")
+
+    body = e.value.read().decode("utf-8")
+    assert e.value.code == 500
+    assert "secret.bin" not in body and "/Users/" not in body, body
+
+
+def test_a_connection_that_never_finishes_its_request_does_not_hold_a_thread():
+    """Pre-auth, so it costs an attacker nothing. Without a socket timeout each
+    half-open connection holds a worker thread until the process dies."""
+    assert srv.REQUEST_TIMEOUT_S > 0
+    handler = srv.make_handler(_FakeEngine(), "tok")
+    assert handler.timeout == srv.REQUEST_TIMEOUT_S

--- a/tests/test_asr_serve.py
+++ b/tests/test_asr_serve.py
@@ -323,6 +323,11 @@ def test_a_non_numeric_content_length_is_a_400_not_a_dropped_connection(server):
     out = _raw(url, _raw_post(token="tok", length="abc"))
 
     assert _statuses(out) == ["400"], out[:200]
+    # ...and the connection must end there: without a readable length we cannot
+    # know where the body stops, so the stream can never be resynced. Found by
+    # reading the diff — `if not drainable and length:` skipped this case because
+    # None is falsy, leaving the very desync this method exists to prevent.
+    assert "connection: close" in out.lower(), out[:300]
 
 
 def test_the_engine_is_never_called_by_two_requests_at_once(server):

--- a/tests/test_asr_serve.py
+++ b/tests/test_asr_serve.py
@@ -373,3 +373,62 @@ def test_a_connection_that_never_finishes_its_request_does_not_hold_a_thread():
     assert srv.REQUEST_TIMEOUT_S > 0
     handler = srv.make_handler(_FakeEngine(), "tok")
     assert handler.timeout == srv.REQUEST_TIMEOUT_S
+
+
+def test_the_server_runs_in_the_calling_thread_and_shuts_down(monkeypatch):
+    """`main` used to start a non-daemon thread and return, so it was finished
+    before the first request arrived: there was no shutdown path at all, and a
+    Ctrl-C was delivered to a thread that had already exited.
+
+    Asserted on the thread identity rather than on "does it block", because a test
+    that hangs proves nothing about why.
+    """
+    seen = {}
+
+    class _FakeServer:
+        def __init__(self, addr, handler):
+            seen["addr"] = addr
+
+        def serve_forever(self):
+            seen["thread"] = threading.get_ident()
+            raise KeyboardInterrupt
+
+        def shutdown(self):
+            seen["shutdown"] = True
+
+        def server_close(self):
+            seen["closed"] = True
+
+    monkeypatch.setattr(srv, "ThreadingHTTPServer", _FakeServer)
+    monkeypatch.setitem(srv.ENGINES, "qwen", lambda model_dir: _FakeEngine())
+
+    rc = srv.main(["--model-dir", "/nowhere", "--port", "0", "--token", "t"])
+
+    assert rc == 0
+    assert seen["thread"] == threading.get_ident(), "serve_forever ran off the main thread"
+    assert seen.get("shutdown") and seen.get("closed"), "no shutdown path"
+    assert seen["addr"] == ("127.0.0.1", 0)
+
+
+def test_the_token_can_come_from_the_environment_instead_of_argv(monkeypatch, capsys):
+    """`--token` is visible in `ps` to anyone on the box."""
+    class _FakeServer:
+        def __init__(self, addr, handler):
+            pass
+
+        def serve_forever(self):
+            raise KeyboardInterrupt
+
+        def shutdown(self):
+            pass
+
+        def server_close(self):
+            pass
+
+    monkeypatch.setattr(srv, "ThreadingHTTPServer", _FakeServer)
+    monkeypatch.setitem(srv.ENGINES, "qwen", lambda model_dir: _FakeEngine())
+    monkeypatch.setenv("ARKIV_ASR_SERVE_TOKEN", "from-the-env")
+
+    srv.main(["--model-dir", "/nowhere", "--token", "from-argv"])
+
+    assert "token=from-the-env" in capsys.readouterr().out

--- a/tests/test_asr_serve.py
+++ b/tests/test_asr_serve.py
@@ -432,3 +432,24 @@ def test_the_token_can_come_from_the_environment_instead_of_argv(monkeypatch, ca
     srv.main(["--model-dir", "/nowhere", "--token", "from-argv"])
 
     assert "token=from-the-env" in capsys.readouterr().out
+
+
+def test_a_client_that_stalls_mid_body_still_gets_its_refusal(server):
+    """The first version of the drain reintroduced the bug it was written to fix.
+
+    Draining before answering looks tidier, but a client that declares 1000 bytes,
+    sends 10, and stops makes the read block until the socket timeout — and the
+    401 is never sent. From the client's side that is indistinguishable from the
+    server being down, which is exactly the symptom of the `Content-Length` crash
+    fixed in the same change. So the answer goes out first.
+    """
+    import socket
+    url = server(_FakeEngine())
+    s = socket.create_connection(("127.0.0.1", _port(url)), timeout=5)
+    try:
+        s.sendall(b"POST /audio/transcriptions HTTP/1.1\r\nHost: x\r\n"
+                  b"Content-Type: multipart/form-data; boundary=B\r\n"
+                  b"Content-Length: 1000\r\n\r\n0123456789")
+        assert _statuses(s.recv(4096).decode("utf-8", "replace")) == ["401"]
+    finally:
+        s.close()


### PR DESCRIPTION
`protocol_version = "HTTP/1.1"` 代表下一個請求從同一條 socket 讀。而 401/404/
400/413 這四條早退路徑**從來沒有讀過 request body** —— 那些 bytes 留在串流裡，
伺服器接著就把 `--B` 當成請求行。用裸 socket 實際重現：

    401 → [asr-serve] code 400, message Bad request syntax ('--B')
        → 客戶端後面那個合法請求，永遠沒有回應

**客戶端拿到的是一個自己沒造成的 400，再下一個直接沒聲音。** arkiv 自己躲過
是因為 `requests.post` 每次開新連線；任何 `requests.Session` 或 curl 的
keep-alive 都會中。修法是 `_refuse()`：小的 body 讀掉讓連線活著，
太大的（或讀不出長度的）就送 `Connection: close` —— 清空是禮貌，
把已經拒絕掉的半 GB 讀進來不是。

其餘五條：

- **非數字 `Content-Length` 直接 `ValueError`**（`int("abc")`），連線被丟掉、
  零回應、每個請求一份 traceback。客戶端分不出這跟「伺服器掛了」的差別。→ 400
- **共用 engine 沒有鎖**：`ThreadingHTTPServer` 併發跑 `do_POST`，而後面是
  一顆 GPU 上的一個 engine 物件。重疊的 `process_file()` 會吐出**混在一起的
  逐字稿而不是錯誤**，那是最糟的失敗方式。序列化不是妥協，是單卡本來就要的
- **500 把例外文字送出去**：裡面有本機路徑與模型內部，客戶端拿它什麼也做不了。
  細節進 operator 的 log，線上只回 `transcription failed`
- **沒有 socket timeout**：半開連線在**驗證之前**就佔住一條 thread。加 60 秒
- **`--token` 在 `ps` 裡看得到**：加 `ARKIV_ASR_SERVE_TOKEN`，優先於旗標
- **`main()` 把 `serve_forever` 丟到 non-daemon thread 然後 return**：沒有任何
  關閉路徑，Ctrl-C 打進一條已經結束的 main thread。改成在 main thread 跑

**`test_uploads_are_capped` 是在 grep 原始碼、不是在測行為** —— 把
`MAX_UPLOAD_BYTES` 乘上 1024²（512 TB）之後 16 支照樣全過，因為它找的那個字串
還在。上限可以退化到零而測試全綠，那等於沒有測試。換成兩支行為測試（超過 → 413
且 engine 沒被呼叫／未超過 → 200），上限用 monkeypatch 調小：受測的是那個比較，
不是那個數字。

8 個 mutation 全紅在該紅的那支。**其中 keep-alive 那支第一版判錯**：JSON body
後面沒有換行，下一個 status line 直接黏在 body 尾巴（`{"error": ...}HTTP/1.1 200 OK`），
用 `splitlines()` 讀會把兩個回應看成一個 —— 伺服器其實兩個都回了，是測試在說謊。
改用 regex 掃整串。

全套 1721 passed / 7 skipped。