### PR TITLE
fix(settings): 一個 project 只能有一種拼法

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,15 @@ jobs:
             "fastapi>=0.100.0" "uvicorn>=0.20.0" "pydantic>=2.0,<3" \
             "pillow>=9.0" "requests>=2.28" "xxhash>=2.0.0" "nanoid>=2.0.0" \
             "psutil>=5.9" "whisper-guard>=0.3" numpy "mcp<2"
-      - name: Run Windows correctness tests (offload deny-policy + MCP stdio)
+      - name: Run Windows correctness tests (offload deny-policy + MCP stdio + settings scope)
         shell: bash
-        run: pytest tests/test_hardening_round4.py tests/test_mcp_e2e.py -q
+        # test_settings_g5.py joins this leg for the same reason the leg exists:
+        # the settings scope key is a filesystem path, canonicalised with
+        # `Path.resolve()` + `os.path.normcase`, and BOTH behave differently on
+        # Windows — `normcase` folds case there and is a no-op here, so the
+        # "C:\Lib and c:\lib are one project" assertion cannot run on macOS at
+        # all. Same class as the `Path('/etc') -> C:\etc` surprise above.
+        run: pytest tests/test_hardening_round4.py tests/test_mcp_e2e.py tests/test_settings_g5.py -q
 
   coverage:
     name: coverage

--- a/routers/settings.py
+++ b/routers/settings.py
@@ -18,20 +18,31 @@ router = APIRouter()
 
 
 def _resolve_settings_scope(scope: str) -> str:
-    """Validate the scope param. 'global' is the library-wide default; any other
-    value must be a known project root (registry or the current PROJECT_ROOT) —
-    we never let an arbitrary string become a scope row, so the table can't be
-    used as free-form key/value storage."""
+    """Validate the scope param, and return it in the one spelling the store uses.
+
+    'global' is the library-wide default; any other value must be a known project
+    root (registry or the current PROJECT_ROOT) — we never let an arbitrary string
+    become a scope row, so the table can't be used as free-form key/value storage.
+
+    Both sides of the comparison are canonicalised, because the two sources
+    genuinely disagree about spelling: `config.PROJECT_ROOT` is whatever the env
+    var said (unresolved), while the registry stores its own. A caller passing the
+    registry's path for the very project this process is serving used to be
+    rejected outright, or — worse — accepted and written to a second row that
+    nothing would ever read back.
+    """
     if not scope or scope == settings_store.GLOBAL_SCOPE:
         return settings_store.GLOBAL_SCOPE
-    known = {str(config.PROJECT_ROOT)}
+    resolved = settings_store.canonical_scope(scope)
+    known = {settings_store.current_scope()}
     try:
-        known.update(p.path for p in project_registry.list_registry_projects())
+        known.update(settings_store.canonical_scope(str(p.path))
+                     for p in project_registry.list_registry_projects())
     except project_registry.RegistryError:
         pass
-    if scope not in known:
+    if resolved not in known:
         raise HTTPException(status_code=400, detail="unknown settings scope: {0}".format(scope))
-    return scope
+    return resolved
 
 
 @router.get("/api/settings")

--- a/settings.py
+++ b/settings.py
@@ -18,12 +18,48 @@ that has no downstream effect.
 from __future__ import annotations
 
 import json
+import os
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 import config
 import db
 
 GLOBAL_SCOPE = "global"
+
+
+def canonical_scope(scope: Optional[str]) -> Optional[str]:
+    """One spelling per project, so that a row written is a row found.
+
+    A scope key is a filesystem path, and a path has more than one spelling:
+    `~/lib`, `/Users/me/lib`, a symlink pointing at it, and a trailing slash are
+    four strings for one project. Measured: with `ARKIV_PROJECT_ROOT` set to a
+    symlink, `str(config.PROJECT_ROOT)` and its resolved form differ —
+    `_validate_writable_path` computes the canonical form only to check it against
+    the system-directory denylist and then returns the path it was given. Meanwhile
+    `routers/settings.py` accepts either that string or the registry's own
+    spelling. So a row written under one and read under the other simply misses,
+    and misses in silence.
+
+    `normcase` rather than a bare `resolve`: on Windows `C:\\x` and `c:\\x` are the
+    same directory and would otherwise be two rows. It is a no-op on POSIX, which
+    is where two paths differing only in case really are two directories.
+
+    `GLOBAL_SCOPE` and None are not paths and pass through untouched.
+    """
+    if not scope or scope == GLOBAL_SCOPE:
+        return scope
+    return os.path.normcase(str(Path(scope).expanduser().resolve(strict=False)))
+
+
+def current_scope() -> str:
+    """The scope key for the library this process is serving.
+
+    Read at call time, not at import: `config.PROJECT_ROOT` is what a test rebinds
+    to point at a temp library, and a value frozen at import would make every such
+    test read the developer's own project.
+    """
+    return canonical_scope(str(config.PROJECT_ROOT))
 
 
 class SettingError(ValueError):
@@ -149,6 +185,7 @@ def _typed_to_stored(value: Any) -> str:
 
 
 def _rows_for(scope: str) -> Dict[str, str]:
+    scope = canonical_scope(scope)
     with db.get_conn() as conn:
         rows = conn.execute(
             "SELECT key, value FROM settings WHERE scope = ?", (scope,)
@@ -228,6 +265,7 @@ def put(values: Dict[str, Any], scope: str = GLOBAL_SCOPE) -> List[str]:
     """
     if not isinstance(values, dict) or not values:
         raise SettingError("values must be a non-empty object")
+    scope = canonical_scope(scope)
     coerced = {k: _coerce(k, v) for k, v in values.items()}  # validates all first
     with db.get_conn() as conn:
         for key, val in coerced.items():
@@ -246,6 +284,7 @@ def reset(key: str, scope: str = GLOBAL_SCOPE) -> None:
     """Drop an override so the key falls back to the next layer down."""
     if key not in SETTINGS_SCHEMA:
         raise SettingError(f"unknown setting key: {key}")
+    scope = canonical_scope(scope)
     with db.get_conn() as conn:
         conn.execute("DELETE FROM settings WHERE scope = ? AND key = ?", (scope, key))
         conn.commit()

--- a/tests/test_settings_g5.py
+++ b/tests/test_settings_g5.py
@@ -212,7 +212,11 @@ def test_current_scope_follows_the_live_project_root(tmp_db, tmp_path, monkeypat
     lib.mkdir()
     monkeypatch.setattr(config, "PROJECT_ROOT", lib)
 
-    assert settings.current_scope() == str(lib.resolve())
+    # Expressed with stdlib `normcase`, not with `canonical_scope` itself — the
+    # latter would compare the function under test to itself. Windows CI caught
+    # the first version, which hard-coded `str(lib.resolve())` and so asserted a
+    # POSIX-shaped answer: there the canonical key is lower-cased.
+    assert settings.current_scope() == os.path.normcase(str(lib.resolve()))
 
 
 @pytest.mark.parametrize("root_is_link", [True, False])
@@ -239,7 +243,7 @@ def test_the_api_accepts_either_spelling_of_the_current_project(
         "/api/settings", json={"scope": asked, "values": {"vision.num_ctx": 2048}})
 
     assert r.status_code == 200, r.text
-    assert r.json()["scope"] == str(real.resolve())
+    assert r.json()["scope"] == os.path.normcase(str(real.resolve()))
 
 
 def test_an_unknown_path_is_still_refused(fastapi_client, tmp_path):

--- a/tests/test_settings_g5.py
+++ b/tests/test_settings_g5.py
@@ -125,7 +125,21 @@ def test_delete_setting_resets(fastapi_client):
 # this, a row written under one and read under another simply missed — silently,
 # which is the same shape as the project rows that were never read at all.
 
-def test_a_symlinked_root_is_the_same_project(tmp_db, tmp_path):
+@pytest.fixture
+def symlinkable(tmp_path):
+    """Creating a symlink needs SeCreateSymbolicLinkPrivilege on Windows, which a
+    runner may not have. Skip rather than fail: the thing under test is path
+    canonicalisation, not the OS's symlink policy."""
+    target = tmp_path / "_probe_target"
+    target.mkdir()
+    try:
+        (tmp_path / "_probe").symlink_to(target)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip("symlinks unavailable here: {0}".format(exc))
+    (tmp_path / "_probe").unlink()
+
+
+def test_a_symlinked_root_is_the_same_project(tmp_db, tmp_path, symlinkable):
     """The measured case. `config.PROJECT_ROOT` keeps whatever the env var said,
     while the registry stores its own resolved spelling — so the same library
     reaches the store as two different keys."""
@@ -146,7 +160,11 @@ def test_the_same_directory_written_four_ways_is_one_row(tmp_db, tmp_path, monke
     settings = importlib.reload(importlib.import_module("settings"))
     lib = tmp_path / "lib"
     lib.mkdir()
+    # POSIX reads HOME; ntpath.expanduser reads USERPROFILE first and never HOME.
+    # Setting only HOME made the `~/lib` spelling resolve somewhere else entirely
+    # on Windows — a second row, which is the exact failure this test exists for.
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     spellings = [str(lib), str(lib) + "/", str(tmp_path / "." / "lib"), "~/lib"]
     for i, spelling in enumerate(spellings):
@@ -160,7 +178,7 @@ def test_the_same_directory_written_four_ways_is_one_row(tmp_db, tmp_path, monke
     assert rows == 1, "four spellings produced {0} rows".format(rows)
 
 
-def test_reset_finds_the_row_whatever_spelling_it_is_given(tmp_db, tmp_path):
+def test_reset_finds_the_row_whatever_spelling_it_is_given(tmp_db, tmp_path, symlinkable):
     """`reset` deleted by raw string, so resetting through a different spelling
     reported success and left the override in place."""
     settings = importlib.reload(importlib.import_module("settings"))
@@ -199,7 +217,7 @@ def test_current_scope_follows_the_live_project_root(tmp_db, tmp_path, monkeypat
 
 @pytest.mark.parametrize("root_is_link", [True, False])
 def test_the_api_accepts_either_spelling_of_the_current_project(
-        fastapi_client, tmp_path, monkeypatch, root_is_link):
+        fastapi_client, tmp_path, monkeypatch, root_is_link, symlinkable):
     """A caller holding the registry's path for the very library this process is
     serving used to be told the scope was unknown.
 

--- a/tests/test_settings_g5.py
+++ b/tests/test_settings_g5.py
@@ -1,5 +1,6 @@
 """Phase 9.7 G5② — persisted settings overrides (module + API)."""
 import importlib
+import os
 
 import pytest
 
@@ -116,3 +117,135 @@ def test_delete_setting_resets(fastapi_client):
     g = fastapi_client.get("/api/settings").json()
     row = next(s for s in g["settings"] if s["key"] == "export.default_dir")
     assert row["source"] == "default"
+
+
+# ── one spelling per project ─────────────────────────────────────────────────
+#
+# The scope key is a filesystem path, and a path has several spellings. Before
+# this, a row written under one and read under another simply missed — silently,
+# which is the same shape as the project rows that were never read at all.
+
+def test_a_symlinked_root_is_the_same_project(tmp_db, tmp_path):
+    """The measured case. `config.PROJECT_ROOT` keeps whatever the env var said,
+    while the registry stores its own resolved spelling — so the same library
+    reaches the store as two different keys."""
+    settings = importlib.reload(importlib.import_module("settings"))
+    real = tmp_path / "lib"
+    real.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real)
+
+    settings.put({"vision.num_ctx": 4096}, scope=str(link))
+
+    assert settings.effective("vision.num_ctx", project=str(real)) == 4096
+    assert settings.effective("vision.num_ctx", project=str(link)) == 4096
+
+
+def test_the_same_directory_written_four_ways_is_one_row(tmp_db, tmp_path, monkeypatch):
+    """Trailing slash, `.` hops, and `~` are spellings, not projects."""
+    settings = importlib.reload(importlib.import_module("settings"))
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    spellings = [str(lib), str(lib) + "/", str(tmp_path / "." / "lib"), "~/lib"]
+    for i, spelling in enumerate(spellings):
+        settings.put({"vision.num_ctx": 1024 + i}, scope=spelling)
+
+    # last write wins because all four are the same row, not four rows
+    assert settings.effective("vision.num_ctx", project=str(lib)) == 1024 + len(spellings) - 1
+    with importlib.import_module("db").get_conn() as conn:
+        rows = conn.execute(
+            "SELECT COUNT(*) c FROM settings WHERE scope <> 'global'").fetchone()["c"]
+    assert rows == 1, "four spellings produced {0} rows".format(rows)
+
+
+def test_reset_finds_the_row_whatever_spelling_it_is_given(tmp_db, tmp_path):
+    """`reset` deleted by raw string, so resetting through a different spelling
+    reported success and left the override in place."""
+    settings = importlib.reload(importlib.import_module("settings"))
+    real = tmp_path / "lib"
+    real.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real)
+    settings.put({"vision.num_ctx": 4096}, scope=str(real))
+
+    settings.reset("vision.num_ctx", scope=str(link))
+
+    config = importlib.import_module("config")
+    assert settings.effective("vision.num_ctx", project=str(real)) == config.OLLAMA_VISION_NUM_CTX
+
+
+def test_global_is_not_a_path(tmp_db):
+    """`canonical_scope` must leave the one non-path scope alone — resolving it
+    would turn 'global' into a directory next to the process's cwd."""
+    settings = importlib.reload(importlib.import_module("settings"))
+    assert settings.canonical_scope("global") == "global"
+    assert settings.canonical_scope(None) is None
+    assert settings.canonical_scope("") == ""
+
+
+def test_current_scope_follows_the_live_project_root(tmp_db, tmp_path, monkeypatch):
+    """Read at call time, not frozen at import — a test that repoints
+    PROJECT_ROOT at a temp library must not read the developer's own."""
+    settings = importlib.reload(importlib.import_module("settings"))
+    config = importlib.import_module("config")
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    monkeypatch.setattr(config, "PROJECT_ROOT", lib)
+
+    assert settings.current_scope() == str(lib.resolve())
+
+
+@pytest.mark.parametrize("root_is_link", [True, False])
+def test_the_api_accepts_either_spelling_of_the_current_project(
+        fastapi_client, tmp_path, monkeypatch, root_is_link):
+    """A caller holding the registry's path for the very library this process is
+    serving used to be told the scope was unknown.
+
+    Both directions, because only one of them can catch a missing canonicalisation
+    on the REQUEST side: when `tmp_path` is already canonical (it is, on macOS),
+    sending the real path proves nothing — the raw string and its canonical form
+    are identical. The first version of this test had only that direction and
+    stayed green with the request-side call deleted.
+    """
+    config = importlib.import_module("config")
+    real = tmp_path / "lib"
+    real.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real)
+    monkeypatch.setattr(config, "PROJECT_ROOT", link if root_is_link else real)
+    asked = str(real) if root_is_link else str(link)
+
+    r = fastapi_client.put(
+        "/api/settings", json={"scope": asked, "values": {"vision.num_ctx": 2048}})
+
+    assert r.status_code == 200, r.text
+    assert r.json()["scope"] == str(real.resolve())
+
+
+def test_an_unknown_path_is_still_refused(fastapi_client, tmp_path):
+    """The guard must not have been widened into "any path that resolves"."""
+    r = fastapi_client.put(
+        "/api/settings",
+        json={"scope": str(tmp_path / "not-a-project"), "values": {"vision.num_ctx": 2048}})
+
+    assert r.status_code == 400
+
+
+@pytest.mark.skipif(os.name != "nt", reason="case-insensitive paths are a Windows property")
+def test_case_only_differences_are_one_project_on_windows(tmp_db):
+    """`C:\\Lib` and `c:\\lib` are one directory, so they must be one row.
+    Runs for real on the `test-windows` CI leg, not just in principle."""
+    settings = importlib.reload(importlib.import_module("settings"))
+    assert settings.canonical_scope("C:\\Lib\\Media") == settings.canonical_scope("c:\\lib\\media")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX paths are case-sensitive")
+def test_case_only_differences_are_two_projects_on_posix(tmp_db):
+    """The decision this pins is the one NOT taken: the registry casefolds
+    unconditionally, and copying that here would merge two genuinely different
+    directories into one settings row on Linux. `normcase` asks the platform
+    instead of assuming."""
+    settings = importlib.reload(importlib.import_module("settings"))
+    assert settings.canonical_scope("/srv/Media") != settings.canonical_scope("/srv/media")


### PR DESCRIPTION
per-project 設定的 scope key 是一個檔案系統路徑，而路徑有很多種拼法：
`~/lib`、`/Users/me/lib`、指向它的 symlink、尾巴多一條斜線 —— 四個字串、
一個 project。**寫進其中一種、用另一種讀，就是靜默漏掉。**

實測：`ARKIV_PROJECT_ROOT` 指向 symlink 時，`str(config.PROJECT_ROOT)` 與它的
resolved 形式並不相同 —— `_validate_writable_path` 算了 canonical 只拿去比對
系統目錄黑名單，**回傳的是原路徑**。而 `routers/settings.py` 兩種都收
（`str(config.PROJECT_ROOT)` 或 registry 的 `p.path`）。

`canonical_scope()` 收斂成一種，`current_scope()` 是它套在 `PROJECT_ROOT` 上。
掛在三個真正碰到資料表的地方：`_rows_for`（讀）、`put`（寫）、`reset`（刪）。
`reset` 尤其惡劣 —— 它按原字串刪，所以用另一種拼法重設會**回報成功而覆寫還在**。
全樹確認：碰 `settings` 表的 SQL 只有那三句，沒有旁路。

**用 `os.path.normcase` 而不是無條件 `casefold()`**：Windows 上 `C:\Lib` 和
`c:\lib` 是同一個目錄、必須是同一列；POSIX 上兩種大小寫是兩個目錄，
併起來會在 Linux 上把不同的庫混成一列。registry 的 `_normalize_key` 是無條件
casefold —— 那是它的選擇，不是這裡該抄的。

**上線前先查過四台十三個庫：project-scoped 設定筆數 0**，所以這支不會讓任何
既有的 row 換位置。唯一存在的一筆是開發機上的 global `export.default_dir`。

行為不變：沒有 project row 時 `effective()` 回的仍是原值，`global` 不是路徑、
原樣通過。

---

### 兩次我自己判斷錯，都是查了才知道

**① router 那支測試綠得但不是因為守衛**（第一版）：`tmp_path` 本身已經是正規
形式，所以「送進來的拼法有沒有被正規化」根本看不出差別 —— 把 request 端那一行
刪掉，測試照樣綠。改成 parametrize 兩個方向（`PROJECT_ROOT` 是 symlink／是真
路徑）才咬得到。**這一波第三次「綠得但不是因為守衛」。**

**② 我宣稱那支 Windows 測試會在 CI 跑，實際上不會**：`test-windows` 是刻意
scoped 的，只跑 `test_hardening_round4.py` 與 `test_mcp_e2e.py`（mlx-whisper
沒有 Windows wheel）。`test-windows` 綠燈跟那支測試無關。

修法是讓那句話變成真的：把 `tests/test_settings_g5.py` 加進那條腿 —— 因為
那條腿存在的理由正好是這個 class（註解自己寫著它是為了 `Path('/etc')` →
`C:\etc` 那次 4-fail），而這支 PR 整個押在 `Path.resolve()` + `normcase` 上。
另補兩個可攜性守衛：symlink 建不起來就 skip（Windows 需要
SeCreateSymbolicLinkPrivilege）、`~` 的展開在 Windows 讀 USERPROFILE 而**完全
不看 HOME**（只設 HOME 會讓 `~/lib` 解析到別處，變成第二列 —— 正是那支測試要抓的）。

13 個 mutation 全紅在該紅的那支。全套 1733 passed / 8 skipped。