### PR TITLE
feat(settings): per-project 設定終於被讀到了

### DIFF
--- a/routers/export.py
+++ b/routers/export.py
@@ -96,7 +96,7 @@ def export_metadata_csv_to(
     # gets the default filename appended.
     raw_dest = (body.dest or "").strip()
     if not raw_dest:
-        default_dir = settings_store.effective("export.default_dir")
+        default_dir = settings_store.export_default_dir()
         if not default_dir:
             raise HTTPException(400, "no dest provided and export.default_dir is unset")
         raw_dest = str(Path(default_dir) / "arkiv-metadata.csv")

--- a/routers/ingest.py
+++ b/routers/ingest.py
@@ -115,22 +115,25 @@ def ingest_engines(
     # effective model so the active selection shows even if detection missed it
     # (or Ollama is down).
     import vision as _vision
-    cur_vision = settings_store.effective("vision.model")
+    cur_vision = settings_store.vision_model()
     vision_models = _vision.list_vision_models()
     if cur_vision and cur_vision not in vision_models:
         vision_models = sorted(set(vision_models) | {cur_vision})
     # Phase 9.7 G5③: the dialog's defaults come from the persisted settings
     # (library default), falling back to config. These are genuinely consumed —
     # IngestSetup pre-fills its pickers from them, and the vision model/num_ctx
-    # are what an ingest run actually uses (ingest.py reads settings.effective).
+    # are what an ingest run actually uses (ingest.py reads the same accessors).
+    # Read at PROJECT scope: these are the defaults for THIS library, and a
+    # bare effective() answered with the global layer no matter what the
+    # project row said.
     return {
         "whisper_modes": modes,
-        "default_mode": settings_store.effective("transcription.default_mode"),
-        "default_language": settings_store.effective("transcription.default_language"),
-        "default_recursive": settings_store.effective("ingest.recursive"),
+        "default_mode": settings_store.transcription_default_mode(),
+        "default_language": settings_store.transcription_default_language(),
+        "default_recursive": settings_store.ingest_recursive(),
         "vision_model": cur_vision,
         "vision_models": vision_models,
-        "vision_num_ctx": settings_store.effective("vision.num_ctx"),
+        "vision_num_ctx": settings_store.vision_num_ctx(),
         "languages": _INGEST_LANGUAGES,
     }
 

--- a/settings.py
+++ b/settings.py
@@ -11,9 +11,12 @@ that PUT coerces + validates against; an out-of-range / wrong-type value is
 rejected (422) rather than silently stored.
 
 Discipline note (no-fake): a setting only belongs here if something actually
-consumes it. The pipeline / export paths read these via effective(); the
-frontend pre-fills its pickers from the same values. We do NOT add a control
-that has no downstream effect.
+consumes it, AT THE SCOPE IT IS OFFERED AT. The pipeline / export paths read
+these through `for_project()` or a typed accessor, so a project override reaches
+them; the frontend pre-fills its pickers from the same values. We do NOT add a
+control that has no downstream effect — and "writable, displayed, never read" is
+that same non-effect wearing a source label, which is what the project layer was
+until 2026-08-27.
 """
 from __future__ import annotations
 
@@ -208,21 +211,69 @@ def effective(key: str, project: Optional[str] = None) -> Any:
     return value
 
 
+def for_project(key: str, project: Optional[str] = None) -> Any:
+    """The effective value for the library this process is serving.
+
+    `effective(key)` with no project answers "the library-wide default", which is
+    the right answer for the settings UI and the wrong one for the pipeline. That
+    difference was not theoretical: the project layer was writable through the API
+    and displayed by `describe()`, and **not one production read passed a project**
+    — so a project override could be set, could be shown as `source: "project"`,
+    and would never change anything. Measured before this: a project row of 30 for
+    `export.subtitle_max_cjk` while the exporter kept using 14.
+
+    Every production read goes through this or a typed helper below, so a new call
+    site cannot quietly get the global-only answer by forgetting an argument —
+    `effective()` now has exactly one caller outside the tests, and it is this
+    function. (The settings UI does not use it either: `describe()` reads the two
+    layers directly so it can report which one won.)
+
+    `project` names a DIFFERENT library; None means this one, not "no project".
+    """
+    return effective(key, project=current_scope() if project is None else project)
+
+
 def subtitle_max_cjk(project: Optional[str] = None) -> int:
     """Effective caption line width. Equals config.SUBTITLE_MAX_CJK when unset, so
     every subtitle export is unchanged until an operator actually moves it."""
-    return effective("export.subtitle_max_cjk", project=project)
+    return for_project("export.subtitle_max_cjk", project)
 
 
 def vision_model(project: Optional[str] = None) -> str:
     """Effective vision model for an ingest run. Equals config.VISION_MODEL when
     unset, so wiring this in is behavior-preserving until an operator overrides."""
-    return effective("vision.model", project=project)
+    return for_project("vision.model", project)
 
 
 def vision_num_ctx(project: Optional[str] = None) -> int:
     """Effective vision num_ctx. Equals config.OLLAMA_VISION_NUM_CTX when unset."""
-    return effective("vision.num_ctx", project=project)
+    return for_project("vision.num_ctx", project)
+
+
+# The remaining four keys had no typed accessor and were read with a bare
+# `effective()` at their call sites — which is exactly how they ended up
+# global-only. Giving every key one accessor is what makes "production never
+# reads at the wrong scope" a property of the module rather than of whoever
+# writes the next call site.
+
+def transcription_default_mode(project: Optional[str] = None) -> int:
+    """Effective whisper-guard mode for an ingest run."""
+    return for_project("transcription.default_mode", project)
+
+
+def transcription_default_language(project: Optional[str] = None) -> str:
+    """Effective forced language; "" means auto-detect."""
+    return for_project("transcription.default_language", project)
+
+
+def ingest_recursive(project: Optional[str] = None) -> bool:
+    """Effective "recurse into sub-folders" default for the ingest dialog."""
+    return for_project("ingest.recursive", project)
+
+
+def export_default_dir(project: Optional[str] = None) -> str:
+    """Effective export destination; "" means "ask the browser to download"."""
+    return for_project("export.default_dir", project)
 
 
 def describe(project: Optional[str] = None) -> List[Dict[str, Any]]:

--- a/tests/test_settings_g5.py
+++ b/tests/test_settings_g5.py
@@ -271,3 +271,92 @@ def test_case_only_differences_are_two_projects_on_posix(tmp_db):
     instead of assuming."""
     settings = importlib.reload(importlib.import_module("settings"))
     assert settings.canonical_scope("/srv/Media") != settings.canonical_scope("/srv/media")
+
+
+# ── every key is read at project scope ───────────────────────────────────────
+#
+# The defect this pins: the project layer was writable through the API and shown
+# by `describe()` as `source: "project"`, and not one production read passed a
+# project — so an override could be set, could look set, and changed nothing.
+# Measured: a project row of 30 for `export.subtitle_max_cjk` while the exporter
+# went on using 14.
+
+def _accessors(settings):
+    """key → (a value to write, the accessor production actually calls).
+
+    One row per schema key. The coverage assertion below turns "someone added a
+    key and never wired it to project scope" into a red test rather than into
+    another control that quietly does nothing.
+    """
+    return {
+        "transcription.default_mode": (2, settings.transcription_default_mode),
+        "transcription.default_language": ("ja", settings.transcription_default_language),
+        "vision.model": ("some-vision:7b", settings.vision_model),
+        "vision.num_ctx": (8192, settings.vision_num_ctx),
+        "export.default_dir": ("/tmp/arkiv-out", settings.export_default_dir),
+        "export.subtitle_max_cjk": (30, settings.subtitle_max_cjk),
+        "ingest.recursive": (False, settings.ingest_recursive),
+    }
+
+
+def test_every_setting_has_an_accessor(tmp_db):
+    """The coverage half. Without it the table below silently stops covering the
+    schema the moment a key is added."""
+    settings = importlib.reload(importlib.import_module("settings"))
+    assert set(_accessors(settings)) == set(settings.SETTINGS_SCHEMA)
+
+
+@pytest.mark.parametrize("key", sorted(_accessors(importlib.import_module("settings"))))
+def test_a_project_override_reaches_the_accessor(tmp_db, tmp_path, monkeypatch, key):
+    settings = importlib.reload(importlib.import_module("settings"))
+    config = importlib.import_module("config")
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    monkeypatch.setattr(config, "PROJECT_ROOT", lib)
+    value, read = _accessors(settings)[key]
+
+    settings.put({key: value}, scope=settings.current_scope())
+
+    assert read() == value, "{0} is still read at global scope".format(key)
+
+
+@pytest.mark.parametrize("key", sorted(_accessors(importlib.import_module("settings"))))
+def test_another_projects_override_is_not_this_projects(tmp_db, tmp_path, monkeypatch, key):
+    """The other half: reading at project scope must not mean reading ANY project
+    row. A single shared row would pass the test above and be worse than global."""
+    settings = importlib.reload(importlib.import_module("settings"))
+    config = importlib.import_module("config")
+    mine, theirs = tmp_path / "mine", tmp_path / "theirs"
+    mine.mkdir()
+    theirs.mkdir()
+    monkeypatch.setattr(config, "PROJECT_ROOT", mine)
+    value, read = _accessors(settings)[key]
+
+    settings.put({key: value}, scope=str(theirs))
+
+    assert read() == settings.SETTINGS_SCHEMA[key]["default"]()
+
+
+def test_the_global_layer_still_answers_the_settings_ui(tmp_db, tmp_path, monkeypatch):
+    """`describe(project=None)` is the one view that must NOT fall through to the
+    current project — it is what the UI shows as the library-wide default.
+
+    Honest note on what this pins: the global view is guarded twice, by
+    `p = {} if not project` AND by `if project and key in p`. Removing either one
+    alone changes nothing and no test goes red — measured. This test only fails
+    when both go. So it holds the BEHAVIOUR, not either guard individually, and
+    the redundancy is not claimed as tested.
+    """
+    settings = importlib.reload(importlib.import_module("settings"))
+    config = importlib.import_module("config")
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    monkeypatch.setattr(config, "PROJECT_ROOT", lib)
+    settings.put({"vision.num_ctx": 8192})                       # global
+    settings.put({"vision.num_ctx": 4096}, scope=settings.current_scope())
+
+    rows = {r["key"]: r for r in settings.describe(project=None)}
+
+    assert rows["vision.num_ctx"]["value"] == 8192
+    assert rows["vision.num_ctx"]["source"] == "global"
+    assert settings.vision_num_ctx() == 4096  # ...while the pipeline sees the project


### PR DESCRIPTION
`effective(key, project)` 的解析鏈（default ← global ← project）從 Phase 9.7
G5② 就完整，project row 寫得進去、`describe()` 也會回報 `source: "project"`
—— 而 **production 沒有一個讀取點帶 `project=`**。實測：project row 設 30，
exporter 照樣用 14。設定得了、看得到、什麼都不會改變。

**八個消費點**（比我第一次數的七個多一個：`routers/ingest.py` 還有一處
`vision.model`）。但我沒有逐點加 `project=` —— 那樣下一個新增的呼叫點還是會忘，
而這個洞正是這樣開的。改成讓 production **沒有裸的 `effective()` 可用**：

- 新 `for_project(key)` = `effective(key, project=current_scope())`
- 七個 key 各有一個 typed accessor（原本只有三個，另外四個就是被裸
  `effective()` 讀的那四個 —— 這不是巧合）
- 全樹確認：`effective()` 現在在 tests 之外只有一個呼叫端，就是 `for_project`

**結構測試釘住覆蓋率**：一張 key → (值, 實際 accessor) 的表，外加
`set(表) == set(SETTINGS_SCHEMA)` 的斷言 —— **下一個人加 key 卻沒接 project
scope，測試會紅**，而不是又多一個安靜什麼都不做的控制項。另一半同樣重要：
斷言**別的 project 的 row 不會被讀成自己的**（只讀「任何一列」會通過上一個
測試，而且比 global 更糟）。

`describe(project=None)` 維持只看 global —— 那是設定 UI 用來顯示「全庫預設」
的那個視角。⚠️ **誠實標註**：它由兩層守衛保護（`p = {}` 與 `if project and …`），
單獨拿掉任一層都沒有測試會紅（實測過）。這支測試釘的是行為，不宣稱釘住任一層。

⚠️ **本 PR 引入一個讀寫不對稱，先講明**：`IngestSetup.svelte` 的
「設為全庫預設」按鈕寫的是 global（按鈕文案就是這個意思），而現在讀的是
project。若某個 project 有 override，按下那顆按鈕會**看起來沒有生效**。
今天不會咬到人 —— 四台十三個庫的 project-scoped 筆數是 0，而且在 PR 3
（scope 切換）之前 UI 根本沒有辦法建立 project row。解法要等 PR 3，
因為「那顆按鈕該寫哪個 scope」是產品決定，不是我該猜的。

順帶改正兩處 prose：模組 docstring 說「pipeline / export paths read these via
effective()」現在不成立；`for_project` 初稿說 `describe()` 是 `effective()` 的
呼叫端，實際上 `describe()` 直接讀兩層 row 好回報誰贏。

7 個 mutation 全紅在該紅的那支（其中兩個各紅 7 支 —— parametrize 過整張表）。
全套 1749 passed / 8 skipped。