### PR TITLE
docs(settings): global 已經是 per-library —— 把這件事釘住，不要再繞一次

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -10,6 +10,23 @@ malicious/garbage PUT can't poison arbitrary state. Each key carries a type
 that PUT coerces + validates against; an out-of-range / wrong-type value is
 rejected (422) rather than silently stored.
 
+**"global" is already per-library, and that is the thing to know before reaching
+for the project layer.** The `settings` table lives in the library's own database
+(`PROJECT_ROOT/.arkiv/project.db`), and one server process serves one library — so
+a `global` row is already scoped to this library and nothing else. The project
+layer means something DIFFERENT only when several `ARKIV_PROJECT_ROOT`s are
+pointed at one `ARKIV_DB_PATH`, which the env vars allow and which nobody was
+found doing: on 2026-08-27, all thirteen libraries across four machines kept their
+settings in their own `.arkiv/project.db`, and no two shared a file.
+
+Consequence, written down because two of us have now walked up to it from the
+other side: **a per-project SETTING does not need the project scope.** Put it in
+the schema, set it in the library, done — the library IS the project. The scope
+layer is for the shared-database configuration, not for "this library's value".
+`test_the_default_database_lives_inside_the_project_root` holds the premise, so if
+the default ever moves the DB out of the library this paragraph goes red instead of
+quietly becoming false.
+
 Discipline note (no-fake): a setting only belongs here if something actually
 consumes it, AT THE SCOPE IT IS OFFERED AT. The pipeline / export paths read
 these through `for_project()` or a typed accessor, so a project override reaches

--- a/tests/test_settings_g5.py
+++ b/tests/test_settings_g5.py
@@ -1,6 +1,7 @@
 """Phase 9.7 G5② — persisted settings overrides (module + API)."""
 import importlib
 import os
+from pathlib import Path
 
 import pytest
 
@@ -360,3 +361,27 @@ def test_the_global_layer_still_answers_the_settings_ui(tmp_db, tmp_path, monkey
     assert rows["vision.num_ctx"]["value"] == 8192
     assert rows["vision.num_ctx"]["source"] == "global"
     assert settings.vision_num_ctx() == 4096  # ...while the pipeline sees the project
+
+
+def test_the_default_database_lives_inside_the_project_root():
+    """The premise the module docstring rests on: `global` is already per-library.
+
+    It holds because the settings table is in the library's own database. If the
+    default ever moves that database somewhere shared, `global` silently becomes
+    machine-wide, every library starts reading every other library's overrides,
+    and the paragraph in settings.py becomes a lie. This turns that into a red
+    test.
+
+    Skipped when `ARKIV_DB_PATH` is set, because that IS the shared-database
+    configuration and pointing the DB outside the root is the whole point of it.
+    """
+    if os.getenv("ARKIV_DB_PATH"):
+        pytest.skip("an explicit ARKIV_DB_PATH is the shared-database case")
+    config = importlib.import_module("config")
+    db_path = Path(config.DB_PATH).expanduser().resolve(strict=False)
+    root = Path(config.PROJECT_ROOT).expanduser().resolve(strict=False)
+
+    assert db_path.is_relative_to(root), (
+        "the settings table moved out of the library: 'global' is no longer "
+        "per-library, and settings.py's module docstring now says something false"
+    )


### PR DESCRIPTION
原本要做 PR 3（`SettingsLive.svelte` 的 scope 切換），查到一半發現前提不成立：

**`settings` 表在庫自己的 DB 裡**（`PROJECT_ROOT/.arkiv/project.db`），
而一個 server 行程服務一個庫。所以 `global` 那一列**已經**只屬於這個庫。
實測：同一個庫裡寫 global 8192 與 project 4096，兩列都在同一個 DB，
而那個 DB 不服務任何別的庫。

project 層只有在 `ARKIV_DB_PATH` 把多個 `ARKIV_PROJECT_ROOT` 指向同一個 DB
時才代表不同的東西 —— env var 允許這樣設（實測可脫鉤），但沒有人這樣用：
2026-08-27 掃過四台十三個庫，每一個都把設定放在自己的 `.arkiv/project.db`，
沒有兩個共用同一個檔。

**推論值得寫下來，因為我跟 Hevin 都從另一邊走到過這裡**：per-project 的
「設定」不需要 project scope。放進 schema、在那個庫裡設好，就結束了 ——
**那個庫就是那個 project**。scope 層是給共用資料庫那個設定用的。

所以 PR 3 不做：加一個對現在每一個使用者都不存在的區別，正是 settings.py
開宗明義禁止的東西的另一種形式 —— 它有效果（project 層贏過 global），
但它不代表任何不同的意思。

**這段 prose 由一支測試撐著**（`test_the_default_database_lives_inside_the_project_root`）：
若預設哪天把 DB 搬出庫外，`global` 會無聲地變成整台機器共用、每個庫開始讀到
別的庫的 override，而這段話會變成謊話。現在它會變紅。
mutation（把預設改成 `~/.arkiv-shared/project.db`）確認咬得到。
`ARKIV_DB_PATH` 有設時 skip —— 那本來就是共用資料庫的情形。

順帶記下一個沒做的原因：scope 是絕對路徑，而 `fable-audit #22` 明訂絕對
project root 只給 admin scope 的呼叫端（`_project_paths_visible`）。所以就算
要做選擇器，非 admin 的遠端客戶端也用不了 —— 得先加一個符號式的 `scope=project`
讓伺服器端解析。列在這裡給下一個人，省得重新發現。

全套 1750 passed / 8 skipped。