### PR TITLE
feat(ops): 探針問「這台機器解得開這個庫嗎」，而不是「ffmpeg 裝了嗎」

### DIFF
--- a/mediaprobe.py
+++ b/mediaprobe.py
@@ -1,0 +1,251 @@
+"""mediaprobe.py — can this environment actually read and decode THIS library's media?
+
+`health.py` answers "is ffmpeg installed". That question has been green on every
+machine where this went wrong. What it does not answer is "can the ffmpeg you have
+decode the files you have", and that is where the silence comes from: extraction
+returns nothing, whisper is handed nothing, the row is stored empty, and the
+library looks like footage with nobody talking in it.
+
+Three real cases, all measured on 2026-08-27/28, all of which pass a presence check:
+
+* **The ffmpeg is codec-crippled.** Synology's bundled ffmpeg 4.1.9 lists `pcm_s16be`
+  in `-decoders` and not `aac`. It demuxes an iPhone `.mov` happily, reports
+  `Audio: aac`, and then says `Decoder (codec aac) not found`. Every iPhone clip in
+  that library would transcribe to nothing, and nothing would say why.
+* **The files cannot be read at all.** A macOS process without Full Disk Access gets
+  `Operation not permitted` on an SMB-mounted NAS. The mount exists, the file
+  `stat()`s, `ls` shows it — and ffmpeg cannot open it. `health.py`'s mount check
+  passes, because it only asks whether `/Volumes/<name>` exists.
+* **The tool being used to check is not the tool doing the work.** Probing on a
+  different machine, or with a different binary, answers a different question. That
+  is not hypothetical: three separate checks of the same nineteen clips gave three
+  different answers before this module existed.
+
+So the rule this module is built on: **the probe runs in the process that will do
+the work, and exercises the same call the pipeline makes.** It shells out to
+`config.FFMPEG_PATH` with `-map a:0 -af volumedetect`, exactly as
+`transcribe._mean_volume_db` does, differing only by `-t` to bound the cost.
+
+**What this cannot tell you**: it catches "cannot", not "wrong". A decoder that
+works and a transcript that is a hallucination both come back OK here — every gate
+is green when whisper invents `謝謝大家` over room tone. That needs a different
+instrument. And it samples: it catches "this whole codec is unusable", not "clip
+847 is corrupt".
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Sequence
+
+import config
+
+OK = "ok"
+MISSING = "missing"
+UNREADABLE = "unreadable"
+NO_AUDIO = "no_audio"
+NO_DECODER = "no_decoder"
+NOT_MEDIA = "not_media"
+PROBE_FAILED = "probe_failed"
+
+# Verdicts that mean "this file will silently produce an empty transcript".
+# `NO_AUDIO` is deliberately absent: a clip with no voice on it is a fact about
+# the footage, and a library can legitimately be full of them.
+BLOCKING = (MISSING, UNREADABLE, NO_DECODER, NOT_MEDIA, PROBE_FAILED)
+
+_AUDIO_STREAM = re.compile(r"Audio:\s*([A-Za-z0-9_]+)")
+_ANY_STREAM = re.compile(r"Stream #\d+:\d+")
+_NO_DECODER = re.compile(r"Decoder \(codec ([^)]+)\) not found")
+_MEAN_VOLUME = re.compile(r"mean_volume:\s*(-?\d+(?:\.\d+)?) dB")
+
+DEFAULT_SECONDS = 5
+DEFAULT_PER_BUCKET = 2
+DEFAULT_MAX_FILES = 12
+
+
+def bucket_key(path: str):
+    """What makes two files "the same kind" for sampling purposes.
+
+    Extension plus immediate parent directory, because that is how a shoot is
+    actually laid out: `A7V/` is PCM off a Sony body and `iPhone Clip/reels/` is
+    AAC off a phone, in the same library, and a sample that ignored the directory
+    would have taken three files from one camera and declared the library fine.
+
+    Chosen without touching the disk — the audio codec is what we actually want to
+    group by, and learning it costs an ffmpeg run per file, which is the thing
+    being budgeted.
+    """
+    p = Path(path)
+    return (p.suffix.lower(), p.parent.name)
+
+
+def choose_sample(paths: Sequence[str], per_bucket: int = DEFAULT_PER_BUCKET,
+                  max_files: int = DEFAULT_MAX_FILES) -> List[str]:
+    """A bounded, spread-out sample: up to `per_bucket` per kind, `max_files` total.
+
+    Deterministic (first-seen order), so two runs on an unchanged library probe the
+    same files and a difference in the report is a difference in the environment.
+    """
+    buckets: Dict[tuple, List[str]] = {}
+    for p in paths:
+        buckets.setdefault(bucket_key(p), []).append(p)
+    out: List[str] = []
+    # Round-robin across buckets rather than draining each in turn, so a cap that
+    # bites still leaves every kind represented — draining would spend the whole
+    # budget on whichever camera happens to sort first.
+    for depth in range(per_bucket):
+        for key in buckets:
+            if len(out) >= max_files:
+                return out
+            if depth < len(buckets[key]):
+                out.append(buckets[key][depth])
+    return out
+
+
+def probe_one(path: str, seconds: int = DEFAULT_SECONDS,
+              ffmpeg: Optional[str] = None, timeout: int = 60) -> Dict:
+    """Four gates, in the order they actually fail. Returns {verdict, codec, detail}."""
+    if not os.path.exists(path):
+        return {"path": path, "verdict": MISSING, "codec": None,
+                "detail": "not found on disk"}
+    try:
+        # The read is the point: a file can exist, stat, and list while the process
+        # is still forbidden to open it (macOS TCC on a network volume). ffmpeg
+        # would report that as an input error and the caller would read it as bad
+        # media.
+        with open(path, "rb") as fh:
+            fh.read(1)
+    except OSError as exc:
+        return {"path": path, "verdict": UNREADABLE, "codec": None,
+                "detail": "{0}: {1}".format(type(exc).__name__, exc)}
+
+    cmd = [ffmpeg or config.FFMPEG_PATH, "-i", path, "-map", "a:0",
+           "-t", str(seconds), "-af", "volumedetect", "-f", "null", "-"]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, timeout=timeout)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"path": path, "verdict": PROBE_FAILED, "codec": None,
+                "detail": "{0}: {1}".format(type(exc).__name__, exc)}
+    err = (proc.stderr or b"").decode("utf-8", "replace")
+
+    missing_decoder = _NO_DECODER.search(err)
+    codec_match = _AUDIO_STREAM.search(err)
+    codec = missing_decoder.group(1) if missing_decoder else (
+        codec_match.group(1) if codec_match else None)
+
+    if missing_decoder:
+        return {"path": path, "verdict": NO_DECODER, "codec": codec,
+                "detail": "this ffmpeg build has no decoder for it"}
+    if codec_match is None:
+        # A file with no audio and a file ffmpeg cannot open at all look the same
+        # from "there was no Audio: line", and they must not be treated the same:
+        # the first is a title card, the second is a zero-byte or truncated file
+        # that will transcribe to nothing. ffmpeg separates them — it lists the
+        # streams it found for real media, and lists nothing for a file it could
+        # not parse.
+        if _ANY_STREAM.search(err) is None:
+            return {"path": path, "verdict": NOT_MEDIA, "codec": None,
+                    "detail": "ffmpeg could not read this as media at all"}
+        return {"path": path, "verdict": NO_AUDIO, "codec": None,
+                "detail": "no audio stream"}
+    if _MEAN_VOLUME.search(err) is None:
+        # Demuxed but produced no samples. Not the same as "no decoder" — the
+        # decoder may exist and still fail on this file — but the consequence for
+        # the pipeline is identical, so it is reported as blocking either way.
+        return {"path": path, "verdict": NO_DECODER, "codec": codec,
+                "detail": "decoded no samples"}
+    return {"path": path, "verdict": OK, "codec": codec, "detail": ""}
+
+
+def ffmpeg_runnable(ffmpeg: Optional[str] = None) -> Optional[str]:
+    """None if the binary runs, else why it doesn't.
+
+    Checked once, up front, because "no ffmpeg" is one fact about the machine and
+    reporting it as twelve unreadable files sends the reader to look at their
+    footage. It matters more than it sounds: without ffmpeg `transcribe._to_wav`
+    returns None, `transcribe()` returns the empty contract, the H1 guard declines
+    to blank the existing row — and the batch reports success having done nothing.
+    The same silence this module exists to break.
+    """
+    binary = ffmpeg or config.FFMPEG_PATH
+    try:
+        subprocess.run([binary, "-version"], capture_output=True, timeout=20)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return "{0}: {1}".format(binary, exc)
+    return None
+
+
+def probe(paths: Sequence[str], resolve: Optional[Callable[[str], str]] = None,
+          per_bucket: int = DEFAULT_PER_BUCKET, max_files: int = DEFAULT_MAX_FILES,
+          seconds: int = DEFAULT_SECONDS, ffmpeg: Optional[str] = None) -> Dict:
+    """Sample the library, run the gates, group the answer by the codec found.
+
+    Grouped by codec because that is the shape the failure has: not "these three
+    files are broken" but "nothing aac in this library can be read". A per-file
+    list would bury that under whichever files the sample happened to draw.
+    """
+    sample = choose_sample(list(paths), per_bucket=per_bucket, max_files=max_files)
+    broken_ffmpeg = ffmpeg_runnable(ffmpeg)
+    if broken_ffmpeg:
+        return {"sampled": 0, "of": len(paths), "files": [], "by_codec": {},
+                "ffmpeg_error": broken_ffmpeg}
+    results = [probe_one(resolve(p) if resolve else p, seconds=seconds, ffmpeg=ffmpeg)
+               for p in sample]
+    by_codec: Dict[str, Dict] = {}
+    for r in results:
+        key = r["codec"] or r["verdict"]
+        slot = by_codec.setdefault(key, {"total": 0, "ok": 0, "verdicts": {}})
+        slot["total"] += 1
+        slot["ok"] += 1 if r["verdict"] == OK else 0
+        slot["verdicts"][r["verdict"]] = slot["verdicts"].get(r["verdict"], 0) + 1
+    return {"sampled": len(sample), "of": len(paths),
+            "files": results, "by_codec": by_codec}
+
+
+def blocking(result: Dict) -> List[str]:
+    """Codec groups where NOTHING decoded — the "silently empty" condition.
+
+    A group is only reported when every probed member failed. One bad file among
+    good ones is a bad file; a whole kind failing is an environment that cannot do
+    the job, and only the second should stop a four-hour batch.
+
+    **`no_audio` never blocks**, which is why `BLOCKING` exists rather than "any
+    non-OK verdict". A clip with no voice on it is a fact about the footage — a
+    title card, a wild shot — and a library can be all of them. The first version
+    of this function ignored `BLOCKING` and let a silent clip halt the run; a test
+    caught it, which is the only reason the constant is load-bearing now.
+    """
+    if result.get("ffmpeg_error"):
+        return ["ffmpeg will not run — {0}".format(result["ffmpeg_error"])]
+    out = []
+    for codec, slot in sorted(result.get("by_codec", {}).items()):
+        blocks = any(v in BLOCKING for v in slot["verdicts"])
+        if slot["ok"] == 0 and slot["total"] > 0 and blocks:
+            kinds = ", ".join(sorted(slot["verdicts"]))
+            out.append("{0}: 0/{1} usable ({2})".format(codec, slot["total"], kinds))
+    return out
+
+
+def format_report(result: Dict) -> str:
+    if result.get("ffmpeg_error"):
+        return ("media probe — ffmpeg will not run\n  {0}\n"
+                "Nothing can be extracted without it; a batch would report success "
+                "and produce nothing.".format(result["ffmpeg_error"]))
+    lines = ["media probe — sampled {0} of {1} clip(s)".format(
+        result.get("sampled", 0), result.get("of", 0))]
+    for codec, slot in sorted(result.get("by_codec", {}).items()):
+        mark = "ok  " if slot["ok"] == slot["total"] else ("FAIL" if slot["ok"] == 0 else "part")
+        lines.append("  [{0}] {1:<14} {2}/{3} decodable".format(
+            mark, codec, slot["ok"], slot["total"]))
+    for r in result.get("files", []):
+        if r["verdict"] != OK:
+            lines.append("     {0}: {1} — {2}".format(
+                Path(r["path"]).name, r["verdict"], r["detail"]))
+    problems = blocking(result)
+    if problems:
+        lines.append("")
+        lines.append("BLOCKING — these would transcribe to nothing, silently:")
+        lines.extend("  " + p for p in problems)
+    return "\n".join(lines)

--- a/routers/retranscribe.py
+++ b/routers/retranscribe.py
@@ -11,6 +11,7 @@ in state.py so this module imports the ONE shared instance, never a copy. Import
 auth + db + corrections + webguard + pathres + state — no server import, no cycle.
 """
 import json
+import logging as _logging
 import re as _re
 from pathlib import Path
 from typing import Optional
@@ -26,6 +27,7 @@ from pydantic import BaseModel, field_validator
 
 import corrections
 import db
+import mediaprobe
 from auth import require_scopes
 from pathres import _resolve_media_path
 from state import (
@@ -77,6 +79,27 @@ def retranscribe_all(
     targets = [(r["id"], r["path"]) for r in rows]
     if not targets:
         return {"queued": 0, "message": "沒有含音訊的素材可重轉錄"}
+    # Preflight, because this batch's characteristic failure is silent. On
+    # 2026-08-25 a full run over three NAS libraries produced 19 empty results;
+    # the H1 guard correctly refused to blank the existing transcripts, so
+    # nothing errored, the run reported success, and the clips kept their wrong
+    # timecodes for three days. Retested on 2026-08-28 the same clips transcribe
+    # fine — the failure was the ENVIRONMENT, and a probe is how you see that
+    # before spending four hours rather than after.
+    #
+    # Only a total failure refuses. One unreadable codec among working ones still
+    # leaves real work to do, and a gate that stops the job over a title card is
+    # a gate people learn to route around.
+    probe_result = mediaprobe.probe([p for _id, p in targets], resolve=db.resolve_path)
+    problems = mediaprobe.blocking(probe_result)
+    usable = sum(1 for f in probe_result["files"] if f["verdict"] == mediaprobe.OK)
+    if problems and usable == 0:
+        raise HTTPException(422, "這台機器讀不了這個庫的素材，批次不會有結果：\n"
+                                 + mediaprobe.format_report(probe_result))
+    if problems:
+        _logging.getLogger(__name__).warning(
+            "[retranscribe-all] 部分素材這台機器處理不了:\n%s",
+            mediaprobe.format_report(probe_result))
     if not _retranscribe_guard.acquire():  # refuse concurrent batch runs (mirrors embed M8)
         raise HTTPException(409, "批次重轉錄已在進行中，請稍候")
     # fable-audit 2026-07-12 (#11): this batch runs whisper IN-PROCESS over the

--- a/scripts/probe_media.py
+++ b/scripts/probe_media.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Ask whether THIS machine can actually read and decode THIS library's media.
+
+    python scripts/probe_media.py                     # the configured library
+    python scripts/probe_media.py --max-files 24      # look harder
+    python scripts/probe_media.py --json
+
+Exits 1 when a whole codec came back unusable, so it can gate a batch. See
+`mediaprobe.py` for why presence checks miss this class entirely.
+
+**Run it where the work will run.** Probing from another machine, or with another
+binary, answers a different question — the nineteen clips that prompted this were
+checked three ways and gave three different answers.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import config  # noqa: E402
+import db  # noqa: E402
+import mediaprobe  # noqa: E402
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--per-bucket", type=int, default=mediaprobe.DEFAULT_PER_BUCKET,
+                    help="files sampled per (extension, folder) — folders are cameras")
+    ap.add_argument("--max-files", type=int, default=mediaprobe.DEFAULT_MAX_FILES)
+    ap.add_argument("--seconds", type=int, default=mediaprobe.DEFAULT_SECONDS,
+                    help="how much audio to decode per file; proving a decoder "
+                         "works does not need the whole clip")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+
+    # The database is the first gate, and it is not a formality: pointed at a
+    # library on an SMB mount from a macOS process without Full Disk Access, the
+    # open fails exactly like the media reads do. The first version of this script
+    # let that surface as a `sqlite3.OperationalError` traceback — a probe whose
+    # whole purpose is to explain an environment, failing to explain the very
+    # environment it was written for.
+    try:
+        with db.get_conn() as conn:
+            rows = conn.execute(
+                "SELECT path FROM media WHERE has_audio = 1 AND path IS NOT NULL "
+                "AND TRIM(path) <> ''").fetchall()
+    except Exception as exc:
+        print("BLOCKING — cannot open this library's database:")
+        print("  {0}".format(db.get_db_path()))
+        print("  {0}: {1}".format(type(exc).__name__, exc))
+        print("  Nothing else can be checked until this reads. On macOS over SMB "
+              "this is usually Full Disk Access for whatever is running arkiv.")
+        return 1
+    paths = [r["path"] for r in rows]
+    if not paths:
+        print("no media with audio in {0} — nothing to probe".format(db.get_db_path()))
+        return 0
+
+    result = mediaprobe.probe(
+        paths, resolve=db.resolve_path, per_bucket=args.per_bucket,
+        max_files=args.max_files, seconds=args.seconds)
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        print("library : {0}".format(config.PROJECT_ROOT))
+        print("ffmpeg  : {0}".format(config.FFMPEG_PATH))
+        print(mediaprobe.format_report(result))
+    return 1 if mediaprobe.blocking(result) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_hardening_concurrency.py
+++ b/tests/test_hardening_concurrency.py
@@ -6,11 +6,30 @@ Pins that whole-library retranscribe now shares the H3 single-flight ingest slot
 """
 import importlib
 
+import pytest
+
 
 def _seed_audio_row(sample_record):
     db = importlib.import_module("db")
     db.upsert(sample_record(path="/tmp/ghost-audio.mp3", filename="ghost-audio.mp3",
                             ext=".mp3", has_audio=1))
+
+
+@pytest.fixture(autouse=True)
+def _skip_media_preflight(monkeypatch):
+    """These tests pin the LOCKS, and their media row is a deliberate ghost path.
+
+    `/api/retranscribe-all` gained a media-capability preflight that (correctly)
+    refuses a batch whose files are all missing — which is what a ghost path is.
+    Stubbing it keeps these tests about the thing they are named for; the
+    preflight has its own tests, including one that asserts a refusal here would
+    NOT leak the very guard these tests measure.
+    """
+    mediaprobe = importlib.import_module("mediaprobe")
+    monkeypatch.setattr(
+        mediaprobe, "probe",
+        lambda paths, **kw: {"sampled": 0, "of": len(list(paths)), "files": [],
+                             "by_codec": {}})
 
 
 def test_retranscribe_all_409_when_ingest_slot_busy(fastapi_client, sample_record):

--- a/tests/test_mediaprobe.py
+++ b/tests/test_mediaprobe.py
@@ -1,0 +1,361 @@
+"""Can this environment read and decode THIS library's media?
+
+Every case here is one that was measured on 2026-08-27/28 and that a
+presence-style health check reports as green: an ffmpeg that exists but has no
+decoder for the library's codec, a file that exists and stats and still cannot be
+opened, a probe that answers about a different binary than the one doing the work.
+
+The ffmpeg-dependent tests drive a fake binary that replays the EXACT stderr the
+real failures produced — the parser's job is to read what ffmpeg actually says,
+not what it seemed to say from memory.
+"""
+from __future__ import annotations
+
+import os
+import stat
+import textwrap
+
+import pytest
+
+import mediaprobe as mp
+
+
+def _fake_ffmpeg(tmp_path, stderr_text, name="ffmpeg-fake"):
+    """A stand-in that prints canned stderr and exits 0, plus records its argv."""
+    argv_log = tmp_path / (name + ".argv")
+    script = tmp_path / name
+    script.write_text(textwrap.dedent("""\
+        #!/bin/sh
+        printf '%s\\n' "$*" >> "{log}"
+        cat >&2 <<'FFEOF'
+        {body}
+        FFEOF
+        exit 0
+        """).format(log=argv_log, body=stderr_text), encoding="utf-8")
+    script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return str(script), argv_log
+
+
+# The real thing, captured from Synology's ffmpeg 4.1.9 on an iPhone .mov.
+NAS_NO_AAC = """\
+  Stream #0:0(und): Video: hevc (hvc1 / 0x31637668), none(bt2020nc/bt2020/unknown), 3840x2160
+    Stream #0:1(und): Audio: aac (mp4a / 0x6134706D), 48000 Hz, stereo, 276 kb/s (default)
+  Stream #0:1 -> #0:0 (? (?) -> pcm_s16le (native))
+Decoder (codec aac) not found for input stream #0:1"""
+
+HEALTHY = """\
+    Stream #0:1(und): Audio: pcm_s16be (in24 / 0x34326E69), 48000 Hz, stereo, 2304 kb/s
+[Parsed_volumedetect_0 @ 0x7f8] mean_volume: -21.5 dB
+[Parsed_volumedetect_0 @ 0x7f8] max_volume: -0.0 dB"""
+
+VIDEO_ONLY = """\
+    Stream #0:0(und): Video: hevc (hvc1 / 0x31637668), 1920x1080, 11478 kb/s
+Stream map 'a:0' matches no streams."""
+
+DEMUXED_NO_SAMPLES = """\
+    Stream #0:1(und): Audio: aac (mp4a / 0x6134706D), 48000 Hz, stereo, 129 kb/s"""
+
+
+@pytest.fixture
+def clip(tmp_path):
+    p = tmp_path / "A7V" / "clip.MP4"
+    p.parent.mkdir(parents=True)
+    p.write_bytes(b"\x00" * 32)
+    return str(p)
+
+
+# ── the gates, in the order they fail ────────────────────────────────────────
+
+def test_a_missing_file_is_named_as_such(tmp_path):
+    r = mp.probe_one(str(tmp_path / "gone.MP4"))
+    assert r["verdict"] == mp.MISSING
+
+
+def test_a_file_that_exists_but_cannot_be_opened(tmp_path, clip):
+    """macOS TCC on a network volume: the mount is there, `stat` works, `ls` shows
+    the file, and the process is still forbidden to read it. `health.py`'s mount
+    check passes — it only asks whether /Volumes/<name> exists."""
+    os.chmod(clip, 0o000)
+    try:
+        if os.access(clip, os.R_OK):  # root, or a filesystem that ignores the mode
+            pytest.skip("this user can read a 000 file; the gate needs a real denial")
+        r = mp.probe_one(clip)
+    finally:
+        os.chmod(clip, 0o644)
+
+    assert r["verdict"] == mp.UNREADABLE
+    assert "Error" in r["detail"] or "denied" in r["detail"].lower()
+
+
+def test_an_ffmpeg_without_the_codec_is_the_headline_case(tmp_path, clip):
+    """Synology 4.1.9 measured: `-decoders` lists pcm_s16be and not aac. It demuxes
+    the file, reports `Audio: aac`, and then cannot decode a sample. Every iPhone
+    clip in that library transcribes to nothing, and nothing says why."""
+    fake, _ = _fake_ffmpeg(tmp_path, NAS_NO_AAC)
+
+    r = mp.probe_one(clip, ffmpeg=fake)
+
+    assert r["verdict"] == mp.NO_DECODER
+    assert r["codec"] == "aac"
+    # The DETAIL is the actionable half, and it is what separates this branch from
+    # the generic "produced no samples" fall-through — same verdict, different
+    # thing to go and fix. Asserting only the verdict let the branch be deleted.
+    assert "no decoder" in r["detail"], r["detail"]
+
+
+def test_a_working_decoder_is_ok(tmp_path, clip):
+    fake, _ = _fake_ffmpeg(tmp_path, HEALTHY)
+    r = mp.probe_one(clip, ffmpeg=fake)
+    assert r["verdict"] == mp.OK and r["codec"] == "pcm_s16be"
+
+
+def test_a_file_with_no_audio_is_not_a_failure_of_the_environment(tmp_path, clip):
+    """A silent clip is a fact about the footage. Reporting it as a broken decoder
+    would send someone to reinstall ffmpeg over a title card."""
+    fake, _ = _fake_ffmpeg(tmp_path, VIDEO_ONLY)
+    assert mp.probe_one(clip, ffmpeg=fake)["verdict"] == mp.NO_AUDIO
+
+
+def test_demuxed_but_no_samples_counts_as_unusable(tmp_path, clip):
+    """The decoder may exist and still yield nothing on this file. Different cause,
+    identical consequence for the pipeline — so it blocks either way."""
+    fake, _ = _fake_ffmpeg(tmp_path, DEMUXED_NO_SAMPLES)
+    r = mp.probe_one(clip, ffmpeg=fake)
+    assert r["verdict"] == mp.NO_DECODER and r["codec"] == "aac"
+
+
+def test_the_probe_bounds_what_it_decodes(tmp_path, clip):
+    """Proving the decoder works does not require decoding a 30-minute clip, and an
+    unbounded probe on a 1,500-clip library is not a preflight."""
+    fake, log = _fake_ffmpeg(tmp_path, HEALTHY)
+
+    mp.probe_one(clip, ffmpeg=fake, seconds=5)
+
+    argv = log.read_text(encoding="utf-8")
+    assert "-t 5" in argv, argv
+    assert "-map a:0" in argv, "must exercise the same stream the pipeline extracts"
+
+
+def test_it_uses_the_pipelines_own_ffmpeg_by_default(tmp_path, clip, monkeypatch):
+    """The rule the whole module rests on: a probe that runs a different binary
+    than the pipeline answers a different question. Three checks of the same
+    nineteen clips gave three different answers before this existed."""
+    fake, log = _fake_ffmpeg(tmp_path, HEALTHY)
+    monkeypatch.setattr(mp.config, "FFMPEG_PATH", fake)
+
+    mp.probe_one(clip)
+
+    assert log.exists(), "probe did not run config.FFMPEG_PATH"
+
+
+# ── sampling: the failure hides in the camera folder you didn't draw from ─────
+
+def test_the_sample_spreads_across_camera_folders():
+    """The measured library: `A7V/` is PCM off a Sony body and `iPhone Clip/reels/`
+    is AAC off a phone. A sample that ignored the directory would have taken three
+    files from one camera and declared the library fine while every phone clip was
+    undecodable."""
+    paths = (["A7V/{0}.MP4".format(i) for i in range(40)]
+             + ["iPhone Clip/reels/{0}.mov".format(i) for i in range(6)])
+
+    chosen = mp.choose_sample(paths, per_bucket=2, max_files=12)
+
+    assert sum(1 for p in chosen if p.startswith("iPhone")) == 2
+    assert sum(1 for p in chosen if p.startswith("A7V")) == 2
+
+
+def test_a_biting_cap_still_leaves_every_kind_represented():
+    """Draining bucket by bucket would spend the whole budget on whichever camera
+    sorts first — which is exactly how a probe misses the broken one."""
+    paths = []
+    for cam in ("A", "B", "C", "D", "E"):
+        paths += ["{0}/{1}.mov".format(cam, i) for i in range(10)]
+
+    chosen = mp.choose_sample(paths, per_bucket=2, max_files=5)
+
+    assert len(chosen) == 5
+    assert len({p.split("/")[0] for p in chosen}) == 5, chosen
+
+
+def test_the_same_library_samples_the_same_files_twice():
+    """So a difference between two runs is a difference in the ENVIRONMENT. A
+    random sample would let a fixed environment look flaky."""
+    paths = ["A7V/{0}.MP4".format(i) for i in range(30)] + ["FX30/{0}.MP4".format(i) for i in range(30)]
+    assert mp.choose_sample(paths) == mp.choose_sample(paths)
+
+
+# ── what stops a batch, and what does not ────────────────────────────────────
+
+def _result(files):
+    by_codec = {}
+    for r in files:
+        slot = by_codec.setdefault(r["codec"] or r["verdict"],
+                                   {"total": 0, "ok": 0, "verdicts": {}})
+        slot["total"] += 1
+        slot["ok"] += 1 if r["verdict"] == mp.OK else 0
+        slot["verdicts"][r["verdict"]] = slot["verdicts"].get(r["verdict"], 0) + 1
+    return {"sampled": len(files), "of": len(files), "files": files, "by_codec": by_codec}
+
+
+def test_a_whole_codec_failing_is_blocking():
+    res = _result([
+        {"path": "a.MP4", "verdict": mp.OK, "codec": "pcm_s16be", "detail": ""},
+        {"path": "b.mov", "verdict": mp.NO_DECODER, "codec": "aac", "detail": "x"},
+        {"path": "c.mov", "verdict": mp.NO_DECODER, "codec": "aac", "detail": "x"},
+    ])
+    assert mp.blocking(res) == ["aac: 0/2 usable (no_decoder)"]
+
+
+def test_one_bad_file_among_good_ones_is_not_blocking():
+    """A corrupt clip is a corrupt clip. Halting a four-hour batch over it would
+    make the guard the thing people switch off."""
+    res = _result([
+        {"path": "a.mov", "verdict": mp.OK, "codec": "aac", "detail": ""},
+        {"path": "b.mov", "verdict": mp.NO_DECODER, "codec": "aac", "detail": "x"},
+    ])
+    assert mp.blocking(res) == []
+
+
+def test_a_silent_clip_never_blocks():
+    """`no_audio` is a fact about the footage, not about the environment — and it
+    is the one verdict that must never stop a run."""
+    res = _result([{"path": "title.mov", "verdict": mp.NO_AUDIO, "codec": None, "detail": ""}])
+    assert mp.blocking(res) == []
+    assert mp.NO_AUDIO not in mp.BLOCKING
+
+
+def test_the_report_names_the_consequence_not_just_the_status():
+    """Someone reading this at 2am needs "these transcribe to nothing, silently",
+    not "aac: 0/2"."""
+    res = _result([{"path": "b.mov", "verdict": mp.NO_DECODER, "codec": "aac", "detail": "no decoder"}])
+    text = mp.format_report(res)
+    assert "silently" in text and "aac" in text
+
+
+def test_probe_resolves_paths_through_the_callers_resolver(tmp_path, monkeypatch):
+    """Library rows hold paths relative to the media root; the probe must go
+    through the same resolver the pipeline uses rather than guessing a root."""
+    real = tmp_path / "A7V" / "clip.MP4"
+    real.parent.mkdir(parents=True)
+    real.write_bytes(b"\x00")
+    fake, log = _fake_ffmpeg(tmp_path, HEALTHY)
+
+    res = mp.probe(["A7V/clip.MP4"], resolve=lambda p: str(tmp_path / p), ffmpeg=fake)
+
+    assert res["files"][0]["verdict"] == mp.OK
+    assert str(real) in log.read_text(encoding="utf-8")
+
+
+# ── the preflight on the batch that produced the silent failure ──────────────
+
+def _seed(paths):
+    import importlib
+    db = importlib.import_module("db")
+    with db.get_conn() as conn:
+        for p in paths:
+            conn.execute("INSERT INTO media (path, filename, has_audio) VALUES (?,?,1)",
+                         (str(p), os.path.basename(str(p))))
+
+
+def test_a_batch_is_refused_when_nothing_on_this_machine_is_readable(
+        fastapi_client, tmp_path, monkeypatch):
+    """The 2026-08-25 shape: four hours of work, nothing errors, nineteen clips
+    come back empty and keep their wrong timecodes for three days. Whatever the
+    caller sees, it must not be "queued: 222".
+
+    A working fake ffmpeg is installed on purpose: without one, a machine that has
+    no ffmpeg refuses for THAT reason instead, and the test would be pinning
+    whichever cause the host happened to have. CI has no ffmpeg — this test needs
+    to exercise the missing-files path in both.
+    """
+    fake, _ = _fake_ffmpeg(tmp_path, HEALTHY, name="ffmpeg-present")
+    monkeypatch.setattr(mp.config, "FFMPEG_PATH", fake)
+    _seed([tmp_path / "A7V" / "gone{0}.MP4".format(i) for i in range(3)])
+
+    r = fastapi_client.post("/api/retranscribe-all", json={})
+
+    assert r.status_code == 422, r.text
+    assert "讀不了" in r.text and "missing" in r.text
+
+
+def test_a_batch_still_runs_when_only_some_media_is_unusable(
+        fastapi_client, tmp_path, monkeypatch):
+    """One dead codec among working ones still leaves real work to do. A gate that
+    halts the job over a title card is a gate people learn to route around."""
+    good = tmp_path / "A7V"
+    good.mkdir(parents=True)
+    paths = []
+    for i in range(3):
+        f = good / "clip{0}.MP4".format(i)
+        f.write_bytes(b"\x00")
+        paths.append(f)
+    paths += [tmp_path / "Missing" / "x{0}.mov".format(i) for i in range(2)]
+    _seed(paths)
+    fake, _ = _fake_ffmpeg(tmp_path, HEALTHY)
+    monkeypatch.setattr(mp.config, "FFMPEG_PATH", fake)
+
+    r = fastapi_client.post("/api/retranscribe-all", json={})
+
+    assert r.status_code == 200, r.text
+    assert r.json()["queued"] == 5
+
+
+def test_a_refused_batch_leaves_no_lock_behind(fastapi_client, tmp_path, monkeypatch):
+    """The preflight sits before the single-flight guard and the ingest slot on
+    purpose. If it bailed after taking them, one bad environment would wedge every
+    later run with a 409 that has nothing to do with the real problem.
+
+    Proven by a batch that WOULD succeed, not by repeating the failing one: with a
+    leaked guard the second call still fails the preflight first and returns the
+    same 422, so repeating it proves nothing. The first version of this test did
+    exactly that and survived the mutation.
+    """
+    _seed([tmp_path / "A7V" / "gone{0}.MP4".format(i) for i in range(3)])
+    assert fastapi_client.post("/api/retranscribe-all", json={}).status_code == 422
+
+    good = tmp_path / "GoodCam"
+    good.mkdir()
+    ok_paths = []
+    for i in range(3):
+        f = good / "clip{0}.MP4".format(i)
+        f.write_bytes(b"\x00")
+        ok_paths.append(f)
+    _seed(ok_paths)
+    fake, _ = _fake_ffmpeg(tmp_path, HEALTHY, name="ffmpeg-ok")
+    monkeypatch.setattr(mp.config, "FFMPEG_PATH", fake)
+
+    second = fastapi_client.post("/api/retranscribe-all", json={})
+
+    assert second.status_code == 200, (
+        "a refused preflight held the single-flight guard: " + second.text)
+
+
+CORRUPT = """\
+[mov,mp4,m4a @ 0x7f8] moov atom not found
+zero.MP4: Invalid data found when processing input"""
+
+
+def test_a_file_ffmpeg_cannot_open_is_not_a_silent_clip(tmp_path, clip):
+    """A zero-byte or truncated file and a title card both produce "no Audio:
+    line". Treating them alike lets a drive full of broken files sail through the
+    preflight as "footage with nobody talking". ffmpeg separates them: it lists
+    the streams it found for real media, and lists nothing for what it cannot
+    parse."""
+    fake, _ = _fake_ffmpeg(tmp_path, CORRUPT, name="ffmpeg-corrupt")
+
+    r = mp.probe_one(clip, ffmpeg=fake)
+
+    assert r["verdict"] == mp.NOT_MEDIA
+    assert mp.NOT_MEDIA in mp.BLOCKING
+
+
+def test_a_missing_ffmpeg_is_reported_as_itself_not_as_bad_footage(tmp_path):
+    """One fact about the machine, not twelve about the files. And it is the same
+    silence: without ffmpeg `_to_wav` returns None, `transcribe()` returns the
+    empty contract, the H1 guard declines to blank the row, and the batch reports
+    success having done nothing."""
+    res = mp.probe(["a.mov", "b.mov"], ffmpeg=str(tmp_path / "no-such-ffmpeg"))
+
+    assert res["files"] == []
+    assert "ffmpeg will not run" in mp.blocking(res)[0]
+    assert "produce nothing" in mp.format_report(res)

--- a/tests/test_retranscribe_all.py
+++ b/tests/test_retranscribe_all.py
@@ -25,6 +25,24 @@ def _seed_audio(tmp_path, transcript=None):
 _seed_audio.n = 0
 
 
+@pytest.fixture(autouse=True)
+def _skip_media_preflight(monkeypatch):
+    """These tests pin the BATCH (queue, status, single-flight, H1 guard); their
+    media rows are one-byte stand-ins.
+
+    `/api/retranscribe-all` gained a media-capability preflight that correctly
+    refuses a batch whose files ffmpeg cannot read as media — which a one-byte
+    file is. Stubbing it keeps these about what they are named for. The preflight
+    has its own tests, and they run without ffmpeg installed so CI (which does not
+    install it) exercises them for real.
+    """
+    mediaprobe = importlib.import_module("mediaprobe")
+    monkeypatch.setattr(
+        mediaprobe, "probe",
+        lambda paths, **kw: {"sampled": 0, "of": len(list(paths)), "files": [],
+                             "by_codec": {}})
+
+
 @pytest.fixture
 def srv(server_module, tmp_path, monkeypatch):
     """batch-retranscribe router module (the worker + the shared single-flight


### PR DESCRIPTION
`health.py` 檢查「有沒有」。今天讓我連錯三次的東西，它**全部顯示綠燈**：

- **Synology 的 ffmpeg 4.1.9 沒有 aac 解碼器**（實查 `-decoders`：有 pcm_s16be、
  沒有 aac）。它把 iPhone `.mov` demux 得好好的、回報 `Audio: aac`，然後說
  `Decoder (codec aac) not found`。那個庫裡每一支 iPhone 素材都會轉錄成空，
  而沒有任何東西會說為什麼。
- **檔案根本讀不到**：macOS 沒有完整取硬碟權限的行程，對 SMB 掛載的 NAS 會拿到
  `Operation not permitted`。掛載點在、`stat` 得到、`ls` 看得見，ffmpeg 就是開不了。
  `health.py` 的掛載檢查會過 —— 它只問 `/Volumes/<name>` 存不存在。
- **拿去檢查的工具不是做事的那個工具**：在別台、或用別的 binary 檢查，回答的是
  別的問題。同一批 19 支片子，三種檢查給了三種答案。

所以整個模組建立在一條規則上：**探針跑在會做事的那個行程裡，走 pipeline 走的
同一條呼叫**（`config.FFMPEG_PATH` + `-map a:0 -af volumedetect`，與
`transcribe._mean_volume_db` 相同，只多一個 `-t` 限成本）。

**四道閘**：存在 → 讀得到（開檔讀 1 byte，這道抓 TCC）→ ffmpeg 看得到音軌 →
**解得開**（volumedetect 吐得出數字）。按 codec 分組報告，因為失效的形狀是
「這個庫裡所有 aac 都讀不了」，不是「這三個檔壞了」。

**取樣鍵是 (副檔名, 上層資料夾)** —— 資料夾就是攝影機：`A7V/` 是 Sony 的 PCM、
`iPhone Clip/reels/` 是手機的 AAC，在同一個庫裡。忽略資料夾的取樣會從同一台機器
抽三個檔然後宣告這個庫沒問題。輪替抽取，讓上限咬到時每一種仍有代表。

**掛在 `/api/retranscribe-all` 之前**（在拿任何鎖之前，測試釘住）。只有**全部**
不可用才拒絕 —— 一種 codec 壞掉但其他能跑，仍然有真的工作要做，而會因為一張
標題卡就擋下四小時批次的閘門，是人們學會繞過的那種閘門。

**這支 PR 的每一條都來自實測，包括三個我自己犯的**：

1. `BLOCKING` 這個常數宣告了卻沒接上 —— 一支純粹沒人聲的片子會擋下整批。測試抓到。
2. **探針在它專門要處理的環境裡自己炸了**：DB 也被 TCC 擋住，使用者看到的是
   `sqlite3.OperationalError` traceback 而不是解釋。加了 DB 閘。
3. **零位元組／損毀的檔會被讀成「沒有人聲」而放行**。ffmpeg 分得開這兩者
   —— 真實媒體它會列出 streams，讀不進去的它什麼都不列。加 `NOT_MEDIA`。

另外補一道 **ffmpeg 本身跑不跑得起來** 的前置檢查，因為那是一件關於機器的事實，
報成十二個「檔案壞掉」會把人送去看素材。而它正是同一種靜默：沒有 ffmpeg，
`_to_wav` 回 None、`transcribe()` 回空合約、H1 守衛拒絕清空、批次回報成功卻什麼
都沒做。**CI 不裝 ffmpeg**，所以那條路是真的會被走到的。

⚠️ **界線先講**：探針抓「不能」，抓不到「錯」。解碼器能動而 whisper 產生幻覺時，
每一道閘都是綠的。而它是取樣的 —— 抓得到「這個 codec 整類不行」，
抓不到「第 847 支剛好壞了」。

13 個 mutation 全紅在該紅的那支。其中兩支我第一版寫的測試不會紅（verdict 相同
掩蓋了兩條不同路徑；洩漏的鎖只會在「下一次本來會成功的批次」上現形），改尖了。
全套 1771 passed / 8 skipped，**並在 `ARKIV_FFMPEG_PATH` 指向不存在路徑的環境下
另跑一次**（＝CI 的情況）確認 21 支全綠。