### PR TITLE
fix(transcribe): 電平正規化預設關掉 —— 13 支實測，0 支變好

### DIFF
--- a/config.py
+++ b/config.py
@@ -203,14 +203,34 @@ SUBTITLE_MAX_CJK = _read_subtitle_max_cjk()
 
 
 # Quiet recordings lose whole passages before whisper ever sees them: VAD reads a
-# low-level track as silence and drops it. Normalising fixes that — but only for
-# tracks that need it. Running dynaudnorm over already well-levelled audio pulls
-# the noise floor up in the quiet passages, which is where hallucinations come
-# from, so this is GATED on a measured level rather than applied to everything.
+# low-level track as silence and drops it. Normalising was supposed to fix that,
+# gated on a measured level so healthy audio is left alone.
 #
-# -30 dB mean is well below normal dialogue (a healthy mix sits around -20 to
-# -26) and comfortably above the level at which VAD starts eating speech.
-AUDIO_NORMALISE = os.getenv("ARKIV_AUDIO_NORMALISE", "1").strip().lower() not in ("0", "false", "no", "off")
+# **Measured 2026-08-28 on 13 clips that all sit below the gate — and it does not
+# do that. Default is now OFF.**
+#
+#   8 identical with and without · 5 WORSE with it · 0 better
+#
+# The three quietest clips in the sample (-55.0, -39.9, -39.7 dB) — precisely
+# where recovering lost speech was the whole point — produced nothing either way.
+# Where it changed the answer it added text rather than recovering it: one clip
+# went from 3 segments to 10 by repeating the same sentence three times, another
+# grew a segment sitting at 0.04 of the clip's peak, and one produced a DIFFERENT
+# transcript on two runs of the same input (`謝謝大家` then `感謝觀看` — the model
+# generating, not transcribing) while the un-normalised run was identical both
+# times. One clip lost a real line to it.
+#
+# The mechanism is the one the old comment already named as the risk: dynaudnorm
+# lifts the noise floor, VAD then keeps far more audio (measured 7% → 22% on one
+# clip), and whisper hallucinates over the extra. The -30 dB gate does not prevent
+# that, because the material this fires on IS mostly noise floor — in one library
+# 42 of 51 clips sit below the gate, so it was the common path, not a rescue.
+#
+# The code stays and the env var turns it back on: 13 clips from two libraries is
+# not every kind of audio, and the premise may hold for material this sample does
+# not contain. What is not defensible is shipping it ON by default on evidence
+# that never showed a single recovery.
+AUDIO_NORMALISE = os.getenv("ARKIV_AUDIO_NORMALISE", "0").strip().lower() not in ("0", "false", "no", "off")
 AUDIO_NORMALISE_BELOW_DB = float(os.getenv("ARKIV_AUDIO_NORMALISE_BELOW_DB", "-30"))
 
 def _detect_exiftool() -> str:

--- a/tests/test_audio_normalise.py
+++ b/tests/test_audio_normalise.py
@@ -9,8 +9,17 @@ tends to be. Normalising the audio recovers them.
 `dynaudnorm` over an already well-levelled track pulls the noise floor up in the
 quiet stretches — which is where hallucinations come from. So the level is measured
 first and the filter is applied only below a threshold.
+
+⚠️ **That is the design. Measured 2026-08-28, it is not what happens** — across 13
+clips all sitting below the gate: 8 identical, 5 worse with it, 0 better, and the
+three quietest produced nothing either way. The default is now OFF (see config.py
+for the numbers). These tests still pin the mechanism, because the mechanism is
+still correct and still reachable by env var; what changed is which way it ships.
 """
 from __future__ import annotations
+
+import importlib
+import os
 
 import subprocess
 
@@ -137,3 +146,34 @@ def test_the_level_is_parsed_from_ffmpeg_stderr(monkeypatch):
     monkeypatch.setattr(subprocess, "run", fake)
 
     assert tr._mean_volume_db("/clip.mp4") == pytest.approx(-33.8)
+
+
+def test_level_normalisation_is_off_by_default(monkeypatch):
+    """Measured 2026-08-28 across 13 clips that all sit below the gate:
+    8 identical, 5 worse with it, **0 better**.
+
+    The three quietest (-55.0, -39.9, -39.7 dB) — where recovering lost speech was
+    the entire point — produced nothing either way. Where it changed the answer it
+    added text rather than recovering it: one clip went from 3 segments to 10 by
+    repeating one sentence three times, and one produced a DIFFERENT transcript on
+    two runs of the same input while the un-normalised run was identical both
+    times. That is the model generating, not transcribing.
+
+    Pinned as a default rather than left to a comment, because the comment that
+    used to justify ON described the exact failure this turned out to have.
+    """
+    if os.getenv("ARKIV_AUDIO_NORMALISE"):
+        pytest.skip("the environment overrides the default under test")
+    config = importlib.reload(importlib.import_module("config"))
+    assert config.AUDIO_NORMALISE is False
+
+
+def test_the_env_var_still_turns_it_back_on(monkeypatch):
+    """The code stays: 13 clips from two libraries is not every kind of audio."""
+    monkeypatch.setenv("ARKIV_AUDIO_NORMALISE", "1")
+    config = importlib.reload(importlib.import_module("config"))
+    try:
+        assert config.AUDIO_NORMALISE is True
+    finally:
+        monkeypatch.delenv("ARKIV_AUDIO_NORMALISE")
+        importlib.reload(config)

--- a/transcribe.py
+++ b/transcribe.py
@@ -917,11 +917,18 @@ def _to_wav(media_path: str):
     _fd, out = tempfile.mkstemp(suffix=".wav"); os.close(_fd)
     filters = []
     if AUDIO_NORMALISE:
+        # OFF by default since 2026-08-28 — see the measurement in config.py. The
+        # gate below is still here and still right in shape; what the numbers say
+        # is that passing it does not help. Kept because 13 clips from two
+        # libraries is not every kind of audio, and someone whose material this
+        # sample does not resemble can turn it back on with ARKIV_AUDIO_NORMALISE.
+        #
         # Gated, not unconditional. A quiet track loses whole passages before
-        # whisper sees them — VAD reads low level as silence and drops it, and the
-        # holes land disproportionately on relaxed, quietly-spoken passages. But
-        # normalising an already healthy track raises its noise floor in exactly
-        # the quiet stretches where hallucinations start, so measure first.
+        # whisper sees them — VAD reads low level as silence and drops it. But
+        # normalising raises the noise floor in exactly the quiet stretches where
+        # hallucinations start, and on this material that is what actually
+        # happened: VAD went from keeping 7% to keeping 22%, and whisper filled
+        # the extra with invention.
         mean_db = _mean_volume_db(media_path)
         if mean_db is not None and mean_db < AUDIO_NORMALISE_BELOW_DB:
             print("  [audio] mean {0:.1f} dB < {1:.0f} dB — normalising".format(


### PR DESCRIPTION
#376 的前提是：安靜的素材會在 whisper 看到之前被 VAD 當成靜音丟掉，正規化把它
救回來，而 −30 dB 的閘門保證只對需要的素材做。

**08-28 對 13 支全部落在閘門以下的片子實測，它不做那件事。**

    8 支開關相同 · 5 支開了更糟 · 0 支變好

**樣本裡最安靜的三支（−55.0 / −39.9 / −39.7 dB）—— 正是「救回被丟掉的語音」
這個理由最該成立的地方 —— 開關兩邊都產出空的。** 它從來沒有救回任何東西。

它改變答案的時候，是**加**字不是救字：

- `9927` 3 段 → 10 段，同一句「我用Cloud做了一個工具」重複三次
- `9935` 多長出一段，落在全片峰值的 **0.04**
- `C610` **同一個輸入跑兩次得到不同文字**（`謝謝大家` → `感謝觀看`），
  而關掉的那邊兩次完全一致 —— **那是模型在生成，不是在轉錄**
- `9925` 反而漏掉一句真的（落在 0.41 的能量比）

機制就是舊註解自己點名過的風險：dynaudnorm 抬高底噪 → VAD 因此保留多得多
（實測 7% → 22%）→ whisper 在多出來的噪音上幻覺。**−30 dB 的閘門擋不住，
因為會觸發它的素材本身大部分就是底噪** —— 某個庫 51 支裡有 42 支低於閘門，
它是常態路徑不是救援。

判準不是我的耳朵：用 v51 修復時用過的做法，對原始音訊逐段量能量，看每一段
落在哪裡；再加上「同一輸入跑兩次是否穩定」——後者是這次量出來的、比詞表更客觀
的幻覺訊號。

**程式碼留著，env var 打得開。** 13 支、兩個庫，不是所有種類的音訊，前提也許在
我沒取樣到的素材上成立。不能接受的是**在一份從未顯示任何一次救援的證據上，
預設開著出貨**。

#376 尚未進過任何 release（最新 tag v1.1.1 是 08-21，#376 是 08-25），
所以這個改動不影響任何已發佈的版本。既有測試全部明確 monkeypatch，不受影響。

2 個 mutation 全紅。全套 1773 passed / 8 skipped。