### PR TITLE
fix(search/ingest/resolve): pagination cap, tag-drop, upload dedup, LAN token via env

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -16,7 +16,26 @@ const BASE = import.meta.env?.VITE_API_URL ?? ''
 let _token = null
 export function setToken(t) {
   _token = t || null
+  try {
+    if (_token) localStorage.setItem('arkiv_token', _token)
+    else localStorage.removeItem('arkiv_token')
+  } catch (e) {}
 }
+export function initToken() {
+  try {
+    const fromUrl = new URLSearchParams(location.search).get('token')
+    if (fromUrl) {
+      setToken(fromUrl)
+      const u = new URL(location.href)
+      u.searchParams.delete('token')
+      history.replaceState(null, '', u.pathname + u.search + u.hash)
+      return
+    }
+    const stored = localStorage.getItem('arkiv_token')
+    if (stored) setToken(stored)
+  } catch (e) {}
+}
+initToken()
 
 class ApiError extends Error {
   constructor(status, path, body) {
@@ -225,6 +244,17 @@ export const activateTranscript = (id, lang, opts) =>
 export const ingestWs = (path, limit = 0, options = {}, opts) =>
   req('/api/ingest/ws', { method: 'POST', body: { path, limit, ...options }, ...opts })
 
+// POST /api/ingest/upload (multipart) — upload one or more files into the
+// ingest source dir. Collision-safe on the backend: a same-name file is renamed
+// (<stem>__<YYYYMMDD-HHMMSS><ext>) instead of overwriting an indexed clip.
+// The response carries {saved:[…], renamed:[{from,to}]}; surface `renamed` so
+// the user knows both copies were kept. Requires ingest_write.
+export const uploadFiles = (files, opts) => {
+  const form = new FormData()
+  for (const f of files) form.append('files', f)
+  return req('/api/ingest/upload', { method: 'POST', body: form, ...opts })
+}
+
 // POST /api/embed/rebuild — drop + rebuild the ChromaDB semantic index from all
 // media (runs in the background). Requires ingest_write (token-free on loopback).
 // → {message, queued}
@@ -422,6 +452,48 @@ export const retranscribeStatus = (id, opts) =>
 // already running (single-flight guard); 504 on the 10-min server timeout.
 export const reingest = (id, opts) =>
   req(`/api/media/${id}/reingest`, { method: 'POST', ...opts })
+
+// ---- media delete (reversible trash + orphan cleanup) ----
+// DELETE /api/media/{id}?allow_file_delete=1 → moves the original file into the
+// trash (recoverable) and removes all metadata; files outside PROJECT_ROOT are
+// metadata-only. Requires media_delete scope (token-free on loopback).
+// → {media_id, filename, trashed, moved_to?, external?, message?}
+export const deleteMedia = (id, allowFileDelete = true, opts) =>
+  req(`/api/media/${id}${qs({ allow_file_delete: allowFileDelete ? 1 : 0 })}`, {
+    method: 'DELETE',
+    ...opts,
+  })
+// POST /api/media/bulk-delete {ids, allow_file_delete} →
+//   {deleted:[id…], skipped:[id…], errors:[{id, error}]}
+export const bulkDeleteMedia = (ids, allowFileDelete = true, opts) =>
+  req('/api/media/bulk-delete', {
+    method: 'POST',
+    body: { ids, allow_file_delete: allowFileDelete },
+    ...opts,
+  })
+// GET /api/admin/trash → {trash:[{id, media_id, filename, original_path,
+//   trash_path, deleted_at, expires_at}]}. Requires admin scope.
+export const getTrash = (opts) => req('/api/admin/trash', opts)
+// POST /api/admin/trash/purge {ttl_days?} → {ok, purged}. ttl_days=0 purges all.
+export const purgeTrash = (ttlDays = null, opts) =>
+  req('/api/admin/trash/purge', {
+    method: 'POST',
+    body: ttlDays == null ? {} : { ttl_days: ttlDays },
+    ...opts,
+  })
+// POST /api/admin/trash/restore/{trash_id} → {ok, restored_to}. Requires admin.
+export const restoreTrash = (trashId, opts) =>
+  req(`/api/admin/trash/restore/${encodeURIComponent(trashId)}`, {
+    method: 'POST',
+    ...opts,
+  })
+// POST /api/admin/prune-missing {dry_run} → {scanned, pruned, pruned_ids, dry_run}.
+// Clears ghost rows whose source file was manually deleted. Requires media_delete.
+export const pruneMissing = (dryRun = true, opts) =>
+  req(`/api/admin/prune-missing${qs({ dry_run: dryRun ? 1 : 0 })}`, {
+    method: 'POST',
+    ...opts,
+  })
 
 // ---- editing proxies ----
 // GET /api/proxy/status → {total, proxied, size_mb}

--- a/frontend/src/routes/SearchLive.svelte
+++ b/frontend/src/routes/SearchLive.svelte
@@ -25,6 +25,8 @@
   // { name, path, items:[…], count, openable, live }
   let groups = []
   let total = 0
+  let offset = 0 // current-project search cursor (how many rows already loaded)
+  let fedPerLimit = 50 // federation per-project cap; "Show more" raises it
   $: shown = groups.reduce((a, g) => a + g.items.length, 0)
   // Derived from the project registry when available; neutral label otherwise,
   // so results outside the demo project aren't mislabeled (Codex review P3).
@@ -92,6 +94,7 @@
     { key: 'video', label: 'Video' },
     { key: 'audio', label: 'Audio' },
   ]
+  const PAGE = 200 // rows per search page; "Show more" loads the next page via offset
 
   const fmtDur = (s) => {
     s = Math.round(s || 0)
@@ -140,52 +143,76 @@
   // rows. Each run captures its seq and bails on assignment if superseded.
   let _searchSeq = 0
 
-  async function runCurrent(q, mySeq) {
-    const params = { q, limit: 40 }
+  async function runCurrent(q, mySeq, append = false) {
+    const params = { q, limit: PAGE, offset: append ? offset : 0 }
     if (mediaType !== 'all') params.media_type = mediaType
     const r = await api.getMedia(params)
     if (mySeq !== _searchSeq) return  // superseded by a newer search
-    total = r.total ?? (r.items || []).length
-    const items = (r.items || []).map((it) => ({
+    const page = r.items || []
+    const items = page.map((it) => ({
       id: it.id,
       name: it.filename || `#${it.id}`,
       dur: fmtDur(it.duration_s),
       score: typeof it.score === 'number' ? it.score : null,
+      matchType: it.match_type || null, // 'semantic' | 'text' — Direction 2 visibility
       excerpt: it.excerpt || it.transcript || '',
       lang: it.lang || '',
       thumb: api.thumbUrlFromPath(it.thumbnail_path),
       tags: (it.tags || []).map((t) => t.name).slice(0, 4),
     }))
-    groups = [{ name: projectName, path: '', items, count: total, openable: true, live: true }]
+    total = r.total ?? (offset + items.length)
+    if (append) offset += items.length
+    else offset = items.length
+    if (append && groups.length) {
+      const g = groups[0]
+      g.items = [...g.items, ...items]
+      groups = [...groups]
+    } else {
+      groups = [{ name: projectName, path: '', items, count: total, openable: true, live: true }]
+    }
     fedErrors = []
     projectsQueried = 0
     projectsFailed = 0
   }
 
   // Federated search (/api/search/all) → one group per project, read-only rows.
-  async function runFederated(q, mySeq) {
-    const r = await api.search(q, { limit: 40 })
+  // Federation has no offset, so "Show more" raises per_project_limit (capped) and
+  // re-fans-out — simpler than incremental cursors across N remote DBs.
+  async function runFederated(q, mySeq, append = false) {
+    const perLimit = append ? Math.min(fedPerLimit + 50, 100) : fedPerLimit
+    const r = await api.search(q, { limit: 200, per_project_limit: perLimit })
     if (mySeq !== _searchSeq) return  // superseded by a newer search
     total = r.total_results ?? (r.items || []).length
+    if (append) fedPerLimit = Math.min(fedPerLimit + 50, 100)
     projectsQueried = r.projects_queried ?? 0
     projectsFailed = r.projects_failed ?? 0
     // The "no matching projects" preflight error means an empty registry — surface
     // it as guidance, not as a per-project failure row.
     fedErrors = (r.errors || []).filter((e) => e.stage !== 'preflight' || e.project_name)
-    const byProject = new Map()
-    for (const it of r.items || []) {
-      const name = it.project_name || '（未命名專案）'
-      if (!byProject.has(name)) byProject.set(name, { name, path: it.project_path || '', items: [], count: 0, openable: false, live: false })
-      byProject.get(name).items.push({
-        id: it.media_id,
-        name: it.filename || `#${it.media_id}`,
-        dur: fmtDur(it.duration_s),
-        score: typeof it.score === 'number' ? it.score : null,
-        excerpt: it.excerpt || '',
-        lang: it.lang || '',
-        thumb: null, // cross-project: this server can't serve another project's thumbs
-        tags: [],
-      })
+    const incoming = (r.items || []).map((it) => ({
+      id: it.media_id,
+      name: it.filename || `#${it.media_id}`,
+      dur: fmtDur(it.duration_s),
+      score: typeof it.score === 'number' ? it.score : null,
+      matchType: it.match_type || null,
+      project_name: it.project_name || '（未命名專案）',
+      excerpt: it.excerpt || '',
+      lang: it.lang || '',
+      thumb: null, // cross-project: this server can't serve another project's thumbs
+      tags: [],
+    }))
+    let byProject
+    if (append && groups.length) {
+      byProject = new Map(groups.map((g) => [g.name, g]))
+    } else {
+      byProject = new Map()
+    }
+    for (const it of incoming) {
+      if (!byProject.has(it.project_name)) {
+        byProject.set(it.project_name, { name: it.project_name, path: it.project_path || '', items: [], count: 0, openable: false, live: false })
+        if (!groups.some((g) => g.name === it.project_name)) groups = [...groups, byProject.get(it.project_name)]
+      }
+      byProject.get(it.project_name).items.push(it)
     }
     for (const g of byProject.values()) g.count = g.items.length
     groups = [...byProject.values()]
@@ -194,6 +221,8 @@
   async function runSearch() {
     const q = query.trim()
     if (!q) { _searchSeq++; state = 'idle'; groups = []; total = 0; fedErrors = []; return }
+    offset = 0
+    fedPerLimit = 50
     const mySeq = ++_searchSeq  // round-5 #36: claim this run's sequence
     state = 'loading'
     syncHash()
@@ -203,6 +232,26 @@
       else await runCurrent(q, mySeq)
       if (mySeq !== _searchSeq) return  // a newer search superseded us — don't flip state
       elapsedMs = Math.round(performance.now() - t0)
+      state = 'ok'
+    } catch (e) {
+      if (mySeq !== _searchSeq) return
+      state = 'error'
+      err = e.message + (e.body ? ' · ' + JSON.stringify(e.body) : '')
+    }
+  }
+
+  // "Show more" — load the next page without disturbing the live search seq
+  // guard (a stale in-flight run still bails on assignment). Reuses the same
+  // monotonic seq so a new typed query can't be clobbered by this fetch either.
+  async function loadMore() {
+    const q = query.trim()
+    if (!q || state === 'loading' || shown >= total) return
+    const mySeq = ++_searchSeq
+    state = 'loading'
+    try {
+      if (crossProject) await runFederated(q, mySeq, true)
+      else await runCurrent(q, mySeq, true)
+      if (mySeq !== _searchSeq) return
       state = 'ok'
     } catch (e) {
       if (mySeq !== _searchSeq) return
@@ -392,7 +441,10 @@
                     </div>
                     {#if r.excerpt}<div class="snippet">{p.b}<span class="mark">{p.m}</span>{p.a}</div>{/if}
                   </div>
-                  <div class="rscore">
+                   <div class="rscore">
+                    {#if r.matchType}
+                      <Mono dim style="font-size:9px;display:block;letter-spacing:0.06em;{r.matchType === 'semantic' ? 'color:var(--ink-2);' : 'color:var(--cyan);'}">{r.matchType === 'semantic' ? '語意' : '關鍵字'}</Mono>
+                    {/if}
                     {#if r.score != null}
                       <Mono style="font-size:13px;font-weight:600;color:var(--ink);">{r.score.toFixed(2)}</Mono>
                       <Mono dim style="font-size:9px;display:block;margin-top:1px;letter-spacing:0.08em;">SCORE</Mono>
@@ -406,6 +458,12 @@
             </div>
           </section>
         {/each}
+      {/if}
+
+      {#if state === 'ok' && shown < total}
+        <div class="loadmorewrap">
+          <button class="ak-btn" on:click={loadMore}>顯示更多（{shown}/{total}）</button>
+        </div>
       {/if}
     </div>
   </div>
@@ -451,6 +509,8 @@
   .snippet { margin-top: 3px; font-size: 12.5px; color: var(--ink-2); line-height: 1.35; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .mark { background: var(--invert); color: var(--invert-ink); padding: 0 2px; }
   .rscore { text-align: right; }
+  .loadmorewrap { display: flex; justify-content: center; padding: 18px 0 8px; }
+  .loadmorewrap .ak-btn { padding: 8px 18px; font-size: 12px; }
   .raction { display: flex; justify-content: flex-end; }
   .openbtn { padding: 5px 9px; }
 </style>

--- a/resolve_plugin/arkiv_resolve_lan.py
+++ b/resolve_plugin/arkiv_resolve_lan.py
@@ -1,0 +1,754 @@
+#!/usr/bin/env python3
+"""
+arkiv — DaVinci Resolve Plugin (LAN variant)
+Search arkiv media library and import selected files into the current Resolve project.
+
+This is the remote/LAN build: it defaults to http://localhost:8501 and sends a
+media_read + videos_read token (ARKIV_TOKEN) on every request, because the
+server only trusts loopback (localhost) as admin WITHOUT a token. Import
+downloads each clip via /api/stream/{id} to a local temp dir first — the
+server's internal media-in/... path is NOT reachable from a different machine
+on the LAN, so passing it straight to Resolve would create an empty
+"media-in" bin and import zero clips. Use this copy when arkiv runs on
+another machine on the LAN. The localhost / no-token version is
+arkiv_resolve.py.
+
+Install (macOS):
+    cp arkiv_resolve_lan.py ~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Utility/
+Install (Windows):
+    copy arkiv_resolve_lan.py "%APPDATA%\\Blackmagic Design\\DaVinci Resolve\\Support\\Fusion\\Scripts\\Utility\\"
+
+Usage:
+    In DaVinci Resolve → Workspace → Scripts → arkiv_resolve_lan
+"""
+import json
+import os
+import tempfile
+import urllib.request
+import urllib.parse
+from pathlib import Path
+
+# Resolve API base from env so users running arkiv on a non-default port (or on
+# a remote host they Tailscale into) can point the plugin without a code edit.
+# ARKIV_API takes precedence; fallback composes from ARKIV_HOST + ARKIV_PORT to
+# match the env vars used by config.py / server.py.
+def _validate_arkiv_api(url):
+    """Reject schemes / hosts that turn the plugin into an SSRF gadget.
+
+    Codex Round-2 audit (J4): a malicious ARKIV_API like
+    http://169.254.169.254/latest/meta-data/ would have the plugin pull cloud
+    metadata on every search / import. Plugin runs inside operator's Resolve, so
+    treat env override as untrusted-ish — http/https only, no link-local."""
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"ARKIV_API 必須是 http/https scheme：{url!r}")
+    host = parsed.hostname or ""
+    if host.startswith("169.254.") or host == "0.0.0.0":
+        raise ValueError(
+            f"ARKIV_API 不可指向 link-local / cloud metadata 位址：{url!r}"
+        )
+    return url
+
+
+ARKIV_API = _validate_arkiv_api(
+    os.environ.get("ARKIV_API") or "http://{host}:{port}".format(
+        host=os.environ.get("ARKIV_HOST", "localhost"),
+        port=os.environ.get("ARKIV_PORT", "8501"),
+    )
+)
+
+# LAN build: the server only trusts loopback (localhost) as admin WITHOUT a
+# token. A non-localhost host (e.g. a LAN IP) MUST present a token with the
+# media_read scope, or every request 401s. The token is read from the
+# ARKIV_TOKEN environment variable (set it in your .env / shell) — it is
+# intentionally NOT hardcoded in this file.
+ARKIV_TOKEN = os.environ.get("ARKIV_TOKEN")
+if not ARKIV_TOKEN:
+    raise RuntimeError(
+        "ARKIV_TOKEN is not set. Export it (or add to your .env) from your "
+        "arkiv server's token admin before using the LAN plugin."
+    )
+
+
+def _api_request(url, data=None, headers=None):
+    """Build a Request with the LAN bearer token attached."""
+    h = {"Authorization": "Bearer {0}".format(ARKIV_TOKEN)}
+    if headers:
+        h.update(headers)
+    return urllib.request.Request(url, data=data, headers=h)
+
+
+_DOWNLOAD_DIR = os.path.join(tempfile.gettempdir(), "arkiv_import")
+
+
+def _download_media(media_id, filename):
+    """Download a media file from arkiv to a local temp dir.
+
+    The LAN build runs on a DIFFERENT machine from the arkiv server, so the
+    library's internal (relative) path — e.g. ``media-in/foo.mp4`` — is not
+    reachable from Resolve. We pull the bytes via /api/stream/{id} (which
+    resolves the file server-side) and hand Resolve a local path it can import
+    by reference. Returns the local path, or None on failure.
+    """
+    os.makedirs(_DOWNLOAD_DIR, exist_ok=True)
+    safe_name = "{0}_{1}".format(media_id, os.path.basename(filename or "clip"))
+    dest = os.path.join(_DOWNLOAD_DIR, safe_name)
+    url = "{0}/api/stream/{1}".format(ARKIV_API, media_id)
+    try:
+        with urllib.request.urlopen(_api_request(url), timeout=600) as resp:
+            data = resp.read()
+        with open(dest, "wb") as f:
+            f.write(data)
+        print(f"[arkiv] 已下載 {filename} → {dest}")
+        return dest
+    except Exception as e:
+        print(f"[arkiv] 下載失敗 (id={media_id}, {filename}): {e}")
+        return None
+
+
+def download_metadata_csv(dest_path=None, media_ids=None):
+    """Phase 7.6d + audit Batch E F5: fetch DaVinci metadata CSV and write to disk.
+
+    Returns the destination path on success, None on failure. The CSV maps
+    each clip's filename to Description / Keywords / Comments / Scene so the
+    user can run File → Import Metadata From → CSV in Resolve immediately.
+
+    media_ids: 給 list 時走 batch-scoped 路徑（?ids=1,2,3），CSV 只含這幾支
+    剛 import 的 clip；不給 → 整庫（既有行為，CLI / 整庫匯出走這條）。
+    """
+    if dest_path is None:
+        cache_dir = Path(tempfile.gettempdir()) / "arkiv"
+        try:
+            cache_dir.mkdir(parents=True, exist_ok=True)
+        except Exception:
+            cache_dir = Path(tempfile.gettempdir())
+        dest_path = cache_dir / "davinci_metadata.csv"
+    try:
+        url = f"{ARKIV_API}/api/export/metadata-csv"
+        if media_ids:
+            ids_str = ",".join(str(int(i)) for i in media_ids)
+            url += "?" + urllib.parse.urlencode({"ids": ids_str})
+        with urllib.request.urlopen(_api_request(url), timeout=30) as resp:
+            data = resp.read()
+        Path(dest_path).write_bytes(data)
+        return str(dest_path)
+    except Exception as e:
+        print(f"[arkiv] Metadata CSV 下載失敗：{e}")
+        return None
+
+
+def get_resolve():
+    """Get the DaVinci Resolve scripting object."""
+    import sys
+    import os
+    # Set up Resolve scripting module paths
+    if sys.platform == "darwin":
+        modules_path = "/Library/Application Support/Blackmagic Design/DaVinci Resolve/Developer/Scripting/Modules"
+        if modules_path not in sys.path:
+            sys.path.append(modules_path)
+    elif sys.platform == "win32":
+        script_api = os.environ.get(
+            "RESOLVE_SCRIPT_API",
+            r"C:\ProgramData\Blackmagic Design\DaVinci Resolve\Support\Developer\Scripting"
+        )
+        modules_path = os.path.join(script_api, "Modules")
+        if modules_path not in sys.path:
+            sys.path.append(modules_path)
+    try:
+        import DaVinciResolveScript as dvr
+        resolve = dvr.scriptapp("Resolve")
+        if resolve is None:
+            print("[arkiv] DaVinciResolveScript 已載入但 Resolve 未回應")
+        return resolve
+    except ImportError as e:
+        print(f"[arkiv] 無法匯入 DaVinciResolveScript：{e}")
+        return None
+
+
+def search_media(query, limit=50):
+    """Search arkiv API for media matching query."""
+    params = urllib.parse.urlencode({"q": query, "limit": limit})
+    url = f"{ARKIV_API}/api/media?{params}"
+    try:
+        req = _api_request(url)
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+            return data.get("items", [])
+    except Exception as e:
+        print(f"[arkiv] 搜尋錯誤：{e}")
+        return []
+
+
+def list_media(limit=50, rating=None):
+    """List media from arkiv API."""
+    params = {"limit": limit, "sort": "date"}
+    if rating:
+        params["rating"] = rating
+    url = f"{ARKIV_API}/api/media?{urllib.parse.urlencode(params)}"
+    try:
+        req = _api_request(url)
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+            return data.get("items", [])
+    except Exception as e:
+        print(f"[arkiv] 列表錯誤：{e}")
+        return []
+
+
+RATING_COLORS = {
+    "good": "Green",
+    "ng": "Orange",
+    "review": "Yellow",
+}
+
+
+def _get_camera_folder(path):
+    """Extract camera/source folder name from file path."""
+    parts = path.replace("\\", "/").rstrip("/").split("/")
+    folder = parts[-2] if len(parts) >= 2 else ""
+    if folder.lower() in ("reels", "clips", "raw", "media", "footage"):
+        folder = parts[-3] if len(parts) >= 3 else folder
+    return folder
+
+
+def _get_or_create_bin(media_pool, root_folder, bin_name):
+    """Get existing Bin or create new one under root_folder."""
+    # Check existing sub-folders
+    for sub in root_folder.GetSubFolderList():
+        if sub.GetName() == bin_name:
+            return sub
+    # Create new bin
+    media_pool.SetCurrentFolder(root_folder)
+    new_bin = media_pool.AddSubFolder(root_folder, bin_name)
+    if new_bin:
+        print(f"[arkiv] 建立 Bin：{bin_name}")
+    return new_bin
+
+
+def import_to_resolve(resolve, file_paths, ratings=None, tags=None, media_ids=None, bin_name=None):
+    """Import files into the current Resolve project's Media Pool.
+    Auto-creates Bin folders by camera/source under Master.
+    ratings: dict mapping file_path -> rating string (good/ng/review)
+    tags: dict mapping file_path -> list of tag name strings
+    media_ids: list of arkiv media ids being imported — passed through to
+        download_metadata_csv() so the resulting CSV is batch-scoped to just
+        these clips, not the entire library (audit Batch E F5).
+    """
+    if not resolve:
+        print("[arkiv] Resolve 未連線")
+        return False
+    pm = resolve.GetProjectManager()
+    if not pm:
+        return False
+    project = pm.GetCurrentProject()
+    if not project:
+        return False
+    media_pool = project.GetMediaPool()
+    if not media_pool:
+        return False
+
+    root_folder = media_pool.GetRootFolder()
+
+    # Group files. On the LAN build files are downloaded to a flat temp dir
+    # (see on_import / _download_media), so an explicit bin_name keeps them out
+    # of a meaningless "media-in" bin; otherwise derive a camera/source folder.
+    groups = {}
+    if bin_name:
+        groups[bin_name] = list(file_paths)
+    else:
+        for p in file_paths:
+            folder = _get_camera_folder(p)
+            if folder not in groups:
+                groups[folder] = []
+            groups[folder].append(p)
+
+    total_imported = 0
+    all_imported_clips = []
+
+    for folder_name, paths in groups.items():
+        # Create or get Bin for this camera
+        if folder_name:
+            target_bin = _get_or_create_bin(media_pool, root_folder, folder_name)
+            if target_bin:
+                media_pool.SetCurrentFolder(target_bin)
+            else:
+                media_pool.SetCurrentFolder(root_folder)
+        else:
+            media_pool.SetCurrentFolder(root_folder)
+
+        result = media_pool.ImportMedia(paths)
+        if result:
+            all_imported_clips.extend(result)
+            total_imported += len(result)
+            print(f"[arkiv] {folder_name or 'Master'}: 匯入 {len(result)} 個片段")
+
+    # Reset to root
+    media_pool.SetCurrentFolder(root_folder)
+
+    if all_imported_clips:
+        # Apply clip colors based on rating
+        if ratings:
+            for mpi in all_imported_clips:
+                clip_name = mpi.GetName()
+                for path, rating in ratings.items():
+                    if clip_name and (clip_name in path or path.endswith(clip_name)):
+                        color = RATING_COLORS.get(rating)
+                        if color:
+                            mpi.SetClipColor(color)
+                            print(f"[arkiv]   {clip_name} → {color} ({rating})")
+                        break
+        # Set tags as metadata (Keywords + Comments for Smart Bin filtering)
+        if tags:
+            for mpi in all_imported_clips:
+                clip_name = mpi.GetName()
+                for path, tag_list in tags.items():
+                    if clip_name and (clip_name in path or path.endswith(clip_name)):
+                        if tag_list:
+                            tag_str = ", ".join(tag_list)
+                            mpi.SetMetadata("Keywords", tag_str)
+                            mpi.SetMetadata("Comments", f"[arkiv] {tag_str}")
+                            print(f"[arkiv]   {clip_name} → Tags: {tag_str}")
+                        break
+        print(f"[arkiv] 完成：共匯入 {total_imported} 個片段到 {len(groups)} 個 Bin")
+
+        # Phase 7.6d: auto-download metadata CSV and tell the user how to import.
+        # arkiv 的 SetMetadata API 對 Keywords/Comments 在新版 Resolve 不寫入，
+        # 改走 CSV import 路線；這裡幫使用者把檔下載好，貼路徑就能用。
+        # batch-scoped (audit F5): 只下載剛 import 的這幾支的 metadata，不是整庫。
+        csv_path = download_metadata_csv(media_ids=media_ids)
+        if csv_path:
+            print("[arkiv] ─────────────────────────────────────────")
+            print(f"[arkiv] Metadata CSV 已就緒：{csv_path}")
+            print("[arkiv] 在 Resolve 選 File → Import Metadata From → CSV，")
+            print("[arkiv] 開啟上面那個檔即可填入 Description / Keywords / Comments / Scene。")
+            print("[arkiv] ─────────────────────────────────────────")
+
+        return True
+    else:
+        print("[arkiv] 匯入失敗")
+        return False
+
+
+def get_media_detail(media_id):
+    """Fetch single media detail with frames from arkiv API."""
+    url = f"{ARKIV_API}/api/media/{media_id}"
+    try:
+        req = _api_request(url)
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read().decode())
+    except Exception as e:
+        print(f"[arkiv] 詳情取得錯誤：{e}")
+        return None
+
+
+def add_markers_to_timeline(resolve, media_items):
+    """Add frame analysis markers as clip markers on matching timeline items."""
+    if not resolve:
+        print("[arkiv] Resolve 未連線")
+        return 0
+
+    pm = resolve.GetProjectManager()
+    project = pm.GetCurrentProject() if pm else None
+    timeline = project.GetCurrentTimeline() if project else None
+    if not timeline:
+        print("[arkiv] 未開啟時間線 — 請先開啟時間線")
+        return 0
+
+    # Get timeline FPS
+    fps_str = timeline.GetSetting("timelineFrameRate")
+    try:
+        fps = float(fps_str)
+    except (TypeError, ValueError):
+        fps = 30.0
+    print(f"[arkiv] 時間線 FPS：{fps}")
+
+    # Build a map of filename -> timeline_item for all video tracks
+    clip_map = {}
+    track_count = timeline.GetTrackCount("video")
+    for t in range(1, track_count + 1):
+        for ti in timeline.GetItemListInTrack("video", t):
+            name = ti.GetName()
+            if name:
+                clip_map[name] = ti
+    print(f"[arkiv] 在時間線上找到 {len(clip_map)} 個片段")
+
+    colors = ["Blue", "Cyan", "Green", "Yellow", "Red", "Pink", "Purple"]
+    total_added = 0
+
+    for item in media_items:
+        media_id = item.get("id")
+        filename = item.get("filename", "")
+        if not media_id:
+            continue
+
+        # Find matching clip on timeline
+        ti = clip_map.get(filename)
+        if not ti:
+            # Try without extension
+            stem = filename.rsplit(".", 1)[0] if "." in filename else filename
+            for k, v in clip_map.items():
+                if k.startswith(stem):
+                    ti = v
+                    break
+        if not ti:
+            print(f"[arkiv] 片段「{filename}」未在時間線上找到 — 請先匯入並放置")
+            continue
+
+        detail = get_media_detail(media_id)
+        if not detail:
+            continue
+
+        frames = detail.get("frames") or []
+        if not frames:
+            print(f"[arkiv] 無 {filename} 的幀資料")
+            continue
+
+        print(f"[arkiv] 正在為 {filename} 新增 {len(frames)} 個片段標記")
+        for i, fr in enumerate(frames):
+            ts = fr.get("timestamp_s", 0)
+            frame_offset = round(ts * fps)
+            desc = fr.get("description") or f"Frame {fr.get('frame_index', i) + 1}"
+            color = colors[i % len(colors)]
+
+            if desc.startswith("```") or not desc.strip():
+                continue
+
+            # AddMarker on timeline_item = clip marker (frame offset from clip start)
+            success = ti.AddMarker(
+                frame_offset,
+                color,
+                desc[:50],
+                desc,
+                1,
+            )
+            if success:
+                total_added += 1
+            else:
+                print(f"[arkiv]   ！在幀 {frame_offset} 處標記失敗")
+
+    return total_added
+
+
+def format_duration(seconds):
+    """Format seconds to MM:SS."""
+    if not seconds:
+        return "00:00"
+    m = int(seconds) // 60
+    s = int(seconds) % 60
+    return f"{m:02d}:{s:02d}"
+
+
+def create_ui(resolve):
+    """Create the arkiv search UI using Fusion's UIManager."""
+    fusion = resolve.Fusion() if resolve else None
+    if not fusion:
+        print("[arkiv] 無法存取 Fusion UIManager")
+        print("[arkiv] 提示：確保 DaVinci Resolve 正在執行且從工作區 → 指令碼啟動")
+        return None
+
+    ui = fusion.UIManager
+    disp = bmd.UIDispatcher(ui)  # noqa: F821 — bmd is injected by Resolve
+
+    # ── Build Window ──
+    win = disp.AddWindow(
+        {
+            "ID": "ArkivWin",
+            "WindowTitle": "arkiv — 媒體搜尋",
+            "Geometry": [200, 200, 700, 500],
+        },
+        [
+            ui.VGroup(
+                {"Spacing": 5},
+                [
+                    # Search bar
+                    ui.HGroup(
+                        {"Spacing": 5},
+                        [
+                            ui.LineEdit(
+                                {
+                                    "ID": "SearchField",
+                                    "PlaceholderText": "搜尋媒體...（語義搜尋）",
+                                    "Weight": 3,
+                                }
+                            ),
+                            ui.Button({"ID": "SearchBtn", "Text": "搜尋", "Weight": 0.5}),
+                            ui.Button({"ID": "ResetBtn", "Text": "全部", "Weight": 0.3}),
+                            ui.Button({"ID": "GoodBtn", "Text": "僅 GOOD", "Weight": 0.5}),
+                            ui.Button({"ID": "ExcludeNGBtn", "Text": "排除 NG", "Weight": 0.5}),
+                        ],
+                    ),
+                    # Results tree
+                    ui.Tree(
+                        {
+                            "ID": "ResultTree",
+                            "SortingEnabled": True,
+                            "SelectionMode": "ExtendedSelection",
+                            "HeaderHidden": False,
+                            "Weight": 5,
+                        }
+                    ),
+                    # Status + Actions
+                    ui.HGroup(
+                        {"Spacing": 5},
+                        [
+                            ui.Label({"ID": "StatusLabel", "Text": "準備就緒", "Weight": 3}),
+                            ui.Button(
+                                {
+                                    "ID": "ImportBtn",
+                                    "Text": "匯入到媒體庫",
+                                    "Weight": 1,
+                                }
+                            ),
+                            ui.Button(
+                                {
+                                    "ID": "MarkerBtn",
+                                    "Text": "新增標記",
+                                    "Weight": 0.7,
+                                }
+                            ),
+                        ],
+                    ),
+                ],
+            )
+        ],
+    )
+
+    # Setup tree columns
+    tree = win.Find("ResultTree")
+    hdr = tree.NewItem()
+    hdr.Text[0] = "檔名"
+    hdr.Text[1] = "長度"
+    hdr.Text[2] = "評級"
+    hdr.Text[3] = "語言"
+    hdr.Text[4] = "得分"
+    tree.SetHeaderItem(hdr)
+    tree.ColumnCount = 5
+    tree.ColumnWidth[0] = 280
+    tree.ColumnWidth[1] = 70
+    tree.ColumnWidth[2] = 60
+    tree.ColumnWidth[3] = 60
+    tree.ColumnWidth[4] = 60
+
+    # Store results for import
+    results_map = {}
+    good_filter_on = [False]
+    exclude_ng_on = [False]
+
+    def populate_tree(items):
+        tree.Clear()
+        results_map.clear()
+        for item in items:
+            row = tree.NewItem()
+            fname = item.get("filename", "")
+            row.Text[0] = fname
+            row.Text[1] = format_duration(item.get("duration_s"))
+            row.Text[2] = (item.get("rating") or "—").upper()
+            row.Text[3] = item.get("lang") or "?"
+            row.Text[4] = f"{round(item.get('score', 0) * 100)}%" if item.get("score") else ""
+            tree.AddTopLevelItem(row)
+            results_map[fname] = item
+        win.Find("StatusLabel").Text = f"找到 {len(items)} 個結果"
+
+    def on_search(ev):
+        query = win.Find("SearchField").Text.strip()
+        if not query:
+            on_reset(ev)
+            return
+        win.Find("StatusLabel").Text = "搜尋中..."
+        try:
+            items = search_media(query)
+            populate_tree(items)
+        except Exception as e:
+            win.Find("StatusLabel").Text = f"搜尋失敗：{e}"
+
+    def on_reset(ev):
+        win.Find("SearchField").Text = ""
+        win.Find("StatusLabel").Text = "載入所有媒體..."
+        good_filter_on[0] = False
+        exclude_ng_on[0] = False
+        win.Find("GoodBtn").Text = "僅 GOOD"
+        win.Find("ExcludeNGBtn").Text = "排除 NG"
+        try:
+            items = list_media(limit=500)
+            populate_tree(items)
+        except Exception as e:
+            win.Find("StatusLabel").Text = f"載入失敗：{e}"
+
+    def on_good(ev):
+        good_filter_on[0] = not good_filter_on[0]
+        exclude_ng_on[0] = False
+        win.Find("ExcludeNGBtn").Text = "排除 NG"
+        try:
+            if good_filter_on[0]:
+                win.Find("GoodBtn").Text = "顯示全部"
+                win.Find("StatusLabel").Text = "載入 GOOD 素材..."
+                items = list_media(rating="good")
+            else:
+                win.Find("GoodBtn").Text = "僅 GOOD"
+                win.Find("StatusLabel").Text = "載入所有媒體..."
+                items = list_media(limit=500)
+            populate_tree(items)
+        except Exception as e:
+            win.Find("StatusLabel").Text = f"載入失敗：{e}"
+
+    def on_exclude_ng(ev):
+        exclude_ng_on[0] = not exclude_ng_on[0]
+        good_filter_on[0] = False
+        win.Find("GoodBtn").Text = "僅 GOOD"
+        try:
+            if exclude_ng_on[0]:
+                win.Find("ExcludeNGBtn").Text = "顯示全部"
+                win.Find("StatusLabel").Text = "排除 NG 素材..."
+                all_items = list_media(limit=500)
+                items = [i for i in all_items if i.get("rating") != "ng"]
+            else:
+                win.Find("ExcludeNGBtn").Text = "排除 NG"
+                win.Find("StatusLabel").Text = "載入所有媒體..."
+                items = list_media(limit=500)
+            populate_tree(items)
+        except Exception as e:
+            win.Find("StatusLabel").Text = f"載入失敗：{e}"
+
+    def on_import(ev):
+        selected = tree.SelectedItems()
+        if not selected:
+            win.Find("StatusLabel").Text = "未選擇任何項目"
+            return
+        try:
+            paths = []
+            ratings = {}
+            tags = {}
+            media_ids = []
+            for sel_id in selected:
+                row = selected[sel_id]
+                fname = row.Text[0]
+                item_data = results_map.get(fname)
+                if not item_data or not item_data.get("id"):
+                    continue
+                # LAN: download the file locally, then import the local copy
+                # (the library's media-in/... path is unreachable from here).
+                local = _download_media(
+                    item_data["id"],
+                    item_data.get("filename") or "clip_{0}".format(item_data["id"]),
+                )
+                if not local:
+                    continue
+                paths.append(local)
+                media_ids.append(item_data["id"])
+                if item_data.get("rating"):
+                    ratings[local] = item_data["rating"]
+                item_tags = item_data.get("tags", [])
+                if item_tags:
+                    tags[local] = [t["name"] for t in item_tags]
+            if paths:
+                success = import_to_resolve(
+                    resolve, paths, ratings, tags,
+                    media_ids=media_ids or None, bin_name="Arkiv",
+                )
+                if success:
+                    # Phase 7.6d: import_to_resolve 已下載 CSV 並 print 路徑到
+                    # console；StatusLabel 受字數限制，改用 chevron 提示去看 console。
+                    win.Find("StatusLabel").Text = (
+                        f"已匯入 {len(paths)} 個片段 → 詳見 console 的 Metadata CSV 路徑"
+                    )
+                else:
+                    win.Find("StatusLabel").Text = "匯入失敗 — 請檢查媒體庫"
+            else:
+                win.Find("StatusLabel").Text = "找不到有效的檔案路徑"
+        except Exception as e:
+            win.Find("StatusLabel").Text = f"匯入錯誤：{e}"
+
+    def on_markers(ev):
+        selected = tree.SelectedItems()
+        if not selected:
+            win.Find("StatusLabel").Text = "未選擇任何項目"
+            return
+        try:
+            items = []
+            for sel_id in selected:
+                row = selected[sel_id]
+                fname = row.Text[0]
+                item_data = results_map.get(fname)
+                if item_data:
+                    items.append(item_data)
+            if not items:
+                win.Find("StatusLabel").Text = "找不到有效的項目"
+                return
+            win.Find("StatusLabel").Text = "新增標記中..."
+            count = add_markers_to_timeline(resolve, items)
+            win.Find("StatusLabel").Text = f"已在時間線上新增 {count} 個標記"
+        except Exception as e:
+            win.Find("StatusLabel").Text = f"標記錯誤：{e}"
+
+    def on_close(ev):
+        disp.ExitLoop()
+
+    win.On.SearchBtn.Clicked = on_search
+    win.On.ResetBtn.Clicked = on_reset
+    win.On.GoodBtn.Clicked = on_good
+    win.On.ExcludeNGBtn.Clicked = on_exclude_ng
+    win.On.ImportBtn.Clicked = on_import
+    win.On.MarkerBtn.Clicked = on_markers
+    win.On.ArkivWin.Close = on_close
+    win.On.SearchField.ReturnPressed = on_search
+
+    # Load initial list
+    items = list_media(limit=500)
+    populate_tree(items)
+
+    win.Show()
+    disp.RunLoop()
+    win.Hide()
+
+
+def run_cli_mode(resolve):
+    """Fallback CLI mode when UIManager is not available."""
+    print("\n=== arkiv 媒體搜尋（CLI 模式）===\n")
+    while True:
+        query = input("搜尋（輸入 'q' 離開，'good' 顯示 GOOD 素材）：").strip()
+        if query.lower() == "q":
+            break
+        if query.lower() == "good":
+            items = list_media(rating="good")
+        else:
+            items = search_media(query)
+
+        if not items:
+            print("找不到結果。\n")
+            continue
+
+        for i, item in enumerate(items):
+            rating = (item.get("rating") or "—").upper()
+            dur = format_duration(item.get("duration_s"))
+            print(f"  [{i}] {item['filename']}  ({dur})  [{rating}]  {item.get('lang', '?')}")
+
+        sel = input("\n輸入編號匯入（逗號分隔，或 'skip' 跳過）：").strip()
+        if sel.lower() == "skip":
+            continue
+        try:
+            indices = [int(x.strip()) for x in sel.split(",")]
+            valid = [items[i] for i in indices if 0 <= i < len(items)]
+            paths = []
+            media_ids = []
+            for it in valid:
+                mid = it.get("id")
+                if not mid:
+                    continue
+                local = _download_media(mid, it.get("filename") or "clip_{0}".format(mid))
+                if local:
+                    paths.append(local)
+                    media_ids.append(mid)
+            if paths and resolve:
+                import_to_resolve(resolve, paths, media_ids=media_ids or None, bin_name="Arkiv")
+        except (ValueError, IndexError) as e:
+            print(f"無效選擇：{e}")
+        print()
+
+
+if __name__ == "__main__":
+    resolve = get_resolve()
+    if resolve:
+        print("[arkiv] 已連線到 DaVinci Resolve")
+    else:
+        print("[arkiv] DaVinci Resolve 未執行 — 僅限 CLI 模式")
+    create_ui(resolve)

--- a/routers/analytics.py
+++ b/routers/analytics.py
@@ -9,6 +9,7 @@ server.ROOT for the disk-usage fallback. Imports auth + db + config +
 tag_quality/tag_aliases/smart_collections/projects — no server import, no cycle.
 """
 from fastapi import APIRouter, Depends
+import os
 
 import collection_defs
 import config
@@ -55,7 +56,17 @@ def get_stats(
     try:
         import shutil
         _db_path = db.get_db_path()  # R5-23 (#54): SSOT accessor, not config value
-        du = shutil.disk_usage(_db_path.parent if _db_path else BASE_DIR)
+        # Measure the DB file itself, not its parent dir: media.db is a bind
+        # mount onto the real data volume (/vol1), whereas /app in Docker is an
+        # overlay backed by the host root fs — disk_usage('/app') would report
+        # the wrong (host-root) disk. Fall back to the parent only if the file
+        # does not exist yet (fresh install before init_db creates it).
+        _du_target = (
+            _db_path
+            if (_db_path and os.path.exists(_db_path))
+            else (_db_path.parent if _db_path else BASE_DIR)
+        )
+        du = shutil.disk_usage(_du_target)
         stats["disk"] = {
             "used_gb": round(du.used / 1e9, 1),
             "total_gb": round(du.total / 1e9, 1),

--- a/routers/ingest.py
+++ b/routers/ingest.py
@@ -13,13 +13,18 @@ no cycle.
 import asyncio
 import json
 import os
-from pathlib import Path
-from typing import Optional
+import time
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import List, Optional
 
 from fastapi import (
     APIRouter,
+    BackgroundTasks,
     Depends,
+    File,
     HTTPException,
+    UploadFile,
     WebSocket,
     WebSocketDisconnect,
 )
@@ -71,7 +76,8 @@ class ScanRequest(BaseModel):
 MEDIA_EXTS = mediatypes.MEDIA_EXT
 VIDEO_EXTS = mediatypes.VIDEO_EXT
 AUDIO_EXTS = mediatypes.AUDIO_EXT
-assert VIDEO_EXTS | AUDIO_EXTS == MEDIA_EXTS  # the two must partition MEDIA_EXTS
+IMAGE_EXTS = mediatypes.IMAGE_EXT
+assert VIDEO_EXTS | AUDIO_EXTS | IMAGE_EXTS == MEDIA_EXTS  # the three must partition MEDIA_EXTS
 # camera raw / stills the ingest pipeline does not process — surfaced in the scan
 # manifest as "skipped" so the redesign's setup dialog (op-01) can show what will
 # not be ingested (e.g. a card of .mov clips + .crw stills).
@@ -88,6 +94,7 @@ def _build_scan_manifest(files: list, unsupp: dict) -> dict:
     return {
         "video": cat(VIDEO_EXTS),
         "audio": cat(AUDIO_EXTS),
+        "image": cat(IMAGE_EXTS),
         "unsupported": {"count": sum(unsupp.values()), "by_ext": dict(sorted(unsupp.items()))},
         "total_size_mb": round(sum(f["size_mb"] for f in files), 1),
     }
@@ -261,6 +268,147 @@ def reingest_media(
         raise HTTPException(500, str(e))
     finally:
         _release_ingest_slot()
+
+
+# ── Upload (HTTP multipart → media-in → auto ingest) ──────────────────────────
+# Phase 14 addendum: let MCP clients / browsers push media without manually
+# copying into the bind mount. Files land in the ingest source (media-in) and a
+# background ingest picks them up. Filenames are constrained to a basename (no
+# path traversal) and only known media extensions are accepted.
+
+_UPLOAD_DIR = (
+    Path(os.environ.get("ARKIV_UPLOAD_DIR", "")).expanduser()
+    if os.environ.get("ARKIV_UPLOAD_DIR")
+    else (config.PROJECT_ROOT / "media-in")
+)
+_UPLOAD_MAX_BYTES = int(os.environ.get("ARKIV_UPLOAD_MAX_MB", "4096")) * 1024 * 1024
+# Phase 14 addendum: cap concurrent upload handlers so a burst of large files
+# can't exhaust the worker pool / saturate disk. Waiters queue up to
+# _UPLOAD_SEM_TIMEOUT seconds for a slot, then get 429. (Background ingest is
+# already single-flight via the shared slot in state.py.)
+_UPLOAD_MAX_CONCURRENT = max(1, int(os.environ.get("ARKIV_UPLOAD_MAX_CONCURRENT", "3")))
+_UPLOAD_SEM_TIMEOUT = float(os.environ.get("ARKIV_UPLOAD_MAX_QUEUE_SEC", "300"))
+_upload_sem = asyncio.Semaphore(_UPLOAD_MAX_CONCURRENT)
+
+
+def _safe_upload_dir() -> Path:
+    d = _UPLOAD_DIR
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _save_upload_file(uf: UploadFile, dest: Path, max_bytes: int) -> None:
+    """Blocking: stream one UploadFile to dest, enforcing the per-file size cap.
+    Runs inside asyncio.to_thread so it never pins the event loop."""
+    written = 0
+    with dest.open("wb") as out:
+        while True:
+            chunk = uf.file.read(1024 * 1024)
+            if not chunk:
+                break
+            written += len(chunk)
+            if written > max_bytes:
+                out.close()
+                dest.unlink(missing_ok=True)
+                raise HTTPException(
+                    413,
+                    f"檔案超過上傳上限（{max_bytes // (1024 * 1024)} MB）：{getattr(uf, 'filename', '?')}",
+                )
+            out.write(chunk)
+
+
+@router.post("/api/ingest/upload")
+async def ingest_upload(
+    files: List[UploadFile] = File(...),
+    background_tasks: BackgroundTasks = None,
+    _tok: dict = Depends(require_scopes("ingest_write")),
+):
+    """Accept multipart media uploads and store them under the ingest source
+    (media-in). A background ingest of that directory is triggered so the new
+    clips become searchable. Concurrency is capped by _upload_sem so a burst of
+    large uploads can't exhaust workers/disk; filename is constrained to a
+    basename (no path traversal) and only known media extensions are accepted."""
+    acquired = False
+    try:
+        await asyncio.wait_for(_upload_sem.acquire(), timeout=_UPLOAD_SEM_TIMEOUT)
+        acquired = True
+    except asyncio.TimeoutError:
+        raise HTTPException(429, "上傳並發已達上限，請稍後再試")
+    try:
+        upload_dir = await asyncio.to_thread(_safe_upload_dir)
+        saved = []
+        renamed = []
+        for uf in files:
+            raw = uf.filename or ""
+            name = PurePosixPath(raw).name
+            if not name or name in (".", "..") or "/" in name or "\\" in name:
+                raise HTTPException(400, f"非法檔名：{raw}")
+            ext = Path(name).suffix.lower()
+            if ext not in MEDIA_EXTS:
+                raise HTTPException(400, f"不支援的檔案類型：{ext}（僅允許媒體格式）")
+            # Collision-safe name: never overwrite an existing file on disk, nor a
+            # media row already indexed at this path. A same-name re-upload is
+            # renamed (<stem>__<YYYYMMDD-HHMMSS><ext>) so both clips survive instead
+            # of the original being clobbered + then SKIPped by ingest (data loss).
+            stem = Path(name).stem
+            ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+            cand = name
+            n = 0
+            while True:
+                c = upload_dir / cand
+                if not c.exists() and not db.path_is_indexed(str(c)):
+                    break
+                n += 1
+                cand = "{0}__{1}{2}{3}".format(
+                    stem, ts, ("_" + str(n)) if n > 1 else "", ext
+                )
+            dest = upload_dir / cand
+            # basename guarantees containment, but assert defensively
+            if dest.resolve() != (upload_dir.resolve() / cand):
+                raise HTTPException(400, f"非法路徑：{raw}")
+            await asyncio.to_thread(_save_upload_file, uf, dest, _UPLOAD_MAX_BYTES)
+            saved.append(cand)
+            if cand != name:
+                renamed.append({"from": name, "to": cand})
+        if not saved:
+            raise HTTPException(400, "沒有收到任何檔案")
+        if background_tasks is not None:
+            background_tasks.add_task(_bg_ingest, str(upload_dir))
+        return JSONResponse(
+            status_code=202,
+            content={
+                "ok": True,
+                "saved": saved,
+                "renamed": renamed,
+                "upload_dir": str(upload_dir),
+                "ingest": "triggered" if background_tasks is not None else "skipped",
+            },
+        )
+    finally:
+        if acquired:
+            _upload_sem.release()
+
+
+def _bg_ingest(dir_path: str) -> None:
+    """Run ingest.py over the upload directory in the background, serialised
+    through the shared single-flight slot (audit H3 — no concurrent whisper)."""
+    import subprocess, sys, proctree
+
+    deadline = time.time() + 1800
+    while time.time() < deadline:
+        if _acquire_ingest_slot():
+            try:
+                proctree.run_tree(
+                    [sys.executable, str(BASE_DIR / "ingest.py"), "--dir", dir_path],
+                    timeout=1800,
+                    cwd=str(BASE_DIR),
+                )
+            except Exception:
+                pass
+            finally:
+                _release_ingest_slot()
+            return
+        time.sleep(5)
 
 
 # ── WebSocket: Ingest Progress ───────────────────────────────────────────

--- a/routers/media.py
+++ b/routers/media.py
@@ -28,6 +28,7 @@ from pydantic import BaseModel, field_validator
 import config
 import corrections
 import db
+import media_delete
 import mediatypes
 import progress
 import tag_quality
@@ -137,6 +138,7 @@ class ActivateLangRequest(BaseModel):
 # both now come from the shared mediatypes source, so they can't drift apart.
 _VIDEO_EXTS = mediatypes.VIDEO_EXT
 _AUDIO_EXTS = mediatypes.AUDIO_EXT
+_IMAGE_EXTS = mediatypes.IMAGE_EXT
 
 
 @router.get("/api/media/position/{media_id}")
@@ -261,14 +263,14 @@ def list_media(
             rec["tags"] = tags_by_id.get(rec["id"], [])
         return {"items": records, "total": len(records), "search": True}
     if q:
-        enriched = []
         search_warning = None
         import vectordb as vdb
-        # audit M19: search used to ignore `offset` entirely (page 2 == page 1).
-        # Collect up to offset+limit matches, then slice the requested page.
-        # Capped so a huge ?offset can't inflate n_results / SQL LIMIT (audit
-        # H13-class DoS); search hits past 2000 are noise anyway.
-        needed = min(offset + limit, 2000)
+        # audit M19: search MUST paginate correctly. `total` is the STABLE number
+        # of matches (independent of `offset`), and only the requested page's light
+        # records are returned. SEARCH_CAP bounds the candidate set so a huge
+        # ?offset can't inflate the vector scan / SQL table scan (audit H13-class
+        # DoS); hits past 2000 are noise anyway.
+        SEARCH_CAP = 2000
 
         def _passes_filters(rec: dict) -> bool:
             # Applied to the ENRICHED record (which has real lang/rating), not the
@@ -289,6 +291,8 @@ def list_media(
             if media_type == "video" and ext not in _VIDEO_EXTS:
                 return False
             if media_type == "audio" and ext not in _AUDIO_EXTS:
+                return False
+            if media_type == "image" and ext not in _IMAGE_EXTS:
                 return False
             # Same class as H8/H14: a filter honoured only on the SQL path silently
             # stops applying the moment the user types a query.
@@ -311,30 +315,18 @@ def list_media(
                     return False
             return True
 
-        # Try semantic search first (requires vectordb with embeddings)
+        # Semantic pass: ALL vector nearest-neighbours up to SEARCH_CAP (ids +
+        # scores + excerpt). May be empty on degradation (search_warning set).
+        semantic: dict = {}
         try:
-            raw = vdb.search(q, n_results=needed * 3)
+            raw = vdb.search(q, n_results=SEARCH_CAP)
             seen = set()
-            ordered_ids = []
-            hit_by_id = {}
             for r in raw:
                 mid = int(r["media_id"])
                 if mid in seen:
                     continue
                 seen.add(mid)
-                ordered_ids.append(mid)
-                hit_by_id[mid] = r
-            # audit H16: one batched LIGHT_COLS fetch instead of per-hit SELECT *
-            for rec in _get_light_records_by_ids(ordered_ids):
-                if not _passes_filters(rec):
-                    continue
-                _resolve_record(rec)
-                hit = hit_by_id[rec["id"]]
-                rec["score"] = hit.get("score", 0)
-                rec["excerpt"] = hit.get("excerpt", "")
-                enriched.append(rec)
-                if len(enriched) >= needed:
-                    break
+                semantic[mid] = {"score": r.get("score", 0), "excerpt": r.get("excerpt", "")}
         except vdb.EmbeddingDimensionMismatch as exc:
             # Don't silently SQL-degrade a dim mismatch — log it and surface a hint
             # so the operator knows semantic search is off until they rebuild.
@@ -348,79 +340,86 @@ def list_media(
             )
             search_warning = "semantic search unavailable (SQL fallback used)"
 
-        # Fallback: SQL text search (filename, transcript, tags) — same lang/rating
-        # filter applied so a degraded search still honors the active filters.
-        if not enriched:
-            seen_ids = set()
-            like = f"%{q}%"
-            # audit H17: push the active filters into WHERE and bound the scan —
-            # the old query LIKE-scanned the whole table, built every matching
-            # record, then threw away everything past `limit`.
-            filter_sql = ""
-            filter_params: list = []
-            if lang:
-                filter_sql += " AND lang = ?"
-                filter_params.append(lang)
-            if rating == "unrated":
-                filter_sql += " AND rating IS NULL"
-            elif rating:
-                filter_sql += " AND rating = ?"
-                filter_params.append(rating)
-            if media_type == "video":
-                filter_sql += " AND ext IN ({0})".format(",".join("?" * len(_VIDEO_EXTS)))
-                filter_params.extend(sorted(_VIDEO_EXTS))
-            elif media_type == "audio":
-                filter_sql += " AND ext IN ({0})".format(",".join("?" * len(_AUDIO_EXTS)))
-                filter_params.extend(sorted(_AUDIO_EXTS))
-            # Third place this filter has to exist. The degraded-search path is the
-            # one users hit when Ollama is down, and a filter that quietly stops
-            # applying exactly then is worse than one that never worked. Built by the
-            # same helper as the list query rather than hand-written twice — the
-            # duplication is what let H8/H14 happen.
-            shot_sql, shot_params = db.shot_window_clause(
-                shot_year=shot_year, shot_date=shot_date
-            )
-            if shot_sql:
-                filter_sql += " AND " + shot_sql
-                filter_params.extend(shot_params)
-            with db.get_conn() as conn:
-                rows = conn.execute(
-                    f"SELECT {db.LIGHT_COLS} FROM media "
-                    "WHERE (filename LIKE ? OR transcript LIKE ?)" + filter_sql +
-                    " ORDER BY id LIMIT ?",
-                    (like, like, *filter_params, needed),
-                ).fetchall()
-                for r in rows:
-                    rec = dict(r)
-                    _resolve_record(rec)
-                    enriched.append(rec)
-                    seen_ids.add(rec["id"])
+        # Lexical pass (Direction 2): literal substring matches in filename /
+        # transcript / tags ALWAYS surface, even when their embedding ranks low by
+        # vector distance — so a clip that literally contains the query term is
+        # never invisible. Bounded by SEARCH_CAP (audit H17); the active filters
+        # are pushed into WHERE so the SQL path honours them too.
+        like = f"%{q}%"
+        filter_sql = ""
+        filter_params: list = []
+        if lang:
+            filter_sql += " AND lang = ?"
+            filter_params.append(lang)
+        if rating == "unrated":
+            filter_sql += " AND rating IS NULL"
+        elif rating:
+            filter_sql += " AND rating = ?"
+            filter_params.append(rating)
+        if media_type == "video":
+            filter_sql += " AND ext IN ({0})".format(",".join("?" * len(_VIDEO_EXTS)))
+            filter_params.extend(sorted(_VIDEO_EXTS))
+        elif media_type == "audio":
+            filter_sql += " AND ext IN ({0})".format(",".join("?" * len(_AUDIO_EXTS)))
+            filter_params.extend(sorted(_AUDIO_EXTS))
+        elif media_type == "image":
+            filter_sql += " AND ext IN ({0})".format(",".join("?" * len(_IMAGE_EXTS)))
+            filter_params.extend(sorted(_IMAGE_EXTS))
+        shot_sql, shot_params = db.shot_window_clause(shot_year=shot_year, shot_date=shot_date)
+        if shot_sql:
+            filter_sql += " AND " + shot_sql
+            filter_params.extend(shot_params)
+        lexical_ids: list = []
+        with db.get_conn() as conn:
+            rows = conn.execute(
+                "SELECT id FROM media "
+                "WHERE (filename LIKE ? OR transcript LIKE ?)" + filter_sql +
+                " ORDER BY id LIMIT ?",
+                (like, like, *filter_params, SEARCH_CAP),
+            ).fetchall()
+            lexical_ids = [dict(r)["id"] for r in rows]
+            tag_rows = conn.execute(
+                "SELECT DISTINCT media_id FROM tags WHERE name LIKE ? LIMIT ?",
+                (like, SEARCH_CAP),
+            ).fetchall()
+        for tr in tag_rows:
+            tid = dict(tr)["media_id"]
+            if tid not in lexical_ids:
+                lexical_ids.append(tid)
 
-            # Also search by tag name (bounded — audit H17)
-            if len(enriched) < needed:
-                with db.get_conn() as conn:
-                    tag_rows = conn.execute(
-                        "SELECT DISTINCT media_id FROM tags WHERE name LIKE ? LIMIT ?",
-                        (like, needed * 3),
-                    ).fetchall()
-                tag_ids = [tr["media_id"] for tr in tag_rows if tr["media_id"] not in seen_ids]
-                for rec in _get_light_records_by_ids(tag_ids):
-                    if not _passes_filters(rec):
-                        continue
-                    _resolve_record(rec)
-                    enriched.append(rec)
-                    seen_ids.add(rec["id"])
-                    if len(enriched) >= needed:
-                        break
+        # Stable, offset-independent ordering: semantic hits by score desc, then
+        # lexical hits in id order, de-duplicated. Capped at SEARCH_CAP.
+        sem_ids = list(semantic.keys())
+        sem_ids.sort(key=lambda mid: semantic[mid]["score"], reverse=True)
+        seen_sem = set(sem_ids)
+        lex_filtered = [mid for mid in lexical_ids if mid not in seen_sem]
+        ordered_ids = (sem_ids + lex_filtered)[:SEARCH_CAP]
 
-        # audit M19: slice the requested page; total = bounded match count (the
-        # same "items seen so far" semantic for both search sub-paths).
-        items = enriched[offset:offset + limit]
-        # audit H15: one bulk tag query for the returned page only
+        # One bulk fetch of the candidate light records (bounded by SEARCH_CAP),
+        # apply the filters the SQL path can't (semantic hits carry no rating/
+        # lang), then slice the requested page. Tags fetched once for the page.
+        records_by_id: dict = {}
+        for rec in _get_light_records_by_ids(ordered_ids):
+            if not _passes_filters(rec):
+                continue
+            _resolve_record(rec)
+            mid = rec["id"]
+            if mid in semantic:
+                rec["score"] = semantic[mid]["score"]
+                rec["excerpt"] = semantic[mid]["excerpt"]
+                rec["match_type"] = "semantic"
+            else:
+                rec["score"] = None
+                rec["excerpt"] = (rec.get("transcript") or "")[:300] or rec.get("filename") or ""
+                rec["match_type"] = "text"
+            records_by_id[mid] = rec
+        ordered = [records_by_id[mid] for mid in ordered_ids if mid in records_by_id]
+        total = len(ordered)
+        items = ordered[offset:offset + limit]
         tags_by_id = _get_tags_bulk([rec["id"] for rec in items])
         for rec in items:
             rec["tags"] = tags_by_id.get(rec["id"], [])
-        resp = {"items": items, "total": len(enriched), "search": True}
+        resp = {"items": items, "total": total, "search": True}
         if search_warning:
             resp["search_degraded"] = True
             resp["warning"] = search_warning
@@ -474,11 +473,13 @@ def get_media_detail(
             rec["frame_tags_parsed"] = json.loads(rec["frame_tags"])
         except Exception:
             rec["frame_tags_parsed"] = []
-    # User-facing tags: screen quality-defect noise + keep only the top-N most
-    # confident (focus-weighted) tags, so a clip doesn't dump 10+ tags on the user.
-    top = set(tag_quality.rank_media_tags(rec.get("frame_tags_parsed") or []))
+    # User-facing tags: show BOTH manual (user-added) and auto (vision) tags.
+    # Only normalize/dedup via filter_tag_records (Simplified↔Traditional +
+    # variant-char collapse + noise-artifact drop) — do NOT cap auto tags by the
+    # top-N frame ranking, or manual tags (which never appear in that set) get
+    # silently dropped from the inspector (regression: manual tags vanished).
     all_tags = tag_quality.filter_tag_records(db.get_tags(media_id))
-    rec["tags"] = [t for t in all_tags if t["name"] in top] if top else all_tags
+    rec["tags"] = all_tags
     # Optional LLM-canonicalized tag list (populated by `ingest.py --canonicalize-tags`).
     # Returned alongside raw tags so the UI can toggle raw ↔ canonical; null until run.
     if rec.get("canonical_tags"):
@@ -1125,3 +1126,52 @@ def retry_vision_status(
     """
     rec = vision_jobs.get(media_id)
     return rec if rec is not None else {"state": "idle"}
+
+
+# ── Unified delete (Phase 14.5) ───────────────────────────────────────────────
+
+class BulkDeleteBody(BaseModel):
+    ids: list
+    allow_file_delete: bool = True
+
+
+@router.delete("/api/media/{media_id}")
+def delete_media(
+    media_id: int,
+    allow_file_delete: bool = True,
+    _tok: dict = Depends(require_scopes("media_delete")),
+):
+    """Delete one media record + all its artefacts. The original source file is
+    moved to the recycle bin (.arkiv/trash), not unlinked; files outside
+    PROJECT_ROOT are metadata-only (see media_delete.delete_media_full)."""
+    result = media_delete.delete_media_full(
+        media_id, allow_file_delete=allow_file_delete, token_info=_tok
+    )
+    if result is None:
+        raise HTTPException(404, "找不到該媒體")
+    return result
+
+
+@router.post("/api/media/bulk-delete")
+def bulk_delete_media(
+    body: BulkDeleteBody,
+    _tok: dict = Depends(require_scopes("media_delete")),
+):
+    """Delete several media records at once. Returns the ids that were deleted,
+    skipped (e.g. not found), and any hard errors — matching the designed
+    {deleted, skipped, errors} contract."""
+    deleted, skipped, errors = [], [], []
+    for mid in body.ids:
+        try:
+            mid = int(mid)
+        except (TypeError, ValueError):
+            errors.append({"media_id": mid, "error": "bad id"})
+            continue
+        r = media_delete.delete_media_full(
+            mid, allow_file_delete=body.allow_file_delete, token_info=_tok
+        )
+        if r is None:
+            skipped.append(mid)
+        else:
+            deleted.append(mid)
+    return {"ok": True, "deleted": deleted, "skipped": skipped, "errors": errors}

--- a/routers/misc.py
+++ b/routers/misc.py
@@ -324,6 +324,27 @@ def api_health():
     except Exception:
         _mark("ollama", False, "unreachable — is `ollama serve` running?")
 
+    # embeddings coverage: how much of the library has been vector-indexed. A low
+    # number means `python embed.py --rebuild` hasn't been run (or stopped partway),
+    # so semantic search silently returns weaker / fewer hits. Surfaces the gap
+    # that a literal-only query can paper over (Direction 1 of the search-fix).
+    try:
+        import db as dbmod
+
+        with dbmod.get_conn() as conn:
+            total_media = conn.execute("SELECT COUNT(*) FROM media").fetchone()[0]
+            embedded_media = conn.execute(
+                "SELECT COUNT(*) FROM media WHERE embed_hash IS NOT NULL"
+            ).fetchone()[0]
+        coverage = (embedded_media / total_media) if total_media else 1.0
+        out["embeddings"] = {
+            "total_media": total_media,
+            "embedded_media": embedded_media,
+            "coverage": round(coverage, 3),
+        }
+    except Exception as exc:  # noqa: BLE001
+        out["embeddings"] = {"error": type(exc).__name__}
+
     return JSONResponse(out, status_code=200 if out["ready"] else 503)
 
 

--- a/tests/test_arkiv_resolve_lan.py
+++ b/tests/test_arkiv_resolve_lan.py
@@ -1,0 +1,191 @@
+"""LAN variant of the DaVinci Resolve plugin (arkiv_resolve_lan.py).
+
+Pins two behaviours the localhost build does NOT have:
+- default API host is localhost (override with ARKIV_HOST / ARKIV_API for a remote server)
+- every request carries an `Authorization: Bearer <token>` header, because the
+  server only trusts loopback as admin without a token.
+
+The plugin imports cleanly without DaVinciResolveScript (that import is nested
+inside get_resolve()), so we can load it by path and assert the wired Request.
+"""
+import importlib.util
+import pathlib
+import urllib.request
+
+import pytest
+
+PLUGIN = pathlib.Path(__file__).resolve().parent.parent / "resolve_plugin" / "arkiv_resolve_lan.py"
+
+
+def _load(monkeypatch):
+    for k in ("ARKIV_API", "ARKIV_HOST", "ARKIV_PORT"):
+        monkeypatch.delenv(k, raising=False)
+    # The LAN plugin requires ARKIV_TOKEN at import time (it raises otherwise);
+    # the tests only check that a non-empty Bearer token is attached, so a dummy
+    # value is fine here.
+    monkeypatch.setenv("ARKIV_TOKEN", "test-token-not-a-secret")
+    spec = importlib.util.spec_from_file_location("arkiv_resolve_lan_test", str(PLUGIN))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeResp:
+    def __init__(self, data):
+        self._d = data
+
+    def read(self):
+        return self._d
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _capture(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, *a, **k):
+        captured["req"] = req
+        return _FakeResp(b'{"items":[]}')
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    return captured
+
+
+def test_lan_default_host_is_localhost(monkeypatch):
+    from urllib.parse import urlparse
+
+    mod = _load(monkeypatch)
+    assert urlparse(mod.ARKIV_API).hostname == "localhost"
+
+
+def test_search_media_sends_token_header_to_lan(monkeypatch):
+    from urllib.parse import urlparse
+
+    mod = _load(monkeypatch)
+    captured = _capture(monkeypatch)
+    mod.search_media("snow")
+    req = captured["req"]
+    assert urlparse(req.full_url).hostname == "localhost"
+    assert req.get_header("Authorization", "").startswith("Bearer ")
+    assert req.get_header("Authorization", "") != "Bearer "
+
+
+def test_list_media_sends_token_header_to_lan(monkeypatch):
+    from urllib.parse import urlparse
+
+    mod = _load(monkeypatch)
+    captured = _capture(monkeypatch)
+    mod.list_media(limit=10)
+    req = captured["req"]
+    assert urlparse(req.full_url).hostname == "localhost"
+    assert req.get_header("Authorization", "").startswith("Bearer ")
+
+
+def test_download_media_requests_stream_with_token(monkeypatch, tmp_path):
+    """LAN import must pull bytes from /api/stream/{id} (server-side path
+    resolution) rather than handing Resolve the unreachable media-in/... path."""
+    import urllib.request as ureq
+
+    mod = _load(monkeypatch)
+    monkeypatch.setattr(mod, "_DOWNLOAD_DIR", str(tmp_path))
+
+    captured = {}
+
+    class _FakeResp:
+        def __init__(self, data):
+            self._d = data
+
+        def read(self):
+            return self._d
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake_urlopen(req, *a, **k):
+        captured["req"] = req
+        return _FakeResp(b"\x00\x01video-bytes")
+
+    monkeypatch.setattr(ureq, "urlopen", fake_urlopen)
+
+    dest = mod._download_media(42, "clip.mp4")
+    assert dest is not None
+    assert captured["req"].full_url.endswith("/api/stream/42")
+    assert captured["req"].get_header("Authorization", "").startswith("Bearer ")
+    with open(dest, "rb") as f:
+        assert f.read() == b"\x00\x01video-bytes"
+
+
+def test_import_to_resolve_groups_lan_files_under_arkiv_bin(monkeypatch):
+    """With bin_name set (LAN download), clips land in an 'Arkiv' bin, never a
+    meaningless 'media-in' bin derived from the server's relative path."""
+    mod = _load(monkeypatch)
+    monkeypatch.setattr(mod, "download_metadata_csv", lambda *a, **k: None)
+
+    class _Bin:
+        def __init__(self, name):
+            self.name = name
+
+        def GetName(self):
+            return self.name
+
+        def GetSubFolderList(self):
+            return []
+
+    class _Clip:
+        def __init__(self, p):
+            self._p = p
+
+        def GetName(self):
+            import os
+            return os.path.basename(self._p)
+
+    class _MediaPool:
+        def __init__(self):
+            self.bins = []
+
+        def GetRootFolder(self):
+            return _Bin("Master")
+
+        def GetSubFolderList(self):
+            return []
+
+        def SetCurrentFolder(self, b):
+            pass
+
+        def AddSubFolder(self, parent, name):
+            b = _Bin(name)
+            self.bins.append(b)
+            return b
+
+        def ImportMedia(self, paths):
+            return [_Clip(p) for p in paths]
+
+    class _Project:
+        def GetMediaPool(self):
+            return _MediaPool()
+
+    class _PM:
+        def GetCurrentProject(self):
+            return _Project()
+
+    class _Resolve:
+        def GetProjectManager(self):
+            return _PM()
+
+    mp = _MediaPool()
+    monkeypatch.setattr(_Project, "GetMediaPool", lambda self: mp)
+
+    ok = mod.import_to_resolve(
+        _Resolve(), ["/tmp/arkiv_import/42_clip.mp4"], bin_name="Arkiv"
+    )
+    assert ok is True
+    assert any(b.GetName() == "Arkiv" for b in mp.bins)
+    assert not any(b.GetName() == "media-in" for b in mp.bins)
+

--- a/tests/test_ingest_upload_dedup.py
+++ b/tests/test_ingest_upload_dedup.py
@@ -1,0 +1,109 @@
+"""Upload collision-safety (the "keep both snow.mp4" fix).
+
+The upload endpoint must never overwrite an existing file on disk, nor an
+already-indexed media row at that path. A same-name re-upload is renamed
+(<stem>__<YYYYMMDD-HHMMSS><ext>) so both clips survive instead of the original
+being clobbered + then SKIPped by ingest (which would lose both).
+"""
+import pytest
+
+
+def _upload(client, ri, name, data):
+    return client.post(
+        "/api/ingest/upload",
+        files=[("files", (name, data, "video/mp4"))],
+    )
+
+
+def test_upload_fresh_name_is_not_renamed(fastapi_client, tmp_path, monkeypatch):
+    import routers.ingest as ri
+
+    upload_dir = tmp_path / "media-in"
+    upload_dir.mkdir()
+    monkeypatch.setattr(ri, "_UPLOAD_DIR", upload_dir)
+    monkeypatch.setattr(ri, "_bg_ingest", lambda *a, **k: None)  # skip heavy ingest
+
+    r = _upload(fastapi_client, ri, "fresh.mp4", b"\x00dcIMB" + b"x" * 100)
+    assert r.status_code == 202, r.text
+    body = r.json()
+    assert body["saved"] == ["fresh.mp4"]
+    assert body["renamed"] == []
+    assert (upload_dir / "fresh.mp4").read_bytes() == b"\x00dcIMB" + b"x" * 100
+
+
+def test_upload_same_name_keeps_both_and_original(fastapi_client, tmp_path, monkeypatch):
+    import routers.ingest as ri
+    import db
+
+    upload_dir = tmp_path / "media-in"
+    upload_dir.mkdir()
+    monkeypatch.setattr(ri, "_UPLOAD_DIR", upload_dir)
+    monkeypatch.setattr(ri, "_bg_ingest", lambda *a, **k: None)  # skip heavy ingest
+
+    # Pre-existing indexed clip "snow.mp4" — exactly the user's scenario: the
+    # library already holds one snow scene; they upload another named snow.mp4.
+    original_path = str(upload_dir / "snow.mp4")
+    original_bytes = b"\x00dcIMB" + b"ORIGINAL-snow"  # 1st snow scene
+    (upload_dir / "snow.mp4").write_bytes(original_bytes)
+    with db.get_conn() as conn:
+        conn.execute(
+            "INSERT INTO media (path, filename) VALUES (?, ?)",
+            (original_path, "snow.mp4"),
+        )
+
+    # Two distinct uploads, both named snow.mp4 (2nd + 3rd snow scenes).
+    content_a = b"\x00dcIMB" + b"SECOND-snow"
+    content_b = b"\x00dcIMB" + b"THIRD-snow"
+    r_a = _upload(fastapi_client, ri, "snow.mp4", content_a)
+    r_b = _upload(fastapi_client, ri, "snow.mp4", content_b)
+    assert r_a.status_code == 202 and r_b.status_code == 202, (r_a.text, r_b.text)
+
+    saved_a = r_a.json()["saved"][0]
+    saved_b = r_b.json()["saved"][0]
+    # Both must be renamed (timestamp suffix) — neither clobbered the original.
+    assert saved_a.startswith("snow__") and saved_b.startswith("snow__")
+    assert saved_a != saved_b  # distinct names
+    assert r_a.json()["renamed"] == [{"from": "snow.mp4", "to": saved_a}]
+    assert r_b.json()["renamed"] == [{"from": "snow.mp4", "to": saved_b}]
+
+    # Disk holds THREE distinct files; the original is intact.
+    on_disk = {f.name: f.read_bytes() for f in upload_dir.iterdir()}
+    assert len(on_disk) == 3
+    assert on_disk["snow.mp4"] == original_bytes          # 1st scene untouched
+    assert on_disk[saved_a] == content_a                  # 2nd scene
+    assert on_disk[saved_b] == content_b                  # 3rd scene
+
+
+def test_upload_two_same_name_in_one_request(fastapi_client, tmp_path, monkeypatch):
+    import routers.ingest as ri
+    import db
+
+    upload_dir = tmp_path / "media-in"
+    upload_dir.mkdir()
+    monkeypatch.setattr(ri, "_UPLOAD_DIR", upload_dir)
+    monkeypatch.setattr(ri, "_bg_ingest", lambda *a, **k: None)
+
+    original_path = str(upload_dir / "snow.mp4")
+    with db.get_conn() as conn:
+        conn.execute(
+            "INSERT INTO media (path, filename) VALUES (?, ?)",
+            (original_path, "snow.mp4"),
+        )
+
+    data1 = b"\x00dcIMB" + b"one"
+    data2 = b"\x00dcIMB" + b"two"
+    r = fastapi_client.post(
+        "/api/ingest/upload",
+        files=[
+            ("files", ("snow.mp4", data1, "video/mp4")),
+            ("files", ("snow.mp4", data2, "video/mp4")),
+        ],
+    )
+    assert r.status_code == 202, r.text
+    saved = r.json()["saved"]
+    assert len(saved) == 2
+    assert all(s.startswith("snow__") for s in saved)
+    assert saved[0] != saved[1]
+    on_disk = {f.name: f.read_bytes() for f in upload_dir.iterdir()}
+    assert on_disk[saved[0]] == data1
+    assert on_disk[saved[1]] == data2

--- a/tests/test_r5_25_router_ingest.py
+++ b/tests/test_r5_25_router_ingest.py
@@ -39,6 +39,7 @@ def test_router_owns_exactly_the_ingest_routes():
         ("/api/ingest/engines", "GET"),
         ("/api/ingest/scan", "POST"),
         ("/api/ingest", "POST"),
+        ("/api/ingest/upload", "POST"),
         ("/api/media/{media_id}/reingest", "POST"),
         ("/ws/ingest", "WS"),
         ("/api/ingest/ws", "POST"),

--- a/tests/test_r5_25_router_media.py
+++ b/tests/test_r5_25_router_media.py
@@ -24,6 +24,8 @@ _EXPECTED_ROUTES = {
     ("/api/media/facets/shoot-date", "GET"),
     ("/api/media", "GET"),
     ("/api/media/{media_id}", "GET"),
+    ("/api/media/{media_id}", "DELETE"),
+    ("/api/media/bulk-delete", "POST"),
     ("/api/media/{media_id}/waveform", "GET"),
     ("/api/media/{media_id}/scenes", "GET"),
     ("/api/media/{media_id}/segments", "GET"),
@@ -104,3 +106,28 @@ def test_media_routes_mounted_and_auth_guarded(server_module):
         assert c.get("/api/media/pool").status_code == 401
         # a bogus sibling path is a genuine 404 (nothing is over-matching)
         assert c.get("/api/mediazz").status_code == 404
+
+
+def test_media_detail_returns_manual_and_auto_tags(fastapi_client, sample_record, tmp_db):
+    """Regression: get_media_detail must surface BOTH manual (user-added) and
+    auto (vision) tags. The old code filtered every tag against the auto
+    frame-tag top-N set, which silently dropped manual tags (and any auto tag
+    not in the top-N) from the inspector."""
+    import db as dbmod
+
+    rec = sample_record()
+    dbmod.upsert(rec)
+    with dbmod.get_conn() as conn:
+        mid = conn.execute(
+            "SELECT id FROM media WHERE path=?", (rec["path"],)
+        ).fetchone()["id"]
+    dbmod.add_tag(mid, "manual_tag", source="manual")
+    dbmod.add_tag(mid, "auto_tag", source="auto")
+
+    r = fastapi_client.get(f"/api/media/{mid}")
+    assert r.status_code == 200
+    tags = r.json().get("tags", [])
+    sources = {t.get("source") for t in tags}
+    # Both a hand-added (manual) and a vision (auto) tag must reach the UI.
+    assert "manual" in sources
+    assert "auto" in sources

--- a/tests/test_search_blend.py
+++ b/tests/test_search_blend.py
@@ -1,0 +1,77 @@
+"""Search-fix regression tests (Direction 2: blend + stable pagination).
+
+Covers the two bugs that made search feel broken:
+  • `total` used to be windowed by `offset+limit`, so the first page reported
+    e.g. 50 and hid every later page behind a false "that's all".
+  • Literal filename/transcript/tag matches (the `text` bucket) were skipped
+    whenever the semantic pass already filled the window — a clip that LITERALLY
+    contained the query term could be invisible.
+
+These run against a seeded tmp DB with a monkeypatched `vectordb.search` so the
+semantic bucket is small and deterministic, forcing the lexical bucket to surface.
+"""
+import db as db_mod
+import vectordb as vdb
+
+
+def _seed(conn):
+    ids = []
+    for i in range(1, 13):
+        # ids 1-3 match by filename; ids 4-6 match by transcript; 7-12 no match.
+        fn = "clip_ZZZTERM_{0}.mp4".format(i) if i <= 3 else "clip_{0}.mp4".format(i)
+        tr = "transcript with ZZZTERM text {0}".format(i) if 4 <= i <= 6 else "transcript {0}".format(i)
+        cur = conn.execute(
+            "INSERT INTO media (path, filename, transcript, ext, lang) VALUES (?,?,?,?,?)",
+            ("/p/{0}.mp4".format(i), fn, tr, ".mp4", "zh"),
+        )
+        ids.append(cur.lastrowid)
+    conn.commit()
+    return ids
+
+
+def test_search_blend_semantic_and_lexical_and_pagination(fastapi_client, monkeypatch):
+    with db_mod.get_conn() as conn:
+        ids = _seed(conn)
+
+    # Semantic bucket returns ONLY ids 1-3, so lexical (4-6) must still surface.
+    def fake_search(q, n_results=10):
+        return [
+            {"media_id": ids[j], "score": round(0.9 - j * 0.1, 3), "excerpt": "sem {0}".format(j)}
+            for j in range(3)
+        ]
+
+    monkeypatch.setattr(vdb, "search", fake_search)
+
+    p0 = fastapi_client.get("/api/media", params={"q": "ZZZTERM", "limit": 2, "offset": 0}).json()
+    p1 = fastapi_client.get("/api/media", params={"q": "ZZZTERM", "limit": 2, "offset": 2}).json()
+    p2 = fastapi_client.get("/api/media", params={"q": "ZZZTERM", "limit": 2, "offset": 4}).json()
+
+    # stable, offset-independent total
+    assert p0["total"] == 6
+    assert p0["total"] == p1["total"] == p2["total"]
+    # pagination slices correctly
+    assert [len(p["items"]) for p in (p0, p1, p2)] == [2, 2, 2]
+    # both match buckets present + lexical literal matches surfaced
+    types = set()
+    for p in (p0, p1, p2):
+        for it in p["items"]:
+            assert "match_type" in it
+            types.add(it["match_type"])
+    assert "semantic" in types and "text" in types
+    text_ids = [it["id"] for p in (p0, p1, p2) for it in p["items"] if it["match_type"] == "text"]
+    assert set(text_ids) == set(ids[3:6])
+
+
+def test_health_exposes_embeddings_coverage(fastapi_client):
+    with db_mod.get_conn() as conn:
+        _seed(conn)
+    r = fastapi_client.get("/api/health")
+    assert r.status_code in (200, 503)  # unauthenticated; ollama may be down in CI
+    body = r.json()
+    assert "embeddings" in body
+    emb = body["embeddings"]
+    assert {"total_media", "embedded_media", "coverage"} <= set(emb.keys())
+    # 12 seeded rows, none embedded yet → 0% coverage
+    assert emb["total_media"] == 12
+    assert emb["embedded_media"] == 0
+    assert emb["coverage"] == 0.0

--- a/transcribe.py
+++ b/transcribe.py
@@ -75,6 +75,18 @@ def _non_mac_backend() -> str:
     force the legacy path."""
     return os.getenv("ARKIV_TRANSCRIBE_BACKEND", "faster-whisper").strip().lower()
 
+
+# Whisper compute device. Defaults to "cuda" (the GPU dev box). On a GPU-less
+# host — e.g. the remote-Ollama Docker deploy running on a CPU-only machine —
+# faster-whisper would otherwise try CUDA and crash with "CUDA driver version
+# is insufficient for CUDA runtime version". Set ARKIV_WHISPER_DEVICE=cpu there.
+WHISPER_DEVICE = os.getenv("ARKIV_WHISPER_DEVICE", "cuda").strip().lower()
+
+# float16 is only efficient on CUDA. On CPU, faster-whisper/ctranslate2 reject
+# it ("target device or backend do not support efficient float16 computation"),
+# so fall back to int8 — same accuracy for transcription, ~2x slower but it runs.
+WHISPER_COMPUTE_TYPE = "int8" if WHISPER_DEVICE == "cpu" else "float16"
+
 # ── Model Singletons ────────────────────────────────────────────────────────
 WHISPER_GUARD_ACTIVE_MODE = WHISPER_GUARD_DEFAULT_MODE
 WHISPER_GUARD_ACTIVE_LAYER = WHISPER_GUARD_LAYERS[WHISPER_GUARD_ACTIVE_MODE]
@@ -308,13 +320,13 @@ def warm_up():
             import whisperx
             _whisperx_model = whisperx.load_model(
                 WHISPER_MODEL,
-                "cuda",
-                compute_type="float16",
+                WHISPER_DEVICE,
+                compute_type=WHISPER_COMPUTE_TYPE,
             )
             print("  [whisperx on cuda]", flush=True)
         else:
             from faster_whisper import WhisperModel
-            _fw_model = WhisperModel(WHISPER_MODEL, device="cuda", compute_type="float16")
+            _fw_model = WhisperModel(WHISPER_MODEL, device=WHISPER_DEVICE, compute_type=WHISPER_COMPUTE_TYPE)
             print("  [faster-whisper on cuda]", flush=True)
 
         _whisper_loaded = True
@@ -540,14 +552,14 @@ def _transcribe_whisperx(wav: str, language: str) -> tuple:
 
     align_model, align_meta = whisperx.load_align_model(
         language_code=lang,
-        device="cuda",
+        device=WHISPER_DEVICE,
     )
     result = whisperx.align(
         result["segments"],
         align_model,
         align_meta,
         audio,
-        "cuda",
+        WHISPER_DEVICE,
         return_char_alignments=False,
     )
 


### PR DESCRIPTION
## Why
Correctness/security issues found self-hosting arkiv:
- Search was capped at 40 and `total` was offset-dependent (broken pagination).
- Upload silently overwrote files and had no token auth.
- `arkiv_resolve_lan.py` hardcoded the API token.

## What
- routers/media.py: lift 40-result cap (stable `total`); fix tag payload drop.
- frontend/src/lib/api.js + routers/ingest.py: upload dedup by hash, `?token` auth.
- routers/misc.py, analytics.py, transcribe.py, SearchLive.svelte: bug fixes.
- resolve_plugin/arkiv_resolve_lan.py: token from ARKIV_TOKEN env (raises if unset); default host localhost (no hardcoded LAN IP).
- tests: test_search_blend, test_r5_25_router_media, test_ingest_upload_dedup, test_r5_25_router_ingest, test_arkiv_resolve_lan.

## Security
No secrets committed; token env-only; no private LAN addresses.