### PR TITLE
fix(ops): persist cross-library 精選集 (bins) in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,15 @@ services:
       - ./media.db:/app/media.db
       - ./chroma_db:/app/chroma_db
       - ./thumbnails:/app/thumbnails
+      # Cross-library 精選集 (bins.py) persistence. Default storage is
+      # ~/.arkiv-bins.json (=/root/.arkiv-bins.json inside the container),
+      # which lives in the container's ephemeral layer — without this bind mount,
+      # `docker compose down` / image rebuild / `--force-recreate` silently
+      # wipes every bin the user has saved. Mount the *directory*, not the file:
+      # bind-mounting a single file that doesn't exist on the host makes Docker
+      # create a directory at the source path, which pollutes ./arkiv_data.
+      # ARKIV_BINS_PATH pins the file inside the mount; bins.py already honours it.
+      - ./arkiv_data/bins:/root/.arkiv-bins
     environment:
       - ARKIV_DB_PATH=/app/media.db
       - ARKIV_CHROMA_PATH=/app/chroma_db
@@ -30,6 +39,8 @@ services:
       # caller full admin with no token. Keep bridge + port mapping.
       - ARKIV_HOST=0.0.0.0
       - ARKIV_PORT=8501
+      # See the ./arkiv_data/bins volume mount above; keep the path in sync.
+      - ARKIV_BINS_PATH=/root/.arkiv-bins/bins.json
     depends_on:
       ollama:
         condition: service_healthy   # F6: wait for ollama READY, not just container-start


### PR DESCRIPTION
## Why

Cross-library 精選集 (`bins.py`) defaults to `~/.arkiv-bins.json`, which inside the container is `/root/.arkiv-bins.json`. That path lives in the container's ephemeral layer — every `docker compose down`, image rebuild, or `--force-recreate` silently wipes every bin the user has saved. `server.py` calls these "persistent named selections" but `docker-compose.yml` did not actually persist them.

`bins.py` already supports `ARKIV_BINS_PATH` (env override for the storage path). The compose file just wasn't using it.

## Fix

Bind-mount the bins directory and pin the file inside it via `ARKIV_BINS_PATH`:

```yaml
volumes:
  # ...existing mounts...
  - ./arkiv_data/bins:/root/.arkiv-bins

environment:
  # ...existing env...
  - ARKIV_BINS_PATH=/root/.arkiv-bins/bins.json
```

The directory is mounted, not the file: bind-mounting a single file that does not exist on the host makes Docker create a *directory* at the source path, which pollutes `./arkiv_data`. Directory mounts behave.

## Verified

Using `arkiv-arkiv:latest` (no rebuild), PR's `docker-compose.yml` + the PR diff applied:

1. `ARKIV_BINS_PATH=/root/.arkiv-bins/bins.json` is injected into the container.
2. `/root/.arkiv-bins` is a Docker bind mount (tmpfs rw).
3. `bins._default_bins_path()` returns the injected path.
4. `bins.create_bin` + `bins.add_items` → host file `./arkiv_data/bins/bins.json` appears with the full JSON.
5. `docker rm -f <container>` + recreate → host file unchanged, `bins.list_bins()` in the new container returns the same `id` + items.

## No code changes

`bins.py` already honoured `ARKIV_BINS_PATH`; this PR only wires the compose side.

## Backward compatibility

- Users who have never created a bin see no behaviour change — the new directory starts empty, `bins.json` is created on first write.
- Users who lost bin data to a prior container rebuild cannot recover it (ephemeral layers don't persist), but they will not lose new data going forward.