### PR TITLE
fix(ops): persist project registry in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,16 @@ services:
       - ./media.db:/app/media.db
       - ./chroma_db:/app/chroma_db
       - ./thumbnails:/app/thumbnails
+      # Project registry (projects.py) persistence. Settings ⇒ Projects ⇒ Add Project
+      # stores the list in ~/.arkiv-projects.json, which inside the container is
+      # /root/.arkiv-projects.json — living in the container's ephemeral layer. Without
+      # this bind mount, `docker compose down` / image rebuild / `--force-recreate`
+      # silently wipes every registered project. Mount the *directory*, not the file:
+      # bind-mounting a single file that doesn't exist on the host makes Docker
+      # create a directory at the source path, which pollutes ./arkiv_data.
+      # ARKIV_PROJECTS_REGISTRY pins the file inside the mount; projects.py already
+      # honours it.
+      - ./arkiv_data/projects:/root/.arkiv-projects
     environment:
       - ARKIV_DB_PATH=/app/media.db
       - ARKIV_CHROMA_PATH=/app/chroma_db
@@ -30,6 +40,8 @@ services:
       # caller full admin with no token. Keep bridge + port mapping.
       - ARKIV_HOST=0.0.0.0
       - ARKIV_PORT=8501
+      # See the ./arkiv_data/projects volume mount above; keep the path in sync.
+      - ARKIV_PROJECTS_REGISTRY=/root/.arkiv-projects/projects.json
     depends_on:
       ollama:
         condition: service_healthy   # F6: wait for ollama READY, not just container-start


### PR DESCRIPTION
## Why

Settings ⇒ Projects ⇒ Add Project stores the project list in `~/.arkiv-projects.json`, which inside the container is `/root/.arkiv-projects.json`. That path lives in the container's ephemeral layer — every `docker compose down`, image rebuild, or `--force-recreate` silently wipes every registered project. `server.py` describes them as "persistent", but `docker-compose.yml` was not actually persisting them.

`projects.py` already supports `ARKIV_PROJECTS_REGISTRY` (env override for the storage path). The compose file just was not wiring it.

## Fix

Bind-mount the projects directory and pin the file inside it via `ARKIV_PROJECTS_REGISTRY`:

```yaml
volumes:
  # ...existing mounts...
  - ./arkiv_data/projects:/root/.arkiv-projects

environment:
  # ...existing env...
  - ARKIV_PROJECTS_REGISTRY=/root/.arkiv-projects/projects.json
```

The directory is mounted, not the file: bind-mounting a single file that does not exist on the host makes Docker create a *directory* at the source path, which pollutes `./arkiv_data`. Directory mounts behave.

## Verified

Using `arkiv-arkiv:latest` (no rebuild), PR's `docker-compose.yml` + the diff applied:

1. `ARKIV_PROJECTS_REGISTRY=/root/.arkiv-projects/projects.json` is injected into the container.
2. `/root/.arkiv-projects` is a Docker bind mount (tmpfs rw).
3. `projects._default_registry_path()` returns the injected path.
4. `projects.add_project(...)` → host file `./arkiv_data/projects/projects.json` appears with the full JSON.
5. `docker rm -f <container>` + recreate → host file unchanged, `projects.list_registry_projects()` in the new container returns the same project name / path / tags.

## No code changes

`projects.py` already honoured `ARKIV_PROJECTS_REGISTRY`; this PR only wires the compose side.

## Backward compatibility

- Users who have never added a project see no behaviour change — the new directory starts empty, `projects.json` is created on first write.
- Users who lost project data to a prior container rebuild cannot recover it (ephemeral layers don't persist), but they will not lose new data going forward.

## Related

Related: #401 (bins persistence — same fix pattern, same root cause).