### PR TITLE
fix(inspector): 瀏覽器不相容編碼可播 + 音頻預覽不再白框

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,9 @@ jobs:
             "fastapi>=0.100.0" "uvicorn>=0.20.0" "pydantic>=2.0,<3" \
             "pillow>=9.0" "requests>=2.28" "xxhash>=2.0.0" "nanoid>=2.0.0" \
             "psutil>=5.9" "whisper-guard>=0.3" numpy mlx-whisper \
+            "python-multipart>=0.0.9" \
             "opencc; python_version >= '3.10'" \
             "mcp>=1.2,<2; python_version >= '3.10'"
-
       - name: Run tests
         run: pytest -q
 
@@ -120,7 +120,7 @@ jobs:
           pip install \
             "fastapi>=0.100.0" "uvicorn>=0.20.0" "pydantic>=2.0,<3" \
             "pillow>=9.0" "requests>=2.28" "xxhash>=2.0.0" "nanoid>=2.0.0" \
-            "psutil>=5.9" "whisper-guard>=0.3" numpy "mcp<2"
+            "psutil>=5.9" "whisper-guard>=0.3" numpy "python-multipart>=0.0.9" "mcp<2"
       - name: Run Windows correctness tests (offload deny-policy + MCP stdio + settings scope)
         shell: bash
         # test_settings_g5.py joins this leg for the same reason the leg exists:
@@ -157,6 +157,7 @@ jobs:
             "fastapi>=0.100.0" "uvicorn>=0.20.0" "pydantic>=2.0,<3" \
             "pillow>=9.0" "requests>=2.28" "xxhash>=2.0.0" "nanoid>=2.0.0" \
             "psutil>=5.9" "whisper-guard>=0.3" numpy mlx-whisper \
+            "python-multipart>=0.0.9" \
             "opencc; python_version >= '3.10'" "mcp>=1.2,<2"
       - name: Coverage
         run: pytest -q -m "not subprocess_stdio" --cov=. --cov-config=pyproject.toml --cov-report=term:skip-covered --cov-fail-under=55

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,14 @@ OVERNIGHT_UI_BUILD.md
 .testdata/
 frontend/vite.config.tailnet.js
 frontend/vite.config.dev8502.js
+
+# ── Local-only / non-upstream files (private-fork hygiene) ────────────────
+# These carry no value upstream and/or hold secrets; never commit them.
+# (gitignore has no inline comments — keep the note above, pattern below)
+devdoc
+CODEX_RESULT.md
+docs/*handover*
+.opencode
+agent-skill-creator
+# Settings overrides per-install — never commit local state.
+settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,13 @@ OVERNIGHT_UI_BUILD.md
 .testdata/
 frontend/vite.config.tailnet.js
 frontend/vite.config.dev8502.js
+
+# ── Local-only / non-upstream files (private-fork hygiene) ────────────────
+# These carry no value upstream and/or hold secrets; never commit them.
+# (gitignore has no inline comments — keep the note above, pattern below)
+devdoc
+CODEX_RESULT.md
+docs/*handover*
+.opencode
+agent-skill-creator
+settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -87,12 +87,5 @@ OVERNIGHT_UI_BUILD.md
 frontend/vite.config.tailnet.js
 frontend/vite.config.dev8502.js
 
-# ── Local-only / non-upstream files (private-fork hygiene) ────────────────
-# These carry no value upstream and/or hold secrets; never commit them.
-# (gitignore has no inline comments — keep the note above, pattern below)
-devdoc
-CODEX_RESULT.md
-docs/*handover*
-.opencode
-agent-skill-creator
+# Settings overrides per-install — never commit local state.
 settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
   - 過去 `<video>`/`<audio>` 直接把 `/api/stream/{id}` 設給 `src`：對 ProRes/HEVC 收到的
     `409 {"need_proxy":true}` 完全沒處理，對 mjpeg/qtrle 則靜默收到解不開的原始檔，都只顯示
     空白/播不出（含帶聲軌影片「音頻沒播放按鈕」的現象）。
-  - stream 路由現在對任何不在瀏覽器可播清單的視頻編碼（mjpeg/qtrle/prores/hevc…）統一回
-    `409 need_proxy`；h264/vp9/av1 仍直接播，純音頻（NULL）走原回退路徑不誤觸。
+  - stream 路由現在對**影片**任何不在瀏覽器可播清單的視頻編碼（mjpeg/qtrle/prores/hevc…）統一回
+    `409 need_proxy`；**圖片/音頻不受影響**（圖片由副檔名 `mediatypes.IMAGE_EXT` 推導，其
+    mjpeg/png/jpeg 編碼不會誤觸 409）。h264/vp9/av1 影片仍直接播，純音頻（NULL）走原回退路徑不誤觸。
   - Inspector 偵測媒體錯誤後顯示「生成代理並播放」，點擊即 `POST /api/proxy/build/{id}`、
     輪詢至代理就緒後自動重載播放器。
   - 純音頻檔本身可播，但舊實作把原生 `<audio controls>` 貼在預覽盒底部，瀏覽器/WebView 的

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### Fixed
+
+- **Inspector 現在能播出瀏覽器不相容編碼的素材，且音頻預覽不再是白框。**
+  - 過去 `<video>`/`<audio>` 直接把 `/api/stream/{id}` 設給 `src`：對 ProRes/HEVC 收到的
+    `409 {"need_proxy":true}` 完全沒處理，對 mjpeg/qtrle 則靜默收到解不開的原始檔，都只顯示
+    空白/播不出（含帶聲軌影片「音頻沒播放按鈕」的現象）。
+  - stream 路由現在對任何不在瀏覽器可播清單的視頻編碼（mjpeg/qtrle/prores/hevc…）統一回
+    `409 need_proxy`；h264/vp9/av1 仍直接播，純音頻（NULL）走原回退路徑不誤觸。
+  - Inspector 偵測媒體錯誤後顯示「生成代理並播放」，點擊即 `POST /api/proxy/build/{id}`、
+    輪詢至代理就緒後自動重載播放器。
+  - 純音頻檔本身可播，但舊實作把原生 `<audio controls>` 貼在預覽盒底部，瀏覽器/WebView 的
+    原生 audio 控制條是白色長條，在深色預覽上看起來像白框、易被忽略；現改為自訂主題化播放器
+    （置中圓形播放/暫停鈕 + 隱藏原生 audio + 時間碼）。
+  - （codec.py / routers/misc.py:63 / frontend/src/lib/Inspector.svelte / MainLive.svelte /
+    api.js 的 `buildProxyOne`/`getProxyStatus`）
+
 ## v1.1.2 - 2026-08-24
 
 **Nothing in this release changes what arkiv does.** It exists so that three changes to the

--- a/auth.py
+++ b/auth.py
@@ -27,6 +27,7 @@ SCOPES = frozenset((
     "ingest_write",
     "chat_read",
     "chat_write",
+    "media_delete",
     "admin",
 ))
 

--- a/codec.py
+++ b/codec.py
@@ -20,6 +20,23 @@ PROXY_CODECS = frozenset({
     "prores", "ap4h", "ap4x", "apch", "apcn", "apcs", "apco",
 })
 
+# Video codecs a browser <video>/<audio> element can actually decode + demux
+# (Chrome / Safari / WKWebView). Anything NOT in this set needs an H.264 proxy
+# before it can play in the Inspector — this is a SUPERSET of PROXY_CODECS so the
+# stream endpoint can return one consistent `409 need_proxy` signal for every
+# browser-incompatible codec (e.g. mjpeg / qtrle), not just HEVC/ProRes.
+BROWSER_PLAYABLE_VIDEO = frozenset({
+    "h264", "avc1", "avc3",
+    "mpeg4", "m4v",
+    "vp8", "vp9", "av1",
+    "theora",
+})
+
+
+def is_browser_playable_video(codec_name: Optional[str]) -> bool:
+    """True if a browser can decode this video codec directly (proxy not needed)."""
+    return (codec_name or "").strip().lower() in BROWSER_PLAYABLE_VIDEO
+
 # Containers a browser cannot demux, whatever is inside them. AVCHD camcorder
 # footage (.mts/.m2ts) is almost always plain H.264 — so the codec check says
 # "playable", we hand over the original bytes labelled video/mp4, and the

--- a/config.py
+++ b/config.py
@@ -93,6 +93,20 @@ THUMBNAILS_DIR = _validate_writable_path(
 PROXIES_DIR = _validate_writable_path(
     Path(os.getenv("ARKIV_PROXIES_DIR", str(_ARKIV_DIR / "proxies"))), "ARKIV_PROXIES_DIR"
 )
+# Phase 14.5: trash (recycle bin) for deleted media originals — a destructive
+# delete moves the source file here instead of unlinking, so a mistaken removal
+# is recoverable for ARKIV_TRASH_TTL_DAYS days.
+TRASH_DIR = _ARKIV_DIR / "trash"
+# Extra filesystem roots the delete endpoint is permitted to physically remove
+# files from (comma-separated). Empty by default → only PROJECT_ROOT is allowed,
+# so offload cold-storage / external-absolute / federated paths are metadata-only.
+MEDIA_ROOTS = [
+    p.strip() for p in os.getenv("ARKIV_MEDIA_ROOTS", "").split(",") if p.strip()
+]
+TRASH_TTL_DAYS = int(os.getenv("ARKIV_TRASH_TTL_DAYS", "30"))
+# Waveform cache lives under BASE_DIR/waveforms (see routers/media.py waveform);
+# kept here so delete + prune can clean it by media id.
+WAVEFORMS_DIR = BASE_DIR / "waveforms"
 # Reviewed library tag alias map (tag_aliases.py) + its proposal staging file.
 # Plain JSON in the project data dir — reviewable, version-controllable, per-project.
 TAG_ALIASES_PATH = _ARKIV_DIR / "tag_aliases.json"

--- a/db.py
+++ b/db.py
@@ -1079,6 +1079,13 @@ def set_canonical_tags(media_id: int, tags: list) -> None:
             "UPDATE media SET canonical_tags=? WHERE id=?",
             (_json.dumps(tags, ensure_ascii=False), media_id),
         )
+    # Re-embed so the new canonical tags are immediately searchable (best-effort;
+    # an Ollama outage must not fail the tag write).
+    try:
+        import embed
+        embed.reindex_media(media_id)
+    except Exception as _e:
+        print("[warn] reindex after set_canonical_tags failed (non-fatal):", _e)
 
 
 def get_stats() -> Dict:
@@ -1137,6 +1144,24 @@ def get_tags(media_id: int) -> List[Dict]:
             (media_id,),
         ).fetchall()
         return [dict(r) for r in rows]
+
+
+def get_manual_tags_by_ids(ids: List[int]) -> Dict[int, List[str]]:
+    """Bulk fetch manual tags (source='manual') keyed by media_id. Used by the
+    vector index so user-authored tags enter semantic search (arkiv handover)."""
+    out = {int(i): [] for i in ids}
+    if not ids:
+        return out
+    placeholders = ",".join("?" * len(ids))
+    with get_conn() as conn:
+        rows = conn.execute(
+            "SELECT media_id, name FROM tags WHERE source='manual' "
+            "AND media_id IN (%s)" % placeholders,
+            tuple(int(i) for i in ids),
+        ).fetchall()
+    for r in rows:
+        out.setdefault(int(r["media_id"]), []).append(r["name"])
+    return out
 
 
 def add_tag(media_id: int, name: str, source: str = "manual", _conn=None):

--- a/db.py
+++ b/db.py
@@ -130,6 +130,22 @@ def dedup_path_variants(path: str) -> List[str]:
     return variants
 
 
+def path_is_indexed(rel_or_abs_path: str) -> bool:
+    """True if a media row already references this path (in any of the stored
+    abs/rel/backslash forms). Used by the upload path to avoid overwriting an
+    already-ingested file: a same-name re-upload must be renamed, not clobber
+    the original on disk AND then get SKIPped by ingest (which would lose both)."""
+    variants = dedup_path_variants(str(rel_or_abs_path))
+    with get_conn() as conn:
+        rows = conn.execute(
+            "SELECT 1 FROM media WHERE path IN ({0}) LIMIT 1".format(
+                ",".join("?" * len(variants))
+            ),
+            variants,
+        ).fetchone()
+    return rows is not None
+
+
 def canonical_stored_path(stored: str) -> str:
     """Canonicalise a STORED path value to forward-slash relative. to_relative alone
     can't convert a backslash-relative path ('media\\clip.mp4' is neither absolute
@@ -506,6 +522,21 @@ def init_db():
                 value      TEXT,
                 updated_at TEXT NOT NULL DEFAULT (datetime('now')),
                 UNIQUE(scope, key)
+            )
+        """)
+        # Phase 14.5: recycle bin for deleted media originals. The source file is
+        # moved here (not unlinked) so a mistaken delete is recoverable until it
+        # expires (see media_delete.purge_trash). metadata-only deletes (external
+        # paths) also record a row with trash_path = '' so the event is auditable.
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS trash (
+                id            INTEGER PRIMARY KEY,
+                media_id      INTEGER,
+                filename      TEXT,
+                original_path TEXT,
+                trash_path    TEXT,
+                deleted_at    TEXT NOT NULL DEFAULT (datetime('now')),
+                expires_at    TEXT
             )
         """)
         # ── library provenance ─────────────────────────────────────────────
@@ -1336,6 +1367,115 @@ def delete_media(media_id: int, _conn=None):
         return _do(conn)
 
 
+# ── Trash (recycle bin) + orphan reconcile (Phase 14.5) ───────────────────────
+
+def trash_media(media_id: int, filename: str, original_path: str, trash_path: str,
+                ttl_days: int = 30) -> None:
+    """Record a deleted media's original in the recycle bin. `trash_path` is the
+    path it was moved to, or '' when only metadata was removed (external path)."""
+    import datetime as _dt
+    deleted_at = _dt.datetime.now(_dt.timezone.utc).isoformat()
+    expires_at = (
+        _dt.datetime.now(_dt.timezone.utc)
+        + _dt.timedelta(days=ttl_days)
+    ).isoformat()
+    with get_conn() as conn:
+        conn.execute(
+            "INSERT INTO trash (media_id, filename, original_path, trash_path, "
+            "deleted_at, expires_at) VALUES (?,?,?,?,?,?)",
+            (media_id, filename, original_path, trash_path, deleted_at, expires_at),
+        )
+
+
+def list_trash() -> list:
+    with get_conn() as conn:
+        rows = conn.execute(
+            "SELECT id, media_id, filename, original_path, trash_path, "
+            "deleted_at, expires_at FROM trash ORDER BY deleted_at DESC"
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def purge_trash(ttl_days: int = 30) -> int:
+    """Delete trash entries older than `ttl_days` AND remove the moved file on
+    disk. Returns the number of purged entries."""
+    import datetime as _dt
+    import os as _os
+    import shutil as _shutil
+    cutoff = (_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(days=ttl_days)).isoformat()
+    purged = 0
+    with get_conn() as conn:
+        rows = conn.execute(
+            "SELECT id, trash_path FROM trash WHERE deleted_at <= ? AND trash_path <> ''",
+            (cutoff,),
+        ).fetchall()
+        for r in rows:
+            tp = r["trash_path"]
+            try:
+                if _os.path.exists(tp):
+                    if _os.path.isdir(tp):
+                        _shutil.rmtree(tp, ignore_errors=True)
+                    else:
+                        _os.remove(tp)
+            except OSError:
+                pass
+            conn.execute("DELETE FROM trash WHERE id=?", (r["id"],))
+            purged += 1
+    return purged
+
+
+def iter_missing() -> list:
+    """Return media rows whose resolved source file no longer exists on disk
+    (the 'ghost' records left by manually-deleted files). Each item is a dict
+    with at least id/path/filename so the caller can reconcile them."""
+    out = []
+    with get_conn() as conn:
+        rows = conn.execute(
+            "SELECT id, path, filename FROM media"
+        ).fetchall()
+    for r in rows:
+        p = r["path"]
+        if not p:
+            continue
+        try:
+            resolved = resolve_path(p)
+        except ValueError:
+            continue
+        if not Path(resolved).exists():
+            out.append({"id": r["id"], "path": p, "filename": r["filename"]})
+    return out
+
+
+def restore_trash(trash_id: int) -> str:
+    """Move a trashed original back next to its original path (or media-in if the
+    parent is gone). Returns the destination path so the caller can re-ingest."""
+    import shutil as _shutil
+    from pathlib import Path as _Path
+    with get_conn() as conn:
+        row = conn.execute(
+            "SELECT id, media_id, filename, original_path, trash_path FROM trash WHERE id=?",
+            (trash_id,),
+        ).fetchone()
+        if row is None:
+            raise ValueError("no such trash entry: %s" % trash_id)
+        src = row["trash_path"]
+        if not src or not Path(src).exists():
+            raise ValueError("trashed file missing: %s" % src)
+        dest_dir = Path(row["original_path"]).parent
+        if not dest_dir.exists():
+            dest_dir = PROJECT_ROOT / "media-in"
+            dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / row["filename"]
+        # don't clobber an existing file with the same name
+        if dest.exists():
+            from datetime import datetime as _dt
+            stamp = _dt.now().strftime("%Y%m%d-%H%M%S")
+            dest = dest_dir / ("%s__%s" % (stamp, row["filename"]))
+        _shutil.move(str(src), str(dest))
+        conn.execute("DELETE FROM trash WHERE id=?", (trash_id,))
+        return str(dest)
+
+
 # ── Enhanced Queries (Phase 4 UI) ─────────────────────────────────────────────
 
 # `media.creation_date` is the SHOOT date and it is stored raw, in whatever shape
@@ -1486,6 +1626,8 @@ def _build_filter_clause(
         clauses.append("ext IN " + mediatypes.sql_in_literal(mediatypes.VIDEO_EXT))
     elif media_type == "audio":
         clauses.append("ext IN " + mediatypes.sql_in_literal(mediatypes.AUDIO_EXT))
+    elif media_type == "image":
+        clauses.append("ext IN " + mediatypes.sql_in_literal(mediatypes.IMAGE_EXT))
     shot_sql, shot_params = shot_window_clause(shot_year=shot_year, shot_date=shot_date)
     if shot_sql:
         clauses.append(shot_sql)

--- a/docker-compose.remote-ollama.yml
+++ b/docker-compose.remote-ollama.yml
@@ -1,0 +1,41 @@
+# arkiv — Docker Compose (remote Ollama variant, EXAMPLE)
+#
+# Run arkiv on one host, point it at an Ollama on another host.
+# No LAN address is baked in — set ARKIV_OLLAMA_URL for your deployment.
+# Data is bind-mounted so a rebuild never loses media.db / chroma / thumbnails.
+#
+# Start:
+#   ARKIV_OLLAMA_URL=http://your-ollama-host:11434 \
+#     docker compose -f docker-compose.remote-ollama.yml up -d --build
+
+services:
+  arkiv:
+    build: .
+    ports:
+      - "8501:8501"
+    env_file:
+      - .env
+    volumes:
+      - ./media.db:/app/media.db
+      - ./chroma_db:/app/chroma_db
+      - ./thumbnails:/app/thumbnails
+      - ./clips:/app/clips
+      - ./arkiv_data:/app/.arkiv
+      - ./hf_cache:/root/.cache/huggingface
+      - ./media-in:/app/media-in:rw
+    environment:
+      - ARKIV_DB_PATH=/app/media.db
+      - ARKIV_CHROMA_PATH=/app/chroma_db
+      - ARKIV_THUMBNAILS_DIR=/app/thumbnails
+      # Point this at your Ollama; override per-deploy via env (no address baked in).
+      - ARKIV_OLLAMA_URL=${ARKIV_OLLAMA_URL:-http://ollama:11434}
+      - ARKIV_EMBED_MODEL=bge-m3
+      - ARKIV_VISION_MODEL=qwen2.5vl:7b
+      - ARKIV_WHISPER_MODEL=large-v3-turbo
+      # Force CPU whisper in containers without a GPU.
+      - ARKIV_WHISPER_DEVICE=cpu
+      # Disable Xet CAS downloads (public models otherwise 401 via cas-server).
+      - HF_HUB_DISABLE_XET=1
+      - ARKIV_HOST=0.0.0.0
+      - ARKIV_PORT=8501
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,15 @@ services:
       - ./media.db:/app/media.db
       - ./chroma_db:/app/chroma_db
       - ./thumbnails:/app/thumbnails
+      # Cross-library 精選集 (bins.py) persistence. Default storage is
+      # ~/.arkiv-bins.json (=/root/.arkiv-bins.json inside the container),
+      # which lives in the container's ephemeral layer — without this bind mount,
+      # `docker compose down` / image rebuild / `--force-recreate` silently
+      # wipes every bin the user has saved. Mount the *directory*, not the file:
+      # bind-mounting a single file that doesn't exist on the host makes Docker
+      # create a directory at the source path, which pollutes ./arkiv_data.
+      # ARKIV_BINS_PATH pins the file inside the mount; bins.py already honours it.
+      - ./arkiv_data/bins:/root/.arkiv-bins
     environment:
       - ARKIV_DB_PATH=/app/media.db
       - ARKIV_CHROMA_PATH=/app/chroma_db
@@ -30,6 +39,8 @@ services:
       # caller full admin with no token. Keep bridge + port mapping.
       - ARKIV_HOST=0.0.0.0
       - ARKIV_PORT=8501
+      # See the ./arkiv_data/bins volume mount above; keep the path in sync.
+      - ARKIV_BINS_PATH=/root/.arkiv-bins/bins.json
     depends_on:
       ollama:
         condition: service_healthy   # F6: wait for ollama READY, not just container-start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,10 +86,15 @@ services:
     # macOS: GPU passthrough not needed (Ollama uses Metal natively on host)
     restart: unless-stopped
 
-  # HTTP/SSE MCP server (LAN build): exposes arkiv's read-only tools to MCP
-  # clients (Claude Desktop/Code) over SSE on 8502. Reuses the already-built
-  # arkiv-arkiv image and the same token library (media.db) — no extra auth.
+  # HTTP/SSE MCP server: exposes arkiv's read-only tools to MCP clients
+  # (Claude Desktop/Code) over SSE on 8502. Reuses the already-built arkiv-arkiv
+  # image and the same token library (media.db) — no extra auth.
   # Point ARKIV_OLLAMA_URL at your Ollama; override per-deploy via env.
+  #
+  # Loopback-bound by default (127.0.0.1): a LAN-facing MCP endpoint must be an
+  # opt-in decision, not a `docker compose up` default. To expose it:
+  #   1. set ARKIV_MCP_BIND=0.0.0.0 below, AND
+  #   2. uncomment the ports: mapping and set your own host port.
   arkiv-mcp:
     image: arkiv-arkiv
     command: python mcp_http_server.py
@@ -98,14 +103,14 @@ services:
       - ARKIV_CHROMA_PATH=/app/chroma_db
       - ARKIV_OLLAMA_URL=${ARKIV_OLLAMA_URL:-http://ollama:11434}
       - ARKIV_EMBED_MODEL=bge-m3
-      - ARKIV_MCP_BIND=0.0.0.0
+      - ARKIV_MCP_BIND=127.0.0.1
       - ARKIV_MCP_PORT=8502
     volumes:
       - ./media.db:/app/media.db
       - ./chroma_db:/app/chroma_db
       - ./arkiv_data:/app/.arkiv
-    ports:
-      - "8502:8502"
+    # ports:                       # ← uncomment + set a host port to go LAN-facing
+    #   - "8502:8502"
     restart: unless-stopped
     # Inherited HEALTHCHECK probes localhost:8501 (main app); this service only
     # listens on 8502, so disable it to avoid a permanent unhealthy report.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ./media.db:/app/media.db
       - ./chroma_db:/app/chroma_db
       - ./thumbnails:/app/thumbnails
+<<<<<<< HEAD
       # Cross-library 精選集 (bins.py) persistence. Default storage is
       # ~/.arkiv-bins.json (=/root/.arkiv-bins.json inside the container),
       # which lives in the container's ephemeral layer — without this bind mount,
@@ -28,6 +29,10 @@ services:
       # ARKIV_PROJECTS_REGISTRY pins the file inside the mount; projects.py already
       # honours it.
       - ./arkiv_data/projects:/root/.arkiv-projects
+      # Ingest drop folder AND HTTP upload target. The upload endpoint
+      # (POST /api/ingest/upload) writes the file here (rw) and auto-ingests it;
+      # you can also drop files on the host and point the UI at /app/media-in.
+      - ./media-in:/app/media-in:rw
     environment:
       - ARKIV_DB_PATH=/app/media.db
       - ARKIV_CHROMA_PATH=/app/chroma_db
@@ -49,10 +54,15 @@ services:
       # caller full admin with no token. Keep bridge + port mapping.
       - ARKIV_HOST=0.0.0.0
       - ARKIV_PORT=8501
+<<<<<<< HEAD
       # See the ./arkiv_data/bins volume mount above; keep the path in sync.
       - ARKIV_BINS_PATH=/root/.arkiv-bins/bins.json
       # See the ./arkiv_data/projects volume mount above; keep the path in sync.
       - ARKIV_PROJECTS_REGISTRY=/root/.arkiv-projects/projects.json
+      # Upload concurrency tuning (defaults baked in; override to taste):
+      # max simultaneous upload handlers, and how long to queue before 429.
+      - ARKIV_UPLOAD_MAX_CONCURRENT=3
+      - ARKIV_UPLOAD_MAX_QUEUE_SEC=300
     depends_on:
       ollama:
         condition: service_healthy   # F6: wait for ollama READY, not just container-start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,5 +86,31 @@ services:
     # macOS: GPU passthrough not needed (Ollama uses Metal natively on host)
     restart: unless-stopped
 
+  # HTTP/SSE MCP server (LAN build): exposes arkiv's read-only tools to MCP
+  # clients (Claude Desktop/Code) over SSE on 8502. Reuses the already-built
+  # arkiv-arkiv image and the same token library (media.db) — no extra auth.
+  # Point ARKIV_OLLAMA_URL at your Ollama; override per-deploy via env.
+  arkiv-mcp:
+    image: arkiv-arkiv
+    command: python mcp_http_server.py
+    environment:
+      - ARKIV_DB_PATH=/app/media.db
+      - ARKIV_CHROMA_PATH=/app/chroma_db
+      - ARKIV_OLLAMA_URL=${ARKIV_OLLAMA_URL:-http://ollama:11434}
+      - ARKIV_EMBED_MODEL=bge-m3
+      - ARKIV_MCP_BIND=0.0.0.0
+      - ARKIV_MCP_PORT=8502
+    volumes:
+      - ./media.db:/app/media.db
+      - ./chroma_db:/app/chroma_db
+      - ./arkiv_data:/app/.arkiv
+    ports:
+      - "8502:8502"
+    restart: unless-stopped
+    # Inherited HEALTHCHECK probes localhost:8501 (main app); this service only
+    # listens on 8502, so disable it to avoid a permanent unhealthy report.
+    healthcheck:
+      disable: true
+
 volumes:
   ollama_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,16 @@ services:
       - ./media.db:/app/media.db
       - ./chroma_db:/app/chroma_db
       - ./thumbnails:/app/thumbnails
+      # Project registry (projects.py) persistence. Settings ⇒ Projects ⇒ Add Project
+      # stores the list in ~/.arkiv-projects.json, which inside the container is
+      # /root/.arkiv-projects.json — living in the container's ephemeral layer. Without
+      # this bind mount, `docker compose down` / image rebuild / `--force-recreate`
+      # silently wipes every registered project. Mount the *directory*, not the file:
+      # bind-mounting a single file that doesn't exist on the host makes Docker
+      # create a directory at the source path, which pollutes ./arkiv_data.
+      # ARKIV_PROJECTS_REGISTRY pins the file inside the mount; projects.py already
+      # honours it.
+      - ./arkiv_data/projects:/root/.arkiv-projects
     environment:
       - ARKIV_DB_PATH=/app/media.db
       - ARKIV_CHROMA_PATH=/app/chroma_db
@@ -30,6 +40,8 @@ services:
       # caller full admin with no token. Keep bridge + port mapping.
       - ARKIV_HOST=0.0.0.0
       - ARKIV_PORT=8501
+      # See the ./arkiv_data/projects volume mount above; keep the path in sync.
+      - ARKIV_PROJECTS_REGISTRY=/root/.arkiv-projects/projects.json
     depends_on:
       ollama:
         condition: service_healthy   # F6: wait for ollama READY, not just container-start

--- a/embed.py
+++ b/embed.py
@@ -10,6 +10,7 @@ Usage:
 """
 from __future__ import annotations
 import argparse
+import json
 import sys
 from datetime import datetime, timezone
 from typing import Dict, List, Tuple
@@ -52,7 +53,27 @@ def get_records_by_ids(ids: List[int]) -> List[Dict]:
                 batch,
             ).fetchall()
             records.extend(dict(r) for r in rows)
+    _attach_search_tags(records)
     return records
+
+
+def _attach_search_tags(records: List[Dict]) -> None:
+    """Normalize canonical_tags (JSON→list) and attach manual_tags (source='manual')
+    onto each record so build_doc_text/build_tag_doc/content_hash include them in
+    the index (arkiv handover: user tags must be searchable)."""
+    if not records:
+        return
+    ids = [r["id"] for r in records]
+    manual_map = db.get_manual_tags_by_ids(ids)
+    for rec in records:
+        ct = rec.get("canonical_tags")
+        if ct and isinstance(ct, str):
+            try:
+                ct = json.loads(ct)
+            except Exception:
+                ct = []
+        rec["canonical_tags"] = ct if isinstance(ct, (list, tuple)) else []
+        rec["manual_tags"] = manual_map.get(rec["id"], [])
 
 
 def get_indexed_media_ids(col) -> set[str]:
@@ -73,23 +94,35 @@ def get_content_signatures() -> Dict[str, Tuple[str, str]]:
     """{str(media_id): (stored_embed_hash, current_content_hash)} for every media.
 
     current_content_hash = vectordb.content_hash over the row's CURRENT source text
-    (build_doc_text). Comparing it to the stored media.embed_hash is how run_embed
-    detects a row whose description/transcript changed AFTER it was embedded — the
-    "向量索引靜默過期" bug — without depending on the caller passing force_ids.
+    (build_doc_text, which now folds in manual + canonical tags). Comparing it to the
+    stored media.embed_hash is how run_embed detects a row whose description/transcript
+    OR tags changed AFTER it was embedded — "向量索引靜默過期" bug — without depending on
+    the caller passing force_ids.
 
-    Pulls ONLY the columns build_doc_text needs (filename, transcript, frame_tags) +
-    embed_hash — deliberately NOT the heavy words_json/segments_json (audit M25: don't
-    load the whole library's heavy columns just to diff freshness)."""
+    Pulls ONLY the columns build_doc_text needs (filename, transcript, frame_tags,
+    canonical_tags) + embed_hash — deliberately NOT the heavy words_json/segments_json
+    (audit M25). manual tags are bulk-fetched separately."""
     sigs: Dict[str, Tuple[str, str]] = {}
     with db.get_conn() as conn:
         rows = conn.execute(
-            "SELECT id, filename, transcript, frame_tags, embed_hash FROM media"
+            "SELECT id, filename, transcript, frame_tags, canonical_tags, embed_hash FROM media"
         ).fetchall()
+    ids = [r["id"] for r in rows]
+    manual_map = db.get_manual_tags_by_ids(ids)
     for r in rows:
+        ct = r["canonical_tags"]
+        if ct and isinstance(ct, str):
+            try:
+                ct = json.loads(ct)
+            except Exception:
+                ct = []
+        ct = ct if isinstance(ct, (list, tuple)) else []
         rec = {
             "filename": r["filename"],
             "transcript": r["transcript"],
             "frame_tags": r["frame_tags"],
+            "canonical_tags": ct,
+            "manual_tags": manual_map.get(r["id"], []),
         }
         sigs[str(r["id"])] = (r["embed_hash"], vdb.content_hash(rec))
     return sigs
@@ -226,6 +259,22 @@ def run_embed(rebuild: bool = False, force_ids=None, prune: bool = True) -> dict
             "new": len(new_ids), "stale": len(stale_ids),
             "unverified": len(unverified_ids), "forced": len(forced),
             "stale_detected": stale_detected}
+
+
+def reindex_media(media_id: int) -> None:
+    """Re-embed a single media after a tag/canonical change (best-effort). Rebuilds
+    its chunks and stamps embed_hash so search reflects the new tag immediately
+    without waiting for a full library re-embed (arkiv handover)."""
+    recs = get_records_by_ids([media_id])
+    if not recs:
+        return
+    rec = recs[0]
+    col = vdb.get_collection()
+    vdb.upsert_record(col, rec)
+    try:
+        db.set_embed_state(rec["id"], vdb.content_hash(rec), _now_iso())
+    except Exception as se:
+        print("[warn] reindex_media embed_hash stamp failed:", se)
 
 
 def run_search(query: str):

--- a/frames.py
+++ b/frames.py
@@ -167,7 +167,9 @@ def extract_thumbnail(video_path: str, duration_s: float, force: bool = False) -
     if not force and out.exists() and out.stat().st_size > 0:
         return str(out)
 
-    t = max(duration_s * 0.5, 1.0)
+    # A still image has duration 0 → sample the single frame at t=0. Videos get
+    # the mid-point (clamped to >=1s so very short clips don't all hit t=0).
+    t = 0.0 if duration_s <= 0 else max(duration_s * 0.5, 1.0)
     return str(out) if _extract_frame_to(video_path, t, out) else None
 
 

--- a/frontend/src/lib/ConfirmDialog.svelte
+++ b/frontend/src/lib/ConfirmDialog.svelte
@@ -1,0 +1,47 @@
+<!-- Reusable confirm modal. Open via `open`; resolves via on:confirm / on:cancel.
+     Backdrop click cancels (unless busy). danger=true paints the confirm button red. -->
+<script>
+  import { createEventDispatcher } from 'svelte'
+  export let open = false
+  export let title = '確認'
+  export let message = ''
+  export let confirmLabel = '確認'
+  export let cancelLabel = '取消'
+  export let busy = false
+  export let danger = false
+  const dispatch = createEventDispatcher()
+</script>
+
+{#if open}
+  <div class="backdrop" on:click={() => !busy && dispatch('cancel')}>
+    <div class="modal" role="dialog" aria-modal="true" on:click|stopPropagation>
+      <div class="title">{title}</div>
+      {#if message}<div class="msg">{message}</div>{/if}
+      <div class="actions">
+        <button class="ak-btn" on:click={() => dispatch('cancel')} disabled={busy}>{cancelLabel}</button>
+        <button
+          class="ak-btn {danger ? 'danger' : 'primary'}"
+          on:click={() => dispatch('confirm')}
+          disabled={busy}
+        >{busy ? '處理中…' : confirmLabel}</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .backdrop {
+    position: fixed; inset: 0; background: rgba(0, 0, 0, 0.5);
+    display: flex; align-items: center; justify-content: center; z-index: 1000;
+  }
+  .modal {
+    background: var(--bg); color: var(--ink); width: 420px; max-width: 90vw;
+    padding: 20px; box-shadow: inset 0 0 0 1px var(--invert);
+    display: flex; flex-direction: column; gap: 14px;
+  }
+  .title { font-family: var(--ak-mono); font-size: 14px; font-weight: 600; }
+  .msg { font-size: 12.5px; line-height: 1.5; color: var(--ink-2); white-space: pre-line; }
+  .actions { display: flex; justify-content: flex-end; gap: 8px; }
+  .danger { background: #b3261e; color: #fff; border-color: #b3261e; }
+  .primary { background: var(--invert); color: var(--invert-ink); border-color: var(--invert); }
+</style>

--- a/frontend/src/lib/ConfirmDialog.svelte
+++ b/frontend/src/lib/ConfirmDialog.svelte
@@ -25,7 +25,14 @@
       }
     }}
   >
-    <div class="modal" role="dialog" aria-modal="true" tabindex="-1" on:click|stopPropagation>
+    <div
+      class="modal"
+      role="dialog"
+      aria-modal="true"
+      tabindex="-1"
+      on:click|stopPropagation
+      on:keydown={(e) => e.stopPropagation()}
+    >
       <div class="title">{title}</div>
       {#if message}<div class="msg">{message}</div>{/if}
       <div class="actions">

--- a/frontend/src/lib/ConfirmDialog.svelte
+++ b/frontend/src/lib/ConfirmDialog.svelte
@@ -13,8 +13,19 @@
 </script>
 
 {#if open}
-  <div class="backdrop" on:click={() => !busy && dispatch('cancel')}>
-    <div class="modal" role="dialog" aria-modal="true" on:click|stopPropagation>
+  <div
+    class="backdrop"
+    role="button"
+    tabindex="-1"
+    on:click={() => !busy && dispatch('cancel')}
+    on:keydown={(e) => {
+      if (!busy && (e.key === 'Enter' || e.key === ' ' || e.key === 'Escape')) {
+        e.preventDefault()
+        dispatch('cancel')
+      }
+    }}
+  >
+    <div class="modal" role="dialog" aria-modal="true" tabindex="-1" on:click|stopPropagation>
       <div class="title">{title}</div>
       {#if message}<div class="msg">{message}</div>{/if}
       <div class="actions">

--- a/frontend/src/lib/FilterRow.svelte
+++ b/frontend/src/lib/FilterRow.svelte
@@ -2,7 +2,7 @@
 <script>
   export let activeFilter = 'all'
   export let activeRating = null
-  const filters = [['all', 'All'], ['video', 'Video'], ['audio', 'Audio']]
+  const filters = [['all', 'All'], ['video', 'Video'], ['audio', 'Audio'], ['image', 'Image']]
   const ratings = [['good', 'Good'], ['rev', 'Review'], ['ng', 'N·G']]
 </script>
 

--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -24,7 +24,8 @@
   // IN/OUT marks snap to exact frame boundaries and frame stepping is enabled.
   // null → the old second-based behaviour (audio, or fps unknown) is unchanged.
   export let fps = null
-  $: useVideo = !!videoSrc && !is360 && !!media && media.kind !== 'audio'
+  $: useImage = !!videoSrc && !!media && media.kind === 'image'
+  $: useVideo = !!videoSrc && !is360 && !!media && media.kind !== 'audio' && media.kind !== 'image'
   $: useAudio = !!videoSrc && !!media && media.kind === 'audio'
   // Frame features only make sense for a video with a known, sane fps.
   $: frameExact = useVideo && typeof fps === 'number' && fps > 0
@@ -226,6 +227,9 @@
   export let onChapters = null
   export let onRemotion = null
   export let onReveal = null
+  // Live delete. onDelete = () => void; when set, a "刪除素材" button appears. The
+  // parent owns the confirm dialog + the API call (so it can also drive bulk delete).
+  export let onDelete = null
   // Live tag editing. tags = [{id,name,source}] → renders the editable Tags block;
   // null → no block (mock screens unchanged). onAddTag/onRemoveTag wire the writes.
   export let tags = null
@@ -346,7 +350,7 @@
 <aside class="inspector">
   <div class="header">
     <Eyebrow style="margin-bottom:8px;">
-      Inspector · {media.kind === 'audio' ? 'AUDIO' : `${media.fps}p · ${media.res}`}
+      Inspector · {media.kind === 'image' ? 'IMAGE' : media.kind === 'audio' ? 'AUDIO' : `${media.fps}p · ${media.res}`}
     </Eyebrow>
     <div class="fname">{media.name}</div>
     <Mono dim style="font-size:10.5px;margin-top:4px;letter-spacing:0.04em;">
@@ -354,9 +358,11 @@
     </Mono>
   </div>
 
-  <div class="preview" class:hasplayer={useVideo || useAudio}>
+  <div class="preview" class:hasplayer={useVideo || useAudio || useImage}>
     {#if is360 && thumbUrl && !imgFailed}
       {#if Pano360}<svelte:component this={Pano360} src={thumbUrl} />{:else}<div class="panoload"><Mono dim style="font-size:11px;">360 · loading…</Mono></div>{/if}
+    {:else if useImage}
+      <img class="previmg" src={videoSrc} alt={media.name} on:error={() => (imgFailed = true)} />
     {:else if useVideo}
       <!-- svelte-ignore a11y-media-has-caption -->
       <video bind:this={playerEl} on:timeupdate={onTimeUpdate} on:loadedmetadata={onLoadedMeta} class="previmg" controls playsinline preload="metadata" poster={thumbUrl || undefined} src={videoSrc}></video>
@@ -370,7 +376,7 @@
     {:else}
       <Thumb seed={media.id} kind={media.kind} {theme} />
     {/if}
-    {#if !useVideo && !useAudio && !live}
+    {#if !useVideo && !useAudio && !useImage && !live}
       <!-- design-mock only: fake scrubber overlay. In live (no player available)
            the poster shows alone — no faked playback chrome. -->
       <div class="scrim"></div>
@@ -620,6 +626,9 @@
     {#if onReveal}
       <button class="ak-btn reveal" on:click={onReveal} title="在 Finder / 檔案總管中顯示原始檔">⊙ 在 Finder 顯示</button>
     {/if}
+    {#if onDelete}
+      <button class="ak-btn del" on:click={onDelete} title="刪除素材（移至回收桶，可還原）">刪除素材</button>
+    {/if}
   </div>
 </aside>
 
@@ -642,6 +651,8 @@
     border-bottom: 1px solid var(--rule);
   }
   .reveal { font-size: 11px; padding: 4px 10px; margin-top: 8px; width: 100%; }
+  .del { font-size: 11px; padding: 4px 10px; margin-top: 8px; width: 100%; color: #d9534f; border-color: #d9534f; }
+  .del:hover { background: #d9534f; color: #fff; }
   /* ancillary export disclosure (成品輔助) — visually secondary to the primary row */
   .moreexp { display: inline-block; margin-top: 8px; font-size: 10.5px; color: var(--quiet); cursor: pointer; }
   .moreexp:hover { color: var(--ink); }

--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -714,7 +714,6 @@
   .previmg { width: 100%; height: 100%; object-fit: cover; display: block; }
   /* the real player: contain (don't crop footage) on black; audio sits at the bottom */
   video.previmg { object-fit: contain; background: #000; }
-  .prevaudio { position: absolute; left: 12px; right: 12px; bottom: 12px; width: auto; }
   /* Custom audio player: a themed, clearly-visible play control instead of the
      browser's native white <audio> bar (which read as a blank "white box" in the
      dark preview and isn't rendered at all in some WebViews). */

--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -27,6 +27,30 @@
   $: useImage = !!videoSrc && !!media && media.kind === 'image'
   $: useVideo = !!videoSrc && !is360 && !!media && media.kind !== 'audio' && media.kind !== 'image'
   $: useAudio = !!videoSrc && !!media && media.kind === 'audio'
+  // Parent hook: build an H.264 proxy so a browser-incompatible clip becomes
+  // playable. `proxyBusy`/`proxyErr` mirror the in-flight build state back.
+  export let onRequestProxy = null
+  export let proxyBusy = false
+  export let proxyErr = null
+  // Custom play/pause for the audio player (native <audio> controls render as an
+  // unthemed white bar in the preview — easy to miss / not shown in some WebViews).
+  let playing = false
+  // Playback failure: the <video>/<audio> element errored (incompatible codec,
+  // or a 409 need_proxy JSON body it received instead of media). Surfaced as a
+  // proxy-build affordance so the clip can be played.
+  let mediaError = null
+  function onMediaError() {
+    mediaError = '此素材編碼瀏覽器無法直接播放，需先生成代理'
+  }
+  function togglePlay() {
+    if (!playerEl) return
+    if (playerEl.paused) playerEl.play().catch(() => {})
+    else playerEl.pause()
+  }
+  function onPlay() { playing = true }
+  function onPause() { playing = false }
+  // A new src (e.g. once a proxy is built) clears the error and reloads cleanly.
+  $: if (videoSrc) { mediaError = null; playing = false }
   // Frame features only make sense for a video with a known, sane fps.
   $: frameExact = useVideo && typeof fps === 'number' && fps > 0
 
@@ -365,12 +389,22 @@
       <img class="previmg" src={videoSrc} alt={media.name} on:error={() => (imgFailed = true)} />
     {:else if useVideo}
       <!-- svelte-ignore a11y-media-has-caption -->
-      <video bind:this={playerEl} on:timeupdate={onTimeUpdate} on:loadedmetadata={onLoadedMeta} class="previmg" controls playsinline preload="metadata" poster={thumbUrl || undefined} src={videoSrc}></video>
+      <video bind:this={playerEl} on:timeupdate={onTimeUpdate} on:loadedmetadata={onLoadedMeta} on:error={onMediaError} class="previmg" controls playsinline preload="metadata" poster={thumbUrl || undefined} src={videoSrc}></video>
     {:else if useAudio}
-      {#if thumbUrl && !imgFailed}
-        <img class="previmg" src={thumbUrl} alt={media.name} on:error={() => (imgFailed = true)} />
-      {/if}
-      <audio bind:this={playerEl} on:timeupdate={onTimeUpdate} on:loadedmetadata={onLoadedMeta} class="prevaudio" controls preload="metadata" src={videoSrc}></audio>
+      <div class="audioplay">
+        <button class="audiobtn" on:click={togglePlay} aria-label="播放 / 暫停">{playing ? '❚❚' : '▶'}</button>
+        <audio
+          bind:this={playerEl}
+          on:timeupdate={onTimeUpdate}
+          on:loadedmetadata={onLoadedMeta}
+          on:play={onPlay}
+          on:pause={onPause}
+          on:error={onMediaError}
+          preload="metadata"
+          src={videoSrc}
+        ></audio>
+        <div class="audiotc">{_tc(playerEl ? playerEl.currentTime : 0)} / {_tc(mediaDuration || 0)}</div>
+      </div>
     {:else if thumbUrl && !imgFailed}
       <img class="previmg" src={thumbUrl} alt={media.name} on:error={() => (imgFailed = true)} />
     {:else}
@@ -387,6 +421,19 @@
           <div class="trackhead"></div>
         </div>
         <Mono style="font-size:11px;color:#f3f2ee;">{media.dur}</Mono>
+      </div>
+    {/if}
+    {#if mediaError && (useVideo || useAudio)}
+      <!-- Browser couldn't decode the stream (incompatible codec / 409 need_proxy).
+           Offer a one-click proxy build; MainLive drives the build + reload. -->
+      <div class="playerr">
+        <div class="playerr-msg">{mediaError}</div>
+        <button
+          class="exp"
+          on:click={() => onRequestProxy && onRequestProxy(media.id)}
+          disabled={proxyBusy || !onRequestProxy}
+        >{proxyBusy ? '生成代理中…' : '生成代理並播放'}</button>
+        {#if proxyErr}<div class="playerr-err">{proxyErr}</div>{/if}
       </div>
     {/if}
   </div>
@@ -668,6 +715,29 @@
   /* the real player: contain (don't crop footage) on black; audio sits at the bottom */
   video.previmg { object-fit: contain; background: #000; }
   .prevaudio { position: absolute; left: 12px; right: 12px; bottom: 12px; width: auto; }
+  /* Custom audio player: a themed, clearly-visible play control instead of the
+     browser's native white <audio> bar (which read as a blank "white box" in the
+     dark preview and isn't rendered at all in some WebViews). */
+  .audioplay {
+    position: absolute; inset: 0; display: flex; flex-direction: column;
+    align-items: center; justify-content: center; gap: 16px; padding: 18px;
+    background: var(--surface-2);
+  }
+  .audiobtn {
+    width: 58px; height: 58px; border-radius: 50%; cursor: pointer;
+    border: 1px solid var(--rule); background: var(--invert); color: var(--invert-ink);
+    font-size: 18px; line-height: 1; display: flex; align-items: center; justify-content: center;
+  }
+  .audiobtn:hover { opacity: 0.9; }
+  .audiotc { color: var(--ink-2); font-family: var(--ak-mono); font-size: 11px; }
+  /* Playback-failure overlay: browser-incompatible codec → offer proxy build. */
+  .playerr {
+    position: absolute; inset: 0; display: flex; flex-direction: column;
+    align-items: center; justify-content: center; gap: 10px; padding: 18px;
+    background: rgba(0, 0, 0, 0.62); text-align: center;
+  }
+  .playerr-msg { color: #f3f2ee; font-size: 12px; line-height: 1.5; max-width: 80%; }
+  .playerr-err { color: #ff9b9b; font-size: 11px; }
   .panoload { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; background: var(--surface-2); }
   .scrim {
     position: absolute; left: 0; right: 0; bottom: 0; height: 40%;

--- a/frontend/src/lib/TrashModal.svelte
+++ b/frontend/src/lib/TrashModal.svelte
@@ -1,0 +1,127 @@
+<!-- Trash (recycle bin) browser. Lists trashed originals, restores one back, or
+     purges expired / all. Requires admin scope on remote; token-free on loopback.
+     Opened via `open`; close via on:close. -->
+<script>
+  import { createEventDispatcher } from 'svelte'
+  import * as api from './api.js'
+  import Eyebrow from './Eyebrow.svelte'
+  import Mono from './Mono.svelte'
+  export let open = false
+  const dispatch = createEventDispatcher()
+
+  let items = []
+  let loading = false
+  let busyId = null
+  let msg = ''
+  let _wasOpen = false
+
+  // (re)load whenever the modal is (re)opened
+  $: if (open && !_wasOpen) { _wasOpen = true; load() }
+  $: if (!open) { _wasOpen = false }
+
+  async function load() {
+    loading = true
+    msg = ''
+    try {
+      const r = await api.getTrash()
+      items = (r && r.trash) || []
+    } catch (e) {
+      msg = '讀取回收桶失敗: ' + e.message
+    } finally {
+      loading = false
+    }
+  }
+
+  async function restore(t) {
+    busyId = t.id
+    msg = ''
+    try {
+      const r = await api.restoreTrash(t.id)
+      msg =
+        r.ingest === 'triggered'
+          ? `已還原並觸發重新匯入：${r.restored_to || t.filename}`
+          : `已還原：${r.restored_to || t.filename}`
+      items = items.filter((x) => x.id !== t.id)
+    } catch (e) {
+      msg = '還原失敗: ' + e.message
+    } finally {
+      busyId = null
+    }
+  }
+
+  async function purge(ttlDays) {
+    busyId = 'purge'
+    msg = ''
+    try {
+      const r = await api.purgeTrash(ttlDays)
+      msg = `已清空 ${r.purged} 項`
+      items = ttlDays ? [] : items
+      await load()
+    } catch (e) {
+      msg = '清空失敗: ' + e.message
+    } finally {
+      busyId = null
+    }
+  }
+
+  const fmt = (s) => (s ? s.replace('T', ' ').slice(0, 16) : '—')
+</script>
+
+{#if open}
+  <div class="backdrop" on:click={() => dispatch('close')}>
+    <div class="modal" role="dialog" aria-modal="true" on:click|stopPropagation>
+      <div class="head">
+        <Eyebrow>回收桶 · Trash</Eyebrow>
+        <div class="head-actions">
+          <button class="ak-btn" on:click={() => purge(null)} disabled={busyId === 'purge' || !items.length} title="清空過期項（依 TTL）">清空過期</button>
+          <button class="ak-btn danger" on:click={() => purge(0)} disabled={busyId === 'purge' || !items.length} title="立即清空全部">清空全部</button>
+          <button class="ak-btn" on:click={() => dispatch('close')}>關閉</button>
+        </div>
+      </div>
+
+      {#if msg}<div class="msg"><Mono>{msg}</Mono></div>{/if}
+
+      {#if loading}
+        <div class="empty"><Mono dim>讀取中…</Mono></div>
+      {:else if items.length === 0}
+        <div class="empty"><Mono dim>回收桶是空的。</Mono></div>
+      {:else}
+        <div class="rows">
+          {#each items as t (t.id)}
+            <div class="row">
+              <div class="meta">
+                <div class="fname">{t.filename}</div>
+                <Mono dim style="font-size:10px;">刪除 {fmt(t.deleted_at)} · 過期 {fmt(t.expires_at)}</Mono>
+              </div>
+              <button class="ak-btn" on:click={() => restore(t)} disabled={busyId === t.id}>還原</button>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .backdrop {
+    position: fixed; inset: 0; background: rgba(0, 0, 0, 0.5);
+    display: flex; align-items: center; justify-content: center; z-index: 1000;
+  }
+  .modal {
+    background: var(--bg); color: var(--ink); width: 560px; max-width: 92vw;
+    max-height: 80vh; padding: 18px; box-shadow: inset 0 0 0 1px var(--invert);
+    display: flex; flex-direction: column; gap: 12px; overflow: hidden;
+  }
+  .head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+  .head-actions { display: flex; gap: 6px; }
+  .msg { font-size: 11.5px; }
+  .empty { padding: 24px 0; text-align: center; }
+  .rows { overflow-y: auto; display: flex; flex-direction: column; gap: 1px; background: var(--rule); }
+  .row {
+    display: flex; align-items: center; justify-content: space-between; gap: 12px;
+    background: var(--bg); padding: 8px 12px;
+  }
+  .meta { min-width: 0; }
+  .fname { font-size: 12.5px; font-weight: 500; word-break: break-all; }
+  .danger { background: #b3261e; color: #fff; border-color: #b3261e; }
+</style>

--- a/frontend/src/lib/TrashModal.svelte
+++ b/frontend/src/lib/TrashModal.svelte
@@ -68,8 +68,19 @@
 </script>
 
 {#if open}
-  <div class="backdrop" on:click={() => dispatch('close')}>
-    <div class="modal" role="dialog" aria-modal="true" on:click|stopPropagation>
+  <div
+    class="backdrop"
+    role="button"
+    tabindex="-1"
+    on:click={() => dispatch('close')}
+    on:keydown={(e) => {
+      if (e.key === 'Enter' || e.key === ' ' || e.key === 'Escape') {
+        e.preventDefault()
+        dispatch('close')
+      }
+    }}
+  >
+    <div class="modal" role="dialog" aria-modal="true" tabindex="-1" on:click|stopPropagation>
       <div class="head">
         <Eyebrow>回收桶 · Trash</Eyebrow>
         <div class="head-actions">

--- a/frontend/src/lib/TrashModal.svelte
+++ b/frontend/src/lib/TrashModal.svelte
@@ -80,7 +80,14 @@
       }
     }}
   >
-    <div class="modal" role="dialog" aria-modal="true" tabindex="-1" on:click|stopPropagation>
+    <div
+      class="modal"
+      role="dialog"
+      aria-modal="true"
+      tabindex="-1"
+      on:click|stopPropagation
+      on:keydown={(e) => e.stopPropagation()}
+    >
       <div class="head">
         <Eyebrow>回收桶 · Trash</Eyebrow>
         <div class="head-actions">

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -16,7 +16,26 @@ const BASE = import.meta.env?.VITE_API_URL ?? ''
 let _token = null
 export function setToken(t) {
   _token = t || null
+  try {
+    if (_token) localStorage.setItem('arkiv_token', _token)
+    else localStorage.removeItem('arkiv_token')
+  } catch (e) {}
 }
+export function initToken() {
+  try {
+    const fromUrl = new URLSearchParams(location.search).get('token')
+    if (fromUrl) {
+      setToken(fromUrl)
+      const u = new URL(location.href)
+      u.searchParams.delete('token')
+      history.replaceState(null, '', u.pathname + u.search + u.hash)
+      return
+    }
+    const stored = localStorage.getItem('arkiv_token')
+    if (stored) setToken(stored)
+  } catch (e) {}
+}
+initToken()
 
 class ApiError extends Error {
   constructor(status, path, body) {
@@ -225,6 +244,17 @@ export const activateTranscript = (id, lang, opts) =>
 export const ingestWs = (path, limit = 0, options = {}, opts) =>
   req('/api/ingest/ws', { method: 'POST', body: { path, limit, ...options }, ...opts })
 
+// POST /api/ingest/upload (multipart) — upload one or more files into the
+// ingest source dir. Collision-safe on the backend: a same-name file is renamed
+// (<stem>__<YYYYMMDD-HHMMSS><ext>) instead of overwriting an indexed clip.
+// The response carries {saved:[…], renamed:[{from,to}]}; surface `renamed` so
+// the user knows both copies were kept. Requires ingest_write.
+export const uploadFiles = (files, opts) => {
+  const form = new FormData()
+  for (const f of files) form.append('files', f)
+  return req('/api/ingest/upload', { method: 'POST', body: form, ...opts })
+}
+
 // POST /api/embed/rebuild — drop + rebuild the ChromaDB semantic index from all
 // media (runs in the background). Requires ingest_write (token-free on loopback).
 // → {message, queued}
@@ -422,6 +452,48 @@ export const retranscribeStatus = (id, opts) =>
 // already running (single-flight guard); 504 on the 10-min server timeout.
 export const reingest = (id, opts) =>
   req(`/api/media/${id}/reingest`, { method: 'POST', ...opts })
+
+// ---- media delete (reversible trash + orphan cleanup) ----
+// DELETE /api/media/{id}?allow_file_delete=1 → moves the original file into the
+// trash (recoverable) and removes all metadata; files outside PROJECT_ROOT are
+// metadata-only. Requires media_delete scope (token-free on loopback).
+// → {media_id, filename, trashed, moved_to?, external?, message?}
+export const deleteMedia = (id, allowFileDelete = true, opts) =>
+  req(`/api/media/${id}${qs({ allow_file_delete: allowFileDelete ? 1 : 0 })}`, {
+    method: 'DELETE',
+    ...opts,
+  })
+// POST /api/media/bulk-delete {ids, allow_file_delete} →
+//   {deleted:[id…], skipped:[id…], errors:[{id, error}]}
+export const bulkDeleteMedia = (ids, allowFileDelete = true, opts) =>
+  req('/api/media/bulk-delete', {
+    method: 'POST',
+    body: { ids, allow_file_delete: allowFileDelete },
+    ...opts,
+  })
+// GET /api/admin/trash → {trash:[{id, media_id, filename, original_path,
+//   trash_path, deleted_at, expires_at}]}. Requires admin scope.
+export const getTrash = (opts) => req('/api/admin/trash', opts)
+// POST /api/admin/trash/purge {ttl_days?} → {ok, purged}. ttl_days=0 purges all.
+export const purgeTrash = (ttlDays = null, opts) =>
+  req('/api/admin/trash/purge', {
+    method: 'POST',
+    body: ttlDays == null ? {} : { ttl_days: ttlDays },
+    ...opts,
+  })
+// POST /api/admin/trash/restore/{trash_id} → {ok, restored_to}. Requires admin.
+export const restoreTrash = (trashId, opts) =>
+  req(`/api/admin/trash/restore/${encodeURIComponent(trashId)}`, {
+    method: 'POST',
+    ...opts,
+  })
+// POST /api/admin/prune-missing {dry_run} → {scanned, pruned, pruned_ids, dry_run}.
+// Clears ghost rows whose source file was manually deleted. Requires media_delete.
+export const pruneMissing = (dryRun = true, opts) =>
+  req(`/api/admin/prune-missing${qs({ dry_run: dryRun ? 1 : 0 })}`, {
+    method: 'POST',
+    ...opts,
+  })
 
 // ---- editing proxies ----
 // GET /api/proxy/status → {total, proxied, size_mb}

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -487,10 +487,10 @@ export const restoreTrash = (trashId, opts) =>
     method: 'POST',
     ...opts,
   })
-// POST /api/admin/prune-missing {dry_run} → {scanned, pruned, pruned_ids, dry_run}.
+// POST /api/media/prune-missing {dry_run} → {scanned, pruned, pruned_ids, dry_run}.
 // Clears ghost rows whose source file was manually deleted. Requires media_delete.
 export const pruneMissing = (dryRun = true, opts) =>
-  req(`/api/admin/prune-missing${qs({ dry_run: dryRun ? 1 : 0 })}`, {
+  req(`/api/media/prune-missing${qs({ dry_run: dryRun ? 1 : 0 })}`, {
     method: 'POST',
     ...opts,
   })

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -833,7 +833,38 @@
   $: inspThumb = selected ? selected.thumb : null
   // Real playback stream for the inspector player (loopback = token-free; remote
   // carries ?token). Inspector turns this into a <video>/<audio> element.
-  $: inspVideoSrc = selected ? api.streamUrl(selected.id) : null
+  $: inspVideoSrc = selected ? api.streamUrl(selected.id) + (proxyNonce ? `&_pn=${proxyNonce}` : '') : null
+  // Browser-incompatible clip → build an H.264 proxy, then reload the stream so
+  // the Inspector player picks up the now-playable proxy. proxyNonce busts the
+  // cached <video>/<audio> src after the proxy is ready.
+  let proxyNonce = 0
+  let proxyBusy = false
+  let proxyErr = null
+  async function requestProxy(id) {
+    if (!id || proxyBusy) return
+    proxyBusy = true
+    proxyErr = null
+    try {
+      await api.buildProxyOne(id)
+      const url = api.streamUrl(id)
+      let ready = false
+      for (let i = 0; i < 80; i++) {
+        // Poll the stream: 200 video/mp4 ⇒ proxy ready; 409 ⇒ still building.
+        try {
+          const r = await fetch(url, { method: 'HEAD' })
+          const ct = r.headers.get('content-type') || ''
+          if (r.ok && ct.includes('video/mp4')) { ready = true; break }
+        } catch (_) { /* transient; keep polling */ }
+        await new Promise((res) => setTimeout(res, 1500))
+      }
+      if (ready) proxyNonce = Date.now()
+      else proxyErr = '代理生成逾時，請稍後重試'
+    } catch (e) {
+      proxyErr = e && e.message ? e.message : '代理生成失敗'
+    } finally {
+      proxyBusy = false
+    }
+  }
   $: inspPath = detailLive ? detailLive.path : null
   // tags: detail carries the quality-filtered tag list [{id,name,source}].
   $: inspTags = detailLive ? (detailLive.tags || []) : null
@@ -1192,6 +1223,9 @@
         live={true}
         thumbUrl={inspThumb}
         videoSrc={inspVideoSrc}
+        onRequestProxy={selected ? requestProxy : null}
+        {proxyBusy}
+        proxyErr={proxyErr}
         fps={inspectorMedia ? inspectorMedia.fpsExact : null}
         peaks={inspPeaks}
         pathLabel={inspPath}

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -15,6 +15,8 @@
   import Inspector from '../lib/Inspector.svelte'
   import Mono from '../lib/Mono.svelte'
   import Eyebrow from '../lib/Eyebrow.svelte'
+  import ConfirmDialog from '../lib/ConfirmDialog.svelte'
+  import TrashModal from '../lib/TrashModal.svelte'
   import { resolvedTheme } from '../lib/prefs.js'
   import { pushToast } from '../lib/toast.js'
   import { createViewGen } from '../lib/viewGen.js'
@@ -94,16 +96,23 @@
   // backend rating value (good/ng/review/null) → UI value (good/ng/rev/none).
   const ratingToUi = (r) => (r === 'review' ? 'rev' : r || 'none')
   // API media item → MediaCard's expected shape.
-  const toCard = (it) => ({
-    id: it.id,
-    name: it.filename || `#${it.id}`,
-    kind: it.has_audio && (it.width === 0 || !it.width) ? 'audio' : 'video',
-    rating: ratingToUi(it.rating),
-    dur: fmtDur(it.duration_s),
-    size: fmtSize(it.size_mb),
-    thumb: api.thumbUrlFromPath(it.thumbnail_path),
-    _raw: it,
-  })
+  const IMG_EXTS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg']);
+  const toCard = (it) => {
+    const ext = (it.ext || '').toLowerCase();
+    const kind = IMG_EXTS.has(ext)
+      ? 'image'
+      : (it.has_audio && (it.width === 0 || !it.width) ? 'audio' : 'video');
+    return {
+      id: it.id,
+      name: it.filename || `#${it.id}`,
+      kind,
+      rating: ratingToUi(it.rating),
+      dur: fmtDur(it.duration_s),
+      size: fmtSize(it.size_mb),
+      thumb: api.thumbUrlFromPath(it.thumbnail_path),
+      _raw: it,
+    };
+  };
 
   let liveTags = null
   let liveCollections = null
@@ -170,6 +179,50 @@
       pushToast(`CSV 匯出失敗: ${e.message}`, 'error')
     }
   }
+  // ---- media delete (reversible: original moved to trash, metadata removed) ----
+  // confirmDel holds the pending delete so the ConfirmDialog can show context and
+  // trigger it; null = no dialog open. Both single (inspector) and bulk (picked)
+  // funnel through here — the backend moves originals to trash, so this is safe.
+  let confirmDel = null
+  let delBusy = false
+  let trashOpen = false
+  function askDeleteSingle() {
+    if (!selected) return
+    confirmDel = { kind: 'single', ids: [selected.id], label: selected.name || `#${selected.id}` }
+  }
+  function askDeleteBulk() {
+    if (!picked.length) return
+    confirmDel = { kind: 'bulk', ids: [...picked], label: `${picked.length} 支素材` }
+  }
+  async function confirmDelete() {
+    if (!confirmDel) return
+    const ids = confirmDel.ids
+    const set = new Set(ids)
+    delBusy = true
+    try {
+      if (confirmDel.kind === 'single') {
+        const r = await api.deleteMedia(ids[0], true)
+        if (r && r.external) pushToast(`外部檔案僅移除資料：${r.message || ''}`)
+        else pushToast(`已移至回收桶 · ${r && r.filename ? r.filename : ids[0]}`)
+      } else {
+        const r = await api.bulkDeleteMedia(ids, true)
+        const n = (r && r.deleted && r.deleted.length) || 0
+        const skipped = (r && r.skipped && r.skipped.length) || 0
+        pushToast(`已刪除 ${n} 支` + (skipped ? ` · 跳過 ${skipped} 支` : ''))
+      }
+      // remove from the grid source so the card/list row disappears immediately
+      items = items.filter((m) => !set.has(m.id))
+      if (confirmDel.kind === 'single' && selectedId === ids[0]) selectedId = null
+      clearPicks()
+      confirmDel = null
+    } catch (e) {
+      pushToast(`刪除失敗: ${e.message}`, 'error')
+      confirmDel = null
+    } finally {
+      delBusy = false
+    }
+  }
+
   // single-clip export from the inspector (auth-safe download).
   async function exportClip(id, fmt, name, trim = null) {
     const stem = (name || `media_${id}`).replace(/\.[^.]+$/, '')
@@ -631,6 +684,7 @@
   $: visible = items.filter((m) => {
     if (activeFilter === 'video' && m.kind !== 'video') return false
     if (activeFilter === 'audio' && m.kind !== 'audio') return false
+    if (activeFilter === 'image' && m.kind !== 'image') return false
     if (activeRating && m.rating !== activeRating) return false
     if (activeCamera && camCategory(m._raw && m._raw.camera_model) !== activeCamera) return false
     return true
@@ -983,6 +1037,7 @@
         >CSV ↓</button>
         <FilterRow bind:activeFilter bind:activeRating />
         <ViewToggle bind:view />
+        <button class="ak-btn trash" on:click={() => (trashOpen = true)} title="回收桶（已刪除、可還原）">回收桶</button>
       </div>
 
       {#if picked.length}
@@ -1007,6 +1062,7 @@
                     title={projectRegName ? '加入跨庫精選集' : '本專案未登記（設定→跨庫專案）'}>加入精選集</button>
             <a class="ak-btn expbtn" href="#/bins" title="檢視精選集">★</a>
             <div class="barvrule"></div>
+            <button class="ak-btn expbtn danger" on:click={askDeleteBulk} title="刪除所選（移至回收桶，可還原）">刪除</button>
             <button class="ak-btn expbtn clear" on:click={clearPicks}>清除</button>
           </div>
         </div>
@@ -1159,6 +1215,7 @@
         onChapters={selected ? (fmt) => exportChapters(selected.id, selected.name, fmt) : null}
         onRemotion={selected ? () => exportRemotion(selected.id, selected.name) : null}
         onReveal={inspPath ? () => revealFile(inspPath, selected && selected.id) : null}
+        onDelete={selected ? askDeleteSingle : null}
         onRate={rate}
         inPoint={detailLive ? detailLive.in_point : null}
         outPoint={detailLive ? detailLive.out_point : null}
@@ -1166,6 +1223,21 @@
       />
     {/if}
   </div>
+
+  <ConfirmDialog
+    open={!!confirmDel}
+    title={confirmDel ? (confirmDel.kind === 'bulk' ? '刪除所選素材' : '刪除素材') : '確認'}
+    message={confirmDel
+      ? `確定要將「${confirmDel.label}」移至回收桶嗎？\n原始檔會保留 30 天，可從回收桶還原。`
+      : ''}
+    confirmLabel="移至回收桶"
+    danger={true}
+    busy={delBusy}
+    on:confirm={confirmDelete}
+    on:cancel={() => (confirmDel = null)}
+  />
+
+  <TrashModal open={trashOpen} on:close={() => (trashOpen = false)} />
 </div>
 
 <style>
@@ -1183,6 +1255,9 @@
   .livesearch { flex: 1 1 200px; min-width: 160px; max-width: 360px; font-size: 12px; }
   .ranked { font-size: 10px; padding: 6px 10px; }
   .metacsv { font-size: 10px; padding: 6px 10px; white-space: nowrap; }
+  .trash { font-size: 10px; padding: 6px 10px; white-space: nowrap; }
+  .expbtn.danger { color: #d9534f; border-color: #d9534f; }
+  .expbtn.danger:hover { background: #d9534f; color: #fff; }
   .gridwrap { flex: 1; overflow: auto; position: relative; }
   /* A1: pre-built sample demo bar — flags the seeded clips as demo + one-click remove */
   .samplebar {

--- a/frontend/src/routes/QueryLive.svelte
+++ b/frontend/src/routes/QueryLive.svelte
@@ -24,7 +24,7 @@
     { key: 'content_type', label: 'Content type', ops: ['contains', 'eq'], kind: 'text' },
     { key: 'lang', label: 'Language', ops: ['eq'], kind: 'text' },
     { key: 'rating', label: 'Rating（評分）', ops: ['eq'], kind: 'enum', options: ['good', 'ng', 'review', 'unrated'] },
-    { key: 'media_type', label: 'Media type', ops: ['eq'], kind: 'enum', options: ['video', 'audio'] },
+    { key: 'media_type', label: 'Media type', ops: ['eq'], kind: 'enum', options: ['video', 'audio', 'image'] },
     { key: 'duration', label: 'Duration（秒）', ops: ['range'], kind: 'range' },
     { key: 'iso', label: 'ISO', ops: ['range'], kind: 'range' },
     { key: 'date', label: 'Processed date', ops: ['range'], kind: 'daterange' },

--- a/frontend/src/routes/SearchLive.svelte
+++ b/frontend/src/routes/SearchLive.svelte
@@ -25,6 +25,8 @@
   // { name, path, items:[…], count, openable, live }
   let groups = []
   let total = 0
+  let offset = 0 // current-project search cursor (how many rows already loaded)
+  let fedPerLimit = 50 // federation per-project cap; "Show more" raises it
   $: shown = groups.reduce((a, g) => a + g.items.length, 0)
   // Derived from the project registry when available; neutral label otherwise,
   // so results outside the demo project aren't mislabeled (Codex review P3).
@@ -92,6 +94,7 @@
     { key: 'video', label: 'Video' },
     { key: 'audio', label: 'Audio' },
   ]
+  const PAGE = 200 // rows per search page; "Show more" loads the next page via offset
 
   const fmtDur = (s) => {
     s = Math.round(s || 0)
@@ -140,52 +143,76 @@
   // rows. Each run captures its seq and bails on assignment if superseded.
   let _searchSeq = 0
 
-  async function runCurrent(q, mySeq) {
-    const params = { q, limit: 40 }
+  async function runCurrent(q, mySeq, append = false) {
+    const params = { q, limit: PAGE, offset: append ? offset : 0 }
     if (mediaType !== 'all') params.media_type = mediaType
     const r = await api.getMedia(params)
     if (mySeq !== _searchSeq) return  // superseded by a newer search
-    total = r.total ?? (r.items || []).length
-    const items = (r.items || []).map((it) => ({
+    const page = r.items || []
+    const items = page.map((it) => ({
       id: it.id,
       name: it.filename || `#${it.id}`,
       dur: fmtDur(it.duration_s),
       score: typeof it.score === 'number' ? it.score : null,
+      matchType: it.match_type || null, // 'semantic' | 'text' — Direction 2 visibility
       excerpt: it.excerpt || it.transcript || '',
       lang: it.lang || '',
       thumb: api.thumbUrlFromPath(it.thumbnail_path),
       tags: (it.tags || []).map((t) => t.name).slice(0, 4),
     }))
-    groups = [{ name: projectName, path: '', items, count: total, openable: true, live: true }]
+    total = r.total ?? (offset + items.length)
+    if (append) offset += items.length
+    else offset = items.length
+    if (append && groups.length) {
+      const g = groups[0]
+      g.items = [...g.items, ...items]
+      groups = [...groups]
+    } else {
+      groups = [{ name: projectName, path: '', items, count: total, openable: true, live: true }]
+    }
     fedErrors = []
     projectsQueried = 0
     projectsFailed = 0
   }
 
   // Federated search (/api/search/all) → one group per project, read-only rows.
-  async function runFederated(q, mySeq) {
-    const r = await api.search(q, { limit: 40 })
+  // Federation has no offset, so "Show more" raises per_project_limit (capped) and
+  // re-fans-out — simpler than incremental cursors across N remote DBs.
+  async function runFederated(q, mySeq, append = false) {
+    const perLimit = append ? Math.min(fedPerLimit + 50, 100) : fedPerLimit
+    const r = await api.search(q, { limit: 200, per_project_limit: perLimit })
     if (mySeq !== _searchSeq) return  // superseded by a newer search
     total = r.total_results ?? (r.items || []).length
+    if (append) fedPerLimit = Math.min(fedPerLimit + 50, 100)
     projectsQueried = r.projects_queried ?? 0
     projectsFailed = r.projects_failed ?? 0
     // The "no matching projects" preflight error means an empty registry — surface
     // it as guidance, not as a per-project failure row.
     fedErrors = (r.errors || []).filter((e) => e.stage !== 'preflight' || e.project_name)
-    const byProject = new Map()
-    for (const it of r.items || []) {
-      const name = it.project_name || '（未命名專案）'
-      if (!byProject.has(name)) byProject.set(name, { name, path: it.project_path || '', items: [], count: 0, openable: false, live: false })
-      byProject.get(name).items.push({
-        id: it.media_id,
-        name: it.filename || `#${it.media_id}`,
-        dur: fmtDur(it.duration_s),
-        score: typeof it.score === 'number' ? it.score : null,
-        excerpt: it.excerpt || '',
-        lang: it.lang || '',
-        thumb: null, // cross-project: this server can't serve another project's thumbs
-        tags: [],
-      })
+    const incoming = (r.items || []).map((it) => ({
+      id: it.media_id,
+      name: it.filename || `#${it.media_id}`,
+      dur: fmtDur(it.duration_s),
+      score: typeof it.score === 'number' ? it.score : null,
+      matchType: it.match_type || null,
+      project_name: it.project_name || '（未命名專案）',
+      excerpt: it.excerpt || '',
+      lang: it.lang || '',
+      thumb: null, // cross-project: this server can't serve another project's thumbs
+      tags: [],
+    }))
+    let byProject
+    if (append && groups.length) {
+      byProject = new Map(groups.map((g) => [g.name, g]))
+    } else {
+      byProject = new Map()
+    }
+    for (const it of incoming) {
+      if (!byProject.has(it.project_name)) {
+        byProject.set(it.project_name, { name: it.project_name, path: it.project_path || '', items: [], count: 0, openable: false, live: false })
+        if (!groups.some((g) => g.name === it.project_name)) groups = [...groups, byProject.get(it.project_name)]
+      }
+      byProject.get(it.project_name).items.push(it)
     }
     for (const g of byProject.values()) g.count = g.items.length
     groups = [...byProject.values()]
@@ -194,6 +221,8 @@
   async function runSearch() {
     const q = query.trim()
     if (!q) { _searchSeq++; state = 'idle'; groups = []; total = 0; fedErrors = []; return }
+    offset = 0
+    fedPerLimit = 50
     const mySeq = ++_searchSeq  // round-5 #36: claim this run's sequence
     state = 'loading'
     syncHash()
@@ -203,6 +232,26 @@
       else await runCurrent(q, mySeq)
       if (mySeq !== _searchSeq) return  // a newer search superseded us — don't flip state
       elapsedMs = Math.round(performance.now() - t0)
+      state = 'ok'
+    } catch (e) {
+      if (mySeq !== _searchSeq) return
+      state = 'error'
+      err = e.message + (e.body ? ' · ' + JSON.stringify(e.body) : '')
+    }
+  }
+
+  // "Show more" — load the next page without disturbing the live search seq
+  // guard (a stale in-flight run still bails on assignment). Reuses the same
+  // monotonic seq so a new typed query can't be clobbered by this fetch either.
+  async function loadMore() {
+    const q = query.trim()
+    if (!q || state === 'loading' || shown >= total) return
+    const mySeq = ++_searchSeq
+    state = 'loading'
+    try {
+      if (crossProject) await runFederated(q, mySeq, true)
+      else await runCurrent(q, mySeq, true)
+      if (mySeq !== _searchSeq) return
       state = 'ok'
     } catch (e) {
       if (mySeq !== _searchSeq) return
@@ -392,7 +441,10 @@
                     </div>
                     {#if r.excerpt}<div class="snippet">{p.b}<span class="mark">{p.m}</span>{p.a}</div>{/if}
                   </div>
-                  <div class="rscore">
+                   <div class="rscore">
+                    {#if r.matchType}
+                      <Mono dim style="font-size:9px;display:block;letter-spacing:0.06em;{r.matchType === 'semantic' ? 'color:var(--ink-2);' : 'color:var(--cyan);'}">{r.matchType === 'semantic' ? '語意' : '關鍵字'}</Mono>
+                    {/if}
                     {#if r.score != null}
                       <Mono style="font-size:13px;font-weight:600;color:var(--ink);">{r.score.toFixed(2)}</Mono>
                       <Mono dim style="font-size:9px;display:block;margin-top:1px;letter-spacing:0.08em;">SCORE</Mono>
@@ -406,6 +458,12 @@
             </div>
           </section>
         {/each}
+      {/if}
+
+      {#if state === 'ok' && shown < total}
+        <div class="loadmorewrap">
+          <button class="ak-btn" on:click={loadMore}>顯示更多（{shown}/{total}）</button>
+        </div>
       {/if}
     </div>
   </div>
@@ -451,6 +509,8 @@
   .snippet { margin-top: 3px; font-size: 12.5px; color: var(--ink-2); line-height: 1.35; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .mark { background: var(--invert); color: var(--invert-ink); padding: 0 2px; }
   .rscore { text-align: right; }
+  .loadmorewrap { display: flex; justify-content: center; padding: 18px 0 8px; }
+  .loadmorewrap .ak-btn { padding: 8px 18px; font-size: 12px; }
   .raction { display: flex; justify-content: flex-end; }
   .openbtn { padding: 5px 9px; }
 </style>

--- a/ingest.py
+++ b/ingest.py
@@ -34,6 +34,11 @@ import vision as vis
 # 360 rigs — see mediatypes for the full rationale.
 SUPPORTED = mediatypes.MEDIA_EXT
 VIDEO_EXT = mediatypes.VIDEO_EXT
+IMAGE_EXT = mediatypes.IMAGE_EXT
+# Raster stills (png/jpg/webp/gif) have a pixel stream ffprobe can read and we can
+# sample a frame from — they get a thumbnail + one frame like video. .svg is
+# vector: no pixel stream, so it records filename/ext only, no pixel assets.
+RASTER_IMAGE_EXTS = IMAGE_EXT - {".svg"}
 # Codecs needing browser-playable proxy — single source of truth in codec.py.
 PROXY_CODECS = codec.PROXY_CODECS
 logger = logging.getLogger(__name__)
@@ -810,10 +815,27 @@ def process_file(path: Path, skip_vision: bool, existing: Optional[Dict] = None,
     hashing the file twice; if None it is computed here.
     """
     _stage("probe", "probe")
+    ext = path.suffix.lower()
     meta = probe(str(path))
     if meta is None:
-        print(" [ffprobe failed]")
-        return {}
+        # ffprobe can't demux a still (an .svg has no pixel stream at all, and a
+        # raster .png/.jpg is captured via a coder ffprobe may not read). A
+        # recognised image extension is still a real media asset: keep a record
+        # with filename/ext but no pixel assets, instead of dropping it entirely
+        # (test_image_ingest SVG case: ext must be recorded, no thumbnail/frames).
+        if ext not in IMAGE_EXT:
+            print(" [ffprobe failed]")
+            return {}
+        meta = {
+            "duration_s": 0.0,
+            "size_mb": 0.0,
+            "width": None,
+            "height": None,
+            "fps": None,
+            "has_audio": 0,
+            "start_tc": None,
+            "codec": None,
+        }
 
     exif = exiftool_extract(str(path), fps=meta.get("fps") or (existing.get("fps") if existing else None))
     sidecar = parse_xavc_sidecar(str(path))
@@ -867,9 +889,11 @@ def process_file(path: Path, skip_vision: bool, existing: Optional[Dict] = None,
         else:
             record["words_json"] = None
 
-    # Thumbnail (video only, always extracted)
-    is_video = path.suffix.lower() in VIDEO_EXT
-    if is_video and meta["duration_s"] > 0:
+    # Thumbnail (video + raster still; both have a pixel stream we can sample).
+    # SVG/vector stills are intentionally excluded — no pixel stream, no thumbnail.
+    is_video = ext in VIDEO_EXT
+    still_raster = ext in RASTER_IMAGE_EXTS
+    if (is_video and meta["duration_s"] > 0) or still_raster:
         _stage("thumb", "thumbnail")
         thumb_path = frm.extract_thumbnail(str(path), meta["duration_s"], force=refresh)
         # Only record a thumbnail when extraction succeeded — omitting the key on
@@ -878,8 +902,8 @@ def process_file(path: Path, skip_vision: bool, existing: Optional[Dict] = None,
         if thumb_path:
             record["thumbnail_path"] = db.to_relative(thumb_path)
 
-    # Frame extraction (video only) — persistent thumbnails + DB records
-    if is_video and meta["duration_s"] > 0:
+    # Frame extraction (video + raster still) — persistent thumbnails + DB records
+    if (is_video and meta["duration_s"] > 0) or still_raster:
         _stage("frames", "frames")
         frame_data = frm.extract_frames(str(path), meta["duration_s"], meta["fps"] or 30, force=refresh)
         for frame in frame_data:

--- a/mcp_http_server.py
+++ b/mcp_http_server.py
@@ -9,19 +9,21 @@ Run (as the `arkiv-mcp` compose service):
     python mcp_http_server.py
 
 Env:
-    ARKIV_MCP_BIND    bind address   (default 0.0.0.0)
+    ARKIV_MCP_BIND    bind address   (default 127.0.0.1 — LAN exposure is opt-in)
     ARKIV_MCP_PORT    listen port    (default 8502)
     ARKIV_DB_PATH     sqlite db path (must match the arkiv service; token store lives here)
     ARKIV_CHROMA_PATH chroma dir     (for semantic search)
 
-Auth: every request must carry a valid arkiv token, via either
-`Authorization: Bearer <token>` or `?token=<token>`. We reuse
+Auth: every request must carry a valid arkiv token via the `Authorization:
+Bearer <token>` header (a token in a URL leaks into access logs, proxies and
+browser history — never accept it as a query param). We reuse
 auth.resolve_raw_token — the exact same token store + IP-allowlist + expiry as
 the HTTP API — so the existing `ui-test` token works unchanged.
 
-Security: this server is LAN-facing. Always require a token and never publish
-8502 to the public internet (use a VPN/firewall). Read-only tools only; no
-ingest/delete is ever exposed.
+Security: this server is token-gated and loopback-bound by default. To expose it
+to the LAN you must deliberately set ARKIV_MCP_BIND=0.0.0.0; even then, never
+publish 8502 to the public internet (use a VPN/firewall). Read-only tools only;
+no ingest/delete is ever exposed.
 """
 from __future__ import annotations
 
@@ -33,22 +35,23 @@ from fastapi import HTTPException
 import auth
 import mcp_server
 
-BIND = os.getenv("ARKIV_MCP_BIND", "0.0.0.0")
+BIND = os.getenv("ARKIV_MCP_BIND", "127.0.0.1")
 PORT = int(os.getenv("ARKIV_MCP_PORT", "8502"))
 
 
 def _extract_token(scope):
-    """Pull a raw token from the Authorization header or ?token= query param."""
+    """Pull a raw bearer token from the Authorization header only.
+
+    No `?token=` query param: a token in a URL persists in uvicorn access logs,
+    any reverse proxy in front of it, and browser history — three places that
+    outlive the request and are not scrubbed. Clients that can't set a header
+    should do so on their side instead."""
     for name, value in scope.get("headers", []):
         if name == b"authorization":
             raw = value.decode("latin-1", "replace")
             if raw.lower().startswith("bearer "):
                 return raw[7:].strip()
             return raw.strip()
-    qs = scope.get("query_string", b"").decode("latin-1", "replace")
-    for pair in qs.split("&"):
-        if pair.startswith("token="):
-            return pair[len("token="):]
     return ""
 
 

--- a/mcp_http_server.py
+++ b/mcp_http_server.py
@@ -1,0 +1,107 @@
+"""arkiv HTTP MCP server — LAN variant of mcp_server.py (Phase 14 addendum).
+
+Serves the SAME 7 read-only tools as the stdio mcp_server, but over HTTP/SSE so
+MCP clients anywhere on the LAN can connect without local DB access. The tools
+are registered once, on mcp_server.mcp (imported below); this file only exposes
+that instance over SSE behind a token gate.
+
+Run (as the `arkiv-mcp` compose service):
+    python mcp_http_server.py
+
+Env:
+    ARKIV_MCP_BIND    bind address   (default 0.0.0.0)
+    ARKIV_MCP_PORT    listen port    (default 8502)
+    ARKIV_DB_PATH     sqlite db path (must match the arkiv service; token store lives here)
+    ARKIV_CHROMA_PATH chroma dir     (for semantic search)
+
+Auth: every request must carry a valid arkiv token, via either
+`Authorization: Bearer <token>` or `?token=<token>`. We reuse
+auth.resolve_raw_token — the exact same token store + IP-allowlist + expiry as
+the HTTP API — so the existing `ui-test` token works unchanged.
+
+Security: this server is LAN-facing. Always require a token and never publish
+8502 to the public internet (use a VPN/firewall). Read-only tools only; no
+ingest/delete is ever exposed.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+from fastapi import HTTPException
+
+import auth
+import mcp_server
+
+BIND = os.getenv("ARKIV_MCP_BIND", "0.0.0.0")
+PORT = int(os.getenv("ARKIV_MCP_PORT", "8502"))
+
+
+def _extract_token(scope):
+    """Pull a raw token from the Authorization header or ?token= query param."""
+    for name, value in scope.get("headers", []):
+        if name == b"authorization":
+            raw = value.decode("latin-1", "replace")
+            if raw.lower().startswith("bearer "):
+                return raw[7:].strip()
+            return raw.strip()
+    qs = scope.get("query_string", b"").decode("latin-1", "replace")
+    for pair in qs.split("&"):
+        if pair.startswith("token="):
+            return pair[len("token="):]
+    return ""
+
+
+async def token_gate(app, scope, receive, send):
+    """ASGI middleware: 401/403 anything without a valid arkiv token.
+
+    Implemented as a plain ASGI middleware (not Starlette BaseHTTPMiddleware) so
+    the long-lived SSE stream is never buffered or consumed by the gate.
+    """
+    if scope["type"] in ("http", "websocket"):
+        client_ip = (scope.get("client") or ("", 0))[0]
+        raw = _extract_token(scope)
+        try:
+            auth.resolve_raw_token(raw, client_ip)
+        except HTTPException as exc:
+            status = getattr(exc, "status_code", 401)
+            body = json.dumps({"error": str(exc.detail)}).encode("utf-8")
+            await send({
+                "type": "http.response.start",
+                "status": status,
+                "headers": [(b"content-type", b"application/json")],
+            })
+            await send({"type": "http.response.body", "body": body})
+            return
+        except Exception:
+            await send({
+                "type": "http.response.start",
+                "status": 401,
+                "headers": [(b"content-type", b"application/json")],
+            })
+            await send({"type": "http.response.body", "body": b'{"error":"unauthorized"}'})
+            return
+    await app(scope, receive, send)
+
+
+class _Wrapped:
+    """Minimal ASGI middleware wrapper (avoids Starlette add_middleware quirks)."""
+
+    def __init__(self, app, middleware):
+        self.app = app
+        self.middleware = middleware
+
+    async def __call__(self, scope, receive, send):
+        await self.middleware(self.app, scope, receive, send)
+
+
+def main():
+    mcp_server._prewarm_vectordb()
+    app = mcp_server.mcp.sse_app()
+    app = _Wrapped(app, token_gate)
+    import uvicorn
+    uvicorn.run(app, host=BIND, port=PORT)
+
+
+if __name__ == "__main__":
+    main()

--- a/media_delete.py
+++ b/media_delete.py
@@ -1,0 +1,160 @@
+"""Unified media delete (Phase 14.5).
+
+Single source of truth for removing a media record AND its on-disk artefacts:
+
+- SQLite row (cascades frames/tags/transcripts via db.delete_media)
+- Chroma vectors (vectordb.delete_media)
+- derivatives: thumbnails, proxy, waveform cache
+- the original source file: moved into the recycle bin (.arkiv/trash) instead of
+  unlinked, so a mistaken delete is recoverable for ARKIV_TRASH_TTL_DAYS days.
+
+External paths (offload cold storage / absolute paths outside PROJECT_ROOT /
+federated libraries) are metadata-only: we refuse to physically remove a file
+arkiv does not own, and record a warning in the audit log.
+
+Reused by:
+- DELETE /api/media/{id} and POST /api/media/bulk-delete (routers/media.py)
+- POST /api/admin/prune-missing (routers/admin.py) with allow_file_delete=False
+- routers/sample.py remove (so sample cleanup also nukes proxies/waveforms)
+"""
+import json
+import os
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+import config
+import db
+
+
+def _within_allowed_roots(resolved: str) -> bool:
+    """True if `resolved` lives under PROJECT_ROOT or one of ARKIV_MEDIA_ROOTS.
+
+    Uses a separator-joined prefix check rather than Path.is_relative_to so the
+    behaviour is identical on 3.9 across platforms (is_relative_to is 3.9 but has
+    edge cases); the trailing os.sep guards against /Volumes/foo being treated as
+    a parent of /Volumes/foobar."""
+    resolved = Path(resolved).resolve()
+    roots = [Path(config.PROJECT_ROOT).resolve()]
+    roots += [Path(r).resolve() for r in config.MEDIA_ROOTS]
+    s = str(resolved)
+    for r in roots:
+        rs = str(r)
+        if s == rs or s.startswith(rs + os.sep):
+            return True
+    return False
+
+
+def _unlink_rel(stored_path: str) -> None:
+    """Unlink a PROJECT_ROOT-relative (or absolute) stored path, best-effort."""
+    try:
+        p = Path(stored_path)
+        target = p if p.is_absolute() else (config.PROJECT_ROOT / p)
+        target.unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
+def _audit(media_id, filename, file_deleted, warning, token_info):
+    try:
+        actor = "unknown"
+        if isinstance(token_info, dict):
+            actor = token_info.get("name") or token_info.get("id") or "unknown"
+        log_dir = config.PROJECT_ROOT / ".arkiv" / "audit"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        line = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "action": "media_delete",
+            "media_id": media_id,
+            "filename": filename,
+            "file_deleted": file_deleted,
+            "warning": warning,
+            "actor": actor,
+        }
+        with (log_dir / "delete.jsonl").open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(line, ensure_ascii=False) + "\n")
+    except Exception:
+        pass
+
+
+def delete_media_full(media_id, allow_file_delete=True, token_info=None):
+    """Delete one media record and all its artefacts.
+
+    Returns a result dict, or None if the media row does not exist (so the
+    caller can answer 404). `allow_file_delete=False` skips the physical move
+    (used by prune-missing where the file is already gone)."""
+    with db.get_conn() as conn:
+        row = conn.execute(
+            "SELECT id, path, filename FROM media WHERE id=?", (media_id,)
+        ).fetchone()
+    if row is None:
+        return None
+
+    path = row["path"]
+    filename = row["filename"] or ""
+
+    thumbs = db.delete_media(media_id) or []
+
+    resolved = ""
+    try:
+        if path:
+            resolved = db.resolve_path(path)
+    except ValueError:
+        resolved = ""
+
+    file_deleted = False
+    warning = None
+    trash_path = ""
+    if resolved and allow_file_delete:
+        if _within_allowed_roots(resolved):
+            try:
+                config.TRASH_DIR.mkdir(parents=True, exist_ok=True)
+                stem = "%d__%s" % (media_id, filename or Path(resolved).name)
+                dest = config.TRASH_DIR / stem
+                if dest.exists():
+                    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+                    dest = config.TRASH_DIR / ("%s__%s" % (stamp, stem))
+                shutil.move(str(resolved), str(dest))
+                trash_path = str(dest)
+                file_deleted = True
+            except Exception:
+                warning = "file move to trash failed; metadata removed"
+        else:
+            warning = "external path outside allowed roots: metadata-only, original kept"
+
+    # derivatives (best-effort, run even when the original was already gone)
+    for rel in thumbs:
+        _unlink_rel(rel)
+    if resolved:
+        try:
+            config.proxy_path_for(media_id, str(resolved)).unlink(missing_ok=True)
+        except Exception:
+            pass
+    try:
+        for f in config.WAVEFORMS_DIR.glob("%d_*" % media_id):
+            f.unlink(missing_ok=True)
+    except Exception:
+        pass
+
+    # vectors
+    try:
+        import vectordb
+        col = vectordb.get_collection()
+        if col is not None:
+            vectordb.delete_media(col, media_id)
+    except Exception:
+        pass
+
+    # Only record a recycle-bin entry when an actual file was moved (it is the
+    # only thing recoverable). Metadata-only deletes are still captured by the
+    # audit log below.
+    if trash_path:
+        db.trash_media(media_id, filename, path or "", trash_path, config.TRASH_TTL_DAYS)
+    _audit(media_id, filename, file_deleted, warning, token_info)
+
+    return {
+        "ok": True,
+        "media_id": media_id,
+        "file_deleted": file_deleted,
+        "warning": warning,
+    }

--- a/media_delete.py
+++ b/media_delete.py
@@ -14,7 +14,7 @@ arkiv does not own, and record a warning in the audit log.
 
 Reused by:
 - DELETE /api/media/{id} and POST /api/media/bulk-delete (routers/media.py)
-- POST /api/admin/prune-missing (routers/admin.py) with allow_file_delete=False
+- POST /api/media/prune-missing (routers/media.py) with allow_file_delete=False
 - routers/sample.py remove (so sample cleanup also nukes proxies/waveforms)
 """
 import json

--- a/mediatypes.py
+++ b/mediatypes.py
@@ -46,8 +46,16 @@ VIDEO_EXT = frozenset({
 # Audio the pipeline transcribes.
 AUDIO_EXT = frozenset({".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg"})
 
-# Everything the ingest pipeline accepts (video + audio partition MEDIA_EXT).
-MEDIA_EXT = VIDEO_EXT | AUDIO_EXT
+# Raster / vector still images treated as first-class media assets (Round 5
+# image-support). ffmpeg thumbs + extracts a single frame from raster formats;
+# vision (Ollama qwen2.5-vl) tags them like video. `.svg` is ingested as an
+# asset but has no decodable pixel stream, so it gets neither thumbnail,
+# frame, nor vision (frontend renders a placeholder).
+IMAGE_EXT = frozenset({".png", ".jpg", ".jpeg", ".webp", ".gif", ".svg"})
+
+# Everything the ingest pipeline accepts (video + audio + image partition
+# MEDIA_EXT).
+MEDIA_EXT = VIDEO_EXT | AUDIO_EXT | IMAGE_EXT
 
 
 def sql_in_literal(exts: FrozenSet[str]) -> str:

--- a/query_builder.py
+++ b/query_builder.py
@@ -59,6 +59,7 @@ _FIELDS: Dict[str, Tuple[Optional[str], set, str]] = {
 # in sync with server._VIDEO_EXTS / _AUDIO_EXTS).
 _VIDEO_EXTS = mediatypes.VIDEO_EXT
 _AUDIO_EXTS = mediatypes.AUDIO_EXT
+_IMAGE_EXTS = mediatypes.IMAGE_EXT
 
 
 def _one_condition(cond: Dict[str, Any]) -> Tuple[Optional[str], List[Any], Optional[str]]:
@@ -100,8 +101,10 @@ def _one_condition(cond: Dict[str, Any]) -> Tuple[Optional[str], List[Any], Opti
             exts = _VIDEO_EXTS
         elif v == "audio":
             exts = _AUDIO_EXTS
+        elif v == "image":
+            exts = _IMAGE_EXTS
         else:
-            raise QueryError("media_type must be 'video' or 'audio'")
+            raise QueryError("media_type must be 'video', 'audio', or 'image'")
         placeholders = ",".join("?" * len(exts))
         return "LOWER(ext) IN ({0})".format(placeholders), list(exts), None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,11 @@ fastapi>=0.140.6
 uvicorn>=0.52.1
 pydantic>=2.0,<3
 chromadb>=1.0,<2
+# upload endpoint (routers/ingest.py: UploadFile = File(...)) needs this at
+# import/collection time — a fresh install without it dies on import even
+# without mcp present. Do NOT let it ride on mcp's transitive pull: on 3.9 the
+# MCP marker is excluded, so python-multipart silently disappears.
+python-multipart>=0.0.9
 requests>=2.28
 xxhash>=3.8.1
 nanoid>=2.0.0

--- a/resolve_plugin/arkiv_resolve_lan.py
+++ b/resolve_plugin/arkiv_resolve_lan.py
@@ -1,0 +1,754 @@
+#!/usr/bin/env python3
+"""
+arkiv — DaVinci Resolve Plugin (LAN variant)
+Search arkiv media library and import selected files into the current Resolve project.
+
+This is the remote/LAN build: it defaults to http://localhost:8501 and sends a
+media_read + videos_read token (ARKIV_TOKEN) on every request, because the
+server only trusts loopback (localhost) as admin WITHOUT a token. Import
+downloads each clip via /api/stream/{id} to a local temp dir first — the
+server's internal media-in/... path is NOT reachable from a different machine
+on the LAN, so passing it straight to Resolve would create an empty
+"media-in" bin and import zero clips. Use this copy when arkiv runs on
+another machine on the LAN. The localhost / no-token version is
+arkiv_resolve.py.
+
+Install (macOS):
+    cp arkiv_resolve_lan.py ~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Scripts/Utility/
+Install (Windows):
+    copy arkiv_resolve_lan.py "%APPDATA%\\Blackmagic Design\\DaVinci Resolve\\Support\\Fusion\\Scripts\\Utility\\"
+
+Usage:
+    In DaVinci Resolve → Workspace → Scripts → arkiv_resolve_lan
+"""
+import json
+import os
+import tempfile
+import urllib.request
+import urllib.parse
+from pathlib import Path
+
+# Resolve API base from env so users running arkiv on a non-default port (or on
+# a remote host they Tailscale into) can point the plugin without a code edit.
+# ARKIV_API takes precedence; fallback composes from ARKIV_HOST + ARKIV_PORT to
+# match the env vars used by config.py / server.py.
+def _validate_arkiv_api(url):
+    """Reject schemes / hosts that turn the plugin into an SSRF gadget.
+
+    Codex Round-2 audit (J4): a malicious ARKIV_API like
+    http://169.254.169.254/latest/meta-data/ would have the plugin pull cloud
+    metadata on every search / import. Plugin runs inside operator's Resolve, so
+    treat env override as untrusted-ish — http/https only, no link-local."""
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"ARKIV_API 必須是 http/https scheme：{url!r}")
+    host = parsed.hostname or ""
+    if host.startswith("169.254.") or host == "0.0.0.0":
+        raise ValueError(
+            f"ARKIV_API 不可指向 link-local / cloud metadata 位址：{url!r}"
+        )
+    return url
+
+
+ARKIV_API = _validate_arkiv_api(
+    os.environ.get("ARKIV_API") or "http://{host}:{port}".format(
+        host=os.environ.get("ARKIV_HOST", "localhost"),
+        port=os.environ.get("ARKIV_PORT", "8501"),
+    )
+)
+
+# LAN build: the server only trusts loopback (localhost) as admin WITHOUT a
+# token. A non-localhost host (e.g. a LAN IP) MUST present a token with the
+# media_read scope, or every request 401s. The token is read from the
+# ARKIV_TOKEN environment variable (set it in your .env / shell) — it is
+# intentionally NOT hardcoded in this file.
+ARKIV_TOKEN = os.environ.get("ARKIV_TOKEN")
+if not ARKIV_TOKEN:
+    raise RuntimeError(
+        "ARKIV_TOKEN is not set. Export it (or add to your .env) from your "
+        "arkiv server's token admin before using the LAN plugin."
+    )
+
+
+def _api_request(url, data=None, headers=None):
+    """Build a Request with the LAN bearer token attached."""
+    h = {"Authorization": "Bearer {0}".format(ARKIV_TOKEN)}
+    if headers:
+        h.update(headers)
+    return urllib.request.Request(url, data=data, headers=h)
+
+
+_DOWNLOAD_DIR = os.path.join(tempfile.gettempdir(), "arkiv_import")
+
+
+def _download_media(media_id, filename):
+    """Download a media file from arkiv to a local temp dir.
+
+    The LAN build runs on a DIFFERENT machine from the arkiv server, so the
+    library's internal (relative) path — e.g. ``media-in/foo.mp4`` — is not
+    reachable from Resolve. We pull the bytes via /api/stream/{id} (which
+    resolves the file server-side) and hand Resolve a local path it can import
+    by reference. Returns the local path, or None on failure.
+    """
+    os.makedirs(_DOWNLOAD_DIR, exist_ok=True)
+    safe_name = "{0}_{1}".format(media_id, os.path.basename(filename or "clip"))
+    dest = os.path.join(_DOWNLOAD_DIR, safe_name)
+    url = "{0}/api/stream/{1}".format(ARKIV_API, media_id)
+    try:
+        with urllib.request.urlopen(_api_request(url), timeout=600) as resp:
+            data = resp.read()
+        with open(dest, "wb") as f:
+            f.write(data)
+        print(f"[arkiv] 已下載 {filename} → {dest}")
+        return dest
+    except Exception as e:
+        print(f"[arkiv] 下載失敗 (id={media_id}, {filename}): {e}")
+        return None
+
+
+def download_metadata_csv(dest_path=None, media_ids=None):
+    """Phase 7.6d + audit Batch E F5: fetch DaVinci metadata CSV and write to disk.
+
+    Returns the destination path on success, None on failure. The CSV maps
+    each clip's filename to Description / Keywords / Comments / Scene so the
+    user can run File → Import Metadata From → CSV in Resolve immediately.
+
+    media_ids: 給 list 時走 batch-scoped 路徑（?ids=1,2,3），CSV 只含這幾支
+    剛 import 的 clip；不給 → 整庫（既有行為，CLI / 整庫匯出走這條）。
+    """
+    if dest_path is None:
+        cache_dir = Path(tempfile.gettempdir()) / "arkiv"
+        try:
+            cache_dir.mkdir(parents=True, exist_ok=True)
+        except Exception:
+            cache_dir = Path(tempfile.gettempdir())
+        dest_path = cache_dir / "davinci_metadata.csv"
+    try:
+        url = f"{ARKIV_API}/api/export/metadata-csv"
+        if media_ids:
+            ids_str = ",".join(str(int(i)) for i in media_ids)
+            url += "?" + urllib.parse.urlencode({"ids": ids_str})
+        with urllib.request.urlopen(_api_request(url), timeout=30) as resp:
+            data = resp.read()
+        Path(dest_path).write_bytes(data)
+        return str(dest_path)
+    except Exception as e:
+        print(f"[arkiv] Metadata CSV 下載失敗：{e}")
+        return None
+
+
+def get_resolve():
+    """Get the DaVinci Resolve scripting object."""
+    import sys
+    import os
+    # Set up Resolve scripting module paths
+    if sys.platform == "darwin":
+        modules_path = "/Library/Application Support/Blackmagic Design/DaVinci Resolve/Developer/Scripting/Modules"
+        if modules_path not in sys.path:
+            sys.path.append(modules_path)
+    elif sys.platform == "win32":
+        script_api = os.environ.get(
+            "RESOLVE_SCRIPT_API",
+            r"C:\ProgramData\Blackmagic Design\DaVinci Resolve\Support\Developer\Scripting"
+        )
+        modules_path = os.path.join(script_api, "Modules")
+        if modules_path not in sys.path:
+            sys.path.append(modules_path)
+    try:
+        import DaVinciResolveScript as dvr
+        resolve = dvr.scriptapp("Resolve")
+        if resolve is None:
+            print("[arkiv] DaVinciResolveScript 已載入但 Resolve 未回應")
+        return resolve
+    except ImportError as e:
+        print(f"[arkiv] 無法匯入 DaVinciResolveScript：{e}")
+        return None
+
+
+def search_media(query, limit=50):
+    """Search arkiv API for media matching query."""
+    params = urllib.parse.urlencode({"q": query, "limit": limit})
+    url = f"{ARKIV_API}/api/media?{params}"
+    try:
+        req = _api_request(url)
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+            return data.get("items", [])
+    except Exception as e:
+        print(f"[arkiv] 搜尋錯誤：{e}")
+        return []
+
+
+def list_media(limit=50, rating=None):
+    """List media from arkiv API."""
+    params = {"limit": limit, "sort": "date"}
+    if rating:
+        params["rating"] = rating
+    url = f"{ARKIV_API}/api/media?{urllib.parse.urlencode(params)}"
+    try:
+        req = _api_request(url)
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+            return data.get("items", [])
+    except Exception as e:
+        print(f"[arkiv] 列表錯誤：{e}")
+        return []
+
+
+RATING_COLORS = {
+    "good": "Green",
+    "ng": "Orange",
+    "review": "Yellow",
+}
+
+
+def _get_camera_folder(path):
+    """Extract camera/source folder name from file path."""
+    parts = path.replace("\\", "/").rstrip("/").split("/")
+    folder = parts[-2] if len(parts) >= 2 else ""
+    if folder.lower() in ("reels", "clips", "raw", "media", "footage"):
+        folder = parts[-3] if len(parts) >= 3 else folder
+    return folder
+
+
+def _get_or_create_bin(media_pool, root_folder, bin_name):
+    """Get existing Bin or create new one under root_folder."""
+    # Check existing sub-folders
+    for sub in root_folder.GetSubFolderList():
+        if sub.GetName() == bin_name:
+            return sub
+    # Create new bin
+    media_pool.SetCurrentFolder(root_folder)
+    new_bin = media_pool.AddSubFolder(root_folder, bin_name)
+    if new_bin:
+        print(f"[arkiv] 建立 Bin：{bin_name}")
+    return new_bin
+
+
+def import_to_resolve(resolve, file_paths, ratings=None, tags=None, media_ids=None, bin_name=None):
+    """Import files into the current Resolve project's Media Pool.
+    Auto-creates Bin folders by camera/source under Master.
+    ratings: dict mapping file_path -> rating string (good/ng/review)
+    tags: dict mapping file_path -> list of tag name strings
+    media_ids: list of arkiv media ids being imported — passed through to
+        download_metadata_csv() so the resulting CSV is batch-scoped to just
+        these clips, not the entire library (audit Batch E F5).
+    """
+    if not resolve:
+        print("[arkiv] Resolve 未連線")
+        return False
+    pm = resolve.GetProjectManager()
+    if not pm:
+        return False
+    project = pm.GetCurrentProject()
+    if not project:
+        return False
+    media_pool = project.GetMediaPool()
+    if not media_pool:
+        return False
+
+    root_folder = media_pool.GetRootFolder()
+
+    # Group files. On the LAN build files are downloaded to a flat temp dir
+    # (see on_import / _download_media), so an explicit bin_name keeps them out
+    # of a meaningless "media-in" bin; otherwise derive a camera/source folder.
+    groups = {}
+    if bin_name:
+        groups[bin_name] = list(file_paths)
+    else:
+        for p in file_paths:
+            folder = _get_camera_folder(p)
+            if folder not in groups:
+                groups[folder] = []
+            groups[folder].append(p)
+
+    total_imported = 0
+    all_imported_clips = []
+
+    for folder_name, paths in groups.items():
+        # Create or get Bin for this camera
+        if folder_name:
+            target_bin = _get_or_create_bin(media_pool, root_folder, folder_name)
+            if target_bin:
+                media_pool.SetCurrentFolder(target_bin)
+            else:
+                media_pool.SetCurrentFolder(root_folder)
+        else:
+            media_pool.SetCurrentFolder(root_folder)
+
+        result = media_pool.ImportMedia(paths)
+        if result:
+            all_imported_clips.extend(result)
+            total_imported += len(result)
+            print(f"[arkiv] {folder_name or 'Master'}: 匯入 {len(result)} 個片段")
+
+    # Reset to root
+    media_pool.SetCurrentFolder(root_folder)
+
+    if all_imported_clips:
+        # Apply clip colors based on rating
+        if ratings:
+            for mpi in all_imported_clips:
+                clip_name = mpi.GetName()
+                for path, rating in ratings.items():
+                    if clip_name and (clip_name in path or path.endswith(clip_name)):
+                        color = RATING_COLORS.get(rating)
+                        if color:
+                            mpi.SetClipColor(color)
+                            print(f"[arkiv]   {clip_name} → {color} ({rating})")
+                        break
+        # Set tags as metadata (Keywords + Comments for Smart Bin filtering)
+        if tags:
+            for mpi in all_imported_clips:
+                clip_name = mpi.GetName()
+                for path, tag_list in tags.items():
+                    if clip_name and (clip_name in path or path.endswith(clip_name)):
+                        if tag_list:
+                            tag_str = ", ".join(tag_list)
+                            mpi.SetMetadata("Keywords", tag_str)
+                            mpi.SetMetadata("Comments", f"[arkiv] {tag_str}")
+                            print(f"[arkiv]   {clip_name} → Tags: {tag_str}")
+                        break
+        print(f"[arkiv] 完成：共匯入 {total_imported} 個片段到 {len(groups)} 個 Bin")
+
+        # Phase 7.6d: auto-download metadata CSV and tell the user how to import.
+        # arkiv 的 SetMetadata API 對 Keywords/Comments 在新版 Resolve 不寫入，
+        # 改走 CSV import 路線；這裡幫使用者把檔下載好，貼路徑就能用。
+        # batch-scoped (audit F5): 只下載剛 import 的這幾支的 metadata，不是整庫。
+        csv_path = download_metadata_csv(media_ids=media_ids)
+        if csv_path:
+            print("[arkiv] ─────────────────────────────────────────")
+            print(f"[arkiv] Metadata CSV 已就緒：{csv_path}")
+            print("[arkiv] 在 Resolve 選 File → Import Metadata From → CSV，")
+            print("[arkiv] 開啟上面那個檔即可填入 Description / Keywords / Comments / Scene。")
+            print("[arkiv] ─────────────────────────────────────────")
+
+        return True
+    else:
+        print("[arkiv] 匯入失敗")
+        return False
+
+
+def get_media_detail(media_id):
+    """Fetch single media detail with frames from arkiv API."""
+    url = f"{ARKIV_API}/api/media/{media_id}"
+    try:
+        req = _api_request(url)
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read().decode())
+    except Exception as e:
+        print(f"[arkiv] 詳情取得錯誤：{e}")
+        return None
+
+
+def add_markers_to_timeline(resolve, media_items):
+    """Add frame analysis markers as clip markers on matching timeline items."""
+    if not resolve:
+        print("[arkiv] Resolve 未連線")
+        return 0
+
+    pm = resolve.GetProjectManager()
+    project = pm.GetCurrentProject() if pm else None
+    timeline = project.GetCurrentTimeline() if project else None
+    if not timeline:
+        print("[arkiv] 未開啟時間線 — 請先開啟時間線")
+        return 0
+
+    # Get timeline FPS
+    fps_str = timeline.GetSetting("timelineFrameRate")
+    try:
+        fps = float(fps_str)
+    except (TypeError, ValueError):
+        fps = 30.0
+    print(f"[arkiv] 時間線 FPS：{fps}")
+
+    # Build a map of filename -> timeline_item for all video tracks
+    clip_map = {}
+    track_count = timeline.GetTrackCount("video")
+    for t in range(1, track_count + 1):
+        for ti in timeline.GetItemListInTrack("video", t):
+            name = ti.GetName()
+            if name:
+                clip_map[name] = ti
+    print(f"[arkiv] 在時間線上找到 {len(clip_map)} 個片段")
+
+    colors = ["Blue", "Cyan", "Green", "Yellow", "Red", "Pink", "Purple"]
+    total_added = 0
+
+    for item in media_items:
+        media_id = item.get("id")
+        filename = item.get("filename", "")
+        if not media_id:
+            continue
+
+        # Find matching clip on timeline
+        ti = clip_map.get(filename)
+        if not ti:
+            # Try without extension
+            stem = filename.rsplit(".", 1)[0] if "." in filename else filename
+            for k, v in clip_map.items():
+                if k.startswith(stem):
+                    ti = v
+                    break
+        if not ti:
+            print(f"[arkiv] 片段「{filename}」未在時間線上找到 — 請先匯入並放置")
+            continue
+
+        detail = get_media_detail(media_id)
+        if not detail:
+            continue
+
+        frames = detail.get("frames") or []
+        if not frames:
+            print(f"[arkiv] 無 {filename} 的幀資料")
+            continue
+
+        print(f"[arkiv] 正在為 {filename} 新增 {len(frames)} 個片段標記")
+        for i, fr in enumerate(frames):
+            ts = fr.get("timestamp_s", 0)
+            frame_offset = round(ts * fps)
+            desc = fr.get("description") or f"Frame {fr.get('frame_index', i) + 1}"
+            color = colors[i % len(colors)]
+
+            if desc.startswith("```") or not desc.strip():
+                continue
+
+            # AddMarker on timeline_item = clip marker (frame offset from clip start)
+            success = ti.AddMarker(
+                frame_offset,
+                color,
+                desc[:50],
+                desc,
+                1,
+            )
+            if success:
+                total_added += 1
+            else:
+                print(f"[arkiv]   ！在幀 {frame_offset} 處標記失敗")
+
+    return total_added
+
+
+def format_duration(seconds):
+    """Format seconds to MM:SS."""
+    if not seconds:
+        return "00:00"
+    m = int(seconds) // 60
+    s = int(seconds) % 60
+    return f"{m:02d}:{s:02d}"
+
+
+def create_ui(resolve):
+    """Create the arkiv search UI using Fusion's UIManager."""
+    fusion = resolve.Fusion() if resolve else None
+    if not fusion:
+        print("[arkiv] 無法存取 Fusion UIManager")
+        print("[arkiv] 提示：確保 DaVinci Resolve 正在執行且從工作區 → 指令碼啟動")
+        return None
+
+    ui = fusion.UIManager
+    disp = bmd.UIDispatcher(ui)  # noqa: F821 — bmd is injected by Resolve
+
+    # ── Build Window ──
+    win = disp.AddWindow(
+        {
+            "ID": "ArkivWin",
+            "WindowTitle": "arkiv — 媒體搜尋",
+            "Geometry": [200, 200, 700, 500],
+        },
+        [
+            ui.VGroup(
+                {"Spacing": 5},
+                [
+                    # Search bar
+                    ui.HGroup(
+                        {"Spacing": 5},
+                        [
+                            ui.LineEdit(
+                                {
+                                    "ID": "SearchField",
+                                    "PlaceholderText": "搜尋媒體...（語義搜尋）",
+                                    "Weight": 3,
+                                }
+                            ),
+                            ui.Button({"ID": "SearchBtn", "Text": "搜尋", "Weight": 0.5}),
+                            ui.Button({"ID": "ResetBtn", "Text": "全部", "Weight": 0.3}),
+                            ui.Button({"ID": "GoodBtn", "Text": "僅 GOOD", "Weight": 0.5}),
+                            ui.Button({"ID": "ExcludeNGBtn", "Text": "排除 NG", "Weight": 0.5}),
+                        ],
+                    ),
+                    # Results tree
+                    ui.Tree(
+                        {
+                            "ID": "ResultTree",
+                            "SortingEnabled": True,
+                            "SelectionMode": "ExtendedSelection",
+                            "HeaderHidden": False,
+                            "Weight": 5,
+                        }
+                    ),
+                    # Status + Actions
+                    ui.HGroup(
+                        {"Spacing": 5},
+                        [
+                            ui.Label({"ID": "StatusLabel", "Text": "準備就緒", "Weight": 3}),
+                            ui.Button(
+                                {
+                                    "ID": "ImportBtn",
+                                    "Text": "匯入到媒體庫",
+                                    "Weight": 1,
+                                }
+                            ),
+                            ui.Button(
+                                {
+                                    "ID": "MarkerBtn",
+                                    "Text": "新增標記",
+                                    "Weight": 0.7,
+                                }
+                            ),
+                        ],
+                    ),
+                ],
+            )
+        ],
+    )
+
+    # Setup tree columns
+    tree = win.Find("ResultTree")
+    hdr = tree.NewItem()
+    hdr.Text[0] = "檔名"
+    hdr.Text[1] = "長度"
+    hdr.Text[2] = "評級"
+    hdr.Text[3] = "語言"
+    hdr.Text[4] = "得分"
+    tree.SetHeaderItem(hdr)
+    tree.ColumnCount = 5
+    tree.ColumnWidth[0] = 280
+    tree.ColumnWidth[1] = 70
+    tree.ColumnWidth[2] = 60
+    tree.ColumnWidth[3] = 60
+    tree.ColumnWidth[4] = 60
+
+    # Store results for import
+    results_map = {}
+    good_filter_on = [False]
+    exclude_ng_on = [False]
+
+    def populate_tree(items):
+        tree.Clear()
+        results_map.clear()
+        for item in items:
+            row = tree.NewItem()
+            fname = item.get("filename", "")
+            row.Text[0] = fname
+            row.Text[1] = format_duration(item.get("duration_s"))
+            row.Text[2] = (item.get("rating") or "—").upper()
+            row.Text[3] = item.get("lang") or "?"
+            row.Text[4] = f"{round(item.get('score', 0) * 100)}%" if item.get("score") else ""
+            tree.AddTopLevelItem(row)
+            results_map[fname] = item
+        win.Find("StatusLabel").Text = f"找到 {len(items)} 個結果"
+
+    def on_search(ev):
+        query = win.Find("SearchField").Text.strip()
+        if not query:
+            on_reset(ev)
+            return
+        win.Find("StatusLabel").Text = "搜尋中..."
+        try:
+            items = search_media(query)
+            populate_tree(items)
+        except Exception as e:
+            win.Find("StatusLabel").Text = f"搜尋失敗：{e}"
+
+    def on_reset(ev):
+        win.Find("SearchField").Text = ""
+        win.Find("StatusLabel").Text = "載入所有媒體..."
+        good_filter_on[0] = False
+        exclude_ng_on[0] = False
+        win.Find("GoodBtn").Text = "僅 GOOD"
+        win.Find("ExcludeNGBtn").Text = "排除 NG"
+        try:
+            items = list_media(limit=500)
+            populate_tree(items)
+        except Exception as e:
+            win.Find("StatusLabel").Text = f"載入失敗：{e}"
+
+    def on_good(ev):
+        good_filter_on[0] = not good_filter_on[0]
+        exclude_ng_on[0] = False
+        win.Find("ExcludeNGBtn").Text = "排除 NG"
+        try:
+            if good_filter_on[0]:
+                win.Find("GoodBtn").Text = "顯示全部"
+                win.Find("StatusLabel").Text = "載入 GOOD 素材..."
+                items = list_media(rating="good")
+            else:
+                win.Find("GoodBtn").Text = "僅 GOOD"
+                win.Find("StatusLabel").Text = "載入所有媒體..."
+                items = list_media(limit=500)
+            populate_tree(items)
+        except Exception as e:
+            win.Find("StatusLabel").Text = f"載入失敗：{e}"
+
+    def on_exclude_ng(ev):
+        exclude_ng_on[0] = not exclude_ng_on[0]
+        good_filter_on[0] = False
+        win.Find("GoodBtn").Text = "僅 GOOD"
+        try:
+            if exclude_ng_on[0]:
+                win.Find("ExcludeNGBtn").Text = "顯示全部"
+                win.Find("StatusLabel").Text = "排除 NG 素材..."
+                all_items = list_media(limit=500)
+                items = [i for i in all_items if i.get("rating") != "ng"]
+            else:
+                win.Find("ExcludeNGBtn").Text = "排除 NG"
+                win.Find("StatusLabel").Text = "載入所有媒體..."
+                items = list_media(limit=500)
+            populate_tree(items)
+        except Exception as e:
+            win.Find("StatusLabel").Text = f"載入失敗：{e}"
+
+    def on_import(ev):
+        selected = tree.SelectedItems()
+        if not selected:
+            win.Find("StatusLabel").Text = "未選擇任何項目"
+            return
+        try:
+            paths = []
+            ratings = {}
+            tags = {}
+            media_ids = []
+            for sel_id in selected:
+                row = selected[sel_id]
+                fname = row.Text[0]
+                item_data = results_map.get(fname)
+                if not item_data or not item_data.get("id"):
+                    continue
+                # LAN: download the file locally, then import the local copy
+                # (the library's media-in/... path is unreachable from here).
+                local = _download_media(
+                    item_data["id"],
+                    item_data.get("filename") or "clip_{0}".format(item_data["id"]),
+                )
+                if not local:
+                    continue
+                paths.append(local)
+                media_ids.append(item_data["id"])
+                if item_data.get("rating"):
+                    ratings[local] = item_data["rating"]
+                item_tags = item_data.get("tags", [])
+                if item_tags:
+                    tags[local] = [t["name"] for t in item_tags]
+            if paths:
+                success = import_to_resolve(
+                    resolve, paths, ratings, tags,
+                    media_ids=media_ids or None, bin_name="Arkiv",
+                )
+                if success:
+                    # Phase 7.6d: import_to_resolve 已下載 CSV 並 print 路徑到
+                    # console；StatusLabel 受字數限制，改用 chevron 提示去看 console。
+                    win.Find("StatusLabel").Text = (
+                        f"已匯入 {len(paths)} 個片段 → 詳見 console 的 Metadata CSV 路徑"
+                    )
+                else:
+                    win.Find("StatusLabel").Text = "匯入失敗 — 請檢查媒體庫"
+            else:
+                win.Find("StatusLabel").Text = "找不到有效的檔案路徑"
+        except Exception as e:
+            win.Find("StatusLabel").Text = f"匯入錯誤：{e}"
+
+    def on_markers(ev):
+        selected = tree.SelectedItems()
+        if not selected:
+            win.Find("StatusLabel").Text = "未選擇任何項目"
+            return
+        try:
+            items = []
+            for sel_id in selected:
+                row = selected[sel_id]
+                fname = row.Text[0]
+                item_data = results_map.get(fname)
+                if item_data:
+                    items.append(item_data)
+            if not items:
+                win.Find("StatusLabel").Text = "找不到有效的項目"
+                return
+            win.Find("StatusLabel").Text = "新增標記中..."
+            count = add_markers_to_timeline(resolve, items)
+            win.Find("StatusLabel").Text = f"已在時間線上新增 {count} 個標記"
+        except Exception as e:
+            win.Find("StatusLabel").Text = f"標記錯誤：{e}"
+
+    def on_close(ev):
+        disp.ExitLoop()
+
+    win.On.SearchBtn.Clicked = on_search
+    win.On.ResetBtn.Clicked = on_reset
+    win.On.GoodBtn.Clicked = on_good
+    win.On.ExcludeNGBtn.Clicked = on_exclude_ng
+    win.On.ImportBtn.Clicked = on_import
+    win.On.MarkerBtn.Clicked = on_markers
+    win.On.ArkivWin.Close = on_close
+    win.On.SearchField.ReturnPressed = on_search
+
+    # Load initial list
+    items = list_media(limit=500)
+    populate_tree(items)
+
+    win.Show()
+    disp.RunLoop()
+    win.Hide()
+
+
+def run_cli_mode(resolve):
+    """Fallback CLI mode when UIManager is not available."""
+    print("\n=== arkiv 媒體搜尋（CLI 模式）===\n")
+    while True:
+        query = input("搜尋（輸入 'q' 離開，'good' 顯示 GOOD 素材）：").strip()
+        if query.lower() == "q":
+            break
+        if query.lower() == "good":
+            items = list_media(rating="good")
+        else:
+            items = search_media(query)
+
+        if not items:
+            print("找不到結果。\n")
+            continue
+
+        for i, item in enumerate(items):
+            rating = (item.get("rating") or "—").upper()
+            dur = format_duration(item.get("duration_s"))
+            print(f"  [{i}] {item['filename']}  ({dur})  [{rating}]  {item.get('lang', '?')}")
+
+        sel = input("\n輸入編號匯入（逗號分隔，或 'skip' 跳過）：").strip()
+        if sel.lower() == "skip":
+            continue
+        try:
+            indices = [int(x.strip()) for x in sel.split(",")]
+            valid = [items[i] for i in indices if 0 <= i < len(items)]
+            paths = []
+            media_ids = []
+            for it in valid:
+                mid = it.get("id")
+                if not mid:
+                    continue
+                local = _download_media(mid, it.get("filename") or "clip_{0}".format(mid))
+                if local:
+                    paths.append(local)
+                    media_ids.append(mid)
+            if paths and resolve:
+                import_to_resolve(resolve, paths, media_ids=media_ids or None, bin_name="Arkiv")
+        except (ValueError, IndexError) as e:
+            print(f"無效選擇：{e}")
+        print()
+
+
+if __name__ == "__main__":
+    resolve = get_resolve()
+    if resolve:
+        print("[arkiv] 已連線到 DaVinci Resolve")
+    else:
+        print("[arkiv] DaVinci Resolve 未執行 — 僅限 CLI 模式")
+    create_ui(resolve)

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -14,7 +14,6 @@ from pydantic import BaseModel
 import admin
 import config
 import db
-import media_delete
 from auth import require_scopes
 
 router = APIRouter()
@@ -73,41 +72,7 @@ def admin_revoke_token(
     return {"ok": True, "deleted": token_id}
 
 
-# ── Orphan reconcile + recycle bin (Phase 14.5) ───────────────────────────────
-
-class PruneMissingBody(BaseModel):
-    dry_run: bool = True
-
-
-@router.post("/api/admin/prune-missing")
-def admin_prune_missing(
-    body: PruneMissingBody,
-    _tok: dict = Depends(require_scopes("media_delete")),
-):
-    """Remove media rows whose source file no longer exists on disk (the ghost
-    records left by manually-deleted files). With dry_run=true (default) nothing
-    is changed — only a count is returned."""
-    missing = db.iter_missing()
-    if body.dry_run:
-        return {
-            "scanned": len(missing),
-            "pruned": 0,
-            "pruned_ids": [],
-            "dry_run": True,
-        }
-    pruned_ids = []
-    for m in missing:
-        r = media_delete.delete_media_full(
-            m["id"], allow_file_delete=False, token_info=_tok
-        )
-        if r is not None:
-            pruned_ids.append(m["id"])
-    return {
-        "scanned": len(missing),
-        "pruned": len(pruned_ids),
-        "pruned_ids": pruned_ids,
-        "dry_run": False,
-    }
+# ── Recycle bin (Phase 14.5) ──────────────────────────────────────────────────
 
 
 @router.get("/api/admin/trash")

--- a/routers/admin.py
+++ b/routers/admin.py
@@ -12,6 +12,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 import admin
+import config
+import db
+import media_delete
 from auth import require_scopes
 
 router = APIRouter()
@@ -68,3 +71,96 @@ def admin_revoke_token(
     if not admin.revoke_token(token_id):
         raise HTTPException(404, "Token not found")
     return {"ok": True, "deleted": token_id}
+
+
+# ── Orphan reconcile + recycle bin (Phase 14.5) ───────────────────────────────
+
+class PruneMissingBody(BaseModel):
+    dry_run: bool = True
+
+
+@router.post("/api/admin/prune-missing")
+def admin_prune_missing(
+    body: PruneMissingBody,
+    _tok: dict = Depends(require_scopes("media_delete")),
+):
+    """Remove media rows whose source file no longer exists on disk (the ghost
+    records left by manually-deleted files). With dry_run=true (default) nothing
+    is changed — only a count is returned."""
+    missing = db.iter_missing()
+    if body.dry_run:
+        return {
+            "scanned": len(missing),
+            "pruned": 0,
+            "pruned_ids": [],
+            "dry_run": True,
+        }
+    pruned_ids = []
+    for m in missing:
+        r = media_delete.delete_media_full(
+            m["id"], allow_file_delete=False, token_info=_tok
+        )
+        if r is not None:
+            pruned_ids.append(m["id"])
+    return {
+        "scanned": len(missing),
+        "pruned": len(pruned_ids),
+        "pruned_ids": pruned_ids,
+        "dry_run": False,
+    }
+
+
+@router.get("/api/admin/trash")
+def admin_list_trash(
+    _tok: dict = Depends(require_scopes("admin")),
+):
+    return {"trash": db.list_trash()}
+
+
+class TrashPurgeBody(BaseModel):
+    ttl_days: Optional[int] = None
+
+
+@router.post("/api/admin/trash/purge")
+def admin_purge_trash(
+    body: TrashPurgeBody = None,
+    _tok: dict = Depends(require_scopes("admin")),
+):
+    if body is not None and body.ttl_days is not None:
+        ttl = body.ttl_days
+    else:
+        ttl = config.TRASH_TTL_DAYS
+    purged = db.purge_trash(ttl)
+    return {"ok": True, "purged": purged}
+
+
+@router.post("/api/admin/trash/restore/{trash_id}")
+def admin_restore_trash(
+    trash_id: int,
+    _tok: dict = Depends(require_scopes("admin")),
+):
+    """Move a trashed original back next to its original path (or media-in) and
+    re-ingest it so it returns to the library with thumbnails / transcript /
+    vectors — not just onto disk. Matches the designed "restore triggers an
+    ingest" behaviour (devdoc/media-delete-design.md §2). The re-ingest runs in
+    the background through the shared single-flight slot (audit H3)."""
+    try:
+        dest = db.restore_trash(trash_id)
+    except ValueError as exc:
+        raise HTTPException(400, str(exc))
+    ingest_status = "skipped"
+    try:
+        # Lazy import avoids any router→router load-cycle; routers.ingest is
+        # already loaded by server.py for its router.
+        from routers.ingest import _bg_ingest
+        import threading
+
+        threading.Thread(
+            target=_bg_ingest, args=(dest,), daemon=True
+        ).start()
+        ingest_status = "triggered"
+    except Exception:
+        # restore already succeeded; a failed re-ingest trigger is non-fatal —
+        # the file is back on disk and can be re-ingested manually.
+        ingest_status = "trigger_failed"
+    return {"ok": True, "restored_to": dest, "ingest": ingest_status}

--- a/routers/analytics.py
+++ b/routers/analytics.py
@@ -9,6 +9,7 @@ server.ROOT for the disk-usage fallback. Imports auth + db + config +
 tag_quality/tag_aliases/smart_collections/projects — no server import, no cycle.
 """
 from fastapi import APIRouter, Depends
+import os
 
 import collection_defs
 import config
@@ -55,7 +56,17 @@ def get_stats(
     try:
         import shutil
         _db_path = db.get_db_path()  # R5-23 (#54): SSOT accessor, not config value
-        du = shutil.disk_usage(_db_path.parent if _db_path else BASE_DIR)
+        # Measure the DB file itself, not its parent dir: media.db is a bind
+        # mount onto the real data volume (/vol1), whereas /app in Docker is an
+        # overlay backed by the host root fs — disk_usage('/app') would report
+        # the wrong (host-root) disk. Fall back to the parent only if the file
+        # does not exist yet (fresh install before init_db creates it).
+        _du_target = (
+            _db_path
+            if (_db_path and os.path.exists(_db_path))
+            else (_db_path.parent if _db_path else BASE_DIR)
+        )
+        du = shutil.disk_usage(_du_target)
         stats["disk"] = {
             "used_gb": round(du.used / 1e9, 1),
             "total_gb": round(du.total / 1e9, 1),

--- a/routers/ingest.py
+++ b/routers/ingest.py
@@ -13,13 +13,18 @@ no cycle.
 import asyncio
 import json
 import os
-from pathlib import Path
-from typing import Optional
+import time
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import List, Optional
 
 from fastapi import (
     APIRouter,
+    BackgroundTasks,
     Depends,
+    File,
     HTTPException,
+    UploadFile,
     WebSocket,
     WebSocketDisconnect,
 )
@@ -71,7 +76,8 @@ class ScanRequest(BaseModel):
 MEDIA_EXTS = mediatypes.MEDIA_EXT
 VIDEO_EXTS = mediatypes.VIDEO_EXT
 AUDIO_EXTS = mediatypes.AUDIO_EXT
-assert VIDEO_EXTS | AUDIO_EXTS == MEDIA_EXTS  # the two must partition MEDIA_EXTS
+IMAGE_EXTS = mediatypes.IMAGE_EXT
+assert VIDEO_EXTS | AUDIO_EXTS | IMAGE_EXTS == MEDIA_EXTS  # the three must partition MEDIA_EXTS
 # camera raw / stills the ingest pipeline does not process — surfaced in the scan
 # manifest as "skipped" so the redesign's setup dialog (op-01) can show what will
 # not be ingested (e.g. a card of .mov clips + .crw stills).
@@ -88,6 +94,7 @@ def _build_scan_manifest(files: list, unsupp: dict) -> dict:
     return {
         "video": cat(VIDEO_EXTS),
         "audio": cat(AUDIO_EXTS),
+        "image": cat(IMAGE_EXTS),
         "unsupported": {"count": sum(unsupp.values()), "by_ext": dict(sorted(unsupp.items()))},
         "total_size_mb": round(sum(f["size_mb"] for f in files), 1),
     }
@@ -261,6 +268,147 @@ def reingest_media(
         raise HTTPException(500, str(e))
     finally:
         _release_ingest_slot()
+
+
+# ── Upload (HTTP multipart → media-in → auto ingest) ──────────────────────────
+# Phase 14 addendum: let MCP clients / browsers push media without manually
+# copying into the bind mount. Files land in the ingest source (media-in) and a
+# background ingest picks them up. Filenames are constrained to a basename (no
+# path traversal) and only known media extensions are accepted.
+
+_UPLOAD_DIR = (
+    Path(os.environ.get("ARKIV_UPLOAD_DIR", "")).expanduser()
+    if os.environ.get("ARKIV_UPLOAD_DIR")
+    else (config.PROJECT_ROOT / "media-in")
+)
+_UPLOAD_MAX_BYTES = int(os.environ.get("ARKIV_UPLOAD_MAX_MB", "4096")) * 1024 * 1024
+# Phase 14 addendum: cap concurrent upload handlers so a burst of large files
+# can't exhaust the worker pool / saturate disk. Waiters queue up to
+# _UPLOAD_SEM_TIMEOUT seconds for a slot, then get 429. (Background ingest is
+# already single-flight via the shared slot in state.py.)
+_UPLOAD_MAX_CONCURRENT = max(1, int(os.environ.get("ARKIV_UPLOAD_MAX_CONCURRENT", "3")))
+_UPLOAD_SEM_TIMEOUT = float(os.environ.get("ARKIV_UPLOAD_MAX_QUEUE_SEC", "300"))
+_upload_sem = asyncio.Semaphore(_UPLOAD_MAX_CONCURRENT)
+
+
+def _safe_upload_dir() -> Path:
+    d = _UPLOAD_DIR
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _save_upload_file(uf: UploadFile, dest: Path, max_bytes: int) -> None:
+    """Blocking: stream one UploadFile to dest, enforcing the per-file size cap.
+    Runs inside asyncio.to_thread so it never pins the event loop."""
+    written = 0
+    with dest.open("wb") as out:
+        while True:
+            chunk = uf.file.read(1024 * 1024)
+            if not chunk:
+                break
+            written += len(chunk)
+            if written > max_bytes:
+                out.close()
+                dest.unlink(missing_ok=True)
+                raise HTTPException(
+                    413,
+                    f"檔案超過上傳上限（{max_bytes // (1024 * 1024)} MB）：{getattr(uf, 'filename', '?')}",
+                )
+            out.write(chunk)
+
+
+@router.post("/api/ingest/upload")
+async def ingest_upload(
+    files: List[UploadFile] = File(...),
+    background_tasks: BackgroundTasks = None,
+    _tok: dict = Depends(require_scopes("ingest_write")),
+):
+    """Accept multipart media uploads and store them under the ingest source
+    (media-in). A background ingest of that directory is triggered so the new
+    clips become searchable. Concurrency is capped by _upload_sem so a burst of
+    large uploads can't exhaust workers/disk; filename is constrained to a
+    basename (no path traversal) and only known media extensions are accepted."""
+    acquired = False
+    try:
+        await asyncio.wait_for(_upload_sem.acquire(), timeout=_UPLOAD_SEM_TIMEOUT)
+        acquired = True
+    except asyncio.TimeoutError:
+        raise HTTPException(429, "上傳並發已達上限，請稍後再試")
+    try:
+        upload_dir = await asyncio.to_thread(_safe_upload_dir)
+        saved = []
+        renamed = []
+        for uf in files:
+            raw = uf.filename or ""
+            name = PurePosixPath(raw).name
+            if not name or name in (".", "..") or "/" in name or "\\" in name:
+                raise HTTPException(400, f"非法檔名：{raw}")
+            ext = Path(name).suffix.lower()
+            if ext not in MEDIA_EXTS:
+                raise HTTPException(400, f"不支援的檔案類型：{ext}（僅允許媒體格式）")
+            # Collision-safe name: never overwrite an existing file on disk, nor a
+            # media row already indexed at this path. A same-name re-upload is
+            # renamed (<stem>__<YYYYMMDD-HHMMSS><ext>) so both clips survive instead
+            # of the original being clobbered + then SKIPped by ingest (data loss).
+            stem = Path(name).stem
+            ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+            cand = name
+            n = 0
+            while True:
+                c = upload_dir / cand
+                if not c.exists() and not db.path_is_indexed(str(c)):
+                    break
+                n += 1
+                cand = "{0}__{1}{2}{3}".format(
+                    stem, ts, ("_" + str(n)) if n > 1 else "", ext
+                )
+            dest = upload_dir / cand
+            # basename guarantees containment, but assert defensively
+            if dest.resolve() != (upload_dir.resolve() / cand):
+                raise HTTPException(400, f"非法路徑：{raw}")
+            await asyncio.to_thread(_save_upload_file, uf, dest, _UPLOAD_MAX_BYTES)
+            saved.append(cand)
+            if cand != name:
+                renamed.append({"from": name, "to": cand})
+        if not saved:
+            raise HTTPException(400, "沒有收到任何檔案")
+        if background_tasks is not None:
+            background_tasks.add_task(_bg_ingest, str(upload_dir))
+        return JSONResponse(
+            status_code=202,
+            content={
+                "ok": True,
+                "saved": saved,
+                "renamed": renamed,
+                "upload_dir": str(upload_dir),
+                "ingest": "triggered" if background_tasks is not None else "skipped",
+            },
+        )
+    finally:
+        if acquired:
+            _upload_sem.release()
+
+
+def _bg_ingest(dir_path: str) -> None:
+    """Run ingest.py over the upload directory in the background, serialised
+    through the shared single-flight slot (audit H3 — no concurrent whisper)."""
+    import subprocess, sys, proctree
+
+    deadline = time.time() + 1800
+    while time.time() < deadline:
+        if _acquire_ingest_slot():
+            try:
+                proctree.run_tree(
+                    [sys.executable, str(BASE_DIR / "ingest.py"), "--dir", dir_path],
+                    timeout=1800,
+                    cwd=str(BASE_DIR),
+                )
+            except Exception:
+                pass
+            finally:
+                _release_ingest_slot()
+            return
+        time.sleep(5)
 
 
 # ── WebSocket: Ingest Progress ───────────────────────────────────────────

--- a/routers/media.py
+++ b/routers/media.py
@@ -28,6 +28,7 @@ from pydantic import BaseModel, field_validator
 import config
 import corrections
 import db
+import embed
 import mediatypes
 import progress
 import tag_quality
@@ -808,6 +809,10 @@ def add_tag(
     if not rec:
         raise HTTPException(404, "找不到")
     db.add_tag(media_id, body.name, body.source)
+    try:
+        embed.reindex_media(media_id)
+    except Exception as e:
+        print("[warn] reindex after add_tag failed (non-fatal):", e)
     return {"ok": True, "tags": db.get_tags(media_id)}
 
 
@@ -818,6 +823,10 @@ def remove_tag(
     _tok: dict = Depends(require_scopes("videos_write")),
 ):
     db.remove_tag(media_id, tag_name)
+    try:
+        embed.reindex_media(media_id)
+    except Exception as e:
+        print("[warn] reindex after remove_tag failed (non-fatal):", e)
     return {"ok": True, "tags": db.get_tags(media_id)}
 
 

--- a/routers/media.py
+++ b/routers/media.py
@@ -28,6 +28,7 @@ from pydantic import BaseModel, field_validator
 import config
 import corrections
 import db
+import media_delete
 import mediatypes
 import progress
 import tag_quality
@@ -137,6 +138,7 @@ class ActivateLangRequest(BaseModel):
 # both now come from the shared mediatypes source, so they can't drift apart.
 _VIDEO_EXTS = mediatypes.VIDEO_EXT
 _AUDIO_EXTS = mediatypes.AUDIO_EXT
+_IMAGE_EXTS = mediatypes.IMAGE_EXT
 
 
 @router.get("/api/media/position/{media_id}")
@@ -261,14 +263,14 @@ def list_media(
             rec["tags"] = tags_by_id.get(rec["id"], [])
         return {"items": records, "total": len(records), "search": True}
     if q:
-        enriched = []
         search_warning = None
         import vectordb as vdb
-        # audit M19: search used to ignore `offset` entirely (page 2 == page 1).
-        # Collect up to offset+limit matches, then slice the requested page.
-        # Capped so a huge ?offset can't inflate n_results / SQL LIMIT (audit
-        # H13-class DoS); search hits past 2000 are noise anyway.
-        needed = min(offset + limit, 2000)
+        # audit M19: search MUST paginate correctly. `total` is the STABLE number
+        # of matches (independent of `offset`), and only the requested page's light
+        # records are returned. SEARCH_CAP bounds the candidate set so a huge
+        # ?offset can't inflate the vector scan / SQL table scan (audit H13-class
+        # DoS); hits past 2000 are noise anyway.
+        SEARCH_CAP = 2000
 
         def _passes_filters(rec: dict) -> bool:
             # Applied to the ENRICHED record (which has real lang/rating), not the
@@ -289,6 +291,8 @@ def list_media(
             if media_type == "video" and ext not in _VIDEO_EXTS:
                 return False
             if media_type == "audio" and ext not in _AUDIO_EXTS:
+                return False
+            if media_type == "image" and ext not in _IMAGE_EXTS:
                 return False
             # Same class as H8/H14: a filter honoured only on the SQL path silently
             # stops applying the moment the user types a query.
@@ -311,30 +315,18 @@ def list_media(
                     return False
             return True
 
-        # Try semantic search first (requires vectordb with embeddings)
+        # Semantic pass: ALL vector nearest-neighbours up to SEARCH_CAP (ids +
+        # scores + excerpt). May be empty on degradation (search_warning set).
+        semantic: dict = {}
         try:
-            raw = vdb.search(q, n_results=needed * 3)
+            raw = vdb.search(q, n_results=SEARCH_CAP)
             seen = set()
-            ordered_ids = []
-            hit_by_id = {}
             for r in raw:
                 mid = int(r["media_id"])
                 if mid in seen:
                     continue
                 seen.add(mid)
-                ordered_ids.append(mid)
-                hit_by_id[mid] = r
-            # audit H16: one batched LIGHT_COLS fetch instead of per-hit SELECT *
-            for rec in _get_light_records_by_ids(ordered_ids):
-                if not _passes_filters(rec):
-                    continue
-                _resolve_record(rec)
-                hit = hit_by_id[rec["id"]]
-                rec["score"] = hit.get("score", 0)
-                rec["excerpt"] = hit.get("excerpt", "")
-                enriched.append(rec)
-                if len(enriched) >= needed:
-                    break
+                semantic[mid] = {"score": r.get("score", 0), "excerpt": r.get("excerpt", "")}
         except vdb.EmbeddingDimensionMismatch as exc:
             # Don't silently SQL-degrade a dim mismatch — log it and surface a hint
             # so the operator knows semantic search is off until they rebuild.
@@ -348,79 +340,86 @@ def list_media(
             )
             search_warning = "semantic search unavailable (SQL fallback used)"
 
-        # Fallback: SQL text search (filename, transcript, tags) — same lang/rating
-        # filter applied so a degraded search still honors the active filters.
-        if not enriched:
-            seen_ids = set()
-            like = f"%{q}%"
-            # audit H17: push the active filters into WHERE and bound the scan —
-            # the old query LIKE-scanned the whole table, built every matching
-            # record, then threw away everything past `limit`.
-            filter_sql = ""
-            filter_params: list = []
-            if lang:
-                filter_sql += " AND lang = ?"
-                filter_params.append(lang)
-            if rating == "unrated":
-                filter_sql += " AND rating IS NULL"
-            elif rating:
-                filter_sql += " AND rating = ?"
-                filter_params.append(rating)
-            if media_type == "video":
-                filter_sql += " AND ext IN ({0})".format(",".join("?" * len(_VIDEO_EXTS)))
-                filter_params.extend(sorted(_VIDEO_EXTS))
-            elif media_type == "audio":
-                filter_sql += " AND ext IN ({0})".format(",".join("?" * len(_AUDIO_EXTS)))
-                filter_params.extend(sorted(_AUDIO_EXTS))
-            # Third place this filter has to exist. The degraded-search path is the
-            # one users hit when Ollama is down, and a filter that quietly stops
-            # applying exactly then is worse than one that never worked. Built by the
-            # same helper as the list query rather than hand-written twice — the
-            # duplication is what let H8/H14 happen.
-            shot_sql, shot_params = db.shot_window_clause(
-                shot_year=shot_year, shot_date=shot_date
-            )
-            if shot_sql:
-                filter_sql += " AND " + shot_sql
-                filter_params.extend(shot_params)
-            with db.get_conn() as conn:
-                rows = conn.execute(
-                    f"SELECT {db.LIGHT_COLS} FROM media "
-                    "WHERE (filename LIKE ? OR transcript LIKE ?)" + filter_sql +
-                    " ORDER BY id LIMIT ?",
-                    (like, like, *filter_params, needed),
-                ).fetchall()
-                for r in rows:
-                    rec = dict(r)
-                    _resolve_record(rec)
-                    enriched.append(rec)
-                    seen_ids.add(rec["id"])
+        # Lexical pass (Direction 2): literal substring matches in filename /
+        # transcript / tags ALWAYS surface, even when their embedding ranks low by
+        # vector distance — so a clip that literally contains the query term is
+        # never invisible. Bounded by SEARCH_CAP (audit H17); the active filters
+        # are pushed into WHERE so the SQL path honours them too.
+        like = f"%{q}%"
+        filter_sql = ""
+        filter_params: list = []
+        if lang:
+            filter_sql += " AND lang = ?"
+            filter_params.append(lang)
+        if rating == "unrated":
+            filter_sql += " AND rating IS NULL"
+        elif rating:
+            filter_sql += " AND rating = ?"
+            filter_params.append(rating)
+        if media_type == "video":
+            filter_sql += " AND ext IN ({0})".format(",".join("?" * len(_VIDEO_EXTS)))
+            filter_params.extend(sorted(_VIDEO_EXTS))
+        elif media_type == "audio":
+            filter_sql += " AND ext IN ({0})".format(",".join("?" * len(_AUDIO_EXTS)))
+            filter_params.extend(sorted(_AUDIO_EXTS))
+        elif media_type == "image":
+            filter_sql += " AND ext IN ({0})".format(",".join("?" * len(_IMAGE_EXTS)))
+            filter_params.extend(sorted(_IMAGE_EXTS))
+        shot_sql, shot_params = db.shot_window_clause(shot_year=shot_year, shot_date=shot_date)
+        if shot_sql:
+            filter_sql += " AND " + shot_sql
+            filter_params.extend(shot_params)
+        lexical_ids: list = []
+        with db.get_conn() as conn:
+            rows = conn.execute(
+                "SELECT id FROM media "
+                "WHERE (filename LIKE ? OR transcript LIKE ?)" + filter_sql +
+                " ORDER BY id LIMIT ?",
+                (like, like, *filter_params, SEARCH_CAP),
+            ).fetchall()
+            lexical_ids = [dict(r)["id"] for r in rows]
+            tag_rows = conn.execute(
+                "SELECT DISTINCT media_id FROM tags WHERE name LIKE ? LIMIT ?",
+                (like, SEARCH_CAP),
+            ).fetchall()
+        for tr in tag_rows:
+            tid = dict(tr)["media_id"]
+            if tid not in lexical_ids:
+                lexical_ids.append(tid)
 
-            # Also search by tag name (bounded — audit H17)
-            if len(enriched) < needed:
-                with db.get_conn() as conn:
-                    tag_rows = conn.execute(
-                        "SELECT DISTINCT media_id FROM tags WHERE name LIKE ? LIMIT ?",
-                        (like, needed * 3),
-                    ).fetchall()
-                tag_ids = [tr["media_id"] for tr in tag_rows if tr["media_id"] not in seen_ids]
-                for rec in _get_light_records_by_ids(tag_ids):
-                    if not _passes_filters(rec):
-                        continue
-                    _resolve_record(rec)
-                    enriched.append(rec)
-                    seen_ids.add(rec["id"])
-                    if len(enriched) >= needed:
-                        break
+        # Stable, offset-independent ordering: semantic hits by score desc, then
+        # lexical hits in id order, de-duplicated. Capped at SEARCH_CAP.
+        sem_ids = list(semantic.keys())
+        sem_ids.sort(key=lambda mid: semantic[mid]["score"], reverse=True)
+        seen_sem = set(sem_ids)
+        lex_filtered = [mid for mid in lexical_ids if mid not in seen_sem]
+        ordered_ids = (sem_ids + lex_filtered)[:SEARCH_CAP]
 
-        # audit M19: slice the requested page; total = bounded match count (the
-        # same "items seen so far" semantic for both search sub-paths).
-        items = enriched[offset:offset + limit]
-        # audit H15: one bulk tag query for the returned page only
+        # One bulk fetch of the candidate light records (bounded by SEARCH_CAP),
+        # apply the filters the SQL path can't (semantic hits carry no rating/
+        # lang), then slice the requested page. Tags fetched once for the page.
+        records_by_id: dict = {}
+        for rec in _get_light_records_by_ids(ordered_ids):
+            if not _passes_filters(rec):
+                continue
+            _resolve_record(rec)
+            mid = rec["id"]
+            if mid in semantic:
+                rec["score"] = semantic[mid]["score"]
+                rec["excerpt"] = semantic[mid]["excerpt"]
+                rec["match_type"] = "semantic"
+            else:
+                rec["score"] = None
+                rec["excerpt"] = (rec.get("transcript") or "")[:300] or rec.get("filename") or ""
+                rec["match_type"] = "text"
+            records_by_id[mid] = rec
+        ordered = [records_by_id[mid] for mid in ordered_ids if mid in records_by_id]
+        total = len(ordered)
+        items = ordered[offset:offset + limit]
         tags_by_id = _get_tags_bulk([rec["id"] for rec in items])
         for rec in items:
             rec["tags"] = tags_by_id.get(rec["id"], [])
-        resp = {"items": items, "total": len(enriched), "search": True}
+        resp = {"items": items, "total": total, "search": True}
         if search_warning:
             resp["search_degraded"] = True
             resp["warning"] = search_warning
@@ -474,11 +473,13 @@ def get_media_detail(
             rec["frame_tags_parsed"] = json.loads(rec["frame_tags"])
         except Exception:
             rec["frame_tags_parsed"] = []
-    # User-facing tags: screen quality-defect noise + keep only the top-N most
-    # confident (focus-weighted) tags, so a clip doesn't dump 10+ tags on the user.
-    top = set(tag_quality.rank_media_tags(rec.get("frame_tags_parsed") or []))
+    # User-facing tags: show BOTH manual (user-added) and auto (vision) tags.
+    # Only normalize/dedup via filter_tag_records (Simplified↔Traditional +
+    # variant-char collapse + noise-artifact drop) — do NOT cap auto tags by the
+    # top-N frame ranking, or manual tags (which never appear in that set) get
+    # silently dropped from the inspector (regression: manual tags vanished).
     all_tags = tag_quality.filter_tag_records(db.get_tags(media_id))
-    rec["tags"] = [t for t in all_tags if t["name"] in top] if top else all_tags
+    rec["tags"] = all_tags
     # Optional LLM-canonicalized tag list (populated by `ingest.py --canonicalize-tags`).
     # Returned alongside raw tags so the UI can toggle raw ↔ canonical; null until run.
     if rec.get("canonical_tags"):
@@ -1125,3 +1126,52 @@ def retry_vision_status(
     """
     rec = vision_jobs.get(media_id)
     return rec if rec is not None else {"state": "idle"}
+
+
+# ── Unified delete (Phase 14.5) ───────────────────────────────────────────────
+
+class BulkDeleteBody(BaseModel):
+    ids: list
+    allow_file_delete: bool = True
+
+
+@router.delete("/api/media/{media_id}")
+def delete_media(
+    media_id: int,
+    allow_file_delete: bool = True,
+    _tok: dict = Depends(require_scopes("media_delete")),
+):
+    """Delete one media record + all its artefacts. The original source file is
+    moved to the recycle bin (.arkiv/trash), not unlinked; files outside
+    PROJECT_ROOT are metadata-only (see media_delete.delete_media_full)."""
+    result = media_delete.delete_media_full(
+        media_id, allow_file_delete=allow_file_delete, token_info=_tok
+    )
+    if result is None:
+        raise HTTPException(404, "找不到該媒體")
+    return result
+
+
+@router.post("/api/media/bulk-delete")
+def bulk_delete_media(
+    body: BulkDeleteBody,
+    _tok: dict = Depends(require_scopes("media_delete")),
+):
+    """Delete several media records at once. Returns the ids that were deleted,
+    skipped (e.g. not found), and any hard errors — matching the designed
+    {deleted, skipped, errors} contract."""
+    deleted, skipped, errors = [], [], []
+    for mid in body.ids:
+        try:
+            mid = int(mid)
+        except (TypeError, ValueError):
+            errors.append({"media_id": mid, "error": "bad id"})
+            continue
+        r = media_delete.delete_media_full(
+            mid, allow_file_delete=body.allow_file_delete, token_info=_tok
+        )
+        if r is None:
+            skipped.append(mid)
+        else:
+            deleted.append(mid)
+    return {"ok": True, "deleted": deleted, "skipped": skipped, "errors": errors}

--- a/routers/media.py
+++ b/routers/media.py
@@ -1175,3 +1175,40 @@ def bulk_delete_media(
         else:
             deleted.append(mid)
     return {"ok": True, "deleted": deleted, "skipped": skipped, "errors": errors}
+
+
+class PruneMissingBody(BaseModel):
+    dry_run: bool = True
+
+
+@router.post("/api/media/prune-missing")
+def prune_missing_media(
+    body: PruneMissingBody,
+    _tok: dict = Depends(require_scopes("media_delete")),
+):
+    """Remove media rows whose source file no longer exists on disk (the ghost
+    records left by manually-deleted files). With dry_run=true (default) nothing
+    is changed — only a count is returned. Moved out of routers/admin.py: a media
+    data-integrity operation (delete_media_full over ghost rows), not a token
+    /admin one (R5-25 route ownership)."""
+    missing = db.iter_missing()
+    if body.dry_run:
+        return {
+            "scanned": len(missing),
+            "pruned": 0,
+            "pruned_ids": [],
+            "dry_run": True,
+        }
+    pruned_ids = []
+    for m in missing:
+        r = media_delete.delete_media_full(
+            m["id"], allow_file_delete=False, token_info=_tok
+        )
+        if r is not None:
+            pruned_ids.append(m["id"])
+    return {
+        "scanned": len(missing),
+        "pruned": len(pruned_ids),
+        "pruned_ids": pruned_ids,
+        "dry_run": False,
+    }

--- a/routers/misc.py
+++ b/routers/misc.py
@@ -144,7 +144,14 @@ def stream_media(media_id: int, _tok: dict = Depends(require_scopes("videos_read
                         conn.execute("UPDATE media SET codec=? WHERE id=?", (stored_codec, media_id))
                 except Exception:
                     pass  # backfill is best-effort; playback must not fail on it
-    if stored_codec and (
+    # Only video needs a browser-playable *video* codec. Images and audio are served
+    # as-is: an image's stored codec is mjpeg/png/jpeg, which is NOT a browser-playable
+    # video codec, so forcing a 409 here would break image preview in the Inspector
+    # (the <img> points at this same /api/stream endpoint and would load a 409 body).
+    # `kind` is not a DB column; the frontend derives it from the file extension, so
+    # we use the same signal here (image extensions never need a playback proxy).
+    is_image = file_path.suffix.lower() in mediatypes.IMAGE_EXT
+    if not is_image and stored_codec and (
         stored_codec in codec.PROXY_CODECS or not codec.is_browser_playable_video(stored_codec)
     ):
         return JSONResponse(

--- a/routers/misc.py
+++ b/routers/misc.py
@@ -324,6 +324,27 @@ def api_health():
     except Exception:
         _mark("ollama", False, "unreachable — is `ollama serve` running?")
 
+    # embeddings coverage: how much of the library has been vector-indexed. A low
+    # number means `python embed.py --rebuild` hasn't been run (or stopped partway),
+    # so semantic search silently returns weaker / fewer hits. Surfaces the gap
+    # that a literal-only query can paper over (Direction 1 of the search-fix).
+    try:
+        import db as dbmod
+
+        with dbmod.get_conn() as conn:
+            total_media = conn.execute("SELECT COUNT(*) FROM media").fetchone()[0]
+            embedded_media = conn.execute(
+                "SELECT COUNT(*) FROM media WHERE embed_hash IS NOT NULL"
+            ).fetchone()[0]
+        coverage = (embedded_media / total_media) if total_media else 1.0
+        out["embeddings"] = {
+            "total_media": total_media,
+            "embedded_media": embedded_media,
+            "coverage": round(coverage, 3),
+        }
+    except Exception as exc:  # noqa: BLE001
+        out["embeddings"] = {"error": type(exc).__name__}
+
     return JSONResponse(out, status_code=200 if out["ready"] else 503)
 
 

--- a/routers/misc.py
+++ b/routers/misc.py
@@ -144,15 +144,19 @@ def stream_media(media_id: int, _tok: dict = Depends(require_scopes("videos_read
                         conn.execute("UPDATE media SET codec=? WHERE id=?", (stored_codec, media_id))
                 except Exception:
                     pass  # backfill is best-effort; playback must not fail on it
-    if stored_codec and stored_codec in codec.PROXY_CODECS:
+    if stored_codec and (
+        stored_codec in codec.PROXY_CODECS or not codec.is_browser_playable_video(stored_codec)
+    ):
         return JSONResponse(
             status_code=409,
             content={
                 "need_proxy": True,
                 "media_id": media_id,
                 "filename": rec.get("filename"),
-                "reason": "browser-incompatible codec (HEVC/ProRes); proxy required for playback",
-                "hint": "POST /api/proxy/build to queue proxy generation",
+                "reason": "browser-incompatible codec ({0}); proxy required for playback".format(
+                    stored_codec
+                ),
+                "hint": "POST /api/proxy/build/{0} to queue proxy generation".format(media_id),
             },
         )
 

--- a/sample_prebuilt.py
+++ b/sample_prebuilt.py
@@ -34,6 +34,7 @@ from pathlib import Path
 
 import config
 import db
+import media_delete
 
 # The four tables the sample corpus lives in. NOT settings/jobs/chat/tokens — those
 # stay the user's. media must go first (frames/tags/transcripts FK it) and reversed
@@ -215,9 +216,10 @@ def load_prebuilt(force: bool = False) -> dict:
 
 def remove_sample() -> dict:
     """One-click remove: delete exactly the seeded media (rows cascade; vectors +
-    thumbnail files + copied clips cleaned best-effort), then set the dismiss flag so
-    auto-seed does not resurrect it next restart. Only touches the marker's ids — a
-    user's own footage ingested alongside the sample is untouched."""
+    thumbnail/proxy/waveform files + copied clips cleaned via the shared
+    delete_media_full core), then set the dismiss flag so auto-seed does not
+    resurrect it next restart. Only touches the marker's ids — a user's own footage
+    ingested alongside the sample is untouched."""
     if not is_loaded():
         return {"ok": True, "removed": 0, "already": True}
     try:
@@ -225,44 +227,16 @@ def remove_sample() -> dict:
     except Exception:  # noqa: BLE001
         marker = {}
     media_ids = marker.get("media_ids", [])
-    clips = marker.get("clips", [])
-
-    col = None
-    try:
-        import vectordb
-        col = vectordb.get_collection()
-    except Exception:  # noqa: BLE001 — chroma may be absent; DB delete still proceeds
-        col = None
 
     removed = 0
     for mid in media_ids:
-        thumbs = db.delete_media(mid)
-        if thumbs is None:
-            continue
-        removed += 1
-        for rel in thumbs:
-            _unlink_rel(rel)
-        if col is not None:
-            try:
-                vectordb.delete_media(col, mid)
-            except Exception:  # noqa: BLE001
-                pass
-    for name in clips:
-        _unlink_rel(str(Path("clips") / name))
+        r = media_delete.delete_media_full(mid, allow_file_delete=True, token_info=None)
+        if r is not None:
+            removed += 1
 
     _loaded_marker().unlink(missing_ok=True)
     _dismissed_marker().write_text("")
     return {"ok": True, "removed": removed}
-
-
-def _unlink_rel(stored_path: str) -> None:
-    """Unlink a PROJECT_ROOT-relative (or absolute) stored path, best-effort."""
-    try:
-        p = Path(stored_path)
-        target = p if p.is_absolute() else (config.PROJECT_ROOT / p)
-        target.unlink(missing_ok=True)
-    except Exception:  # noqa: BLE001
-        pass
 
 
 def maybe_autoseed() -> dict:

--- a/tests/test_arkiv_resolve_lan.py
+++ b/tests/test_arkiv_resolve_lan.py
@@ -1,0 +1,191 @@
+"""LAN variant of the DaVinci Resolve plugin (arkiv_resolve_lan.py).
+
+Pins two behaviours the localhost build does NOT have:
+- default API host is localhost (override with ARKIV_HOST / ARKIV_API for a remote server)
+- every request carries an `Authorization: Bearer <token>` header, because the
+  server only trusts loopback as admin without a token.
+
+The plugin imports cleanly without DaVinciResolveScript (that import is nested
+inside get_resolve()), so we can load it by path and assert the wired Request.
+"""
+import importlib.util
+import pathlib
+import urllib.request
+
+import pytest
+
+PLUGIN = pathlib.Path(__file__).resolve().parent.parent / "resolve_plugin" / "arkiv_resolve_lan.py"
+
+
+def _load(monkeypatch):
+    for k in ("ARKIV_API", "ARKIV_HOST", "ARKIV_PORT"):
+        monkeypatch.delenv(k, raising=False)
+    # The LAN plugin requires ARKIV_TOKEN at import time (it raises otherwise);
+    # the tests only check that a non-empty Bearer token is attached, so a dummy
+    # value is fine here.
+    monkeypatch.setenv("ARKIV_TOKEN", "test-token-not-a-secret")
+    spec = importlib.util.spec_from_file_location("arkiv_resolve_lan_test", str(PLUGIN))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeResp:
+    def __init__(self, data):
+        self._d = data
+
+    def read(self):
+        return self._d
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _capture(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, *a, **k):
+        captured["req"] = req
+        return _FakeResp(b'{"items":[]}')
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    return captured
+
+
+def test_lan_default_host_is_localhost(monkeypatch):
+    from urllib.parse import urlparse
+
+    mod = _load(monkeypatch)
+    assert urlparse(mod.ARKIV_API).hostname == "localhost"
+
+
+def test_search_media_sends_token_header_to_lan(monkeypatch):
+    from urllib.parse import urlparse
+
+    mod = _load(monkeypatch)
+    captured = _capture(monkeypatch)
+    mod.search_media("snow")
+    req = captured["req"]
+    assert urlparse(req.full_url).hostname == "localhost"
+    assert req.get_header("Authorization", "").startswith("Bearer ")
+    assert req.get_header("Authorization", "") != "Bearer "
+
+
+def test_list_media_sends_token_header_to_lan(monkeypatch):
+    from urllib.parse import urlparse
+
+    mod = _load(monkeypatch)
+    captured = _capture(monkeypatch)
+    mod.list_media(limit=10)
+    req = captured["req"]
+    assert urlparse(req.full_url).hostname == "localhost"
+    assert req.get_header("Authorization", "").startswith("Bearer ")
+
+
+def test_download_media_requests_stream_with_token(monkeypatch, tmp_path):
+    """LAN import must pull bytes from /api/stream/{id} (server-side path
+    resolution) rather than handing Resolve the unreachable media-in/... path."""
+    import urllib.request as ureq
+
+    mod = _load(monkeypatch)
+    monkeypatch.setattr(mod, "_DOWNLOAD_DIR", str(tmp_path))
+
+    captured = {}
+
+    class _FakeResp:
+        def __init__(self, data):
+            self._d = data
+
+        def read(self):
+            return self._d
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake_urlopen(req, *a, **k):
+        captured["req"] = req
+        return _FakeResp(b"\x00\x01video-bytes")
+
+    monkeypatch.setattr(ureq, "urlopen", fake_urlopen)
+
+    dest = mod._download_media(42, "clip.mp4")
+    assert dest is not None
+    assert captured["req"].full_url.endswith("/api/stream/42")
+    assert captured["req"].get_header("Authorization", "").startswith("Bearer ")
+    with open(dest, "rb") as f:
+        assert f.read() == b"\x00\x01video-bytes"
+
+
+def test_import_to_resolve_groups_lan_files_under_arkiv_bin(monkeypatch):
+    """With bin_name set (LAN download), clips land in an 'Arkiv' bin, never a
+    meaningless 'media-in' bin derived from the server's relative path."""
+    mod = _load(monkeypatch)
+    monkeypatch.setattr(mod, "download_metadata_csv", lambda *a, **k: None)
+
+    class _Bin:
+        def __init__(self, name):
+            self.name = name
+
+        def GetName(self):
+            return self.name
+
+        def GetSubFolderList(self):
+            return []
+
+    class _Clip:
+        def __init__(self, p):
+            self._p = p
+
+        def GetName(self):
+            import os
+            return os.path.basename(self._p)
+
+    class _MediaPool:
+        def __init__(self):
+            self.bins = []
+
+        def GetRootFolder(self):
+            return _Bin("Master")
+
+        def GetSubFolderList(self):
+            return []
+
+        def SetCurrentFolder(self, b):
+            pass
+
+        def AddSubFolder(self, parent, name):
+            b = _Bin(name)
+            self.bins.append(b)
+            return b
+
+        def ImportMedia(self, paths):
+            return [_Clip(p) for p in paths]
+
+    class _Project:
+        def GetMediaPool(self):
+            return _MediaPool()
+
+    class _PM:
+        def GetCurrentProject(self):
+            return _Project()
+
+    class _Resolve:
+        def GetProjectManager(self):
+            return _PM()
+
+    mp = _MediaPool()
+    monkeypatch.setattr(_Project, "GetMediaPool", lambda self: mp)
+
+    ok = mod.import_to_resolve(
+        _Resolve(), ["/tmp/arkiv_import/42_clip.mp4"], bin_name="Arkiv"
+    )
+    assert ok is True
+    assert any(b.GetName() == "Arkiv" for b in mp.bins)
+    assert not any(b.GetName() == "media-in" for b in mp.bins)
+

--- a/tests/test_image_ingest.py
+++ b/tests/test_image_ingest.py
@@ -1,0 +1,74 @@
+"""Round 5 image-support: still images (png/jpg/webp/gif/svg) are first-class
+media assets. Raster images get a thumbnail + one vision frame like video; SVG
+has no pixel stream so it gets neither (frontend shows a placeholder).
+"""
+import ingest
+import frames as frm
+from pathlib import Path
+
+
+def _stub_light(monkeypatch, tmp_path):
+    """Stub the ffmpeg/ffprobe/exif heavy steps so process_file only builds the
+    record. Mirrors tests/test_audit_20260610.py's H6 stub."""
+    monkeypatch.setattr(ingest, "exiftool_extract", lambda *a, **k: {})
+    monkeypatch.setattr(ingest, "parse_xavc_sidecar", lambda p: {})
+    monkeypatch.setattr(ingest, "_file_hash", lambda p: "deadbeef")
+
+
+def test_raster_image_gets_thumbnail_and_frame(monkeypatch, tmp_path):
+    monkeypatch.setattr(ingest, "probe", lambda p: {
+        "duration_s": 0.0, "size_mb": 0.1, "width": 1920, "height": 1080,
+        "fps": None, "has_audio": 0, "start_tc": None, "codec": "png",
+    })
+    monkeypatch.setattr(ingest.frm, "extract_thumbnail",
+                        lambda *a, **k: str(tmp_path / "t.jpg"))
+    monkeypatch.setattr(ingest.frm, "extract_frames", lambda *a, **k: [
+        {"index": 0, "timestamp_s": 0.0, "thumbnail_path": str(tmp_path / "f.jpg")},
+    ])
+    _stub_light(monkeypatch, tmp_path)
+
+    f = tmp_path / "still.png"
+    f.write_bytes(b"\x89PNG\r\n\x1a\n")  # probe is stubbed; content irrelevant
+    rec = ingest.process_file(f, skip_vision=True)
+    assert rec.get("thumbnail_path"), "raster image must get a thumbnail"
+    frames = rec.get("_frames")
+    assert isinstance(frames, list) and len(frames) == 1, "raster image yields 1 frame"
+    assert rec.get("transcript") is None, "images have no speech to transcribe"
+    assert rec.get("ext") == ".png"
+
+
+def test_svg_image_gets_no_pixel_assets(monkeypatch, tmp_path):
+    monkeypatch.setattr(ingest, "probe", lambda p: None)  # ffprobe can't read SVG
+    calls = {"thumb": 0, "frames": 0}
+
+    def _thumb(*a, **k):
+        calls["thumb"] += 1
+        return str(tmp_path / "t.jpg")
+
+    def _frames(*a, **k):
+        calls["frames"] += 1
+        return []
+
+    monkeypatch.setattr(ingest.frm, "extract_thumbnail", _thumb)
+    monkeypatch.setattr(ingest.frm, "extract_frames", _frames)
+    _stub_light(monkeypatch, tmp_path)
+
+    f = tmp_path / "logo.svg"
+    f.write_text("<svg xmlns='http://www.w3.org/2000/svg'></svg>")
+    rec = ingest.process_file(f, skip_vision=True)
+    assert rec.get("thumbnail_path") is None, "SVG has no pixel stream → no thumbnail"
+    assert rec.get("_frames") is None, "SVG has no pixel stream → no frames"
+    assert calls["thumb"] == 0 and calls["frames"] == 0, "pixel steps must not run for SVG"
+    assert rec.get("ext") == ".svg"
+    assert rec.get("has_audio", 0) == 0
+
+
+def test_query_builder_image_bucket(monkeypatch):
+    import query_builder as qb
+    sql, params, _sem = qb._one_condition(
+        {"field": "media_type", "op": "eq", "value": "image"}
+    )
+    assert "ext" in sql.lower()
+    assert ".png" in params
+    assert ".mp4" not in params
+    assert ".mp3" not in params

--- a/tests/test_ingest_upload_dedup.py
+++ b/tests/test_ingest_upload_dedup.py
@@ -1,0 +1,109 @@
+"""Upload collision-safety (the "keep both snow.mp4" fix).
+
+The upload endpoint must never overwrite an existing file on disk, nor an
+already-indexed media row at that path. A same-name re-upload is renamed
+(<stem>__<YYYYMMDD-HHMMSS><ext>) so both clips survive instead of the original
+being clobbered + then SKIPped by ingest (which would lose both).
+"""
+import pytest
+
+
+def _upload(client, ri, name, data):
+    return client.post(
+        "/api/ingest/upload",
+        files=[("files", (name, data, "video/mp4"))],
+    )
+
+
+def test_upload_fresh_name_is_not_renamed(fastapi_client, tmp_path, monkeypatch):
+    import routers.ingest as ri
+
+    upload_dir = tmp_path / "media-in"
+    upload_dir.mkdir()
+    monkeypatch.setattr(ri, "_UPLOAD_DIR", upload_dir)
+    monkeypatch.setattr(ri, "_bg_ingest", lambda *a, **k: None)  # skip heavy ingest
+
+    r = _upload(fastapi_client, ri, "fresh.mp4", b"\x00dcIMB" + b"x" * 100)
+    assert r.status_code == 202, r.text
+    body = r.json()
+    assert body["saved"] == ["fresh.mp4"]
+    assert body["renamed"] == []
+    assert (upload_dir / "fresh.mp4").read_bytes() == b"\x00dcIMB" + b"x" * 100
+
+
+def test_upload_same_name_keeps_both_and_original(fastapi_client, tmp_path, monkeypatch):
+    import routers.ingest as ri
+    import db
+
+    upload_dir = tmp_path / "media-in"
+    upload_dir.mkdir()
+    monkeypatch.setattr(ri, "_UPLOAD_DIR", upload_dir)
+    monkeypatch.setattr(ri, "_bg_ingest", lambda *a, **k: None)  # skip heavy ingest
+
+    # Pre-existing indexed clip "snow.mp4" — exactly the user's scenario: the
+    # library already holds one snow scene; they upload another named snow.mp4.
+    original_path = str(upload_dir / "snow.mp4")
+    original_bytes = b"\x00dcIMB" + b"ORIGINAL-snow"  # 1st snow scene
+    (upload_dir / "snow.mp4").write_bytes(original_bytes)
+    with db.get_conn() as conn:
+        conn.execute(
+            "INSERT INTO media (path, filename) VALUES (?, ?)",
+            (original_path, "snow.mp4"),
+        )
+
+    # Two distinct uploads, both named snow.mp4 (2nd + 3rd snow scenes).
+    content_a = b"\x00dcIMB" + b"SECOND-snow"
+    content_b = b"\x00dcIMB" + b"THIRD-snow"
+    r_a = _upload(fastapi_client, ri, "snow.mp4", content_a)
+    r_b = _upload(fastapi_client, ri, "snow.mp4", content_b)
+    assert r_a.status_code == 202 and r_b.status_code == 202, (r_a.text, r_b.text)
+
+    saved_a = r_a.json()["saved"][0]
+    saved_b = r_b.json()["saved"][0]
+    # Both must be renamed (timestamp suffix) — neither clobbered the original.
+    assert saved_a.startswith("snow__") and saved_b.startswith("snow__")
+    assert saved_a != saved_b  # distinct names
+    assert r_a.json()["renamed"] == [{"from": "snow.mp4", "to": saved_a}]
+    assert r_b.json()["renamed"] == [{"from": "snow.mp4", "to": saved_b}]
+
+    # Disk holds THREE distinct files; the original is intact.
+    on_disk = {f.name: f.read_bytes() for f in upload_dir.iterdir()}
+    assert len(on_disk) == 3
+    assert on_disk["snow.mp4"] == original_bytes          # 1st scene untouched
+    assert on_disk[saved_a] == content_a                  # 2nd scene
+    assert on_disk[saved_b] == content_b                  # 3rd scene
+
+
+def test_upload_two_same_name_in_one_request(fastapi_client, tmp_path, monkeypatch):
+    import routers.ingest as ri
+    import db
+
+    upload_dir = tmp_path / "media-in"
+    upload_dir.mkdir()
+    monkeypatch.setattr(ri, "_UPLOAD_DIR", upload_dir)
+    monkeypatch.setattr(ri, "_bg_ingest", lambda *a, **k: None)
+
+    original_path = str(upload_dir / "snow.mp4")
+    with db.get_conn() as conn:
+        conn.execute(
+            "INSERT INTO media (path, filename) VALUES (?, ?)",
+            (original_path, "snow.mp4"),
+        )
+
+    data1 = b"\x00dcIMB" + b"one"
+    data2 = b"\x00dcIMB" + b"two"
+    r = fastapi_client.post(
+        "/api/ingest/upload",
+        files=[
+            ("files", ("snow.mp4", data1, "video/mp4")),
+            ("files", ("snow.mp4", data2, "video/mp4")),
+        ],
+    )
+    assert r.status_code == 202, r.text
+    saved = r.json()["saved"]
+    assert len(saved) == 2
+    assert all(s.startswith("snow__") for s in saved)
+    assert saved[0] != saved[1]
+    on_disk = {f.name: f.read_bytes() for f in upload_dir.iterdir()}
+    assert on_disk[saved[0]] == data1
+    assert on_disk[saved[1]] == data2

--- a/tests/test_media_delete.py
+++ b/tests/test_media_delete.py
@@ -1,0 +1,127 @@
+"""Tests for unified media delete + orphan reconcile (Phase 14.5).
+
+Covers: file moved to trash (not unlinked), derivatives (proxy/waveform/thumbnail)
+cleaned, external paths are metadata-only, missing rows -> None, and
+prune-missing removes ghost records.
+"""
+import db as db_mod
+import config as config_mod
+import media_delete
+
+
+def _insert_media(path, filename, thumbnail=None):
+    with db_mod.get_conn() as conn:
+        cur = conn.execute(
+            "INSERT INTO media (path, filename, thumbnail_path) VALUES (?,?,?)",
+            (path, filename, thumbnail),
+        )
+        return cur.lastrowid
+
+
+def _set_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(config_mod, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(config_mod, "TRASH_DIR", tmp_path / ".arkiv" / "trash")
+    monkeypatch.setattr(config_mod, "WAVEFORMS_DIR", tmp_path / "waveforms")
+    monkeypatch.setattr(config_mod, "MEDIA_ROOTS", [])
+    monkeypatch.setattr(config_mod, "TRASH_TTL_DAYS", 30)
+    (tmp_path / ".arkiv").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "waveforms").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "media-in").mkdir(parents=True, exist_ok=True)
+
+
+def test_delete_moves_original_to_trash(tmp_path, tmp_db, monkeypatch):
+    _set_env(tmp_path, monkeypatch)
+    src = tmp_path / "media-in" / "clip.mp4"
+    src.write_bytes(b"dummy")
+    mid = _insert_media("media-in/clip.mp4", "clip.mp4")
+
+    result = media_delete.delete_media_full(mid, allow_file_delete=True, token_info=None)
+
+    assert result is not None
+    assert result["file_deleted"] is True
+    assert result["warning"] is None
+    assert not src.exists()
+    trash_files = list((config_mod.TRASH_DIR).glob("*__clip.mp4"))
+    assert trash_files, "original should be moved into trash"
+    with db_mod.get_conn() as conn:
+        row = conn.execute("SELECT id FROM media WHERE id=?", (mid,)).fetchone()
+    assert row is None
+
+
+def test_delete_cleans_proxy_waveform_thumbnail(tmp_path, tmp_db, monkeypatch):
+    _set_env(tmp_path, monkeypatch)
+    src = tmp_path / "media-in" / "clip.mp4"
+    src.write_bytes(b"dummy")
+    thumb = tmp_path / ".arkiv" / "thumb.jpg"
+    thumb.write_bytes(b"t")
+    mid = _insert_media("media-in/clip.mp4", "clip.mp4", thumbnail=".arkiv/thumb.jpg")
+    proxy = config_mod.proxy_path_for(mid, str(tmp_path / "media-in" / "clip.mp4"))
+    proxy.write_bytes(b"p")
+    wf = config_mod.WAVEFORMS_DIR / ("%d_8.json" % mid)
+    wf.write_bytes(b"w")
+
+    media_delete.delete_media_full(mid, allow_file_delete=True, token_info=None)
+
+    assert not proxy.exists(), "proxy should be removed"
+    assert not wf.exists(), "waveform cache should be removed"
+    assert not thumb.exists(), "thumbnail should be removed"
+
+
+def test_external_path_is_metadata_only(tmp_path, tmp_db, monkeypatch):
+    _set_env(tmp_path, monkeypatch)
+    ext = "/etc/arkiv_external_test_clip.mp4"
+    mid = _insert_media(ext, "ext_clip.mp4")
+
+    result = media_delete.delete_media_full(mid, allow_file_delete=True, token_info=None)
+
+    assert result is not None
+    assert result["file_deleted"] is False
+    assert "metadata-only" in (result["warning"] or "")
+    with db_mod.get_conn() as conn:
+        row = conn.execute("SELECT id FROM media WHERE id=?", (mid,)).fetchone()
+    assert row is None
+
+
+def test_delete_missing_row_returns_none(tmp_db):
+    assert media_delete.delete_media_full(999999) is None
+
+
+def test_prune_missing_removes_ghost_records(tmp_path, tmp_db, monkeypatch):
+    _set_env(tmp_path, monkeypatch)
+    ghost = _insert_media("media-in/gone.mp4", "gone.mp4")
+    src = tmp_path / "media-in" / "keep.mp4"
+    src.write_bytes(b"x")
+    keep = _insert_media("media-in/keep.mp4", "keep.mp4")
+
+    missing = db_mod.iter_missing()
+    assert any(m["id"] == ghost for m in missing)
+    assert not any(m["id"] == keep for m in missing)
+
+    removed = 0
+    for m in missing:
+        r = media_delete.delete_media_full(m["id"], allow_file_delete=False, token_info=None)
+        if r is not None:
+            removed += 1
+
+    assert removed == 1
+    with db_mod.get_conn() as conn:
+        rows = conn.execute("SELECT id FROM media").fetchall()
+    ids = [r["id"] for r in rows]
+    assert ghost not in ids
+    assert keep in ids
+
+
+def test_trash_list_and_purge(tmp_path, tmp_db, monkeypatch):
+    _set_env(tmp_path, monkeypatch)
+    src = tmp_path / "media-in" / "clip.mp4"
+    src.write_bytes(b"dummy")
+    mid = _insert_media("media-in/clip.mp4", "clip.mp4")
+    media_delete.delete_media_full(mid, allow_file_delete=True, token_info=None)
+
+    trash = db_mod.list_trash()
+    assert len(trash) == 1
+    assert trash[0]["media_id"] == mid
+
+    purged = db_mod.purge_trash(ttl_days=0)
+    assert purged == 1
+    assert db_mod.list_trash() == []

--- a/tests/test_r5_24_mediatypes.py
+++ b/tests/test_r5_24_mediatypes.py
@@ -14,9 +14,11 @@ def test_video_set_includes_360():
     assert mediatypes.VIDEO_360_EXT <= mediatypes.VIDEO_EXT
 
 
-def test_media_partitions_into_video_and_audio():
-    assert mediatypes.VIDEO_EXT | mediatypes.AUDIO_EXT == mediatypes.MEDIA_EXT
+def test_media_partitions_into_video_audio_and_image():
+    assert mediatypes.VIDEO_EXT | mediatypes.AUDIO_EXT | mediatypes.IMAGE_EXT == mediatypes.MEDIA_EXT
     assert mediatypes.VIDEO_EXT.isdisjoint(mediatypes.AUDIO_EXT)
+    assert mediatypes.VIDEO_EXT.isdisjoint(mediatypes.IMAGE_EXT)
+    assert mediatypes.AUDIO_EXT.isdisjoint(mediatypes.IMAGE_EXT)
 
 
 def test_mxf_is_indexable_video_not_a_pro_unsupported_format():
@@ -54,16 +56,19 @@ def test_every_module_references_the_shared_set():
     # moved to routers/ingest.py with the /api/ingest family; still the shared object.
     assert ri.VIDEO_EXTS is mediatypes.VIDEO_EXT
     assert ri.AUDIO_EXTS is mediatypes.AUDIO_EXT
+    assert ri.IMAGE_EXTS is mediatypes.IMAGE_EXT
     assert ri.MEDIA_EXTS is mediatypes.MEDIA_EXT
     # R5-25 #51: _VIDEO_EXTS/_AUDIO_EXTS (list_media's search-branch filter buckets)
     # moved to routers/media.py with the media route group; still the shared object.
     assert rm._VIDEO_EXTS is mediatypes.VIDEO_EXT
     assert rm._AUDIO_EXTS is mediatypes.AUDIO_EXT
+    assert rm._IMAGE_EXTS is mediatypes.IMAGE_EXT
 
     assert watch.MEDIA_EXTS is mediatypes.MEDIA_EXT
 
     assert query_builder._VIDEO_EXTS is mediatypes.VIDEO_EXT
     assert query_builder._AUDIO_EXTS is mediatypes.AUDIO_EXT
+    assert query_builder._IMAGE_EXTS is mediatypes.IMAGE_EXT
 
     assert frames._FISHEYE_360_EXT is mediatypes.VIDEO_360_EXT
 
@@ -82,6 +87,12 @@ def test_db_video_filter_now_includes_360():
     audio_clause, _ = db._build_filter_clause(media_type="audio")
     assert ".insv" not in audio_clause
     assert ".mp3" in audio_clause
+
+    image_clause, _ = db._build_filter_clause(media_type="image")
+    for ext in mediatypes.IMAGE_EXT:
+        assert "'{0}'".format(ext) in image_clause
+    assert ".mp4" not in image_clause
+    assert ".mp3" not in image_clause
 
 
 def test_sql_in_literal_shape():

--- a/tests/test_r5_25_router_admin.py
+++ b/tests/test_r5_25_router_admin.py
@@ -20,7 +20,7 @@ def test_admin_router_is_a_leaf_module():
     assert not re.search(r"^\s*from\s+server\b", src, re.M)
 
 
-def test_router_owns_the_four_token_routes():
+def test_router_owns_the_admin_routes():
     import routers.admin as ra
     # one (path, method) pair per handler, ignoring the auto-added HEAD on GET
     pairs = {
@@ -34,6 +34,9 @@ def test_router_owns_the_four_token_routes():
         ("/api/admin/tokens", "GET"),
         ("/api/admin/tokens/{token_id}", "GET"),
         ("/api/admin/tokens/{token_id}", "DELETE"),
+        ("/api/admin/trash", "GET"),
+        ("/api/admin/trash/purge", "POST"),
+        ("/api/admin/trash/restore/{trash_id}", "POST"),
     }
     # the body model moved WITH the router
     assert hasattr(ra, "CreateTokenRequest")

--- a/tests/test_r5_25_router_ingest.py
+++ b/tests/test_r5_25_router_ingest.py
@@ -39,6 +39,7 @@ def test_router_owns_exactly_the_ingest_routes():
         ("/api/ingest/engines", "GET"),
         ("/api/ingest/scan", "POST"),
         ("/api/ingest", "POST"),
+        ("/api/ingest/upload", "POST"),
         ("/api/media/{media_id}/reingest", "POST"),
         ("/ws/ingest", "WS"),
         ("/api/ingest/ws", "POST"),

--- a/tests/test_r5_25_router_media.py
+++ b/tests/test_r5_25_router_media.py
@@ -24,6 +24,8 @@ _EXPECTED_ROUTES = {
     ("/api/media/facets/shoot-date", "GET"),
     ("/api/media", "GET"),
     ("/api/media/{media_id}", "GET"),
+    ("/api/media/{media_id}", "DELETE"),
+    ("/api/media/bulk-delete", "POST"),
     ("/api/media/{media_id}/waveform", "GET"),
     ("/api/media/{media_id}/scenes", "GET"),
     ("/api/media/{media_id}/segments", "GET"),
@@ -104,3 +106,28 @@ def test_media_routes_mounted_and_auth_guarded(server_module):
         assert c.get("/api/media/pool").status_code == 401
         # a bogus sibling path is a genuine 404 (nothing is over-matching)
         assert c.get("/api/mediazz").status_code == 404
+
+
+def test_media_detail_returns_manual_and_auto_tags(fastapi_client, sample_record, tmp_db):
+    """Regression: get_media_detail must surface BOTH manual (user-added) and
+    auto (vision) tags. The old code filtered every tag against the auto
+    frame-tag top-N set, which silently dropped manual tags (and any auto tag
+    not in the top-N) from the inspector."""
+    import db as dbmod
+
+    rec = sample_record()
+    dbmod.upsert(rec)
+    with dbmod.get_conn() as conn:
+        mid = conn.execute(
+            "SELECT id FROM media WHERE path=?", (rec["path"],)
+        ).fetchone()["id"]
+    dbmod.add_tag(mid, "manual_tag", source="manual")
+    dbmod.add_tag(mid, "auto_tag", source="auto")
+
+    r = fastapi_client.get(f"/api/media/{mid}")
+    assert r.status_code == 200
+    tags = r.json().get("tags", [])
+    sources = {t.get("source") for t in tags}
+    # Both a hand-added (manual) and a vision (auto) tag must reach the UI.
+    assert "manual" in sources
+    assert "auto" in sources

--- a/tests/test_r5_25_router_media.py
+++ b/tests/test_r5_25_router_media.py
@@ -26,6 +26,7 @@ _EXPECTED_ROUTES = {
     ("/api/media/{media_id}", "GET"),
     ("/api/media/{media_id}", "DELETE"),
     ("/api/media/bulk-delete", "POST"),
+    ("/api/media/prune-missing", "POST"),
     ("/api/media/{media_id}/waveform", "GET"),
     ("/api/media/{media_id}/scenes", "GET"),
     ("/api/media/{media_id}/segments", "GET"),
@@ -52,7 +53,7 @@ def test_media_router_is_a_leaf_module():
     assert not re.search(r"^\s*from\s+server\b", src, re.M)
 
 
-def test_router_owns_exactly_the_22_media_routes():
+def test_router_owns_all_the_media_routes():
     import routers.media as rm
     pairs = {
         (r.path, m)

--- a/tests/test_search_blend.py
+++ b/tests/test_search_blend.py
@@ -1,0 +1,77 @@
+"""Search-fix regression tests (Direction 2: blend + stable pagination).
+
+Covers the two bugs that made search feel broken:
+  • `total` used to be windowed by `offset+limit`, so the first page reported
+    e.g. 50 and hid every later page behind a false "that's all".
+  • Literal filename/transcript/tag matches (the `text` bucket) were skipped
+    whenever the semantic pass already filled the window — a clip that LITERALLY
+    contained the query term could be invisible.
+
+These run against a seeded tmp DB with a monkeypatched `vectordb.search` so the
+semantic bucket is small and deterministic, forcing the lexical bucket to surface.
+"""
+import db as db_mod
+import vectordb as vdb
+
+
+def _seed(conn):
+    ids = []
+    for i in range(1, 13):
+        # ids 1-3 match by filename; ids 4-6 match by transcript; 7-12 no match.
+        fn = "clip_ZZZTERM_{0}.mp4".format(i) if i <= 3 else "clip_{0}.mp4".format(i)
+        tr = "transcript with ZZZTERM text {0}".format(i) if 4 <= i <= 6 else "transcript {0}".format(i)
+        cur = conn.execute(
+            "INSERT INTO media (path, filename, transcript, ext, lang) VALUES (?,?,?,?,?)",
+            ("/p/{0}.mp4".format(i), fn, tr, ".mp4", "zh"),
+        )
+        ids.append(cur.lastrowid)
+    conn.commit()
+    return ids
+
+
+def test_search_blend_semantic_and_lexical_and_pagination(fastapi_client, monkeypatch):
+    with db_mod.get_conn() as conn:
+        ids = _seed(conn)
+
+    # Semantic bucket returns ONLY ids 1-3, so lexical (4-6) must still surface.
+    def fake_search(q, n_results=10):
+        return [
+            {"media_id": ids[j], "score": round(0.9 - j * 0.1, 3), "excerpt": "sem {0}".format(j)}
+            for j in range(3)
+        ]
+
+    monkeypatch.setattr(vdb, "search", fake_search)
+
+    p0 = fastapi_client.get("/api/media", params={"q": "ZZZTERM", "limit": 2, "offset": 0}).json()
+    p1 = fastapi_client.get("/api/media", params={"q": "ZZZTERM", "limit": 2, "offset": 2}).json()
+    p2 = fastapi_client.get("/api/media", params={"q": "ZZZTERM", "limit": 2, "offset": 4}).json()
+
+    # stable, offset-independent total
+    assert p0["total"] == 6
+    assert p0["total"] == p1["total"] == p2["total"]
+    # pagination slices correctly
+    assert [len(p["items"]) for p in (p0, p1, p2)] == [2, 2, 2]
+    # both match buckets present + lexical literal matches surfaced
+    types = set()
+    for p in (p0, p1, p2):
+        for it in p["items"]:
+            assert "match_type" in it
+            types.add(it["match_type"])
+    assert "semantic" in types and "text" in types
+    text_ids = [it["id"] for p in (p0, p1, p2) for it in p["items"] if it["match_type"] == "text"]
+    assert set(text_ids) == set(ids[3:6])
+
+
+def test_health_exposes_embeddings_coverage(fastapi_client):
+    with db_mod.get_conn() as conn:
+        _seed(conn)
+    r = fastapi_client.get("/api/health")
+    assert r.status_code in (200, 503)  # unauthenticated; ollama may be down in CI
+    body = r.json()
+    assert "embeddings" in body
+    emb = body["embeddings"]
+    assert {"total_media", "embedded_media", "coverage"} <= set(emb.keys())
+    # 12 seeded rows, none embedded yet → 0% coverage
+    assert emb["total_media"] == 12
+    assert emb["embedded_media"] == 0
+    assert emb["coverage"] == 0.0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1048,13 +1048,16 @@ def test_stream_returns_409_when_hevc_source_has_no_proxy(
     resp = fastapi_client.get("/api/stream/1")
     assert resp.status_code == 409
     body = resp.json()
-    assert body == {
-        "need_proxy": True,
-        "media_id": 1,
-        "filename": "iphone_clip.mov",
-        "reason": "browser-incompatible codec (HEVC/ProRes); proxy required for playback",
-        "hint": "POST /api/proxy/build to queue proxy generation",
-    }
+    # Static shape — the reason/hint bodies are dynamic (formatted with the
+    # probed codec + media_id, see routers/misc.py:stream_media), so match the
+    # stable parts and substring-check the formatted ones.
+    assert body["need_proxy"] is True
+    assert body["media_id"] == 1
+    assert body["filename"] == "iphone_clip.mov"
+    assert "hevc" in body["reason"]
+    assert "proxy required" in body["reason"]
+    assert "POST /api/proxy/build/1" in body["hint"]
+    assert "queue proxy generation" in body["hint"]
 
 
 def test_stream_serves_h264_source_unchanged_when_proxy_check_says_no(

--- a/transcribe.py
+++ b/transcribe.py
@@ -75,6 +75,18 @@ def _non_mac_backend() -> str:
     force the legacy path."""
     return os.getenv("ARKIV_TRANSCRIBE_BACKEND", "faster-whisper").strip().lower()
 
+
+# Whisper compute device. Defaults to "cuda" (the GPU dev box). On a GPU-less
+# host — e.g. the remote-Ollama Docker deploy running on a CPU-only machine —
+# faster-whisper would otherwise try CUDA and crash with "CUDA driver version
+# is insufficient for CUDA runtime version". Set ARKIV_WHISPER_DEVICE=cpu there.
+WHISPER_DEVICE = os.getenv("ARKIV_WHISPER_DEVICE", "cuda").strip().lower()
+
+# float16 is only efficient on CUDA. On CPU, faster-whisper/ctranslate2 reject
+# it ("target device or backend do not support efficient float16 computation"),
+# so fall back to int8 — same accuracy for transcription, ~2x slower but it runs.
+WHISPER_COMPUTE_TYPE = "int8" if WHISPER_DEVICE == "cpu" else "float16"
+
 # ── Model Singletons ────────────────────────────────────────────────────────
 WHISPER_GUARD_ACTIVE_MODE = WHISPER_GUARD_DEFAULT_MODE
 WHISPER_GUARD_ACTIVE_LAYER = WHISPER_GUARD_LAYERS[WHISPER_GUARD_ACTIVE_MODE]
@@ -308,13 +320,13 @@ def warm_up():
             import whisperx
             _whisperx_model = whisperx.load_model(
                 WHISPER_MODEL,
-                "cuda",
-                compute_type="float16",
+                WHISPER_DEVICE,
+                compute_type=WHISPER_COMPUTE_TYPE,
             )
             print("  [whisperx on cuda]", flush=True)
         else:
             from faster_whisper import WhisperModel
-            _fw_model = WhisperModel(WHISPER_MODEL, device="cuda", compute_type="float16")
+            _fw_model = WhisperModel(WHISPER_MODEL, device=WHISPER_DEVICE, compute_type=WHISPER_COMPUTE_TYPE)
             print("  [faster-whisper on cuda]", flush=True)
 
         _whisper_loaded = True
@@ -540,14 +552,14 @@ def _transcribe_whisperx(wav: str, language: str) -> tuple:
 
     align_model, align_meta = whisperx.load_align_model(
         language_code=lang,
-        device="cuda",
+        device=WHISPER_DEVICE,
     )
     result = whisperx.align(
         result["segments"],
         align_model,
         align_meta,
         audio,
-        "cuda",
+        WHISPER_DEVICE,
         return_char_alignments=False,
     )
 

--- a/vectordb.py
+++ b/vectordb.py
@@ -293,6 +293,59 @@ def build_doc_text(record: dict) -> str:
                     chunks.append(kw.strip())
             if chunks:
                 parts.append(" ".join(chunks))
+    manual = record.get("manual_tags")
+    if manual:
+        parts.append(" ".join(t for t in manual if isinstance(t, str) and t.strip()))
+    canon = record.get("canonical_tags")
+    if canon:
+        if isinstance(canon, str):
+            try:
+                canon = json.loads(canon)
+            except (json.JSONDecodeError, TypeError):
+                canon = [canon]
+        if isinstance(canon, (list, tuple)):
+            parts.append(" ".join(str(t) for t in canon if isinstance(t, str) and t.strip()))
+    return " ".join(parts)
+
+
+def build_tag_doc(record: dict) -> str:
+    """Searchable text from filename + frame_tags + manual/canonical tags — i.e.
+    everything EXCEPT the transcript. Used for the always-present '_f0' tag chunk
+    so tag/vision search works even for clips that also have a transcript (previously
+    only transcript chunks were indexed for those, dropping all visual/tag signal)."""
+    parts = ["[%s]" % record.get("filename", "")]
+    ft = record.get("frame_tags")
+    if ft:
+        try:
+            frames = json.loads(ft) if isinstance(ft, str) else ft
+        except (json.JSONDecodeError, TypeError):
+            frames = []
+        if isinstance(frames, list):
+            for f in frames:
+                if not isinstance(f, dict):
+                    continue
+                desc = f.get("description")
+                if isinstance(desc, str) and desc.strip():
+                    parts.append(desc.strip())
+                tags_field = f.get("tags")
+                if isinstance(tags_field, list):
+                    parts.extend(t.strip() for t in tags_field
+                                 if isinstance(t, str) and t.strip())
+                kw = f.get("keywords")
+                if isinstance(kw, str) and kw.strip():
+                    parts.append(kw.strip())
+    manual = record.get("manual_tags")
+    if manual:
+        parts.append(" ".join(t for t in manual if isinstance(t, str) and t.strip()))
+    canon = record.get("canonical_tags")
+    if canon:
+        if isinstance(canon, str):
+            try:
+                canon = json.loads(canon)
+            except (json.JSONDecodeError, TypeError):
+                canon = [canon]
+        if isinstance(canon, (list, tuple)):
+            parts.append(" ".join(str(t) for t in canon if isinstance(t, str) and t.strip()))
     return " ".join(parts)
 
 
@@ -323,7 +376,6 @@ def upsert_record(col, record: dict) -> int:
     # would stack stale vectors (H5).
     delete_media(col, media_id)
     transcript = record.get("transcript") or ""
-    frame_doc = build_doc_text(record)
 
     meta_base = {
         "media_id": media_id,
@@ -337,6 +389,15 @@ def upsert_record(col, record: dict) -> int:
 
     ids, embeddings, documents, metadatas = [], [], [], []
 
+    # Always index the tag/vision chunk (_f0) — even for clips that also have a
+    # transcript — so manual/canonical/frame tags are searchable regardless.
+    tag_doc = build_tag_doc(record)
+    if tag_doc.strip():
+        ids.append(f"{media_id}_f0")
+        documents.append(tag_doc)
+        embeddings.append(embed(tag_doc))
+        metadatas.append({**meta_base, "chunk_type": "tags", "chunk_idx": 0})
+
     if transcript:
         chunks = chunk_text(transcript)
         vectors = embed_batch(chunks)  # audit M27: one HTTP call for all chunks
@@ -346,13 +407,6 @@ def upsert_record(col, record: dict) -> int:
             documents.append(chunk)
             embeddings.append(vec)
             metadatas.append({**meta_base, "chunk_type": "transcript", "chunk_idx": i})
-    else:
-        # No transcript — embed frame tags / filename only
-        doc_id = f"{media_id}_f0"
-        ids.append(doc_id)
-        documents.append(frame_doc)
-        embeddings.append(embed(frame_doc))
-        metadatas.append({**meta_base, "chunk_type": "frame_tags", "chunk_idx": 0})
 
     try:
         col.upsert(ids=ids, embeddings=embeddings, documents=documents, metadatas=metadatas)


### PR DESCRIPTION
## Summary
- Inspector 的 `<video>`/`<audio>` 直接把 `/api/stream/{id}` 設給 `src`：對 ProRes/HEVC 收到的 `409 need_proxy` 完全沒處理，對 mjpeg/qtrle 則靜默收到解不開的原始檔，結果都是空白/播不出（含帶聲軌影片「音頻沒播放按鈕」的現象）。
- stream 路由對任何不在瀏覽器可播清單的視頻編碼統一回 `409 need_proxy`（h264/vp9/av1 仍直接播，純音頻 NULL 走原回退）。
- Inspector 偵測媒體錯誤後顯示「生成代理並播放」，點擊即建 H.264 proxy、輪詢至就緒後自動重載播放器（复用 api.buildProxyOne / getProxyStatus）。
- 純音頻檔本身可播，但舊實作把原生 `<audio controls>` 貼在預覽盒底部，原生控制條是白色長條，在深色預覽上看起來像白框；現改為自訂主題化播放器（置中圓形播放/暫停鈕 + 隱藏原生 audio + 時間碼）。

## Test plan
- [x] `cd frontend && npm run build` 通過（212 modules, no errors）
- [x] `python3 -m py_compile codec.py routers/misc.py` 通過
- [ ] 實機：選 ProRes/qtrle 素材 -> 出現「生成代理並播放」-> 點擊後代理就緒自動播放
- [ ] 實機：選純音頻素材 -> 置中圓形播放鈕可播放，不再白框
