### PR TITLE
docs(contributing): 把 17 支 route-ownership 測試寫成貢獻者看得到的東西

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,11 @@
 <!-- e.g. `pytest -q` locally, ingested a file and searched, checked the UI at 1440px.
      Screenshots welcome for anything visual. -->
 
+<!-- Paste the last line of `pytest -q` here if you ran it (e.g. "1788 passed, 8 skipped").
+     Couldn't run it? Say that instead — it's a fine answer and we'll run it for you.
+     Heads-up: adding a route/setting/version string trips a structural invariant test —
+     see CONTRIBUTING.md "Structural invariants". -->
+
 ## Checklist
 
 - [ ] I've read the [contributor terms](../CONTRIBUTING.md#contributor-terms) and my

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,30 @@ chore: update requirements.txt
 Run the suite with `pytest -q`. CI runs it on macOS (Python 3.9 + 3.12) plus a scoped
 Windows correctness leg — those are the blocking correctness gates.
 
+### Structural invariants (the tests most likely to surprise you)
+
+Some tests do not test behaviour — they assert that a **registry stays in sync with the
+code**. They exist because the thing they guard has silently drifted before, and each one
+fails loudly rather than letting the drift ship. If you add a route, a setting, a version
+string, or a media extension, one of these will go red, and the fix is to register your
+addition, not to loosen the assertion:
+
+| If you add… | This goes red | Fix |
+| --- | --- | --- |
+| an endpoint to a router | `tests/test_r5_25_router_<name>.py` — each of the 17 routers has a route-ownership test pinning the exact `(path, method)` set it owns | add your `(path, method)` pair to that test's expected set |
+| a settings key | `tests/test_settings_g5.py` — asserts `set(accessors) == set(SETTINGS_SCHEMA)` | add a typed accessor for the key; production code must never call bare `effective()` |
+| a place the version number appears | `tests/test_version_sync.py` — `VERSION_SOURCES` | add the new location to `VERSION_SOURCES` |
+| a media extension | `routers/ingest.py` asserts `VIDEO_EXTS \| AUDIO_EXTS \| IMAGE_EXTS == MEDIA_EXTS` | put the extension in exactly one of the three sets in `mediatypes.py` |
+
+The route-ownership tests are the ones outside contributors hit most often: they came out of
+the R5-25 router split (`server.py` 4531 → 487 lines across 15 routers), and their whole job
+is to stop a route quietly migrating to the wrong module. A red one means your route landed
+somewhere the split did not expect — usually that is fine and the test just needs your pair,
+but it is worth a second look at whether the route belongs in that router.
+
+`pytest -q` locally catches every one of these before CI does. If you cannot run the suite,
+say so in the PR — that is a perfectly good answer, and we will run it for you.
+
 **Coverage is a non-blocking regression ratchet, not a quality bar.** The `coverage` CI
 job is `continue-on-error` on purpose:
 


### PR DESCRIPTION
## What this changes

外部貢獻者 `pixb` 的 #396 在 `routers/admin.py` 加了 `POST /api/admin/prune-missing`，
`test_r5_25_router_admin.py::test_router_owns_the_four_token_routes` 因此變紅。

那支測試做了它該做的事。但它守的不變量在 `CONTRIBUTING.md`、`AGENTS.md`、`README.md`、
`.github/` **全部 grep 零命中** —— 貢獻者沒有任何管道知道它存在。

破壞是對方造成的（`pytest -q` 跑一次就會看到），但「不變量沒有寫下來」是我們這邊的缺口。

- `CONTRIBUTING.md` 補一節 **Structural invariants**，列出四類會因為「加了東西沒登記」
  而變紅的測試：route ownership（17 支 `test_r5_25_router_*.py`）、`SETTINGS_SCHEMA`、
  `VERSION_SOURCES`、`mediatypes` 三集合分割。明說**修法是登記你的新增，不是放寬斷言**。
- `.github/PULL_REQUEST_TEMPLATE.md` 的「How it was tested」原本只是 HTML 註解，
  容易整段略過（那 11 支 PR 沒有一支套用 template）。補上具體提示：貼 `pytest -q`
  最後一行，跑不了就直說。**刻意保留「guide, not a gate」的語氣** —— 目標是讓人知道
  要講，不是把門關上。

## How it was tested

`pytest -q` → **1773 passed, 8 skipped**（`tests/test_acknowledgements.py` 會實際讀
`CONTRIBUTING.md`，5 passed）。純 markdown 改動，無程式碼路徑變更。

## Checklist

- [x] I've read the contributor terms and my contribution is offered under them.
- [x] Commit messages follow conventional commits.
- [x] `pytest -q` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BznCya8zniew2fVKvPXJrP