### PR TITLE
fix(ui): 側欄那份「PROJECTS」從來不是專案清單，是你開著的那個庫

### DIFF
--- a/frontend/src/lib/PoolSidebar.svelte
+++ b/frontend/src/lib/PoolSidebar.svelte
@@ -5,7 +5,8 @@
   import { PROJECTS, TAGS } from './mockData.js'
   import { DAY_CAP } from './shotYear.js'
   // Live overrides — all default to mock so mock screens stay byte-identical.
-  export let liveProjects = null // [{id,name,count,active,health?}]
+  export let liveProjects = null // [{id,name,count,active,health?}]; count null = unknown
+  export let entitlement = null // /api/entitlements; null -> the line is omitted entirely
   export let livePools = null // [[label, count], ...]
   export let liveTags = null // [{name, count}]
   export let onTag = null // (name) => void; live tag-click → filter
@@ -34,6 +35,16 @@
     ['No transcript', 12],
   ]
   $: projects = liveProjects ?? PROJECTS
+  // Says what the install is actually entitled to, from the endpoint that enforces
+  // it. Omitted when unknown rather than guessed: a wrong tier label is worse than
+  // no label, and the refusal itself already explains the cap when someone hits it.
+  $: tierLine = !entitlement
+    ? null
+    : entitlement.grandfathered
+      ? '此安裝永久解除專案上限'
+      : entitlement.pro
+        ? 'Pro · 無限專案'
+        : `${entitlement.projects_used} / ${entitlement.free_project_limit} 個免費專案`
   $: pools = livePools ?? MOCK_POOLS
   $: tags = liveTags ?? TAGS
   // Cap the cloud so a long tail (74+ on a real library) doesn't bury the useful
@@ -64,13 +75,18 @@
 
 <aside class="pool">
   <section>
-    <Eyebrow style="margin-bottom:10px;">Projects · {projects.length}</Eyebrow>
+    <Eyebrow style="margin-bottom:{tierLine ? '3px' : '10px'};">Projects · {projects.length}</Eyebrow>
+    {#if tierLine}
+      <Mono dim style="font-size:9.5px;letter-spacing:0.06em;display:block;margin-bottom:9px;">{tierLine}</Mono>
+    {/if}
     <div class="col">
       {#each projects as p (p.id)}
         <div class="proj" class:active={p.active} style="opacity:{p.health ? 0.6 : 1};">
           <div class="projrow">
             <span class="projname" class:activename={p.active}>{p.name}</span>
-            <Mono dim style="font-size:10px;flex:0 0 auto;">{p.count}</Mono>
+            {#if p.count != null}
+              <Mono dim style="font-size:10px;flex:0 0 auto;">{p.count}</Mono>
+            {/if}
           </div>
           {#if p.health}
             <Mono dim style="font-size:9.5px;letter-spacing:0.06em;display:block;margin-top:1px;">◇ {p.health}</Mono>

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -89,6 +89,12 @@ const qs = (params = {}) => {
 export const getStats = (opts) => req('/api/stats', opts)
 export const getProjects = (opts) => req('/api/projects', opts)
 export const getProjectsHealth = (opts) => req('/api/projects/health', opts)
+// GET /api/entitlements -> {armed, pro, grandfathered, free_project_limit,
+// projects_used, can_add_project, add_project_reason, cross_project, ...}.
+// Read from the code that ENFORCES the tier - a second copy of the rules in
+// the frontend drifts, and the drift shows up as a user promised one thing
+// and refused another.
+export const getEntitlements = (opts) => req('/api/entitlements', opts)
 // ---- first-run: version / sample seed / log tail ----
 export const getVersion = (opts) => req('/api/version', opts)
 export const seedSample = (opts) => req('/api/sample/seed', { method: 'POST', ...opts })

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -39,6 +39,8 @@
   let moreParams = null
   let loadingMore = false
   let stats = null
+  let registryProjects = null // /api/projects rows; null = not loaded / unreachable
+  let entitlement = null // /api/entitlements; null = not loaded (section then says nothing)
   // First-run readiness gate: 'checking' until /api/health answers, then
   // 'ready' | 'notready' (deps missing, 503) | 'unreachable' (backend down).
   let health = null
@@ -292,16 +294,22 @@
     readyState = ready
     if (readyState === 'unreachable') { state = 'ok'; return } // panel renders via readyState
     try {
-      const [s, m, t, c, si, f] = await Promise.all([
+      const [s, m, t, c, si, f, pr, ent] = await Promise.all([
         api.getStats(),
         api.getMedia(mediaParams({ limit: PAGE, ...shotArgs() })),
         api.getTags(), api.getCollections(),
         api.sampleStatus().catch(() => null), // non-fatal: chip just stays hidden
         api.getShootDateFacets().catch((e) => ({ _error: e.message })),
+        // Both non-fatal on purpose: the sidebar falls back to naming just the
+        // open library, which is strictly what it showed before this existed.
+        api.getProjects().catch(() => null),
+        api.getEntitlements().catch(() => null),
       ])
       viewGen.apply(gen, () => {
         stats = s
         sampleInfo = si
+        registryProjects = pr?.projects ?? null
+        entitlement = ent
         deepLinkSubset = false
         applyShotYearFacets(f)
         items = (m.items || []).map(toCard)
@@ -479,7 +487,30 @@
       ]
     : null
   $: projectName = (stats && stats.project) || '素材庫'
-  $: liveProjects = stats ? [{ id: 'proj', name: projectName, count: stats.total, active: true }] : null
+  // The sidebar's Projects list is the REGISTRY (~/.arkiv-projects.json), not the
+  // open library. It used to be a single hardcoded row naming whatever library was
+  // open, which meant a project you added in Settings never appeared here and the
+  // header read "Projects · 1" no matter how many you had.
+  //
+  // The open library still gets a row, because it is what every other number on
+  // this page describes — but it is only synthesised when no registry entry claims
+  // to be it. `is_current` comes from the backend: it holds `config.PROJECT_ROOT`
+  // and the frontend does not, so the frontend must not try to guess the match.
+  //
+  // Counts: only the open library has one here. A registry entry's item count would
+  // need a query per project, and a wrong number is worse than no number.
+  $: liveProjects = (() => {
+    if (!stats) return null
+    const open = { id: 'cur', name: projectName, count: stats.total, active: true }
+    if (!registryProjects || !registryProjects.length) return [open]
+    const rows = registryProjects.map((p) => ({
+      id: `reg:${p.name}`,
+      name: p.name,
+      count: p.is_current ? stats.total : null,
+      active: !!p.is_current,
+    }))
+    return rows.some((r) => r.active) ? rows : [open, ...rows]
+  })()
   // real disk usage for the sidebar Storage footer (replaces the mock placeholder)
   $: liveStorage = stats?.disk ?? null
   // The header used to always read stats.total, so picking "2025 · 54" left the only
@@ -955,7 +986,7 @@
 <div class="artboard" data-theme={theme}>
   <TopBar />
   <div class="body">
-    <PoolSidebar {liveProjects} {livePools} {liveTags} {liveCollections} {liveStorage} {liveCameras} {liveShotYears} onTag={onTagClick} onCollection={onCollectionClick} {activeCollection} onCamera={onCameraClick} {activeCamera} onShotYear={onShotYearClick} {activeShotYear} onShotDate={onShotDateClick} {activeShotDate} onPool={onPoolClick} {activePool} liveBins={binList} onBin={() => (window.location.hash = '#/bins')} />
+    <PoolSidebar {liveProjects} {entitlement} {livePools} {liveTags} {liveCollections} {liveStorage} {liveCameras} {liveShotYears} onTag={onTagClick} onCollection={onCollectionClick} {activeCollection} onCamera={onCameraClick} {activeCamera} onShotYear={onShotYearClick} {activeShotYear} onShotDate={onShotDateClick} {activeShotDate} onPool={onPoolClick} {activePool} liveBins={binList} onBin={() => (window.location.hash = '#/bins')} />
 
     <main class="center">
       <div class="toolrow">

--- a/routers/projects.py
+++ b/routers/projects.py
@@ -7,11 +7,13 @@ sanitisers (fable-audit #22: absolute roots only leak to admin-scoped callers)
 are projects-local and move here. Imports auth + projects + pathres — no server
 import, no cycle.
 """
+from pathlib import Path
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, field_validator
 
+import config
 import projects as project_registry
 from auth import require_scopes
 from pathres import _basename_safe
@@ -61,6 +63,36 @@ def _sanitize_project_paths(projects: list, tok: dict) -> list:
     return projects
 
 
+def _mark_current(projects: list) -> list:
+    """Flag the registry entry that IS the library this install currently has open.
+
+    The frontend cannot work this out for itself. `/api/stats` reports the library
+    by folder name (`.arkiv`) while the registry stores a chosen project name
+    (`九月分鏡課promo`) against an absolute path; those two never match, so a UI
+    that tried would either guess wrong or give up. The backend already holds
+    `config.PROJECT_ROOT`, so the answer belongs here — the same reasoning as #343,
+    where an entitlement verdict was wrong precisely because the code could not see
+    the library it was itself serving.
+
+    🔴 Must run BEFORE `_sanitize_project_paths`: that replaces `path` with a
+    basename for non-admin callers, and a basename cannot be compared to a root.
+    """
+    try:
+        here = project_registry._normalize_key(config.PROJECT_ROOT)
+    except Exception:  # noqa: BLE001 — an unresolvable root is "no entry is current"
+        here = None
+    for p in projects:
+        marked = False
+        raw = p.get("path")
+        if here and raw:
+            try:
+                marked = project_registry._normalize_key(Path(raw)) == here
+            except Exception:  # noqa: BLE001 — one bad row must not blank the rest
+                marked = False
+        p["is_current"] = marked
+    return projects
+
+
 @router.get("/api/projects")
 def list_projects(
     _tok: dict = Depends(require_scopes("projects_read")),
@@ -71,6 +103,7 @@ def list_projects(
         projects = [project.to_dict() for project in project_registry.list_registry_projects()]
     except project_registry.RegistryError as exc:
         raise HTTPException(status_code=500, detail="project registry unreadable: {0}".format(exc))
+    _mark_current(projects)
     _sanitize_project_paths(projects, _tok)
     return {"projects": projects, "total": len(projects)}
 

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -71,3 +71,84 @@ def test_save_registry_uses_unique_tmp_file(tmp_path, monkeypatch):
     # the shared, fixed-name tmp must not survive a save (unique + cleaned up)
     assert not (tmp_path / "arkiv-projects.json.tmp").exists()
     assert reg.exists() and "projects" in reg.read_text(encoding="utf-8")
+
+def _registry_with(tmp_path, monkeypatch, entries):
+    """Point the registry at a temp file and add each (name, root) in order."""
+    import projects as project_registry
+    reg = tmp_path / "arkiv-projects.json"
+    monkeypatch.setattr(project_registry, "_default_registry_path", lambda: reg)
+    for name, root in entries:
+        root.mkdir(parents=True, exist_ok=True)
+        project_registry.add_project(name, str(root))
+    return reg
+
+
+def test_list_projects_flags_the_open_library(fastapi_client, tmp_path, monkeypatch):
+    """`is_current` marks the registry entry that IS config.PROJECT_ROOT.
+
+    The sidebar needs this because it cannot derive it: /api/stats names the open
+    library by folder (`.arkiv`) while the registry stores a chosen project name
+    against an absolute path, and those never match. Same shape as #343 — the
+    judgement has to be made where the root is known.
+    """
+    import config
+    here = tmp_path / "open-one"
+    other = tmp_path / "other-one"
+    _registry_with(tmp_path, monkeypatch, [("open-one", here), ("other-one", other)])
+    monkeypatch.setattr(config, "PROJECT_ROOT", here)
+
+    rows = fastapi_client.get("/api/projects").json()["projects"]
+    flags = {r["name"]: r["is_current"] for r in rows}
+    assert flags == {"open-one": True, "other-one": False}
+
+
+def test_is_current_is_computed_before_paths_are_sanitised(server_module, tmp_path, monkeypatch):
+    """Ordering guard: `_mark_current` must run BEFORE `_sanitize_project_paths`.
+
+    A non-admin caller gets basenames instead of absolute roots (fable-audit #22).
+    A basename cannot be compared to PROJECT_ROOT, so if the two steps were ever
+    swapped every row would silently report `is_current: false` — and the only
+    visible symptom would be the sidebar failing to highlight the open library,
+    which is exactly the kind of thing nobody writes a bug report about.
+    """
+    import admin
+    import config
+    from starlette.testclient import TestClient
+
+    here = tmp_path / "open-one"
+    _registry_with(tmp_path, monkeypatch, [("open-one", here)])
+    monkeypatch.setattr(config, "PROJECT_ROOT", here)
+
+    token = admin.create_token(name="pytest-readonly", scopes=["projects_read"])
+    headers = {"Authorization": "Bearer {0}".format(token["raw_token"])}
+    with TestClient(server_module.app, headers=headers) as client:
+        rows = client.get("/api/projects").json()["projects"]
+
+    assert len(rows) == 1
+    # the path really was reduced to a basename for this caller...
+    assert rows[0]["path"] == "open-one"
+    # ...and the flag survived it anyway.
+    assert rows[0]["is_current"] is True
+
+
+def test_unresolvable_project_root_leaves_every_row_not_current(fastapi_client, tmp_path, monkeypatch):
+    """A root we cannot normalise means "no entry is current", not a 500.
+
+    `/api/projects` is on the first paint of the main view; a library root that
+    has gone away (unmounted NAS, renamed folder) must degrade to an unhighlighted
+    list rather than taking the whole sidebar down with it.
+    """
+    import config
+    import routers.projects as rp
+
+    _registry_with(tmp_path, monkeypatch, [("a", tmp_path / "a"), ("b", tmp_path / "b")])
+    monkeypatch.setattr(config, "PROJECT_ROOT", tmp_path / "gone")
+
+    def _boom(_path):
+        raise OSError("root is unreachable")
+
+    monkeypatch.setattr(rp.project_registry, "_normalize_key", _boom)
+
+    resp = fastapi_client.get("/api/projects")
+    assert resp.status_code == 200
+    assert [r["is_current"] for r in resp.json()["projects"]] == [False, False]


### PR DESCRIPTION
## What this changes

使用者回報「**我沒有實際拿到我實際串進去的 project**」。不是操作問題。

`MainLive.svelte:482` 是一行寫死的單筆：

```js
$: liveProjects = stats ? [{ id: 'proj', name: projectName, count: stats.total, active: true }] : null
```

`name` 取自 `stats.project`（當前庫的**資料夾名**），`count` 取自當前庫的素材數，而且**從來沒有呼叫過 `/api/projects`**。所以不管 registry 裡有幾個專案，標題永遠是「Projects · 1」，在 Settings 加的專案永遠不會出現在主畫面。

實機上 registry 有「九月分鏡課promo」，側欄顯示的卻是 `.arkiv`。

同一個檔案 524 行的註解證明作者知道 registry 存在（`// ~/.arkiv-projects.json registry, which is empty here`）—— 這是**接了一半**，不是沒想過。

### 為什麼判斷放後端

前端無法自己判斷 registry 裡哪一筆是當前庫：`/api/stats` 用資料夾名報，registry 存的是使用者取的專案名配絕對路徑，**兩者永遠對不上**。`config.PROJECT_ROOT` 在後端，所以 `is_current` 由後端給。

這跟 #343 是同一個形狀：那次授權判定給錯答案，正是因為程式看不到它自己正在服務的那個庫。

### 🔴 一個順序不變量

`_mark_current` 必須跑在 `_sanitize_project_paths` **之前**。後者會把非 admin 呼叫者的 `path` 換成 basename（fable-audit #22），而 basename 沒辦法跟 root 比對。

順序一旦對調，每一列都會靜默回報 `is_current: false`，唯一的症狀是側欄不再 highlight 當前庫 —— **沒有人會為這種事開 bug**。一支測試專門釘這個順序。

### 其他決定

- **當前庫仍然有一列**（頁面上其他每個數字都是在講它），但只在沒有任何 registry 條目自稱是它的時候才合成，避免重複。
- **筆數只給當前庫**：其他專案要一個一個查才知道，而錯的數字比沒有數字更糟。
- **順手接上 `/api/entitlements`**。那個端點的 docstring 自己寫著「The UI needs the tier in order to label the Pro features honestly」，而前端 grep `entitlements` **零命中** —— 端點為了 UI 而蓋，UI 從沒接。閘門本來是活的但隱形，要撞到第 4 個專案被拒才第一次看到有這回事。
- **兩支 fetch 都是 non-fatal**（`.catch(() => null)`），失敗時退回本次改動之前的行為，不是空清單。

## How it was tested

- `pytest -q` → **1776 passed, 8 skipped**（原 1773 + 新增 3 支）
- `npm run check` → **0 errors, 0 warnings**
- **mutation-check 兩處，全紅在該紅的位置**：順序對調 → 順序那支紅；`is_current` 恆 False → 兩支都紅
- **實機截圖驗證**（起 uvicorn 指向真 registry）：側欄長出

```
PROJECTS · 2
此安裝永久解除專案上限
uiverify              4     ← 開著的庫，highlight + 筆數
九月分鏡課promo              ← registry 專案，無筆數（不亂編）
```

## Checklist

- [x] I've read the contributor terms and my contribution is offered under them.
- [x] Commit messages follow conventional commits.
- [x] `pytest -q` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BznCya8zniew2fVKvPXJrP