### PR TITLE
feat(media): media pool 帶上拍攝日

### DIFF
--- a/routers/media.py
+++ b/routers/media.py
@@ -181,10 +181,24 @@ def media_position(
 def media_pool(
     _tok: dict = Depends(require_scopes("videos_read")),
 ):
-    """Lightweight full list for left sidebar media pool — grouped by folder."""
+    """Lightweight full list for left sidebar media pool — grouped by folder.
+
+    Carries `shot_date` (when it was SHOT), not `processed_at` (when it was
+    ingested). The two are not interchangeable and the difference is not
+    academic: measured on a real 62-clip library, 55 of the 56 dated clips were
+    shot in a different year than they were ingested — the same measurement that
+    settled it for the shoot-date facet below. An editor scanning a pool wants
+    the day the camera rolled.
+
+    `shot_date` is already the normalised ISO form of `creation_date`
+    (`db.normalise_shot_date`), and it is None when the date could not be read
+    rather than a plausible-looking guess — so an undated clip stays visibly
+    undated instead of being filed under a year nobody verified.
+    """
     with db.get_conn() as conn:
         rows = conn.execute(
-            "SELECT id, filename, ext, duration_s, rating, path FROM media ORDER BY path, filename"
+            "SELECT id, filename, ext, duration_s, rating, path, shot_date "
+            "FROM media ORDER BY path, filename"
         ).fetchall()
     items = []
     for r in rows:
@@ -201,6 +215,9 @@ def media_pool(
             "duration_s": r["duration_s"],
             "rating": r["rating"],
             "folder": folder,
+            # None when the clip carries no readable shoot date — the caller
+            # renders that as unknown, it does not fall back to ingest time.
+            "shot_date": r["shot_date"],
         })
     return {"items": items, "total": len(items)}
 

--- a/tests/test_media_pool_shot_date.py
+++ b/tests/test_media_pool_shot_date.py
@@ -1,0 +1,72 @@
+"""`/api/media/pool` carries the day the camera rolled, not the day we ingested.
+
+The pool is the flat list an editor scans. Sorting or scanning it by ingest time
+is worse than showing no date at all: the ordering looks authoritative and is
+wrong. `routers/media.py` records the measurement that settled this for the
+shoot-date facet — on a real 62-clip library, 55 of the 56 dated clips were shot
+in a different year than they were ingested.
+"""
+
+
+def _pool_by_filename(client):
+    r = client.get("/api/media/pool")
+    assert r.status_code == 200
+    return {it["filename"]: it for it in r.json()["items"]}
+
+
+def test_media_pool_carries_shot_date(fastapi_client, tmp_db, sample_record):
+    import db
+
+    rec = sample_record(filename="sunset.mp4")
+    db.upsert(rec)
+    with db.get_conn() as conn:
+        conn.execute(
+            "UPDATE media SET shot_date = '2019-05-04' WHERE path = ?", (rec["path"],)
+        )
+
+    assert _pool_by_filename(fastapi_client)["sunset.mp4"]["shot_date"] == "2019-05-04"
+
+
+def test_media_pool_shot_date_is_not_ingest_time(fastapi_client, tmp_db, sample_record):
+    """The invariant worth pinning: a 2019 clip ingested today reads 2019.
+
+    Swapping the column to `processed_at` — or falling back to it when the shoot
+    date is missing — would still return a plausible ISO date for every row, so
+    nothing would look broken. This is the assertion that would go red.
+    """
+    import db
+
+    rec = sample_record(filename="old-shoot.mp4")
+    db.upsert(rec)
+    with db.get_conn() as conn:
+        conn.execute(
+            "UPDATE media SET shot_date = '2019-05-04' WHERE path = ?", (rec["path"],)
+        )
+        ingested = conn.execute(
+            "SELECT processed_at FROM media WHERE path = ?", (rec["path"],)
+        ).fetchone()["processed_at"]
+
+    got = _pool_by_filename(fastapi_client)["old-shoot.mp4"]["shot_date"]
+    assert got == "2019-05-04"
+    # and it is genuinely a different value from the ingest stamp, so the
+    # assertion above is not passing by coincidence on a same-day fixture
+    assert ingested is None or not str(ingested).startswith("2019-05-04")
+
+
+def test_media_pool_undated_clip_stays_undated(fastapi_client, tmp_db, sample_record):
+    """No readable shoot date → None, not a guess.
+
+    `db.normalise_shot_date` returns None rather than inventing a date, and the
+    pool must carry that through: an undated clip should look undated to the
+    editor, not be filed under a year nobody verified.
+    """
+    import db
+
+    rec = sample_record(filename="no-exif.mp4")
+    db.upsert(rec)
+    with db.get_conn() as conn:
+        conn.execute("UPDATE media SET shot_date = NULL WHERE path = ?", (rec["path"],))
+
+    item = _pool_by_filename(fastapi_client)["no-exif.mp4"]
+    assert "shot_date" in item, "key must be present so callers can distinguish absent from unknown"
+    assert item["shot_date"] is None


### PR DESCRIPTION
## 現況

`/api/media/pool` 的 SELECT 是：

```sql
SELECT id, filename, ext, duration_s, rating, path FROM media ORDER BY path, filename
```

**連日期欄位都沒撈**，回傳的物件裡沒有任何時間資訊。

> 順帶一提：**前端目前也沒有接這支端點**（`frontend/src` 搜 `media/pool` 零命中）。

## 用 `shot_date` 不是 `processed_at`

理由不是偏好，是**量過的**。同一個檔案裡的 shoot-date facet 就記著：

> measured on a real 62-clip library, **55 of the 56 dated clips were shot in a different year than they were ingested**

剪輯師掃 pool 要的是相機轉動的那天。

`shot_date` 已經是 `creation_date` 的正規化 ISO 形式（`db.normalise_shot_date`），而且**讀不出來時回 `None` 而不是猜一個看起來合理的日期** —— 那個性質必須傳到 pool：沒有日期的 clip 要**看起來就是沒有日期**，不是被歸到一個沒人驗證過的年份。

## 三支測試，中間那支是真正的守衛

一支 2019 拍、今天入庫的 clip 必須讀成 2019。

把欄位換成 `processed_at`（或在缺值時 fallback 到它）**仍然會給每一列一個看起來合理的 ISO 日期**，畫面上不會有任何東西看起來壞掉 —— 那支斷言是唯一會紅的。

**mutation 實測**：換成 `processed_at AS shot_date` → **三支全紅**。

## 驗證

全套 **1799 passed / 8 skipped**。

## ⚠️ 這支只補 API

前端要顯示它還要另外接。但那是另一件事，而且該端點目前沒有任何消費者。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BznCya8zniew2fVKvPXJrP
