### PR TITLE
feat(ui): 素材卡片顯示拍攝日

### DIFF
--- a/frontend/src/lib/MediaCard.svelte
+++ b/frontend/src/lib/MediaCard.svelte
@@ -44,7 +44,12 @@
     <div class="name" class:ng={m.rating === 'ng'}>{m.name}</div>
     <div class="row">
       <Rating value={m.rating} />
-      <Mono dim style="font-size:10px;">{m.size}</Mono>
+      <span class="tail">
+        <!-- 拍攝日：讀不到就整個不顯示。列一個 fallback 到入庫時間的日期，
+             會讓整格看起來很權威而且是錯的。 -->
+        {#if m.shot}<Mono dim style="font-size:10px;">{m.shot}</Mono>{/if}
+        <Mono dim style="font-size:10px;">{m.size}</Mono>
+      </span>
     </div>
   </div>
 </div>
@@ -74,5 +79,6 @@
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
   .name.ng { text-decoration: line-through; opacity: 0.5; }
-  .row { display: flex; justify-content: space-between; align-items: center; }
+  .row { display: flex; justify-content: space-between; align-items: center; gap: 8px; }
+  .tail { display: flex; align-items: center; gap: 8px; flex: 0 0 auto; }
 </style>

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -111,6 +111,9 @@
       rating: ratingToUi(it.rating),
       dur: fmtDur(it.duration_s),
       size: fmtSize(it.size_mb),
+      // 拍攝日，不是入庫日。null 就讓它是 null —— 卡片上不顯示，好過顯示
+      // 一個沒人驗證過的日期。/api/media 一直有回這個欄位，只是沒人用。
+      shot: it.shot_date || null,
       thumb: api.thumbUrlFromPath(it.thumbnail_path),
       _raw: it,
     };


### PR DESCRIPTION
## 接 #415，但走了更短的路

#415 把 `shot_date` 加進 `/api/media/pool`。實際查之後發現：**`/api/media`（網格真正在用的那支端點）本來就回 `shot_date`** —— 資料一直都在，只是 `toCard` 沒有取出來。

所以這支不碰 pool 那條路。

## 為什麼是卡片，不是側欄

卡片是剪輯師掃素材時**真正在看的地方**，而側欄已經有拍攝日的 facet（#316）：

- **facet 負責篩選**（年 → 日鑽取）
- **卡片負責顯示**（這一支是哪天拍的）

兩者互補不重疊。先前擔心的「做出兩個做類似事情的東西」在這個做法下不成立。

## `null` 就整個不顯示

不 fallback 到 `processed_at`。理由跟 #415 同一條：

> 列一個 fallback 到入庫時間的日期，會讓那一格看起來**很權威而且是錯的**，而且畫面上不會有任何東西看起來壞掉。

沒有日期的素材要**看起來就是沒有日期**。

## 驗證：兩種狀態都看過畫面

起 uvicorn 指向乾淨庫，手動讓 4 支範例片**其中 2 支有 `shot_date`、2 支保持 `NULL`** —— 因為只驗有日期那半，等於沒驗 null 的處理。

| 卡片 | 顯示 |
|---|---|
| `wing_it.mp4`、`glass_half.mp4`（NULL） | 只有 `0 MB`，**沒有硬塞日期** |
| `coffee_run.mp4` | `2024-11-18　0 MB` |
| `caminandes_llama.mp4` | `2019-05-04　0 MB` |

`npm run check` **0 errors 0 warnings**；`pytest -q` **1799 passed / 8 skipped**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BznCya8zniew2fVKvPXJrP
