### PR TITLE
fix(ingest): 靜態圖不再被 seek —— 每一張 JPEG 之前都沒有縮圖、沒有格、沒有視覺標籤

### DIFF
--- a/frames.py
+++ b/frames.py
@@ -67,6 +67,18 @@ def _frame_vf_args(video_path: str) -> List[str]:
     return ["-vf", _NORMAL_SCALE]
 
 
+def _is_still_raster(video_path: str) -> bool:
+    """True for a single-frame raster still (png/jpg/jpeg/webp/gif), which must be
+    read whole rather than seeked into.
+
+    Deliberately keyed on the extension, NOT on the probed duration: ffprobe hands
+    back `duration=0.040000` for a `.jpg` (mjpeg, one frame at an assumed 25fps)
+    and `N/A` → 0.0 for `.png` / `.webp`, so the old `duration_s <= 0` test called
+    every JPEG a video.
+    """
+    return Path(video_path).suffix.lower() in mediatypes.STILL_RASTER_EXT
+
+
 def _safe_stem(video_path: str) -> str:
     """Thumbnail filename stem scoped by a hash of the absolute source path.
 
@@ -140,8 +152,16 @@ def _extract_frame_to(video_path: str, t: float, out: Path) -> bool:
     # ("Unable to choose an output format"). The <pid> keeps concurrent refreshes of
     # the same output from clobbering each other's temp.
     tmp = out.with_name("{0}.tmp.{1}{2}".format(out.stem, os.getpid(), out.suffix))
+    # A still has exactly one frame, so there is nothing to seek to. The seek is
+    # not merely redundant, it is destructive: `-ss` before `-i` on a single-frame
+    # mjpeg makes ffmpeg exit 0 having encoded nothing ("Output file is empty"),
+    # which _run_ffmpeg then correctly rejects as a 0-byte result. It happens even
+    # at `-ss 0`, so no choice of `t` rescues it. That is why every .jpg big enough
+    # to be a real photo used to land with no thumbnail and no frames while
+    # .png / .webp came through fine. Omit the seek entirely for stills.
+    seek = [] if _is_still_raster(video_path) else ["-ss", str(t)]
     cmd = (
-        [config.FFMPEG_PATH, "-ss", str(t), "-i", video_path]
+        [config.FFMPEG_PATH] + seek + ["-i", video_path]
         + _frame_vf_args(video_path)
         + ["-frames:v", "1", str(tmp), "-y"]
     )
@@ -167,9 +187,10 @@ def extract_thumbnail(video_path: str, duration_s: float, force: bool = False) -
     if not force and out.exists() and out.stat().st_size > 0:
         return str(out)
 
-    # A still image has duration 0 → sample the single frame at t=0. Videos get
-    # the mid-point (clamped to >=1s so very short clips don't all hit t=0).
-    t = 0.0 if duration_s <= 0 else max(duration_s * 0.5, 1.0)
+    # Stills sample their only frame; videos get the mid-point (clamped to >=1s so
+    # very short clips don't all hit t=0). The still test is by extension, not by
+    # duration — see _is_still_raster for why a .jpg reports 0.04s.
+    t = 0.0 if (_is_still_raster(video_path) or duration_s <= 0) else max(duration_s * 0.5, 1.0)
     return str(out) if _extract_frame_to(video_path, t, out) else None
 
 
@@ -221,7 +242,13 @@ def _extract_fixed_persistent(
     n_frames: int = 3,
     force: bool = False,
 ) -> List[Dict]:
-    positions = [float(i) / float(n_frames + 1) for i in range(1, n_frames + 1)]
+    # One frame at t=0 for a still: sampling "50% of 0.04s" would both record a
+    # meaningless timestamp and, before the seek fix in _extract_frame_to, extract
+    # nothing at all.
+    if _is_still_raster(video_path):
+        positions = [0.0]
+    else:
+        positions = [float(i) / float(n_frames + 1) for i in range(1, n_frames + 1)]
     results = []
     for i, pct in enumerate(positions):
         t = duration_s * pct

--- a/ingest.py
+++ b/ingest.py
@@ -38,7 +38,9 @@ IMAGE_EXT = mediatypes.IMAGE_EXT
 # Raster stills (png/jpg/webp/gif) have a pixel stream ffprobe can read and we can
 # sample a frame from — they get a thumbnail + one frame like video. .svg is
 # vector: no pixel stream, so it records filename/ext only, no pixel assets.
-RASTER_IMAGE_EXTS = IMAGE_EXT - {".svg"}
+# Alias kept for readability at the call sites below; the set itself lives in
+# mediatypes so frames.py answers "is this a still?" from the same source.
+RASTER_IMAGE_EXTS = mediatypes.STILL_RASTER_EXT
 # Codecs needing browser-playable proxy — single source of truth in codec.py.
 PROXY_CODECS = codec.PROXY_CODECS
 logger = logging.getLogger(__name__)

--- a/mediatypes.py
+++ b/mediatypes.py
@@ -53,6 +53,21 @@ AUDIO_EXT = frozenset({".mp3", ".wav", ".flac", ".aac", ".m4a", ".ogg"})
 # frame, nor vision (frontend renders a placeholder).
 IMAGE_EXT = frozenset({".png", ".jpg", ".jpeg", ".webp", ".gif", ".svg"})
 
+# The image formats that DO have a decodable pixel stream — IMAGE_EXT minus the
+# vector one. Named here rather than re-derived per module because frames.py now
+# needs it too: a still must never be seeked into.
+#
+# Measured 2026-09-03. ffprobe reports a `.jpg` as codec `mjpeg` and, once the
+# file is big enough for it to compute a bit_rate (a 1600x900 photo is; a 1.5 KB
+# swatch is not), hands back duration `0.040000` — one frame at an assumed 25fps.
+# `.png` / `.webp` report `duration=N/A` → 0.0. So "is this a still?" cannot be
+# answered by `duration_s <= 0`, and that misread is not cosmetic: for exactly the
+# JPEGs that carry a duration, an `-ss` placed before `-i` makes ffmpeg exit 0
+# having encoded nothing ("Output file is empty"), even at `-ss 0`. Every JPEG a
+# camera or editor produces is on the wrong side of that line, so they silently
+# landed with no thumbnail, no frames, and therefore no vision tags at all.
+STILL_RASTER_EXT = IMAGE_EXT - {".svg"}
+
 # Everything the ingest pipeline accepts (video + audio + image partition
 # MEDIA_EXT).
 MEDIA_EXT = VIDEO_EXT | AUDIO_EXT | IMAGE_EXT

--- a/tests/test_still_raster_frames.py
+++ b/tests/test_still_raster_frames.py
@@ -1,0 +1,196 @@
+"""A still image must never be seeked into — regression for the silent JPEG hole.
+
+Measured 2026-09-03 on a 3-image library (png / jpg / webp, identical pixels):
+
+    [1/3] alpha-bars.png    >thumb >frames [OK]
+    [2/3] bravo-bars.jpg    >thumb >frames  WARNING: extracted 0 frames
+    [3/3] charlie-bars.webp >thumb >frames [OK]
+
+Two facts combine into the bug:
+
+1. ffprobe reports a `.jpg` as codec ``mjpeg`` with duration ``0.040000`` (one
+   frame at an assumed 25fps), while `.png` / `.webp` report ``duration=N/A``
+   → 0.0. So ``duration_s <= 0``, the old "is this a still?" test, called every
+   JPEG a video and sent it down the mid-point-seek path.
+2. ``-ss`` placed *before* ``-i`` on a single-frame mjpeg makes ffmpeg exit 0
+   having encoded nothing ("Output file is empty, nothing was encoded"), which
+   _run_ffmpeg then correctly rejects as a 0-byte result. This holds even for
+   ``-ss 0`` — the seek is fatal, not merely misplaced.
+
+The visible damage was not the missing poster. Zero frames means ``ingest.py``'s
+``if not skip_vision and frame_data:`` never fires, so the vision model never saw
+a single JPEG: no scene description, no auto tags, and the clip is unreachable by
+any content search.
+"""
+import importlib
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+frames = importlib.import_module("frames")
+mediatypes = importlib.import_module("mediatypes")
+
+_needs_ffmpeg = pytest.mark.skipif(
+    not shutil.which("ffmpeg"), reason="ffmpeg not on PATH"
+)
+
+
+# ── the extension set is the single source of truth ─────────────────────────
+def test_still_raster_ext_is_image_ext_minus_vector():
+    assert mediatypes.STILL_RASTER_EXT < mediatypes.IMAGE_EXT
+    assert ".svg" not in mediatypes.STILL_RASTER_EXT
+    assert mediatypes.IMAGE_EXT - mediatypes.STILL_RASTER_EXT == {".svg"}
+
+
+def test_ingest_alias_is_the_same_object():
+    """ingest must not re-derive its own copy — that drift is what mediatypes exists to stop."""
+    ingest = importlib.import_module("ingest")
+    assert ingest.RASTER_IMAGE_EXTS is mediatypes.STILL_RASTER_EXT
+
+
+@pytest.mark.parametrize("name", ["a.png", "a.jpg", "a.jpeg", "a.webp", "a.gif", "A.JPG"])
+def test_is_still_raster_true(name):
+    assert frames._is_still_raster(name) is True
+
+
+@pytest.mark.parametrize("name", ["a.svg", "a.mp4", "a.mov", "a.insv", "a.360", "a.wav"])
+def test_is_still_raster_false(name):
+    assert frames._is_still_raster(name) is False
+
+
+# ── the seek must be absent for stills, present for video ───────────────────
+def _capture_cmd(monkeypatch):
+    seen = {}
+
+    def fake_run(cmd, out_path=None, timeout=60):
+        seen["cmd"] = cmd
+        return False  # don't touch the filesystem
+
+    monkeypatch.setattr(frames, "_run_ffmpeg", fake_run)
+    monkeypatch.setattr(frames, "_frame_vf_args", lambda p: ["-vf", "scale=320:-1"])
+    return seen
+
+
+def test_still_command_carries_no_ss(monkeypatch, tmp_path):
+    seen = _capture_cmd(monkeypatch)
+    frames._extract_frame_to("/x/shot.jpg", 0.02, tmp_path / "o.jpg")
+    assert "-ss" not in seen["cmd"], seen["cmd"]
+    # and the input is still the very next thing ffmpeg is told about
+    assert seen["cmd"][1] == "-i"
+
+
+def test_video_command_keeps_ss(monkeypatch, tmp_path):
+    seen = _capture_cmd(monkeypatch)
+    frames._extract_frame_to("/x/clip.mp4", 4.5, tmp_path / "o.jpg")
+    assert seen["cmd"][1:4] == ["-ss", "4.5", "-i"], seen["cmd"]
+
+
+# ── the JPEG duration lie must not reach the seek maths ─────────────────────
+def test_thumbnail_of_jpeg_samples_t0_despite_nonzero_duration(monkeypatch, tmp_path):
+    """A .jpg probes as 0.04s. The old code turned that into max(0.02, 1.0) = 1.0."""
+    monkeypatch.setattr(frames, "THUMBNAILS_DIR", tmp_path)
+    seen = {}
+    monkeypatch.setattr(
+        frames, "_extract_frame_to", lambda p, t, out: seen.setdefault("t", t) is None or True
+    )
+    frames.extract_thumbnail("/x/shot.jpg", 0.04, force=True)
+    assert seen["t"] == 0.0
+
+
+def test_thumbnail_of_video_still_uses_midpoint(monkeypatch, tmp_path):
+    monkeypatch.setattr(frames, "THUMBNAILS_DIR", tmp_path)
+    seen = {}
+    monkeypatch.setattr(
+        frames, "_extract_frame_to", lambda p, t, out: seen.setdefault("t", t) is None or True
+    )
+    frames.extract_thumbnail("/x/clip.mp4", 30.0, force=True)
+    assert seen["t"] == 15.0
+
+
+def test_fixed_frames_of_still_is_one_frame_at_zero(monkeypatch, tmp_path):
+    monkeypatch.setattr(frames, "THUMBNAILS_DIR", tmp_path)
+
+    def fake_extract(p, t, out):
+        out.write_bytes(b"\xff\xd8jpegbytes")
+        return True
+
+    monkeypatch.setattr(frames, "_extract_frame_to", fake_extract)
+    res = frames._extract_fixed_persistent(
+        "/x/shot.jpg", 0.04, 25.0, "shot", n_frames=3, force=True
+    )
+    assert len(res) == 1
+    assert res[0]["timestamp_s"] == 0.0
+
+
+# ── end-to-end: the test that would actually have caught this ───────────────
+def _synth(tmp_path, name):
+    """One solid-colour still, written by Pillow.
+
+    Deliberately NOT written by ffmpeg's lavfi source: a JPEG ffmpeg encodes that
+    way probes as duration 0.0, so it would quietly sidestep the very condition
+    under test. An ordinary Pillow-written JPEG reproduces the real 0.04s reading,
+    the same as any file a camera or an editor produces. Pillow is a declared
+    dependency (requirements.txt) and CI installs it in every job, and it also
+    writes WebP without needing ffmpeg's optional webp *encoder* (ffmpeg only has
+    to decode it here).
+    """
+    from PIL import Image
+
+    # 1600x900, not a thumbnail-sized swatch: ffprobe only reports a duration for a
+    # JPEG once it has a size/bit_rate to compute one from. A 320x180 solid colour
+    # compresses to ~1.5 KB, probes as `duration=N/A`, and survives the old seek —
+    # so a small fixture would pass while every real photo still broke.
+    out = tmp_path / name
+    Image.new("RGB", (1600, 900), (255, 140, 0)).save(out)
+    assert out.stat().st_size > 0
+    return out
+
+
+def _probed_duration(path):
+    """Whatever ffprobe actually claims — 0.04 for jpg, N/A→0.0 for png/webp.
+
+    Read live rather than hard-coded so the test keeps exercising the real
+    discrepancy if a future ffmpeg changes what it reports.
+    """
+    out = subprocess.run(
+        [
+            "ffprobe", "-v", "error", "-show_entries", "format=duration",
+            "-of", "default=nw=1:nk=1", str(path),
+        ],
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    try:
+        return float(out)
+    except ValueError:
+        return 0.0
+
+
+@_needs_ffmpeg
+@pytest.mark.parametrize("name", ["still.png", "still.jpg", "still.webp"])
+def test_real_ffmpeg_thumbnail_for_every_raster_format(tmp_path, monkeypatch, name):
+    monkeypatch.setattr(frames, "THUMBNAILS_DIR", tmp_path / "thumbs")
+    src = _synth(tmp_path, name)
+    got = frames.extract_thumbnail(str(src), _probed_duration(src), force=True)
+    assert got is not None, "{0}: no thumbnail produced".format(name)
+    assert pathlib.Path(got).stat().st_size > 0
+
+
+@_needs_ffmpeg
+@pytest.mark.parametrize("name", ["still.png", "still.jpg", "still.webp"])
+def test_real_ffmpeg_frames_for_every_raster_format(tmp_path, monkeypatch, name):
+    monkeypatch.setattr(frames, "THUMBNAILS_DIR", tmp_path / "thumbs")
+    src = _synth(tmp_path, name)
+    res = frames.extract_frames(str(src), _probed_duration(src), 25.0, force=True)
+    # Non-empty is the whole point: zero frames means vision never runs.
+    assert res, "{0}: extracted 0 frames".format(name)
+    assert all(pathlib.Path(r["thumbnail_path"]).stat().st_size > 0 for r in res)
+
+
+@_needs_ffmpeg
+def test_jpeg_really_does_report_a_nonzero_duration(tmp_path):
+    """Pin the premise. If this ever fails, the fix's rationale changed, not the fix."""
+    assert _probed_duration(_synth(tmp_path, "still.jpg")) > 0
+    assert _probed_duration(_synth(tmp_path, "still.png")) == 0.0


### PR DESCRIPTION
起點是 pixb 的 #418（Inspector 圖片預覽壞掉）。**照他寫的那樣重現不出來** —— PNG / JPG / WebP 在 v1.2.0 的 Inspector 裡都正常渲染（`<img src=/api/stream/N>`、`naturalWidth 1600 × naturalHeight 900`、`complete: true`，零 console 與網路錯誤）。那條 `useImage` 路徑是他自己的 #407（`b7dc826`）帶進來的。

但照著測下去，撞到另一個更深的洞。

## 實測

一個 png / jpg / webp 各一張、像素完全相同的庫：

```
[1/3] alpha-bars.png    >thumb >frames [OK]
[2/3] bravo-bars.jpg    >thumb >frames  WARNING: extracted 0 frames
[3/3] charlie-bars.webp >thumb >frames [OK]
```

## 成因（兩件事疊在一起）

1. ffprobe 把 `.jpg` 判成 codec `mjpeg`，而且只要檔案大到算得出 bit_rate（1600×900 的照片算得出，1.5 KB 的色塊算不出），就回報 duration `0.040000` ＝ 25fps 下的一格；`.png` / `.webp` 回 `duration=N/A` → 0.0。所以舊的判定式 `duration_s <= 0` **把每一張 JPEG 都當成影片**，送進取中點的 seek 路徑。
2. `-ss` 放在 `-i` 之前，對單格 mjpeg 會讓 ffmpeg 以 rc=0 結束卻什麼都沒編碼（`Output file is empty, nothing was encoded`），`_run_ffmpeg` 再正確地以 0-byte 判失敗。**即使 `-ss 0` 也一樣**，所以沒有任何 `t` 值救得回來。

## 真正的損害不是縮圖

frames 為 0 ⇒ `ingest.py` 的 `if not skip_vision and frame_data:` 永遠不成立 ⇒ **視覺模型從來沒看過任何一張 JPEG**。沒有場景描述、沒有自動標籤，那張圖無法被任何內容搜尋找到。落地頁那句「靜態圖片（PNG／JPG／WebP）也放同一個庫，同樣搜得到」，對 JPG 在此之前並不成立。

## 修法

問對問題：靜態圖只有一格，本來就不該 seek。判定改用副檔名而非 duration，集合收進 `mediatypes.STILL_RASTER_EXT` 當單一真相來源 —— `ingest.RASTER_IMAGE_EXTS` 原本各自推導一份，正是 mediatypes 這個模組存在要防的漂移。

## 測試 `tests/test_still_raster_frames.py`（26 支）

- **端到端真的跑 ffmpeg**，png / jpg / webp 三種格式各驗縮圖與抽格。
- 素材用 **Pillow** 產而非 ffmpeg lavfi：lavfi 產的 JPEG 回報 duration 0.0，會悄悄繞開受測條件。Pillow 是既有依賴，CI 三個 job 都裝。
- **1600×900 而非小色塊**：小到 1.5 KB 的 JPEG 回報 `N/A`、舊碼也過得去，用小素材會綠假的。
- **Mutation 驗證**：把三處修正逐一還原，`still.jpg` 的兩支端到端測試立刻紅並噴出原本那句 `WARNING: extracted 0 frames`，png / webp 仍綠。
- 另釘住前提（JPEG 確實回報非零 duration）與 `ingest.RASTER_IMAGE_EXTS is mediatypes.STILL_RASTER_EXT` 的同一性。

## 驗證

全套 **1822 passed / 11 skipped**。修好後重跑同一個庫：

```
alpha-bars.png         dur=0.0    thumb=有  frames=1
bravo-bars.jpg         dur=0.04   thumb=有  frames=1
charlie-bars.webp      dur=0.0    thumb=有  frames=1
```

JPEG 的 `dur=0.04` 依舊 —— 那是 ffprobe 的事實，不去改它，只是不再讓它決定要不要 seek。

Closes #418 的相鄰問題（#418 本身所述的 Inspector 黑框無法重現，建議請 pixb 對 main 重測後再決定是否關閉）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BznCya8zniew2fVKvPXJrP