### PR TITLE
fix(vectordb): 跨行程寫入後搜尋看不到新素材，而 count() 一直是對的

### DIFF
--- a/state.py
+++ b/state.py
@@ -104,6 +104,13 @@ def _rebuild_embeddings():
     except Exception as e:
         print(f"[embed] rebuild failed: {e}")
     finally:
+        # embed.py just rewrote the vector store from a SEPARATE OS process, so
+        # this process's cached chroma client is now serving a stale HNSW index
+        # (#408). get_collection() would catch it on the next call via the
+        # mtime check, but dropping it here closes the window immediately and
+        # covers the case where the rebuild leaves mtime unchanged.
+        import vectordb as _vectordb
+        _vectordb.clear_client_cache()
         embed_rebuild.release()  # audit M8: always free the single-flight slot
 
 # ── Ingest single-flight guard ────────────────────────────────────────────────

--- a/tests/test_chroma_staleness.py
+++ b/tests/test_chroma_staleness.py
@@ -1,0 +1,198 @@
+"""Cross-process HNSW staleness (#408).
+
+Why this file does not patch `SharedSystemClient` directly
+----------------------------------------------------------
+`tests/conftest.py` installs a stub `chromadb` module (PersistentClient only, no
+`chromadb.api` submodule). Any test that does
+
+    from chromadb.api.shared_system_client import SharedSystemClient
+    SharedSystemClient.clear_system_cache = <spy>
+
+raises ImportError, and if that import sits inside a `try/except` the spy is
+never installed and every assertion guarded by it is skipped. Such a test is
+green without having exercised the thing it names. (Measured: the assertion
+never ran, and separately the real `clear_system_cache` is a *staticmethod*
+taking no arguments, so a `lambda self:` spy would `TypeError` even with the
+real module present — two mistakes that mask each other.)
+
+So the unit tests below patch `vectordb._drop_chroma_system_cache`, a seam on
+our own module, and the end-to-end behaviour is covered by a subprocess test
+that runs against the real chromadb.
+"""
+import importlib
+import subprocess
+import sys
+
+import pytest
+
+vectordb = importlib.import_module("vectordb")
+config = importlib.import_module("config")
+
+
+@pytest.fixture
+def chroma_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(vectordb, "CHROMA_PATH", tmp_path)
+    monkeypatch.setattr(vectordb, "_CHROMA_DB_MTIME", 0.0)
+    return tmp_path
+
+
+def _spy(monkeypatch, succeeds=True):
+    calls = {"n": 0}
+
+    def fake():
+        calls["n"] += 1
+        return succeeds
+
+    monkeypatch.setattr(vectordb, "_drop_chroma_system_cache", fake)
+    return calls
+
+
+# ── the seam itself ──────────────────────────────────────────────────────────
+def test_drop_returns_false_when_api_missing(monkeypatch):
+    """Under the conftest stub there is no chromadb.api — the helper must report
+    that, not raise. This is the condition every other test here relies on."""
+    assert vectordb._drop_chroma_system_cache() is False
+
+
+# ── mtime tracking ───────────────────────────────────────────────────────────
+def test_no_db_file_is_a_noop(chroma_dir, monkeypatch):
+    calls = _spy(monkeypatch)
+    vectordb._check_chroma_staleness()
+    assert calls["n"] == 0
+    assert vectordb._CHROMA_DB_MTIME == 0.0
+
+
+def test_first_sight_of_db_drops_cache_and_records_mtime(chroma_dir, monkeypatch):
+    (chroma_dir / "chroma.sqlite3").write_text("v1")
+    calls = _spy(monkeypatch)
+    vectordb._check_chroma_staleness()
+    assert calls["n"] == 1
+    assert vectordb._CHROMA_DB_MTIME > 0
+
+
+def test_unchanged_mtime_does_not_drop_again(chroma_dir, monkeypatch):
+    (chroma_dir / "chroma.sqlite3").write_text("v1")
+    calls = _spy(monkeypatch)
+    vectordb._check_chroma_staleness()
+    assert calls["n"] == 1
+    vectordb._check_chroma_staleness()
+    vectordb._check_chroma_staleness()
+    assert calls["n"] == 1, "an unchanged DB must not keep clearing the cache"
+
+
+def test_external_write_drops_cache_again(chroma_dir, monkeypatch):
+    db = chroma_dir / "chroma.sqlite3"
+    db.write_text("v1")
+    calls = _spy(monkeypatch)
+    vectordb._check_chroma_staleness()
+    first = vectordb._CHROMA_DB_MTIME
+
+    import os
+    os.utime(db, (first + 10, first + 10))  # simulate the other process's write
+
+    vectordb._check_chroma_staleness()
+    assert calls["n"] == 2
+    assert vectordb._CHROMA_DB_MTIME != first
+
+
+# ── the ordering that pixb/arkiv#18 had backwards ────────────────────────────
+def test_failed_drop_does_not_consume_the_mtime(chroma_dir, monkeypatch):
+    """🔴 The regression this file exists for.
+
+    Advancing the mtime before the drop succeeds means one silent failure marks
+    that write as handled forever: the next call compares equal, skips, and the
+    index stays stale until the process restarts. The retry must survive.
+    """
+    (chroma_dir / "chroma.sqlite3").write_text("v1")
+    calls = _spy(monkeypatch, succeeds=False)
+
+    vectordb._check_chroma_staleness()
+    assert calls["n"] == 1
+    assert vectordb._CHROMA_DB_MTIME == 0.0, "a failed drop must not record the mtime"
+
+    vectordb._check_chroma_staleness()
+    assert calls["n"] == 2, "the same staleness must be retried, not swallowed"
+
+
+def test_recovers_once_the_drop_starts_working(chroma_dir, monkeypatch):
+    (chroma_dir / "chroma.sqlite3").write_text("v1")
+    _spy(monkeypatch, succeeds=False)
+    vectordb._check_chroma_staleness()
+    assert vectordb._CHROMA_DB_MTIME == 0.0
+
+    calls = _spy(monkeypatch, succeeds=True)
+    vectordb._check_chroma_staleness()
+    assert calls["n"] == 1
+    assert vectordb._CHROMA_DB_MTIME > 0
+
+
+# ── get_collection wires it in ───────────────────────────────────────────────
+def test_get_collection_checks_staleness(monkeypatch):
+    seen = {"n": 0}
+    monkeypatch.setattr(vectordb, "_check_chroma_staleness",
+                        lambda: seen.__setitem__("n", seen["n"] + 1))
+    monkeypatch.setattr(vectordb, "_assert_collection_compatible", lambda col: None)
+    monkeypatch.setattr(vectordb, "VECTOR_BACKEND", "chroma")
+    vectordb.get_collection()
+    assert seen["n"] == 1
+
+
+# ── end-to-end against the real chromadb ─────────────────────────────────────
+def _real_chromadb_available() -> bool:
+    r = subprocess.run(
+        [sys.executable, "-c", "import chromadb.api.shared_system_client"],
+        capture_output=True,
+    )
+    return r.returncode == 0
+
+
+_needs_real_chromadb = pytest.mark.skipif(
+    not _real_chromadb_available(), reason="real chromadb not importable"
+)
+
+# Runs in a clean interpreter so the conftest stub is out of the way. Writes from
+# a grandchild process, then asks OUR get_collection() whether search can see it.
+_E2E = r'''
+import os, sys, subprocess, pathlib
+os.environ["ANONYMIZED_TELEMETRY"] = "False"
+chroma = sys.argv[1]
+os.environ["ARKIV_CHROMA_PATH"] = chroma
+os.environ["ARKIV_PROJECT_ROOT"] = str(pathlib.Path(chroma).parent)
+sys.path.insert(0, sys.argv[2])
+
+import vectordb
+D = vectordb.EMBED_DIM
+def emb(s): return [float((s * 3 + i) % 11) / 11.0 for i in range(D)]
+
+col = vectordb.get_collection()
+col.add(ids=["parent1"], embeddings=[emb(1)], documents=["parent"])
+col.query(query_embeddings=[emb(1)], n_results=10)   # force the HNSW index in
+
+child = (
+    'import os\n'
+    'os.environ["ANONYMIZED_TELEMETRY"] = "False"\n'
+    'import chromadb\n'
+    'c = chromadb.PersistentClient(path=r"%s")\n'
+    'col = c.get_or_create_collection("%s")\n'
+    'col.add(ids=["c1","c2","c3"], embeddings=[%s,%s,%s], documents=["a","b","c"])\n'
+) % (chroma, vectordb.COLLECTION_NAME, emb(5), emb(6), emb(7))
+subprocess.run([sys.executable, "-c", child], capture_output=True, check=True)
+
+res = vectordb.get_collection().query(query_embeddings=[emb(5)], n_results=10)
+print("HITS", len(res["ids"][0]))
+'''
+
+
+@_needs_real_chromadb
+def test_search_sees_another_process_write(tmp_path):
+    """Without the fix this returns 1 of 4: count() is right while query() is not."""
+    chroma = tmp_path / "chroma"
+    chroma.mkdir()
+    r = subprocess.run(
+        [sys.executable, "-c", _E2E, str(chroma), str(config.BASE_DIR)],
+        capture_output=True, text=True, timeout=180,
+    )
+    assert r.returncode == 0, r.stderr[-2000:]
+    hits = [l for l in r.stdout.splitlines() if l.startswith("HITS")]
+    assert hits, r.stdout[-2000:] + r.stderr[-2000:]
+    assert hits[0] == "HITS 4", "search missed rows written by another process"

--- a/vectordb.py
+++ b/vectordb.py
@@ -207,19 +207,79 @@ def _assert_collection_compatible(col) -> None:
 _CHROMA_LOCK = threading.Lock()
 
 
+def _drop_chroma_system_cache() -> bool:
+    """Drop chromadb's process-global System cache. Returns whether it happened.
+
+    Named rather than inlined at the two call sites for two reasons. It is the
+    seam the tests monkeypatch — `tests/conftest.py` installs a stub `chromadb`
+    module with no `chromadb.api` submodule, so a test that patches
+    `SharedSystemClient` never runs against anything and passes vacuously. And
+    the boolean lets the caller distinguish "cache dropped" from "this chromadb
+    has no such API", which the staleness tracker below depends on.
+
+    Best-effort by design: a chromadb version without this API just means the
+    pre-existing restart-to-see-it behaviour, never a crash.
+
+    Acquires no lock — both callers already hold `_CHROMA_LOCK`, which is a
+    plain non-reentrant `threading.Lock`.
+    """
+    try:
+        from chromadb.api.shared_system_client import SharedSystemClient
+        SharedSystemClient.clear_system_cache()
+        return True
+    except Exception:
+        return False
+
+
 def clear_client_cache():
     """Drop chromadb's process-global System cache so the NEXT PersistentClient(path)
     rebuilds from the on-disk dir. After rmtree'ing CHROMA_PATH, the cached System
     still serves the DELETED index in-process until the server restarts — so a
     rebuild is invisible and search returns the old deleted index all session
-    (fable-audit round-5 #15). Best-effort: a chromadb version without this API just
-    means the pre-existing restart-to-see-it behaviour, never a crash."""
+    (fable-audit round-5 #15)."""
     with _CHROMA_LOCK:
-        try:
-            from chromadb.api.shared_system_client import SharedSystemClient
-            SharedSystemClient.clear_system_cache()
-        except Exception:
-            pass
+        _drop_chroma_system_cache()
+
+
+# ── Cross-process HNSW staleness ──────────────────────────────────────────────
+# chromadb caches the PersistentClient per OS process. When `embed.py`, the MCP
+# server or an ingest subprocess writes through a SEPARATE process, this one's
+# in-memory HNSW index keeps serving the vectors it loaded at warm-up.
+#
+# 🔴 The failure is quiet in the worst way: `count()` reads SQLite and is
+# correct, while `query()` reads the stale in-memory index and silently misses
+# the new rows. Measured on chromadb 1.5.5 — parent writes 1, a child process
+# writes 3, parent then reports `count()==4` but `query()` returns 1 of 4. The
+# UI says "4 indexed" and the user cannot find three of them, which reads as
+# "search is bad", not "search is broken".
+#
+# Reported as issue #408 by pixb, who also published the mtime-tracking
+# approach used here (pixb/arkiv#18).
+_CHROMA_DB_MTIME: float = 0.0
+
+
+def _check_chroma_staleness() -> None:
+    """Detect an external write to chroma.sqlite3 and drop the stale client cache.
+
+    Caller must hold `_CHROMA_LOCK` (see `_drop_chroma_system_cache`).
+
+    🔴 The mtime advances ONLY after the cache was actually dropped. Recording it
+    first and then attempting the drop — the obvious ordering — means a failed
+    drop still marks that mtime as handled, so the next call compares equal and
+    that particular staleness is never retried: one silent failure and the index
+    stays stale until the process restarts.
+    """
+    global _CHROMA_DB_MTIME
+    try:
+        current = (CHROMA_PATH / "chroma.sqlite3").stat().st_mtime
+    except OSError:
+        # No DB on disk yet (fresh install, or a pg backend that never writes
+        # one). Nothing to be stale against.
+        return
+    if current == _CHROMA_DB_MTIME:
+        return
+    if _drop_chroma_system_cache():
+        _CHROMA_DB_MTIME = current
 
 
 def get_collection(reset: bool = False):
@@ -236,6 +296,7 @@ def get_collection(reset: bool = False):
         return col
 
     with _CHROMA_LOCK:  # audit M11
+        _check_chroma_staleness()
         client = chromadb.PersistentClient(path=str(CHROMA_PATH))
         if reset:
             try:


### PR DESCRIPTION
Closes #408.

由 @pixb 回報，機制也是他找到的（[pixb/arkiv#18](https://github.com/pixb/arkiv/pull/18)）。這支採用他的方法，修掉一個順序缺陷，並重寫測試。

## bug 已在我們 main 上實測重現

chromadb 把 `PersistentClient` 依 OS 行程快取。`embed.py`、MCP server 或 ingest 子行程從**另一個行程**寫入時，這個行程記憶體裡的 HNSW 索引仍然服務它 warm-up 當下載入的那批向量。

🔴 **它安靜的方式最糟：`count()` 讀 SQLite 是對的，`query()` 讀記憶體索引卻漏。**

chromadb 1.5.5 實測，父行程寫 1 筆、子行程寫 3 筆：

```
count()  = 4       ← SQLite 看得到全部
query()  = 1 筆     ← 子行程那 3 筆搜尋完全找不到
清快取後 = 4 筆
```

介面顯示「已索引 4 支」，使用者卻搜不到其中 3 支。**看起來像「搜尋不準」，不像「搜尋壞了」**，所以不會有人開 bug。

端到端對照（同一支腳本，兩棵樹）：

```
未修（main）      → 命中 1 筆 ['parent1']
本 PR            → 命中 4 筆 ['c1','c2','c3','parent1']
```

## 修法

`get_collection()` 在 `_CHROMA_LOCK` 內比對 `chroma.sqlite3` 的 mtime，變了就丟掉 chromadb 的 process-global System 快取。`state.py` 的 embed rebuild 收尾再補一次，把子行程寫完到下次查詢之間的窗口關掉。

🔴 **mtime 只在快取真的清掉之後才前進。** 先記 mtime 再嘗試清（直覺的寫法，也是 pixb/arkiv#18 的寫法）會讓一次失敗的清除把那個 mtime 標記成「已處理」，下一次比對相等就跳過，**那一次的 staleness 直到行程重啟都不會再被偵測**。

`clear_client_cache()` 與 staleness 檢查共用抽出的 `_drop_chroma_system_cache()`。它不取鎖：兩個呼叫端都已持有 `_CHROMA_LOCK`，而那是非重入的 `threading.Lock`，在鎖內呼叫 `clear_client_cache()` 會 deadlock（這點 pixb 也已指出）。

## 測試為什麼不直接 patch `SharedSystemClient`

🔴 **`tests/conftest.py:142` 安裝了一個 stub `chromadb`，沒有 `chromadb.api` 子模組。** 任何在 `try` 內 `from chromadb.api.shared_system_client import ...` 的測試都會 ImportError、spy 從未裝上，被它守住的斷言整段跳過 —— **測試綠了，卻沒有執行過它名字裡宣稱的那件事**。

另外真正的 `clear_system_cache` 是 **`staticmethod`、簽名 `() -> None`**，用 `lambda self:` 當 spy 就算 import 成功也會 `TypeError`，再被產品碼的 `except Exception` 吞掉。兩個錯誤剛好互相遮蔽。

所以：
- **單元測試**改 patch `vectordb._drop_chroma_system_cache` —— 我們自己模組上的 seam，不受 stub 影響
- **端到端**由一支在乾淨直譯器子行程裡跑真 chromadb 的測試覆蓋，真的讓另一個行程寫入，再問我們的 `get_collection()` 搜不搜得到

## 驗證

9 支測試，兩組 mutation 都驗過：

| Mutation | 結果 |
|---|---|
| 拿掉 `get_collection()` 裡的檢查 | e2e 紅（`search missed rows written by another process`）＋ 接線測試紅 |
| 順序改回「先記 mtime 再清」 | 兩支順序測試紅 |

全套 **1831 passed / 11 skipped**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BznCya8zniew2fVKvPXJrP