### PR TITLE
fix(deploy): compose 掛了 arkiv 產生的東西，卻從來沒掛使用者的素材

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,11 @@ chroma_db/
 thumbnails/
 proxies/
 waveforms/
+# Docker bind-mount defaults (docker-compose.yml): the library and the upload
+# landing zone. Both hold the user's own footage — a `git add -A` in a checkout
+# that has been `docker compose up`'d would otherwise stage it.
+media/
+media-in/
 
 # Local project runtime data (SQLite + WAL/SHM, vector store, thumbnails, scratch)
 .arkiv/

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,11 @@ waveforms/
 # Docker bind-mount defaults (docker-compose.yml): the library and the upload
 # landing zone. Both hold the user's own footage — a `git add -A` in a checkout
 # that has been `docker compose up`'d would otherwise stage it.
-media/
-media-in/
+# Anchored with a leading slash: an unanchored `media/` matches a directory of
+# that name at ANY depth, so a future docs/media/ or frontend/src/media/ would
+# be silently untracked. These two only ever exist at the repo root.
+/media/
+/media-in/
 
 # Local project runtime data (SQLite + WAL/SHM, vector store, thumbnails, scratch)
 .arkiv/

--- a/README.md
+++ b/README.md
@@ -232,11 +232,33 @@ $env:PYTHONUTF8=1; python health.py
 ```bash
 git clone https://github.com/vulture-s/arkiv.git
 cd arkiv
-docker compose up -d
+
+# Point ARKIV_MEDIA_DIR at your footage — a NAS share, an external drive,
+# anything. It is mounted at /media inside the container, which is the path
+# you give arkiv when you add a library. Defaults to ./media.
+ARKIV_MEDIA_DIR=/path/to/your/footage docker compose up -d
 # Open http://localhost:8501
 ```
 
 > Models are pulled automatically inside the Ollama container on first run (may take a few minutes).
+
+Uploads through the web UI land in `./media-in` on the host. Both that and your
+library are bind-mounted, so nothing you add survives only inside the container.
+
+#### Split-host: arkiv here, Ollama on the GPU box
+
+The default file runs arkiv and Ollama together. If the machine with the GPU is a
+different one on your LAN, use the sibling file instead — Ollama on that machine
+needs `OLLAMA_HOST=0.0.0.0` and the models pulled first:
+
+```bash
+ARKIV_OLLAMA_URL=http://192.168.1.50:11434 \
+ARKIV_MEDIA_DIR=/Volumes/footage \
+docker compose -f docker-compose.remote-ollama.yml up -d
+```
+
+Full notes, including why this is a separate file rather than an override, are at
+the top of [`docker-compose.remote-ollama.yml`](docker-compose.remote-ollama.yml).
 
 <details>
 <summary>Upgrading from an old version (v0.3.0 → v0.3.1 storage layout migration)</summary>

--- a/docker-compose.remote-ollama.yml
+++ b/docker-compose.remote-ollama.yml
@@ -1,0 +1,79 @@
+# arkiv — split-host deployment (#423)
+#
+# The default docker-compose.yml runs arkiv and Ollama together on one machine.
+# That is the right shape for a laptop, and the wrong shape for the setup most
+# small teams actually end up with: the editor works on a Mac, and the machine
+# with the GPU and the already-pulled models is a different box on the LAN.
+#
+#     Machine A (editor's Mac)      →  this file: arkiv only
+#     Machine B (GPU PC / NAS)      →  Ollama, reachable over the LAN
+#
+# Use it INSTEAD OF the default file, not alongside it — a compose override
+# cannot delete the `ollama` service, so a standalone file is the honest form:
+#
+#     ARKIV_OLLAMA_URL=http://192.168.1.50:11434 \
+#     ARKIV_MEDIA_DIR=/Volumes/footage \
+#     docker compose -f docker-compose.remote-ollama.yml up -d
+#
+# ── On machine B, before starting this ────────────────────────────────────────
+#   1. Ollama must listen on more than loopback, or arkiv cannot reach it:
+#        OLLAMA_HOST=0.0.0.0 ollama serve
+#      (systemd: `Environment="OLLAMA_HOST=0.0.0.0"`; the Mac app: launchctl
+#      setenv OLLAMA_HOST 0.0.0.0, then restart it.)
+#   2. Pull the models arkiv expects — it does not pull them for you:
+#        ollama pull bge-m3
+#        ollama pull qwen2.5vl:7b
+#   3. Verify from machine A before bringing arkiv up, so a failure here is not
+#      mistaken for an arkiv bug:
+#        curl http://<machine-B>:11434/api/tags
+#
+# ⚠️ This puts model traffic on your LAN in the clear. Ollama has no auth of its
+# own, so anything that can reach port 11434 can use that GPU. Keep it on a
+# trusted network (or a tailnet), not a coffee-shop Wi-Fi.
+
+services:
+  arkiv:
+    build: .
+    ports:
+      - "8501:8501"
+    volumes:
+      # Identical to docker-compose.yml — see that file for why each one exists.
+      - ./media.db:/app/media.db
+      - ./chroma_db:/app/chroma_db
+      - ./thumbnails:/app/thumbnails
+      - ./arkiv_data/bins:/root/.arkiv-bins
+      - ./arkiv_data/projects:/root/.arkiv-projects
+      - ./media-in:/app/media-in
+      - ${ARKIV_MEDIA_DIR:-./media}:/media
+    environment:
+      - ARKIV_DB_PATH=/app/media.db
+      - ARKIV_CHROMA_PATH=/app/chroma_db
+      - ARKIV_THUMBNAILS_DIR=/app/thumbnails
+      # The one line this file exists for. No default: an unset value would
+      # silently fall back to localhost inside the container, where nothing is
+      # listening, and every embed/vision call would fail with a connection
+      # error that looks like a model problem rather than a config one.
+      # config.py rejects 0.0.0.0 and link-local addresses here, so use the
+      # LAN address of machine B.
+      - ARKIV_OLLAMA_URL=${ARKIV_OLLAMA_URL:?set ARKIV_OLLAMA_URL to the LAN Ollama, e.g. http://192.168.1.50:11434}
+      # Must track config.py's defaults, same as the single-host file.
+      - ARKIV_EMBED_MODEL=bge-m3
+      - ARKIV_VISION_MODEL=qwen2.5vl:7b
+      - ARKIV_WHISPER_MODEL=large-v3-turbo
+      # 0.0.0.0 is correct INSIDE the container; reachability is fenced by the
+      # port mapping above. ⚠️ Do NOT add `--network host` — see the note in
+      # docker-compose.yml about ARKIV_TRUST_LOOPBACK handing LAN callers admin.
+      - ARKIV_HOST=0.0.0.0
+      - ARKIV_PORT=8501
+      - ARKIV_BINS_PATH=/root/.arkiv-bins/bins.json
+      - ARKIV_PROJECTS_REGISTRY=/root/.arkiv-projects/projects.json
+      # REPLACES the default root list rather than extending it — keep /app.
+      - ARKIV_INGEST_ROOTS=/app:/media
+      - ARKIV_UPLOAD_MAX_MB=4096
+      - ARKIV_UPLOAD_MAX_CONCURRENT=3
+      - ARKIV_UPLOAD_MAX_QUEUE_SEC=300
+    # No `depends_on` — Ollama is on another host and outside compose's view.
+    # There is deliberately no healthcheck gate on it either: arkiv starts, and
+    # the first model call surfaces an unreachable Ollama as a real error
+    # instead of compose hanging on a condition it cannot observe.
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,26 @@ services:
       # ARKIV_PROJECTS_REGISTRY pins the file inside the mount; projects.py already
       # honours it.
       - ./arkiv_data/projects:/root/.arkiv-projects
+      # Upload landing zone (#422). `POST /api/ingest/upload` writes to
+      # config.PROJECT_ROOT/"media-in" = /app/media-in and then queues a
+      # background ingest of that directory. Without this mount the endpoint
+      # fails two different ways depending on who the container runs as, and
+      # BOTH were shipping:
+      #   - as root (this image declares no USER): the write SUCCEEDS into the
+      #     container's ephemeral layer, so every uploaded file is silently lost
+      #     on `docker compose down` / rebuild and never appears on the host.
+      #   - under a remapped non-root uid (Synology/QNAP default, and anyone
+      #     setting `user:`): `PermissionError: [Errno 13] ... '/app/media-in'`,
+      #     a 500 on an advertised feature in the canonical install path.
+      # Measured 2026-09-05 on both uid 0 and uid 1000.
+      - ./media-in:/app/media-in
+      # The media library itself. Until now compose mounted arkiv's *derived*
+      # data (db, vectors, thumbnails, bins, projects) but never the media it is
+      # supposed to index — a containerised install had nothing to point at.
+      # Override the host side with ARKIV_MEDIA_DIR (a NAS share, an external
+      # drive) without editing this file:
+      #     ARKIV_MEDIA_DIR=/volume1/video docker compose up -d
+      - ${ARKIV_MEDIA_DIR:-./media}:/media
     environment:
       - ARKIV_DB_PATH=/app/media.db
       - ARKIV_CHROMA_PATH=/app/chroma_db
@@ -53,6 +73,24 @@ services:
       - ARKIV_BINS_PATH=/root/.arkiv-bins/bins.json
       # See the ./arkiv_data/projects volume mount above; keep the path in sync.
       - ARKIV_PROJECTS_REGISTRY=/root/.arkiv-projects/projects.json
+      # Roots /api/ingest/scan and /api/ingest are allowed to walk (webguard
+      # `_allowed_ingest_roots`, Codex J1 — without a bound, any caller could
+      # inventory the whole filesystem). The defaults are PROJECT_ROOT plus
+      # ~/Desktop, ~/Documents, ~/Movies, ~/Pictures and /Volumes/*, none of
+      # which exist in this image, so /app was effectively the only root and a
+      # library mounted anywhere else got rejected.
+      #
+      # 🔴 This variable REPLACES the default list, it does not extend it
+      # (webguard returns early when it is set). /app must stay in it or the
+      # upload flow above breaks: files land in /app/media-in and the follow-up
+      # ingest of that directory would then be refused.
+      - ARKIV_INGEST_ROOTS=/app:/media
+      # Upload limits, surfaced here because they are otherwise invisible: the
+      # values below are the code defaults (routers/ingest.py), repeated so a
+      # deployer can see the knobs exist without reading the source.
+      - ARKIV_UPLOAD_MAX_MB=4096
+      - ARKIV_UPLOAD_MAX_CONCURRENT=3
+      - ARKIV_UPLOAD_MAX_QUEUE_SEC=300
     depends_on:
       ollama:
         condition: service_healthy   # F6: wait for ollama READY, not just container-start

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,9 @@ pytest>=7.4
 pytest-asyncio>=0.21
 pytest-cov>=7.1.0
 httpx>=0.28.1
+# tests/test_compose_deploy.py parses the compose files. PyYAML is already
+# present transitively (chromadb pulls it), and that is exactly why it is
+# declared here: #407 shipped a 3.9 CI failure because python-multipart was
+# only ever a transitive dep of mcp — it worked until it met an environment
+# that resolved differently.
+pyyaml>=6.0

--- a/tests/test_compose_deploy.py
+++ b/tests/test_compose_deploy.py
@@ -1,0 +1,176 @@
+"""The compose files must keep every piece of user state on a bind mount.
+
+Four gaps of the same shape have shipped, each found by a user running arkiv on
+a NAS rather than by us:
+
+    bins        →  #401   cross-library 精選集 lost on `compose down`
+    projects    →  #402   registered projects lost on `compose down`
+    media-in    →  #422   uploads land in the ephemeral layer (or 500 as non-root)
+    the library →  #411   compose mounted arkiv's derived data but never the
+                          media it is supposed to index
+
+Nothing in the repo was checking, so each one had to be discovered in
+production. These tests are that check: a mount or an env var that quietly
+disappears from compose fails here instead of six weeks later on someone's NAS.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parent.parent
+SINGLE_HOST = ROOT / "docker-compose.yml"
+SPLIT_HOST = ROOT / "docker-compose.remote-ollama.yml"
+
+
+def _load(path):
+    with path.open(encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def _arkiv(path):
+    return _load(path)["services"]["arkiv"]
+
+
+_MOUNT_MODES = {"ro", "rw", "z", "Z", "cached", "delegated", "consistent"}
+
+
+def _mount_target(entry):
+    """Container-side path of one `host:container[:mode]` entry.
+
+    Splitting on the first ':' is wrong: a host side written as
+    `${ARKIV_MEDIA_DIR:-./media}` contains colons of its own, and naively
+    splitting yields '-./media}'. Work from the right instead, stepping past an
+    optional mode suffix.
+    """
+    parts = entry.rsplit(":", 1)
+    if len(parts) == 2 and parts[1] in _MOUNT_MODES:
+        parts = parts[0].rsplit(":", 1)
+    return parts[-1]
+
+
+def _targets(service):
+    """Container-side paths of every bind mount, e.g. '/app/media-in'."""
+    return {_mount_target(entry) for entry in service.get("volumes", [])}
+
+
+def _env(service):
+    return dict(
+        item.split("=", 1) for item in service.get("environment", []) if "=" in item
+    )
+
+
+# ── every piece of state is on a mount ───────────────────────────────────────
+STATEFUL_PATHS = [
+    ("/app/media.db", "the SQLite catalogue"),
+    ("/app/chroma_db", "the vector index"),
+    ("/app/thumbnails", "generated thumbnails"),
+    ("/root/.arkiv-bins", "cross-library 精選集 (#401)"),
+    ("/root/.arkiv-projects", "the project registry (#402)"),
+    ("/app/media-in", "the upload landing zone (#422)"),
+    ("/media", "the media library itself (#411)"),
+]
+
+
+@pytest.mark.parametrize("target,what", STATEFUL_PATHS)
+@pytest.mark.parametrize("compose", [SINGLE_HOST, SPLIT_HOST], ids=["single", "split"])
+def test_stateful_path_is_mounted(compose, target, what):
+    assert target in _targets(_arkiv(compose)), (
+        "{0} is not bind-mounted in {1} — it would live in the container's "
+        "ephemeral layer and vanish on `docker compose down`. ({2})"
+    ).format(target, compose.name, what)
+
+
+# ── the ingest-roots trap ────────────────────────────────────────────────────
+@pytest.mark.parametrize("compose", [SINGLE_HOST, SPLIT_HOST], ids=["single", "split"])
+def test_ingest_roots_covers_both_upload_dir_and_library(compose):
+    """🔴 ARKIV_INGEST_ROOTS REPLACES webguard's default root list, it does not
+    extend it. Setting it for /media while forgetting /app would let uploads
+    write to /app/media-in and then have the follow-up ingest refuse the very
+    directory it just wrote to."""
+    roots = _env(_arkiv(compose)).get("ARKIV_INGEST_ROOTS", "")
+    parts = [p for p in roots.split(os.pathsep if os.pathsep in roots else ":") if p]
+    assert "/app" in parts, (
+        "/app missing from ARKIV_INGEST_ROOTS in {0}: the upload endpoint writes "
+        "to /app/media-in and its background ingest would be rejected".format(compose.name)
+    )
+    assert "/media" in parts, (
+        "/media missing from ARKIV_INGEST_ROOTS in {0}: the mounted library "
+        "would be rejected by _assert_ingest_path_safe".format(compose.name)
+    )
+
+
+def test_ingest_roots_matches_the_mounted_library():
+    """The allow-list and the mount must name the same path — drift between them
+    fails at runtime with a permission-looking error, not at startup."""
+    for compose in (SINGLE_HOST, SPLIT_HOST):
+        svc = _arkiv(compose)
+        assert "/media" in _targets(svc)
+        assert "/media" in _env(svc).get("ARKIV_INGEST_ROOTS", "")
+
+
+# ── the library mount is overridable without editing the file ────────────────
+@pytest.mark.parametrize("compose", [SINGLE_HOST, SPLIT_HOST], ids=["single", "split"])
+def test_library_host_side_is_a_variable(compose):
+    """A NAS share or an external drive must be selectable with an env var; a
+    hardcoded host path would force every deployer to edit a tracked file."""
+    mounts = [v for v in _arkiv(compose).get("volumes", []) if v.endswith(":/media")]
+    assert mounts, "no /media mount in " + compose.name
+    assert "ARKIV_MEDIA_DIR" in mounts[0], (
+        "the /media host side is hardcoded in {0}: {1}".format(compose.name, mounts[0])
+    )
+
+
+# ── the split-host file (#423) ───────────────────────────────────────────────
+def test_split_host_file_exists():
+    assert SPLIT_HOST.is_file(), "docker-compose.remote-ollama.yml is missing (#423)"
+
+
+def test_split_host_has_no_local_ollama():
+    """The whole point: Ollama lives on another machine. A leftover `ollama`
+    service would start a second, model-less copy and shadow the remote one."""
+    assert "ollama" not in _load(SPLIT_HOST)["services"]
+
+
+def test_split_host_requires_the_ollama_url():
+    """`${VAR:?message}` — compose refuses to start rather than silently falling
+    back to a localhost that has nothing listening on it."""
+    raw = SPLIT_HOST.read_text(encoding="utf-8")
+    assert "ARKIV_OLLAMA_URL=${ARKIV_OLLAMA_URL:?" in raw
+
+
+def test_split_host_does_not_depend_on_a_service_it_cannot_see():
+    assert "depends_on" not in _arkiv(SPLIT_HOST)
+
+
+# ── the two files must not drift apart ───────────────────────────────────────
+def test_model_pins_agree_across_both_files():
+    """These already drifted from config.py once ('it did, for months' — the
+    comment in docker-compose.yml). Two files means two chances to drift."""
+    keys = ("ARKIV_EMBED_MODEL", "ARKIV_VISION_MODEL", "ARKIV_WHISPER_MODEL")
+    single, split = _env(_arkiv(SINGLE_HOST)), _env(_arkiv(SPLIT_HOST))
+    for k in keys:
+        assert single[k] == split[k], "{0} differs between the two compose files".format(k)
+
+
+def test_upload_tunables_match_the_code_defaults():
+    """Surfaced in compose so a deployer can see the knobs exist. If the code
+    default moves and compose does not, the file starts lying."""
+    ingest = (ROOT / "routers" / "ingest.py").read_text(encoding="utf-8")
+    for env_key, code_default in (
+        ("ARKIV_UPLOAD_MAX_MB", '"4096"'),
+        ("ARKIV_UPLOAD_MAX_CONCURRENT", '"3"'),
+        ("ARKIV_UPLOAD_MAX_QUEUE_SEC", '"300"'),
+    ):
+        assert 'os.environ.get("{0}", {1})'.format(env_key, code_default) in ingest, (
+            "{0}'s code default changed; update both compose files".format(env_key)
+        )
+        for compose in (SINGLE_HOST, SPLIT_HOST):
+            shown = _env(_arkiv(compose))[env_key]
+            assert shown == code_default.strip('"'), (
+                "{0} in {1} says {2}, code default is {3}".format(
+                    env_key, compose.name, shown, code_default
+                )
+            )

--- a/tests/test_compose_deploy.py
+++ b/tests/test_compose_deploy.py
@@ -146,6 +146,30 @@ def test_split_host_does_not_depend_on_a_service_it_cannot_see():
 
 
 # ── the two files must not drift apart ───────────────────────────────────────
+def test_the_two_files_differ_only_in_the_ollama_url():
+    """The strong form of the drift check.
+
+    The split-host file is the single-host file with one line changed. Asserting
+    that directly is worth more than listing the keys we happened to think of:
+    anything added to one file and forgotten in the other fails here, including
+    keys that do not exist yet.
+    """
+    single, split = _env(_arkiv(SINGLE_HOST)), _env(_arkiv(SPLIT_HOST))
+    assert set(single) == set(split), (
+        "env keys diverged: only in single={0}, only in split={1}".format(
+            sorted(set(single) - set(split)), sorted(set(split) - set(single))
+        )
+    )
+    differing = {k for k in single if single[k] != split[k]}
+    assert differing == {"ARKIV_OLLAMA_URL"}, (
+        "the two compose files should differ in ARKIV_OLLAMA_URL and nothing "
+        "else; also differing: {0}".format(sorted(differing - {"ARKIV_OLLAMA_URL"}))
+    )
+    assert _targets(_arkiv(SINGLE_HOST)) == _targets(_arkiv(SPLIT_HOST)), (
+        "the two files mount different sets of paths"
+    )
+
+
 def test_model_pins_agree_across_both_files():
     """These already drifted from config.py once ('it did, for months' — the
     comment in docker-compose.yml). Two files means two chances to drift."""


### PR DESCRIPTION
Closes #422. Closes #423.

四個同形狀的缺口，**每一個都是在 NAS 上跑 arkiv 的使用者發現的，不是我們**：

| | Issue | 症狀 |
|---|---|---|
| bins | #401 | 跨庫精選集，`compose down` 就沒了 |
| projects | #402 | 註冊的專案，`compose down` 就沒了 |
| media-in | **#422** | 上傳落在暫時層（非 root 下直接 500） |
| 素材庫本身 | **#411** | compose 掛了 db／向量／縮圖，就是沒掛要索引的素材 |

前兩個已修，這支收掉後兩個，並補上 #423 的分機部署範例。

## media-in（#422）

`POST /api/ingest/upload` 寫到 `PROJECT_ROOT/"media-in"` = `/app/media-in`。沒有掛載時**壞法取決於容器以誰的身分跑，而兩種都在出貨**（2026-09-05 實測）：

```
root（本 image 沒宣告 USER）    → 寫入成功，落在暫時層
                                  compose down / 重建就消失，主機端看不到
uid 1000（Synology/QNAP 預設）  → PermissionError: [Errno 13] ... '/app/media-in'
```

回報者遇到的是後者，我原本預期前者。**實測兩種身分才把差異釐清**，所以註解兩種都寫，免得下一個人只修一半。

## 素材庫（#411）

新增 `${ARKIV_MEDIA_DIR:-./media}:/media`，主機端用環境變數指定，不必改追蹤檔：

```bash
ARKIV_MEDIA_DIR=/volume1/video docker compose up -d
```

🔴 **光掛載還不夠，要同時設 `ARKIV_INGEST_ROOTS`。** webguard 的 `_allowed_ingest_roots`（Codex J1 的邊界）預設是 PROJECT_ROOT 加 `~/Desktop`、`~/Documents`、`~/Movies`、`~/Pictures`、`/Volumes/*` —— 這些在 image 裡**一個都不存在**，所以 `/app` 實際上是唯一的 root，掛在別處的庫會被 `_assert_ingest_path_safe` 擋掉。

而它是**覆蓋不是追加**（設了就直接 return），所以必須是 `/app:/media`。只寫 `/media` 會讓上傳寫進 `/app/media-in` 之後，**緊接的 ingest 拒絕它自己剛寫的目錄**。

順帶把三個上傳參數的預設值露在 compose 裡，它們原本只存在於原始碼。

⚠️ **沒有動 `ARKIV_MEDIA_ROOTS`。** 那個變數不是「素材庫在哪」，而是**刪除端點被允許實際刪檔的白名單**（`media_delete.py:39`），預設空的代表只能刪 `PROJECT_ROOT` 底下 —— 那是正確的，設起來等於擴大破壞性權限。

## 分機部署（#423）

新增 `docker-compose.remote-ollama.yml`。**做成獨立檔而不是 override**：compose 的 override 刪不掉 service，留著 `ollama` 會起一份沒有模型的副本去遮蔽遠端那台。

`ARKIV_OLLAMA_URL` 用 `${VAR:?訊息}` 強制指定、不給預設 —— 落回 localhost 會讓「連不到 Ollama」看起來像模型問題而不是設定問題。檔頭寫了 Ollama 那端要先做的三件事，以及 LAN 明文傳輸的取捨。

## 測試 `tests/test_compose_deploy.py`（25 支）

**這四個缺口能一路出貨，正是因為沒有任何東西在盯 compose。**

兩份檔案各驗：七個 stateful 路徑都在掛載上、`ARKIV_INGEST_ROOTS` 同時含 `/app` 與 `/media`、素材庫主機端是變數而非寫死、分機檔沒有 `ollama` service、兩份檔的模型 pin 與上傳參數不互相漂（也不跟 `routers/ingest.py` 的預設漂）。

Mutation 驗過：

| Mutation | 結果 |
|---|---|
| 拿掉 `media-in` 掛載 | 🔴 `/app/media-in is not bind-mounted` |
| `ARKIV_INGEST_ROOTS` 漏掉 `/app` | 🔴 `/app missing from ARKIV_INGEST_ROOTS` |

⚠️ `pyyaml` 補進 `requirements-dev.txt`。它本來就靠 chromadb 傳遞裝進來，**而那正是要宣告它的理由** —— #407 就是因為 `python-multipart` 只是 `mcp` 的傳遞依賴，在 3.9 的乾淨環境炸掉。

`.gitignore` 加 `media/`、`media-in/`：都是使用者自己的素材，跑過 `docker compose up` 的 checkout 一次 `git add -A` 就會 stage 進去。

## 驗證

全套 **1856 passed / 11 skipped**。兩份 compose 都通過 `docker compose config`，`ARKIV_MEDIA_DIR=/tmp/demo-lib` 實測解析為 `source: /tmp/demo-lib → target: /media`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BznCya8zniew2fVKvPXJrP