### PR TITLE
feat(subtitle): 字幕終於有了時間維度 —— 但缺的不是 todo 以為的那個

### DIFF
--- a/subtitle.py
+++ b/subtitle.py
@@ -19,6 +19,51 @@ from typing import Dict, List, Optional, Tuple
 # One laid-out cue: start seconds, end seconds, the lines to show.
 Cue = Tuple[float, float, List[str]]
 
+
+class TimingPolicy(object):
+    """How long a cue stays up, and how it relates to its neighbours.
+
+    Until this existed the layout engine had only a SPATIAL dimension — line
+    width in units, two lines per cue — and inherited every timing decision
+    from Whisper unchanged. Measured on 34 real zh clips (312 segments → 315
+    cues) before this was added:
+
+        cue 短於 0.8s   28 (8.9%)   shortest 0.24s — "真的" on screen for a
+                                    quarter second, read as a flicker
+        gap == 0        256 (91.1%) Whisper segments abut exactly, so one cue
+                                    is replaced by the next with no visual break
+        split imbalance up to 28x   a segment split across cues divided its span
+                                    EQUALLY while the text divided unequally:
+                                    9.5 cps on the first cue, 0.3 on the second
+
+    CPS deliberately is not the headline. The same measurement put the median at
+    4.7 and only 1.3% above the zh-Hant guideline of 9 — the repo's own todo
+    assumed reading speed was the gap, and on real material it is not. The
+    target is kept as a soft pull (extend into slack when there is room) rather
+    than a hard constraint that would fight the three real defects above.
+
+    Every adjustment moves a cue's END, never its START: text may linger after
+    the words, but must never appear before them.
+    """
+
+    __slots__ = ("min_dur", "max_dur", "min_gap", "target_cps", "enabled")
+
+    def __init__(self, min_dur=0.8, max_dur=7.0, min_gap=0.08,
+                 target_cps=9.0, enabled=True):
+        self.min_dur = float(min_dur)
+        self.max_dur = float(max_dur)
+        # ~2 frames at 24fps: below this the eye reads a change as a flicker
+        # rather than as one cue ending and another starting.
+        self.min_gap = float(min_gap)
+        self.target_cps = float(target_cps)
+        self.enabled = bool(enabled)
+
+
+# Applied unless a caller passes its own. `TimingPolicy(enabled=False)` restores
+# the pre-timing behaviour exactly, which is what the regression tests compare
+# against.
+DEFAULT_TIMING = TimingPolicy()
+
 # Punctuation that a line should prefer to break AFTER (kept on the upper line).
 _BREAK_AFTER = "。，、！？；：…—)）」』】》”’"
 # Latin width relative to one CJK unit (≈ Netflix 42 Latin ≈ 14 CJK).
@@ -208,6 +253,7 @@ def layout_cues(
     max_units: float = 14.0,
     max_lines: int = 2,
     translate_key: Optional[str] = None,
+    timing: Optional[TimingPolicy] = None,
 ) -> List[Cue]:
     """Lay Whisper segments out as cues: `[(start, end, lines), ...]`.
 
@@ -223,6 +269,7 @@ def layout_cues(
     reached any of this. A renderer-independent seam is what lets every path
     (SRT, VTT, timeline, batch) share one layout.
     """
+    policy = timing if timing is not None else DEFAULT_TIMING
     cues: List[Cue] = []
     for seg in segments:
         text = (seg.get("text") or "").strip()
@@ -241,11 +288,106 @@ def layout_cues(
             continue
         cap = max(1, max_lines)
         chunks = [lines[i:i + cap] for i in range(0, len(lines), cap)]
-        n = len(chunks)
         span = max(0.0, end - start)
-        for ci, chunk in enumerate(chunks):
-            cues.append((start + span * ci / n, start + span * (ci + 1) / n, chunk))
-    return cues
+        cues.extend(_split_span(start, span, chunks, policy.enabled))
+    return _apply_timing(cues, policy)
+
+
+def _split_span(start: float, span: float, chunks: List[List[str]],
+                proportional: bool = True) -> List[Cue]:
+    """Divide one segment's span across its chunks IN PROPORTION TO TEXT.
+
+    The old code gave every chunk `span / n` regardless of how much text it
+    held. Measured on real material that produced a 28x reading-speed swing
+    inside a single sentence — 9.5 cps on a chunk carrying most of the words,
+    0.3 cps on the short tail that inherited an equal slice of time.
+
+    Falls back to equal division when the weights are unusable (all-empty text,
+    or a zero-length span), which keeps a degenerate segment behaving exactly as
+    before rather than dividing by zero.
+    """
+    n = len(chunks)
+    if n == 1:
+        return [(start, start + span, chunks[0])]
+
+    weights = [sum(display_units(ln) for ln in ch) for ch in chunks]
+    total = sum(weights)
+    # `proportional=False` is the pre-timing behaviour, kept whole so that
+    # `TimingPolicy(enabled=False)` reproduces the old output byte for byte —
+    # which is what the layout-extraction regression guard asserts.
+    if not proportional or total <= 0 or span <= 0:
+        return [(start + span * i / n, start + span * (i + 1) / n, ch)
+                for i, ch in enumerate(chunks)]
+
+    out: List[Cue] = []
+    at = start
+    for i, ch in enumerate(chunks):
+        # Last chunk closes on the segment end exactly, so accumulated float
+        # error cannot leave a sliver of time unassigned or overshoot the audio.
+        end_i = start + span if i == n - 1 else at + span * weights[i] / total
+        out.append((at, end_i, ch))
+        at = end_i
+    return out
+
+
+def _apply_timing(cues: List[Cue], policy: TimingPolicy) -> List[Cue]:
+    """Adjust cue ENDS so short cues linger and neighbours do not butt together.
+
+    Three passes, in this order because each one's room depends on the previous:
+
+    1. extend — pull each end toward `min_dur`, then toward `target_cps`, but
+       never past the next cue's start minus `min_gap`.
+    2. gap — where two cues still abut (Whisper hands us `end[i] == start[i+1]`
+       for 91% of adjacent pairs), shave the earlier one's end. Shaving the
+       outgoing cue is the only safe direction: moving the later cue's start
+       would put its text on screen before the words are spoken.
+    3. merge — a cue still under `min_dur` had no slack to grow into. Fold it
+       into the next one when the combined lines still fit, so "真的" stops
+       being a 0.24s flash and rides along with the sentence it belongs to.
+
+    `max_dur` only ever shortens, and only a cue that has room to spare.
+    """
+    if not policy.enabled or not cues:
+        return cues
+
+    out = [(s, e, list(ln)) for s, e, ln in cues]
+
+    # ── 1. extend into available slack ───────────────────────────────────────
+    for i, (s, e, lines) in enumerate(out):
+        limit = (out[i + 1][0] - policy.min_gap) if i + 1 < len(out) else float("inf")
+        want = s + policy.min_dur
+        units = sum(display_units(ln) for ln in lines)
+        if policy.target_cps > 0:
+            want = max(want, s + units / policy.target_cps)
+        want = min(want, s + policy.max_dur)
+        if want > e:
+            out[i] = (s, max(e, min(want, limit)), lines)
+
+    # ── 2. carve the gap out of the earlier cue ──────────────────────────────
+    for i in range(len(out) - 1):
+        s, e, lines = out[i]
+        nxt = out[i + 1][0]
+        if e > nxt - policy.min_gap:
+            # Never shave a cue out of existence: a tiny cue with no room keeps
+            # its original end and is dealt with by the merge pass below.
+            shaved = nxt - policy.min_gap
+            if shaved > s:
+                out[i] = (s, shaved, lines)
+
+    # ── 3. merge what is still too short ─────────────────────────────────────
+    merged: List[Cue] = []
+    i = 0
+    while i < len(out):
+        s, e, lines = out[i]
+        if (e - s) < policy.min_dur and i + 1 < len(out):
+            ns, ne, nlines = out[i + 1]
+            if len(lines) + len(nlines) <= 2 and (ne - s) <= policy.max_dur:
+                merged.append((s, ne, lines + nlines))
+                i += 2
+                continue
+        merged.append((s, e, lines))
+        i += 1
+    return merged
 
 
 def _render_lines(lines: List[str], restrict_punct: bool) -> List[str]:
@@ -268,9 +410,10 @@ def segments_to_srt(
     max_lines: int = 2,
     translate_key: Optional[str] = None,
     restrict_punct: bool = True,
+    timing: Optional[TimingPolicy] = None,
 ) -> str:
     """Render Whisper segments to laid-out SRT. Layout lives in `layout_cues`."""
-    cues = layout_cues(segments, max_units, max_lines, translate_key)
+    cues = layout_cues(segments, max_units, max_lines, translate_key, timing)
     return "\n".join(format_cue(i, start, end, _render_lines(lines, restrict_punct))
                      for i, (start, end, lines) in enumerate(cues, 1))
 
@@ -281,11 +424,12 @@ def segments_to_vtt(
     max_lines: int = 2,
     translate_key: Optional[str] = None,
     restrict_punct: bool = True,
+    timing: Optional[TimingPolicy] = None,
 ) -> str:
     """Same layout, WebVTT syntax: `.` for the millisecond separator, no cue
     numbers (they are optional in WebVTT, and the exports users already have
     don't carry them)."""
-    cues = layout_cues(segments, max_units, max_lines, translate_key)
+    cues = layout_cues(segments, max_units, max_lines, translate_key, timing)
     body = "\n".join("{0} --> {1}\n{2}\n".format(_ts(start, "."), _ts(end, "."),
                                                 "\n".join(_render_lines(lines, restrict_punct)))
                      for start, end, lines in cues)

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -117,8 +117,16 @@ def test_segments_to_srt_basic():
         {"start": 2.0, "end": 4.0, "text": "再見"},
     ]
     srt = sub.segments_to_srt(segs)
-    assert "1\n00:00:00,000 --> 00:00:02,000\n你好世界\n" in srt
+    # The first cue now ends a min_gap early: Whisper hands us end[0] == start[1]
+    # and two cues that swap with no blank frame read as a flicker.
+    assert "1\n00:00:00,000 --> 00:00:01,920\n你好世界\n" in srt
     assert "2\n00:00:02,000 --> 00:00:04,000\n再見\n" in srt
+
+    # Starts are untouched — text must never precede the words it transcribes.
+    assert "00:00:02,000 --> 00:00:04,000\n再見" in srt
+
+    legacy = sub.segments_to_srt(segs, timing=sub.TimingPolicy(enabled=False))
+    assert "1\n00:00:00,000 --> 00:00:02,000\n你好世界\n" in legacy
 
 
 def test_segments_to_srt_skips_empty():
@@ -225,10 +233,38 @@ GOLDEN_SRT = (
 
 
 def test_srt_layout_is_byte_identical_after_the_extraction():
-    """`restrict_punct=False` is the pre-punctuation-policy output. Layout has not
-    moved a byte since the layout/render split; only the punctuation policy did."""
+    """The pre-timing layout is still reproducible, byte for byte.
+
+    This golden was captured before `layout_cues` was extracted, to catch a
+    refactor silently changing what lands in someone's Resolve timeline. The
+    timing pass changes that output DELIBERATELY, so the guard now runs against
+    `TimingPolicy(enabled=False)` — which keeps its original meaning (nothing
+    drifted by accident) and additionally pins the claim that disabling timing
+    restores the old engine exactly, split arithmetic included.
+    """
     assert sub.segments_to_srt(GOLDEN_SEGMENTS, translate_key="translation",
-                               restrict_punct=False) == GOLDEN_SRT
+                               restrict_punct=False,
+                               timing=sub.TimingPolicy(enabled=False)) == GOLDEN_SRT
+
+
+# The same input with timing on. Captured so an accidental change to the NEW
+# behaviour is caught the same way the old one was.
+GOLDEN_SRT_TIMED = (
+    # No gap carved out of cue 1: the blank segment at 3.0-4.0 is dropped, so
+    # the next cue starts at 4.0 and there is nothing to pull away from.
+    "1\n00:00:00,000 --> 00:00:03,000\n今天天氣很好，我們去了海邊。\n"
+    "\n"
+    "2\n00:00:04,000 --> 00:00:10,060\n這是一段很長的旁白，\n長到一行字幕根本放不下，\n"
+    "\n"
+    "3\n00:00:10,140 --> 00:00:15,920\n所以引擎會把它拆成好幾個\ncue，時間按比例分。\n"
+    "\n"
+    "4\n00:00:16,000 --> 00:00:19,500\nHello world, state-of-the-art 3.5公斤。\n你好世界。\n"
+)
+
+
+def test_srt_with_timing_is_pinned_too():
+    assert sub.segments_to_srt(GOLDEN_SEGMENTS, translate_key="translation",
+                               restrict_punct=False) == GOLDEN_SRT_TIMED
 
 
 def test_layout_cues_returns_start_end_lines():
@@ -245,12 +281,35 @@ def test_layout_cues_drops_blank_segments():
     assert not any(3.0 <= s < 4.0 for s, _e, _lines in cues)
 
 
-def test_layout_cues_splits_a_long_segment_and_divides_the_span():
-    cues = sub.layout_cues([{"start": 4.0, "end": 16.0, "text": GOLDEN_SEGMENTS[2]["text"]}])
+def test_layout_cues_legacy_split_is_by_cue_count():
+    """The pre-timing division: every chunk got span/n regardless of its text."""
+    cues = sub.layout_cues([{"start": 4.0, "end": 16.0, "text": GOLDEN_SEGMENTS[2]["text"]}],
+                           timing=sub.TimingPolicy(enabled=False))
 
     assert len(cues) == 2
     assert cues[0][0] == 4.0 and cues[1][1] == 16.0
     assert cues[0][1] == cues[1][0] == 10.0  # contiguous, evenly split by cue count
+
+
+def test_layout_cues_splits_a_long_segment_in_proportion_to_its_text():
+    """🔴 Equal division was measured producing a 28x reading-speed swing inside
+    one sentence: 9.5 cps on the chunk carrying the words, 0.3 on the short tail
+    that inherited an equal slice of time. Time follows the text now."""
+    cues = sub.layout_cues([{"start": 4.0, "end": 16.0, "text": GOLDEN_SEGMENTS[2]["text"]}])
+
+    assert len(cues) == 2
+    assert cues[0][0] == 4.0 and cues[1][1] == 16.0
+
+    w0 = sum(sub.display_units(ln) for ln in cues[0][2])
+    w1 = sum(sub.display_units(ln) for ln in cues[1][2])
+    d0 = cues[0][1] - cues[0][0]
+    d1 = cues[1][1] - cues[1][0]
+    # Reading speed is what the split is FOR, so assert on cps rather than on
+    # the boundary: the two cues must demand a similar speed of the viewer.
+    assert abs((w0 / d0) - (w1 / d1)) < 0.5
+
+    # The gap comes out of the earlier cue; the segment still ends where it ended.
+    assert cues[1][0] - cues[0][1] >= sub.DEFAULT_TIMING.min_gap - 1e-9
 
 
 def test_layout_cues_keeps_a_bilingual_segment_as_one_cue():

--- a/tests/test_subtitle_timing.py
+++ b/tests/test_subtitle_timing.py
@@ -1,0 +1,217 @@
+"""Cue timing: how long a cue holds, and how it meets its neighbour.
+
+The layout engine had only a spatial dimension — 14 units a line, two lines a
+cue — and took every timing decision from Whisper unchanged. Measured on the
+34 zh clips in the reel-scout library (312 segments → 315 cues):
+
+    cue 短於 0.8s   28 (8.9%)    shortest 0.24s
+    gap == 0        256 (91.1%)  every adjacent pair, Whisper abuts them exactly
+    split imbalance up to 28x    9.5 cps on one half of a sentence, 0.3 on the other
+
+After: 3 (1.0%) / 0 (0.0%) / equalised. Cues violating any rule went 10.2% → 1.7%.
+
+One invariant outranks the rest and is asserted from several directions below:
+**a cue's START never moves.** Text may linger after the words; it must never
+appear before them.
+"""
+import importlib
+
+import pytest
+
+sub = importlib.import_module("subtitle")
+
+OFF = sub.TimingPolicy(enabled=False)
+
+
+def seg(start, end, text):
+    return {"start": start, "end": end, "text": text}
+
+
+def durs(cues):
+    return [round(e - s, 4) for s, e, _ in cues]
+
+
+# ── the invariant that outranks everything ───────────────────────────────────
+@pytest.mark.parametrize("segments", [
+    [seg(0.0, 0.3, "真的"), seg(0.3, 4.0, "這是一段比較長的句子")],
+    [seg(0.0, 2.0, "你好"), seg(2.0, 2.2, "嗯"), seg(2.2, 5.0, "然後呢")],
+    [seg(0.0, 0.2, "對"), seg(0.2, 0.4, "嗯"), seg(0.4, 0.6, "好")],
+    [seg(1.5, 9.0, "一段很長的旁白" * 6)],
+])
+def test_no_cue_starts_before_its_words(segments):
+    """Every emitted start must be one of the segment starts we were given."""
+    allowed = {s["start"] for s in segments}
+    for start, _end, _lines in sub.layout_cues(segments):
+        assert any(abs(start - a) < 1e-6 or start > a for a in allowed)
+        assert start >= min(allowed) - 1e-9
+
+
+@pytest.mark.parametrize("segments", [
+    [seg(0.0, 0.3, "真的"), seg(0.3, 4.0, "這是一段比較長的句子")],
+    [seg(0.0, 2.0, "你好"), seg(2.0, 2.2, "嗯"), seg(2.2, 5.0, "然後呢")],
+    [seg(0.0, 0.2, "對"), seg(0.2, 0.4, "嗯"), seg(0.4, 0.6, "好")],
+])
+def test_cues_never_overlap(segments):
+    cues = sub.layout_cues(segments)
+    for a, b in zip(cues, cues[1:]):
+        assert b[0] >= a[1] - 1e-9, "cue {0} overlaps {1}".format(a, b)
+
+
+def test_end_never_passes_the_next_start():
+    cues = sub.layout_cues([seg(0.0, 0.3, "真的"), seg(3.0, 6.0, "後面這句")])
+    assert cues[0][1] <= cues[1][0] + 1e-9
+
+
+# ── 1. extend a short cue into the slack after it ────────────────────────────
+def test_short_cue_grows_into_following_silence():
+    """0.24s of "真的" with three seconds of nothing after it should hold."""
+    cues = sub.layout_cues([seg(0.0, 0.24, "真的"), seg(4.0, 6.0, "下一句")])
+    assert durs(cues)[0] >= sub.DEFAULT_TIMING.min_dur
+    assert cues[0][0] == 0.0  # start untouched
+
+
+def test_extension_takes_only_what_it_needs():
+    """A short cue grows to min_dur and stops, even with seconds of silence
+    after it. Filling the silence would park text on screen long after the words,
+    which is a different (and unasked-for) editorial choice."""
+    cues = sub.layout_cues([seg(0.0, 0.2, "對"), seg(1.5, 3.0, "接著說")])
+    assert len(cues) == 2, "it had room to grow, so it must not merge"
+    assert cues[0][1] == pytest.approx(sub.DEFAULT_TIMING.min_dur)
+
+
+def test_the_neighbour_caps_the_cps_pull():
+    """Where the neighbour limit actually bites.
+
+    It can never bind on min_dur alone: if the cap is below min_dur the cue
+    merges instead, and if it is above, the extension stops at min_dur anyway.
+    The cap is only visible on the reading-speed pull, which for a full line of
+    text wants far more than min_dur — 12 units at 9 cps is 1.33s, and here it
+    may only have 1.0.
+    """
+    text = "十二個中文字的一整行字"          # ~11 units → ~1.2s at 9 cps
+    cues = sub.layout_cues([seg(0.0, 0.9, text), seg(1.08, 5.0, "一段夠長的下一句")])
+    assert len(cues) == 2, "long enough not to merge"
+    assert cues[0][1] == pytest.approx(1.08 - sub.DEFAULT_TIMING.min_gap)
+
+
+def test_the_cps_pull_extends_a_cramped_cue_when_there_is_room():
+    text = "十二個中文字的一整行字"
+    cues = sub.layout_cues([seg(0.0, 0.9, text), seg(6.0, 8.0, "下一句")])
+    units = sub.display_units(text)
+    assert cues[0][1] == pytest.approx(units / sub.DEFAULT_TIMING.target_cps)
+
+
+def test_a_cue_that_cannot_grow_enough_merges_instead():
+    """0.3s of slack takes a 0.2s cue to 0.42s — still a flash. Growing failed,
+    so the merge pass has to finish the job."""
+    cues = sub.layout_cues([seg(0.0, 0.2, "對"), seg(0.5, 3.0, "接著說")])
+    assert len(cues) == 1
+    assert cues[0] == (0.0, 3.0, ["對", "接著說"])
+
+
+def test_extension_respects_max_dur():
+    cues = sub.layout_cues([seg(0.0, 0.3, "短")], sub.DEFAULT_TIMING.min_dur)
+    assert durs(cues)[0] <= sub.DEFAULT_TIMING.max_dur + 1e-9
+
+
+def test_a_long_enough_cue_is_left_alone():
+    cues = sub.layout_cues([seg(0.0, 3.0, "這句本來就夠久了"), seg(9.0, 11.0, "下一句")])
+    assert cues[0] == (0.0, 3.0, ["這句本來就夠久了"])
+
+
+# ── 2. the gap is carved out of the OUTGOING cue ─────────────────────────────
+def test_abutting_cues_are_pulled_apart():
+    """Whisper hands us end[0] == start[1] for 91% of pairs."""
+    cues = sub.layout_cues([seg(0.0, 2.0, "第一句話說完了"), seg(2.0, 4.0, "第二句接著說")])
+    assert cues[1][0] - cues[0][1] == pytest.approx(sub.DEFAULT_TIMING.min_gap)
+    assert cues[1][0] == 2.0, "the later cue's start must not move"
+
+
+def test_the_gap_comes_from_the_earlier_cue_not_the_later_one():
+    before = sub.layout_cues([seg(0.0, 2.0, "第一句話說完了"), seg(2.0, 4.0, "第二句接著說")],
+                             timing=OFF)
+    after = sub.layout_cues([seg(0.0, 2.0, "第一句話說完了"), seg(2.0, 4.0, "第二句接著說")])
+    assert after[0][1] < before[0][1]      # earlier cue gave up the time
+    assert after[1][0] == before[1][0]     # later cue did not
+
+
+# ── 3. merge what cannot grow ────────────────────────────────────────────────
+def test_a_short_cue_with_no_slack_merges_forward():
+    """Nothing to grow into and nothing to shave — the only fix left is to ride
+    along with the next cue."""
+    cues = sub.layout_cues([seg(0.0, 0.2, "真的"), seg(0.2, 2.5, "然後我們就去了")])
+    assert len(cues) == 1
+    assert cues[0][0] == 0.0 and cues[0][1] == 2.5
+    assert cues[0][2] == ["真的", "然後我們就去了"]
+
+
+def test_merge_is_refused_when_the_lines_would_not_fit():
+    """Two lines is the cap; a merge that would make three must not happen."""
+    long_two_liner = "這是一段夠長的句子會被折成兩行給你看看效果如何呢好的"
+    cues = sub.layout_cues([seg(0.0, 0.2, "真的"), seg(0.2, 2.0, long_two_liner)])
+    assert len(cues) == 2
+    assert all(len(lines) <= 2 for _s, _e, lines in cues)
+
+
+def test_merge_is_refused_when_the_result_would_overstay():
+    cues = sub.layout_cues([seg(0.0, 0.2, "真的"), seg(0.2, 20.0, "很長的一段")])
+    assert len(cues) == 2
+
+
+# ── 4. the split follows the text, not the cue count ─────────────────────────
+def test_split_equalises_reading_speed_across_the_halves():
+    """🔴 The 28x defect. Equal division gave the wordy half 9.5 cps and the
+    short tail 0.3 — same sentence, same speaker, wildly different demand."""
+    text = "這是一段很長的旁白長到一行字幕根本放不下所以引擎會把它拆開，短尾巴"
+    cues = sub.layout_cues([seg(0.0, 12.0, text)])
+    assert len(cues) >= 2
+    speeds = [sum(sub.display_units(ln) for ln in lines) / (e - s)
+              for s, e, lines in cues]
+    assert max(speeds) / min(speeds) < 1.6
+
+
+def test_split_still_ends_where_the_segment_ends():
+    cues = sub.layout_cues([seg(4.0, 16.0, "很長的一段話" * 8)])
+    assert cues[0][0] == 4.0
+    assert cues[-1][1] == pytest.approx(16.0)
+
+
+def test_degenerate_span_falls_back_to_equal_division():
+    """A zero-length segment cannot be divided by weight without dividing by
+    zero; it must behave exactly as before rather than raise."""
+    cues = sub.layout_cues([seg(5.0, 5.0, "很長的一段話" * 8)])
+    assert cues and all(e >= s for s, e, _ in cues)
+
+
+# ── 5. the off switch really is off ──────────────────────────────────────────
+def test_disabled_policy_reproduces_the_old_engine():
+    segments = [seg(0.0, 2.0, "第一句"), seg(2.0, 2.2, "嗯"), seg(2.2, 5.0, "第三句")]
+    cues = sub.layout_cues(segments, timing=OFF)
+    assert len(cues) == 3
+    assert cues[0] == (0.0, 2.0, ["第一句"])
+    assert cues[1] == (2.0, 2.2, ["嗯"])          # the 0.2s flash is preserved
+    assert cues[2][0] == 2.2                       # still abutting
+
+
+def test_disabled_policy_keeps_equal_division():
+    cues = sub.layout_cues([seg(4.0, 16.0, "很長的一段話" * 8)], timing=OFF)
+    spans = durs(cues)
+    assert max(spans) - min(spans) < 1e-9
+
+
+# ── 6. the renderers pass the policy through ─────────────────────────────────
+@pytest.mark.parametrize("render", ["segments_to_srt", "segments_to_vtt"])
+def test_renderers_thread_the_policy(render):
+    segments = [seg(0.0, 2.0, "第一句"), seg(2.0, 4.0, "第二句")]
+    timed = getattr(sub, render)(segments)
+    legacy = getattr(sub, render)(segments, timing=OFF)
+    assert timed != legacy, "{0} ignored the timing policy".format(render)
+
+
+def test_srt_output_has_a_real_gap_at_millisecond_precision():
+    """The float ends land on 0.07999999999999996; what matters is what the file
+    says after rounding. (A measurement that missed this counted 132 phantom
+    violations — the metric was wrong, not the layout.)"""
+    srt = sub.segments_to_srt([seg(0.0, 2.0, "第一句"), seg(2.0, 4.0, "第二句")])
+    assert "00:00:00,000 --> 00:00:01,920" in srt
+    assert "00:00:02,000 --> 00:00:04,000" in srt


### PR DESCRIPTION
`subtitle.py` 只有**空間**維度（每行 14 個 CJK unit、每個 cue 兩行），時間全部原樣沿用 Whisper。`references/todo/arkiv.md:176` 把這件事記成「缺 cps」。

**先在真素材上量，結果不是那樣。**

## 量測基準

reel-scout 庫，34 支 zh、312 個 Whisper segment → 315 個 cue：

| | 實測 |
|---|---|
| CPS | 中位數 **4.7**，僅 1.3% 超過 zh 慣例的 9，**0% 超過 20** |
| 短 cue | **28 個（8.9%）短於 0.8s**，最短 0.24s（「真的」閃 0.24 秒） |
| 零間隔 | **256 個（91.1%）** —— Whisper 的 segment 首尾相接 |
| 切割失衡 | 最糟 **28 倍**：同一句被切開，一半 9.5 cps、另一半 0.3 |

🔴 **差點照 todo 的假設改一整晚。** 真正的缺陷是「一閃而過」與「沒有間隔」，CPS 只是陪襯 —— 所以它在這裡是**軟性拉力**（有空檔才延長），不是硬性約束，免得跟前兩項打架。

## 修法

`TimingPolicy(min_dur, max_dur, min_gap, target_cps)`，三個 pass 依序：

1. **延長** — end 拉到 `min_dur`，再依 `target_cps` 續拉，不得越過下一個 cue 的 start 減 `min_gap`。**只取所需，不把靜音填滿** —— 填滿是另一種編輯主張。
2. **讓出間隔** — 從**前一個** cue 的尾巴削。削前面是唯一安全的方向，移動後面的 start 會讓字幕出現在話被說出來之前。
3. **合併** — 延長後仍太短代表沒空檔可長。兩行放得下就併進下一個 cue。

切割也改了：**時間依文字比例分，不再依 chunk 數等分**。那個 28 倍就是等分造成的。

🔴 **貫穿全部的不變量：cue 的 start 永不移動。**

## 結果（同一支腳本、同一批素材）

| | 改前 | 改後 |
|---|---|---|
| cue 數 | 315 | 290（合併掉 25） |
| 短於 0.8s | 28（8.9%） | **3（1.0%）** |
| 間隔 < 0.08s | 256（91.1%） | **0（0.0%）** |
| CPS > 9 | 4（1.3%） | 1（0.3%） |
| **至少違反一項** | **32（10.2%）** | **5（1.7%）** |

⚠️ **一個誠實的代價**：最大 CPS 從 10.0 微升到 10.3。讓出間隔會讓 cue 短一點點（1.12s → 1.04s），CPS 就跟著升。機制上的必然。

⚠️ **量測本身錯過一次。** 改完第一版顯示仍有 132 個間隔違規（51.6%）。實際查是浮點誤差 —— 削到 `next - 0.08` 落在 `0.07999999999999996`，裸的 `< 0.08` 把它算成違規。渲染後的 SRT 是毫秒精度，**256 個相鄰對全部剛好 0.080s、零重疊**。是量測在說謊，不是程式。

## 相容性

`TimingPolicy(enabled=False)` **完整還原舊引擎，含等分切割**。既有那支「layout 沒動過一個 byte」的重構守衛因此原封保留，只是改走 disabled 路徑 —— 原本的意義（沒有東西意外漂掉）不變，還額外釘住「關掉就等於舊行為」這個宣稱。另立 `GOLDEN_SRT_TIMED` 守新行為。

## 測試

`tests/test_subtitle_timing.py` 28 支。五組 mutation 全數被抓：

| Mutation | 結果 |
|---|---|
| M1 取消 gap pass | 8 紅 |
| M2 切割回到等分 | 2 紅 |
| M3 取消 merge pass | 2 紅 |
| M4 取消 extend pass | 4 紅 |
| **M5 移動 start 而非 end** | **5 紅** ← 最重要的不變量真的有守衛 |

寫測試時我連錯三次期望值，都是先寫我希望的值而不是先想清楚程式會怎麼做。其中一次逼出一個我自己沒意識到的性質：**鄰居上限永遠不會單獨生效**（低於 `min_dur` 就走合併、高於就停在 `min_dur`），它只在 CPS 拉力想要更多時間時才咬住。那支測試因此改成從 CPS 這一側驗。

全套 **1887 passed / 11 skipped**。`export.py` 與 `export_builders.py` 不需改動就吃到新行為。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BznCya8zniew2fVKvPXJrP