### PR TITLE
feat(mcp): HTTP/SSE transport 讓 LAN 上的 client 連得到，而 Host 白名單才是真正的關卡

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,30 @@ automation, or let Claude/OpenClaw query your library.
 
 → **[API auth, token scopes, and the library Chat (RAG) endpoint: docs/api.md](docs/api.md)**
 
+### MCP over the LAN
+
+The default MCP server speaks **stdio**, which needs a local process and local access to
+the database — neither of which crosses a network. `mcp_http_server.py` serves the same
+read-only tools over **HTTP/SSE** so a client on another machine can query the library:
+
+```bash
+ARKIV_MCP_BIND=0.0.0.0 \
+ARKIV_MCP_ALLOWED_HOSTS=192.168.1.50:8502 \
+python mcp_http_server.py            # or: the arkiv-mcp service in docker compose
+```
+
+Point your MCP client at `http://<host>:8502/sse` with an `Authorization: Bearer <token>`
+header. Tokens are the same ones the REST API uses, so revoking one revokes it everywhere.
+
+> 🔴 **`ARKIV_MCP_ALLOWED_HOSTS` is not optional for LAN use.** The MCP SDK ships DNS
+> rebinding protection with a loopback-only allow-list, so a request arriving as
+> `Host: 192.168.1.50:8502` is refused with **421 Misdirected Request** before arkiv sees
+> it. List the address your clients dial. Values are *added* to the loopback defaults, so
+> `localhost` keeps working; `*` switches the host check off entirely.
+>
+> The bind address defaults to `127.0.0.1` — publishing an MCP endpoint to the network is
+> a decision, not a default.
+
 ## Quick Start
 
 ### Download the app (macOS Apple Silicon · Windows x64)

--- a/docker-compose.remote-ollama.yml
+++ b/docker-compose.remote-ollama.yml
@@ -77,3 +77,30 @@ services:
     # the first model call surfaces an unreachable Ollama as a real error
     # instead of compose hanging on a condition it cannot observe.
     restart: unless-stopped
+
+  # LAN MCP (#417). Split-host deployments want this more than single-host ones
+  # do — the whole premise here is that the machines are already separate.
+  arkiv-mcp:
+    build: .
+    command: ["python", "mcp_http_server.py"]
+    ports:
+      - "8502:8502"
+    volumes:
+      # Read-only: MCP exposes queries, never ingest or delete.
+      - ./media.db:/app/media.db:ro
+      - ./chroma_db:/app/chroma_db:ro
+      - ./thumbnails:/app/thumbnails:ro
+      - ${ARKIV_MEDIA_DIR:-./media}:/media:ro
+    environment:
+      - ARKIV_DB_PATH=/app/media.db
+      - ARKIV_CHROMA_PATH=/app/chroma_db
+      - ARKIV_THUMBNAILS_DIR=/app/thumbnails
+      - ARKIV_OLLAMA_URL=${ARKIV_OLLAMA_URL:?set ARKIV_OLLAMA_URL to the LAN Ollama, e.g. http://192.168.1.50:11434}
+      - ARKIV_EMBED_MODEL=bge-m3
+      - ARKIV_MCP_BIND=0.0.0.0
+      - ARKIV_MCP_PORT=8502
+      # 🔴 Required in practice here: if the clients were on this machine they
+      # would not need an HTTP transport. See docker-compose.yml for why an
+      # unset value means 421 rather than a connection error.
+      - ARKIV_MCP_ALLOWED_HOSTS=${ARKIV_MCP_ALLOWED_HOSTS:-}
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,5 +124,49 @@ services:
     # macOS: GPU passthrough not needed (Ollama uses Metal natively on host)
     restart: unless-stopped
 
+  # HTTP/SSE MCP for clients on other machines (#417). stdio MCP needs a local
+  # process and a local DB, neither of which crosses a LAN, so an editor on
+  # another Mac cannot reach the library at all without this.
+  #
+  # Same image, same read-only tools, different transport — it imports the tool
+  # definitions from mcp_server rather than re-declaring them, so the two
+  # transports cannot drift apart.
+  arkiv-mcp:
+    build: .
+    command: ["python", "mcp_http_server.py"]
+    ports:
+      - "8502:8502"
+    volumes:
+      # Read-only: MCP exposes queries, never ingest or delete. The mount being
+      # ro is a second lock behind that, not a substitute for it.
+      - ./media.db:/app/media.db:ro
+      - ./chroma_db:/app/chroma_db:ro
+      - ./thumbnails:/app/thumbnails:ro
+      - ${ARKIV_MEDIA_DIR:-./media}:/media:ro
+    environment:
+      - ARKIV_DB_PATH=/app/media.db
+      - ARKIV_CHROMA_PATH=/app/chroma_db
+      - ARKIV_THUMBNAILS_DIR=/app/thumbnails
+      - ARKIV_OLLAMA_URL=http://ollama:11434
+      - ARKIV_EMBED_MODEL=bge-m3
+      # 0.0.0.0 INSIDE the container, fenced by the port mapping above — the same
+      # split as ARKIV_HOST on the arkiv service. Running mcp_http_server.py
+      # directly defaults to 127.0.0.1 instead, so publishing it stays a decision.
+      - ARKIV_MCP_BIND=0.0.0.0
+      - ARKIV_MCP_PORT=8502
+      # 🔴 Set this to the address your MCP clients actually dial, or every LAN
+      # request dies with 421 before arkiv sees it. The MCP SDK ships DNS
+      # rebinding protection ON with a loopback-only allow-list; measured on
+      # mcp 1.28.0, `Host: 192.168.1.50:8502` is refused while `127.0.0.1:8502`
+      # passes. Values here are ADDED to the loopback defaults, never swapped
+      # for them, so localhost keeps working while you debug. `*` turns the
+      # host check off entirely — spelled out, so it cannot happen by accident.
+      #   ARKIV_MCP_ALLOWED_HOSTS=192.168.1.50:8502,arkiv.local:8502
+      - ARKIV_MCP_ALLOWED_HOSTS=${ARKIV_MCP_ALLOWED_HOSTS:-}
+    depends_on:
+      ollama:
+        condition: service_healthy
+    restart: unless-stopped
+
 volumes:
   ollama_data:

--- a/mcp_http_server.py
+++ b/mcp_http_server.py
@@ -1,0 +1,180 @@
+"""arkiv HTTP/SSE MCP server — the LAN variant of `mcp_server.py` (issue #417).
+
+Serves the SAME read-only tools as the stdio server, over HTTP/SSE, so an MCP
+client on another machine can query the library without local DB access. The
+tools are registered once on `mcp_server.mcp`; this file only exposes that
+instance over SSE behind a token gate.
+
+    Machine A (editor's Mac)   MCP client  ──HTTP/SSE──▶  Machine B: arkiv + this
+    stdio                      needs a local process and a local DB. Neither
+                               travels across a LAN, which is why #417 exists.
+
+Design credit: @pixb, who built this in his fork (pixb/arkiv#…) and reported
+#417. Three of his decisions are kept verbatim because they are right:
+
+  * reuse `mcp_server.mcp` rather than re-register the tools — one definition,
+    no chance of the two transports drifting apart;
+  * a plain ASGI middleware for the token gate, NOT Starlette's
+    `BaseHTTPMiddleware` — the latter buffers the response, and an SSE stream
+    that never ends would never be delivered;
+  * refuse `?token=` entirely. A token in a URL lands in uvicorn's access log,
+    any reverse proxy in front of it, and browser history — three places that
+    outlive the request and nobody scrubs.
+
+Env:
+    ARKIV_MCP_BIND          bind address (default 127.0.0.1)
+    ARKIV_MCP_PORT          listen port (default 8502)
+    ARKIV_MCP_ALLOWED_HOSTS extra Host: values to accept, comma-separated
+                            (see the DNS-rebinding note below)
+"""
+from __future__ import annotations
+
+import json
+import os
+
+from fastapi import HTTPException
+
+import auth
+import mcp_server
+
+# 127.0.0.1, not 0.0.0.0. Running this file directly is the "I am on the box"
+# case and should not silently publish an MCP endpoint to the network. The
+# compose service sets 0.0.0.0 explicitly, where the port mapping is the fence —
+# the same split, and the same reasoning, as ARKIV_HOST in docker-compose.yml.
+BIND = os.getenv("ARKIV_MCP_BIND", "127.0.0.1")
+PORT = int(os.getenv("ARKIV_MCP_PORT", "8502"))
+
+
+def _configured_hosts() -> list:
+    """Extra `Host:` values this deployment answers to.
+
+    ── Why this exists ──────────────────────────────────────────────────────
+    The MCP SDK ships DNS-rebinding protection ON, with an allow-list of
+    loopback patterns. Measured on the version this repo pins (mcp 1.28.0):
+
+        Host: 127.0.0.1:8502      ✅
+        Host: localhost:8502      ✅
+        Host: 192.168.1.50:8502   🔴 421 Misdirected Request
+        Host: arkiv.local:8502    🔴 421
+
+    So a LAN client is rejected before any arkiv code runs. That is the real
+    complaint in #424 — though not for the reasons it gives: the protection is
+    already on at 1.28 (not "1.29+"), `allowed_hosts` is not empty, and
+    `127.0.0.1` is not rejected. The symptom is right, the diagnosis was not.
+
+    🔴 The fix is NOT to turn the protection off. Rebinding protection is what
+    stops a page in the operator's browser from resolving a name to their LAN
+    and talking to this port. Instead the deployment states which names it
+    actually answers to, and everything else stays refused.
+
+    🔴 These are APPENDED to the loopback defaults, never substituted for them.
+    Assigning `allowed_hosts` replaces the list outright — set it to the LAN
+    address alone and `127.0.0.1` starts failing, which is a maddening thing to
+    debug from the same machine. (`ARKIV_INGEST_ROOTS` in webguard has exactly
+    this shape and exactly this trap; there it replaces, and the compose file
+    carries a comment saying so.)
+
+    `*` disables host checking. It is spelled out rather than inferred so that
+    it can never be reached by accident.
+    """
+    raw = os.getenv("ARKIV_MCP_ALLOWED_HOSTS", "").strip()
+    return [h.strip() for h in raw.split(",") if h.strip()]
+
+
+def apply_transport_security(mcp_instance) -> None:
+    """Widen the Host/Origin allow-list from the environment, additively."""
+    extra = _configured_hosts()
+    if not extra:
+        return
+
+    settings = mcp_instance.settings.transport_security
+    if "*" in extra:
+        # Explicit opt-out. Everything else in this file (the token gate above
+        # all) still applies; this only stops arkiv answering to a name it was
+        # not told about.
+        settings.enable_dns_rebinding_protection = False
+        return
+
+    hosts = list(settings.allowed_hosts or [])
+    origins = list(settings.allowed_origins or [])
+    for h in extra:
+        if h not in hosts:
+            hosts.append(h)
+        for scheme in ("http://", "https://"):
+            o = scheme + h
+            if o not in origins:
+                origins.append(o)
+    settings.allowed_hosts = hosts
+    settings.allowed_origins = origins
+
+
+def _extract_token(scope) -> str:
+    """Pull a raw bearer token from the Authorization header, and only there."""
+    for name, value in scope.get("headers", []):
+        if name == b"authorization":
+            raw = value.decode("latin-1", "replace")
+            if raw.lower().startswith("bearer "):
+                return raw[7:].strip()
+            return raw.strip()
+    return ""
+
+
+async def token_gate(app, scope, receive, send):
+    """ASGI middleware: reject anything without a valid arkiv token.
+
+    Reuses `auth.resolve_raw_token`, so this endpoint inherits the same token
+    store, IP allow-list and expiry as the HTTP API — an existing token works
+    here unchanged, and revoking one revokes it everywhere.
+    """
+    if scope["type"] in ("http", "websocket"):
+        client_ip = (scope.get("client") or ("", 0))[0]
+        try:
+            auth.resolve_raw_token(_extract_token(scope), client_ip)
+        except HTTPException as exc:
+            await _refuse(send, getattr(exc, "status_code", 401), str(exc.detail))
+            return
+        except Exception:
+            # Never leak the internals of an auth failure to an unauthenticated
+            # caller; the server log already has the traceback.
+            await _refuse(send, 401, "unauthorized")
+            return
+    await app(scope, receive, send)
+
+
+async def _refuse(send, status: int, detail: str) -> None:
+    body = json.dumps({"error": detail}).encode("utf-8")
+    await send({
+        "type": "http.response.start",
+        "status": status,
+        "headers": [(b"content-type", b"application/json")],
+    })
+    await send({"type": "http.response.body", "body": body})
+
+
+class ASGIMiddleware:
+    """Minimal wrapper. Starlette's `add_middleware` builds a BaseHTTPMiddleware
+    stack, which reads the response body to completion — fatal for SSE."""
+
+    def __init__(self, app, middleware):
+        self.app = app
+        self.middleware = middleware
+
+    async def __call__(self, scope, receive, send):
+        await self.middleware(self.app, scope, receive, send)
+
+
+def build_app():
+    """The ASGI app, assembled but not served. Separated from `main` so tests can
+    exercise the gate without binding a port."""
+    apply_transport_security(mcp_server.mcp)
+    return ASGIMiddleware(mcp_server.mcp.sse_app(), token_gate)
+
+
+def main() -> None:
+    mcp_server._prewarm_vectordb()
+    import uvicorn
+    uvicorn.run(build_app(), host=BIND, port=PORT)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_compose_deploy.py
+++ b/tests/test_compose_deploy.py
@@ -170,6 +170,52 @@ def test_the_two_files_differ_only_in_the_ollama_url():
     )
 
 
+# ── the LAN MCP service (#417) ───────────────────────────────────────────────
+def _mcp(path):
+    return _load(path)["services"]["arkiv-mcp"]
+
+
+@pytest.mark.parametrize("compose", [SINGLE_HOST, SPLIT_HOST], ids=["single", "split"])
+def test_mcp_service_exists_and_runs_the_http_server(compose):
+    svc = _mcp(compose)
+    assert svc["command"] == ["python", "mcp_http_server.py"]
+    assert "8502:8502" in svc["ports"]
+
+
+@pytest.mark.parametrize("compose", [SINGLE_HOST, SPLIT_HOST], ids=["single", "split"])
+def test_mcp_mounts_are_read_only(compose):
+    """MCP exposes queries, never ingest or delete. `:ro` is a second lock behind
+    the tool surface, not a substitute for it — a bug that let a write through
+    would still hit a read-only filesystem."""
+    for entry in _mcp(compose)["volumes"]:
+        assert entry.endswith(":ro"), "writable mount on the MCP service: " + entry
+
+
+@pytest.mark.parametrize("compose", [SINGLE_HOST, SPLIT_HOST], ids=["single", "split"])
+def test_mcp_allowed_hosts_is_wired_through(compose):
+    """🔴 Without this the transport exists and every LAN client still gets 421:
+    the MCP SDK's rebinding allow-list is loopback-only. Measured on mcp 1.28.0,
+    `Host: 192.168.1.50:8502` is refused while `127.0.0.1:8502` passes."""
+    env = _env(_mcp(compose))
+    assert "ARKIV_MCP_ALLOWED_HOSTS" in env
+    assert "ARKIV_MCP_ALLOWED_HOSTS" in env["ARKIV_MCP_ALLOWED_HOSTS"], (
+        "must be overridable from the environment, not baked in"
+    )
+
+
+@pytest.mark.parametrize("compose", [SINGLE_HOST, SPLIT_HOST], ids=["single", "split"])
+def test_mcp_binds_wide_only_inside_the_container(compose):
+    """0.0.0.0 here is fenced by the port mapping, exactly like ARKIV_HOST on the
+    arkiv service. The module default is 127.0.0.1 so a bare `python
+    mcp_http_server.py` never publishes to the network by surprise."""
+    assert _env(_mcp(compose))["ARKIV_MCP_BIND"] == "0.0.0.0"
+
+
+def test_mcp_service_is_absent_from_neither_file():
+    for compose in (SINGLE_HOST, SPLIT_HOST):
+        assert "arkiv-mcp" in _load(compose)["services"], compose.name
+
+
 def test_model_pins_agree_across_both_files():
     """These already drifted from config.py once ('it did, for months' — the
     comment in docker-compose.yml). Two files means two chances to drift."""

--- a/tests/test_mcp_http_server.py
+++ b/tests/test_mcp_http_server.py
@@ -1,0 +1,250 @@
+"""The LAN MCP transport (#417) and the Host allow-list it needs (#424).
+
+stdio MCP needs a local process and a local DB; neither travels across a LAN, so
+an editor on another machine cannot query the library at all. That is #417.
+
+#424 is what stands in the way once the transport exists. The MCP SDK ships DNS
+rebinding protection ON with a loopback allow-list, so a LAN client is refused
+with 421 before any arkiv code runs. Measured on the pinned SDK (mcp 1.28.0):
+
+    Host: 127.0.0.1:8502      ✅
+    Host: localhost:8502      ✅
+    Host: 192.168.1.50:8502   🔴 421
+    Host: arkiv.local:8502    🔴 421
+
+The issue's own diagnosis is wrong on two counts — the protection is already on
+at 1.28 rather than "1.29+", and `allowed_hosts` is not empty, so `127.0.0.1`
+was never rejected. The symptom is real; the explanation was not. These tests
+pin the symptom, so a future SDK bump that changes the behaviour is visible.
+"""
+import asyncio
+import importlib
+
+import pytest
+
+mcp_http_server = pytest.importorskip("mcp_http_server")
+pytest.importorskip("mcp.server.transport_security")
+
+from mcp.server.transport_security import (  # noqa: E402
+    TransportSecurityMiddleware,
+    TransportSecuritySettings,
+)
+
+
+class FakeMCP:
+    """Just the one attribute `apply_transport_security` touches."""
+
+    class _S:
+        pass
+
+    def __init__(self, hosts=None, origins=None, protection=True):
+        self.settings = self._S()
+        self.settings.transport_security = TransportSecuritySettings(
+            enable_dns_rebinding_protection=protection,
+            allowed_hosts=list(hosts if hosts is not None else ["127.0.0.1:*", "localhost:*"]),
+            allowed_origins=list(origins if origins is not None else ["http://127.0.0.1:*"]),
+        )
+
+
+def _host_allowed(settings, host):
+    mw = TransportSecurityMiddleware(settings)
+
+    class R:
+        headers = {"host": host}
+
+    return asyncio.run(mw.validate_request(R(), is_post=False)) is None
+
+
+# ── reading the env ──────────────────────────────────────────────────────────
+@pytest.mark.parametrize("raw,expected", [
+    ("", []),
+    ("   ", []),
+    ("a:1", ["a:1"]),
+    ("a:1,b:2", ["a:1", "b:2"]),
+    (" a:1 , , b:2 ", ["a:1", "b:2"]),
+])
+def test_configured_hosts_parsing(monkeypatch, raw, expected):
+    monkeypatch.setenv("ARKIV_MCP_ALLOWED_HOSTS", raw)
+    assert mcp_http_server._configured_hosts() == expected
+
+
+def test_unset_env_changes_nothing(monkeypatch):
+    monkeypatch.delenv("ARKIV_MCP_ALLOWED_HOSTS", raising=False)
+    m = FakeMCP()
+    before = list(m.settings.transport_security.allowed_hosts)
+    mcp_http_server.apply_transport_security(m)
+    assert m.settings.transport_security.allowed_hosts == before
+
+
+# ── the additive property ────────────────────────────────────────────────────
+def test_lan_host_is_added_without_losing_loopback(monkeypatch):
+    """🔴 Assigning `allowed_hosts` REPLACES the list. Setting it to the LAN
+    address alone makes 127.0.0.1 start failing — a maddening thing to debug
+    from the same machine. (webguard's ARKIV_INGEST_ROOTS has this exact shape
+    and does replace; that trap is documented in docker-compose.yml.)"""
+    monkeypatch.setenv("ARKIV_MCP_ALLOWED_HOSTS", "192.168.1.50:8502")
+    m = FakeMCP()
+    mcp_http_server.apply_transport_security(m)
+    s = m.settings.transport_security
+
+    assert _host_allowed(s, "192.168.1.50:8502"), "the LAN host must now pass"
+    assert _host_allowed(s, "127.0.0.1:8502"), "loopback must survive"
+    assert not _host_allowed(s, "evil.example:8502"), "everything else stays refused"
+
+
+def test_protection_stays_on(monkeypatch):
+    """The fix is a wider allow-list, NOT switching the protection off. Rebinding
+    protection is what stops a page in the operator's browser resolving a name to
+    their LAN and reaching this port."""
+    monkeypatch.setenv("ARKIV_MCP_ALLOWED_HOSTS", "192.168.1.50:8502")
+    m = FakeMCP()
+    mcp_http_server.apply_transport_security(m)
+    assert m.settings.transport_security.enable_dns_rebinding_protection is True
+
+
+def test_origins_get_the_host_too(monkeypatch):
+    monkeypatch.setenv("ARKIV_MCP_ALLOWED_HOSTS", "arkiv.local:8502")
+    m = FakeMCP()
+    mcp_http_server.apply_transport_security(m)
+    origins = m.settings.transport_security.allowed_origins
+    assert "http://arkiv.local:8502" in origins
+    assert "https://arkiv.local:8502" in origins
+
+
+def test_repeated_application_does_not_duplicate(monkeypatch):
+    monkeypatch.setenv("ARKIV_MCP_ALLOWED_HOSTS", "arkiv.local:8502")
+    m = FakeMCP()
+    mcp_http_server.apply_transport_security(m)
+    mcp_http_server.apply_transport_security(m)
+    hosts = m.settings.transport_security.allowed_hosts
+    assert hosts.count("arkiv.local:8502") == 1
+
+
+# ── the explicit opt-out ─────────────────────────────────────────────────────
+def test_star_disables_and_must_be_spelled_out(monkeypatch):
+    monkeypatch.setenv("ARKIV_MCP_ALLOWED_HOSTS", "*")
+    m = FakeMCP()
+    mcp_http_server.apply_transport_security(m)
+    assert m.settings.transport_security.enable_dns_rebinding_protection is False
+
+
+def test_a_normal_host_never_disables_protection(monkeypatch):
+    """Only the literal `*` opts out; nothing else may reach that branch."""
+    for value in ("192.168.1.50:8502", "star", "**", "a,*b"):
+        monkeypatch.setenv("ARKIV_MCP_ALLOWED_HOSTS", value)
+        m = FakeMCP()
+        mcp_http_server.apply_transport_security(m)
+        assert m.settings.transport_security.enable_dns_rebinding_protection is True, value
+
+
+# ── the token gate ───────────────────────────────────────────────────────────
+def _scope(headers=None, query=b"", client=("10.0.0.9", 5555)):
+    return {
+        "type": "http",
+        "headers": headers or [],
+        "query_string": query,
+        "client": client,
+        "path": "/sse",
+    }
+
+
+def _run_gate(monkeypatch, scope, resolver):
+    monkeypatch.setattr(mcp_http_server.auth, "resolve_raw_token", resolver)
+    sent = []
+    reached = {"app": False}
+
+    async def app(s, r, sd):
+        reached["app"] = True
+
+    async def send(msg):
+        sent.append(msg)
+
+    asyncio.run(mcp_http_server.token_gate(app, scope, None, send))
+    return reached["app"], sent
+
+
+def test_no_token_is_refused(monkeypatch):
+    def resolver(raw, ip):
+        raise Exception("no token")
+
+    reached, sent = _run_gate(monkeypatch, _scope(), resolver)
+    assert reached is False
+    assert sent[0]["status"] == 401
+
+
+def test_valid_token_reaches_the_app(monkeypatch):
+    seen = {}
+
+    def resolver(raw, ip):
+        seen["raw"], seen["ip"] = raw, ip
+        return {"scopes": ["videos_read"]}
+
+    reached, _ = _run_gate(
+        monkeypatch, _scope([(b"authorization", b"Bearer tok-123")]), resolver)
+    assert reached is True
+    assert seen["raw"] == "tok-123"
+    assert seen["ip"] == "10.0.0.9", "the peer IP must reach the allow-list check"
+
+
+def test_query_param_token_is_not_accepted(monkeypatch):
+    """🔴 A token in a URL lands in uvicorn's access log, any proxy in front of
+    it, and browser history. `?token=` must not be a way in."""
+    def resolver(raw, ip):
+        if not raw:
+            raise Exception("empty")
+        return {"scopes": []}
+
+    reached, sent = _run_gate(
+        monkeypatch, _scope(query=b"token=tok-123"), resolver)
+    assert reached is False
+    assert sent[0]["status"] == 401
+
+
+def test_bearer_prefix_is_optional_but_stripped(monkeypatch):
+    got = {}
+
+    def resolver(raw, ip):
+        got["raw"] = raw
+        return {}
+
+    _run_gate(monkeypatch, _scope([(b"authorization", b"bearer  spaced  ")]), resolver)
+    assert got["raw"] == "spaced"
+
+
+def test_auth_failure_detail_is_not_leaked(monkeypatch):
+    """An unauthenticated caller learns that it failed, not how."""
+    import json
+
+    def resolver(raw, ip):
+        raise ValueError("token store at /Users/someone/.arkiv/media.db is locked")
+
+    _reached, sent = _run_gate(monkeypatch, _scope(), resolver)
+    body = json.loads(sent[1]["body"])
+    assert body == {"error": "unauthorized"}
+
+
+def test_lifespan_scope_is_not_gated(monkeypatch):
+    """ASGI lifespan has no client and no headers; gating it would stop the app
+    from starting."""
+    def resolver(raw, ip):
+        raise AssertionError("the gate must not run for lifespan")
+
+    reached, _ = _run_gate(monkeypatch, {"type": "lifespan"}, resolver)
+    assert reached is True
+
+
+# ── deployment defaults ──────────────────────────────────────────────────────
+def test_bind_defaults_to_loopback():
+    """Running this file directly is the "I am on the box" case. Publishing an
+    MCP endpoint to the network has to be a decision, not a default; compose
+    sets 0.0.0.0 explicitly, where the port mapping is the fence."""
+    mod = importlib.reload(mcp_http_server)
+    assert mod.BIND == "127.0.0.1"
+    assert mod.PORT == 8502
+
+
+def test_the_gate_is_plain_asgi_not_basehttpmiddleware():
+    """BaseHTTPMiddleware reads the response to completion. An SSE stream never
+    completes, so the whole transport would hang."""
+    import starlette.middleware.base as base
+    assert not issubclass(mcp_http_server.ASGIMiddleware, base.BaseHTTPMiddleware)


### PR DESCRIPTION
Closes #417. Closes #424.

stdio MCP 需要本機行程與本機 DB，兩者都不跨網路 —— 所以另一台機器的剪輯師**根本連不上這個素材庫**。

## 設計沿用 @pixb

他在自己 fork 做出來並回報 #417。三個決定我原封保留，因為是對的：

- **重用 `mcp_server.mcp`** 而不是重新註冊工具 —— 一份定義，兩個 transport 不可能漂開
- **純 ASGI middleware 做 token gate，不用 `BaseHTTPMiddleware`** —— 後者會把 response 讀到底，而 SSE 永遠不會結束，整條就掛住
- **完全拒絕 `?token=`** —— token 出現在 URL 會留在 uvicorn access log、前面任何一層 proxy、瀏覽器歷史

## 但 #424 的診斷有兩處是錯的

實測我們釘的 SDK（**mcp 1.28.0**）：

```
Host: 127.0.0.1:8502      ✅
Host: localhost:8502      ✅
Host: 192.168.1.50:8502   🔴 421 Misdirected Request
Host: arkiv.local:8502    🔴 421
```

**症狀對，解釋不對**：

| #424 說 | 實際 |
|---|---|
| 「MCP SDK 1.29+ 才預設開啟」 | **1.28 就已經開了** |
| 「`allowed_hosts` 是空的」 | 是 `['127.0.0.1:*', 'localhost:*', '[::1]:*']` |
| 「連 `127.0.0.1:8502` 都會被拒」 | **從來沒有被拒** |

## 🔴 所以修法不是把防護關掉

那個防護擋的是「操作者瀏覽器裡的頁面把某個名字解析到他的區網、再去打這個埠」。關掉它，`evil.example` 也會一起放行。

改成讓部署**講明自己回應哪些名字**：`ARKIV_MCP_ALLOWED_HOSTS` 逗號分隔，**追加在 loopback 預設之上、不是取代**。

```
allowed_hosts: ['127.0.0.1:*', 'localhost:*', '[::1]:*', '192.168.1.50:8502']
  127.0.0.1:8502     ✅ 保留
  192.168.1.50:8502  ✅ 通過
  evil.example:8502  🔴 仍被拒
  rebinding 防護      仍然是開的
```

指派 `allowed_hosts` 是整個換掉的：只填 LAN 位址，`127.0.0.1` 就開始失敗 —— 從同一台機器 debug 時最難想到的方向。（`webguard` 的 `ARKIV_INGEST_ROOTS` 就是這個形狀而且真的取代，#425 的 compose 註解記著這件事。）`*` 才關閉檢查，必須明寫。

**bind 預設 `127.0.0.1`。** 直接跑這支檔案是「我人在這台機器上」的情境；把 MCP 端點發佈到網路必須是一個決定。compose 明寫 `0.0.0.0`，以 port mapping 為界 —— 跟 `ARKIV_HOST` 同一個分法。

## compose

兩份檔都加 `arkiv-mcp` 服務（8502）。**掛載全部唯讀** —— MCP 只開查詢，不開 ingest 與刪除；`:ro` 是那個工具面之後的第二道鎖，不是它的替代品。

## 測試

`tests/test_mcp_http_server.py` 20 支 + compose 5 支。七組 mutation 全數被抓：

| Mutation | 結果 |
|---|---|
| M1 `allowed_hosts` 改成覆蓋而非追加 | 1 紅 |
| **M2 直接關掉 rebinding 防護（原提案作法）** | **5 紅** |
| M3 token gate 也接受 `?token=` | 1 紅 |
| M4 bind 預設改成 `0.0.0.0` | 1 紅 |
| M5 認證失敗把細節洩漏出去 | 1 紅 |
| M6 MCP 掛載改成可寫 | 1 紅 |
| M7 拿掉 `ARKIV_MCP_ALLOWED_HOSTS` | 1 紅 |

全套 **1886 passed / 11 skipped**，兩份 compose 都通過 `docker compose config`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BznCya8zniew2fVKvPXJrP