### PR TITLE
fix(stream): 瀏覽器播不了的編碼一律回 409，而不是只有那兩種

### DIFF
--- a/codec.py
+++ b/codec.py
@@ -20,6 +20,46 @@ PROXY_CODECS = frozenset({
     "prores", "ap4h", "ap4x", "apch", "apcn", "apcs", "apco",
 })
 
+# What a browser will actually decode. An ALLOW-list, deliberately: the codecs
+# browsers play are a short, slow-moving set, while the ones they refuse are
+# unbounded — mjpeg, qtrle, dnxhd, cinepak, rawvideo, whatever the next screen
+# recorder emits. PROXY_CODECS was that unbounded list, so it only ever named
+# the two formats someone had already been bitten by (issue #420: an mjpeg or
+# qtrle clip is handed over raw and the player shows a black pane with no error
+# and no way to ask for a proxy).
+#
+# PROXY_CODECS stays as it is: it names the codecs the proxy BUILDER knows how
+# to transcode, which is a different question from what a browser can show.
+BROWSER_PLAYABLE_VIDEO = frozenset({
+    "h264", "avc1",          # the overwhelming majority of everything
+    "vp8", "vp9",
+    "av1", "av01",
+    "theora",                # Firefox-era, still decoded
+    "mpeg4",                 # Simple Profile in MP4 — Safari and Chrome do play it
+})
+
+
+def is_browser_playable_video(codec_name: Optional[str]) -> Optional[bool]:
+    """True / False / None for "can a browser show this video codec?".
+
+    None means *unknown*, not *no*: ffprobe failing, the binary missing, or a
+    NAS being unreachable must keep the pre-existing fall-through (hand over the
+    original bytes and let the browser try) rather than turning into a 409 that
+    tells the user to build a proxy for a file we could not even read.
+
+    🔴 Only ask this about a VIDEO file. A JPEG still probes as `mjpeg` and an
+    MP3 as `mp3`; both would answer False here and neither wants a proxy. The
+    caller gates on the extension — see `routers/misc.py::stream_media`.
+    """
+    name = (codec_name or "").strip().lower()
+    # Strip FIRST, then test for emptiness: a whitespace-only value is truthy,
+    # so an `if not codec_name` guard lets "   " through and the set lookup
+    # answers False — "the browser cannot play this", from a probe that returned
+    # nothing at all.
+    if not name:
+        return None
+    return name in BROWSER_PLAYABLE_VIDEO
+
 # Containers a browser cannot demux, whatever is inside them. AVCHD camcorder
 # footage (.mts/.m2ts) is almost always plain H.264 — so the codec check says
 # "playable", we hand over the original bytes labelled video/mp4, and the

--- a/frontend/src/lib/Inspector.svelte
+++ b/frontend/src/lib/Inspector.svelte
@@ -256,6 +256,10 @@
   export let languages = null // [{code,label}] for the retranscribe picker
   export let mediaLang = null // current clip language → default selection
   let imgFailed = false
+  // Reset per clip: a failure that stuck would make the NEXT clip look broken
+  // too, which is worse than the black pane it replaces.
+  let videoFailed = false
+  $: if (media) { videoFailed = false }
   let showMore = false // reveal the ancillary (成品輔助) export group
   let tagInput = ''
   function submitTag() {
@@ -363,9 +367,22 @@
       {#if Pano360}<svelte:component this={Pano360} src={thumbUrl} />{:else}<div class="panoload"><Mono dim style="font-size:11px;">360 · loading…</Mono></div>{/if}
     {:else if useImage}
       <img class="previmg" src={videoSrc} alt={media.name} on:error={() => (imgFailed = true)} />
+    {:else if useVideo && videoFailed}
+      <!-- The stream endpoint answers 409 {need_proxy} for a codec no browser
+           decodes, but a <video> has no way to show a JSON body: it just fails
+           to load and leaves a black pane. Without this the 409 is invisible
+           and the clip reads as broken rather than as needing one click (#420). -->
+      <div class="playfail">
+        <Mono dim style="font-size:11px;">此編碼瀏覽器播不了</Mono>
+        {#if onReprocess}
+          <button class="ak-btn" disabled={!!reBusy} on:click={() => doReprocess('proxy')}>
+            {reBusy === 'proxy' ? '排入中…' : '建立 proxy 後可播放'}
+          </button>
+        {/if}
+      </div>
     {:else if useVideo}
       <!-- svelte-ignore a11y-media-has-caption -->
-      <video bind:this={playerEl} on:timeupdate={onTimeUpdate} on:loadedmetadata={onLoadedMeta} class="previmg" controls playsinline preload="metadata" poster={thumbUrl || undefined} src={videoSrc}></video>
+      <video bind:this={playerEl} on:timeupdate={onTimeUpdate} on:loadedmetadata={onLoadedMeta} on:error={() => (videoFailed = true)} class="previmg" controls playsinline preload="metadata" poster={thumbUrl || undefined} src={videoSrc}></video>
     {:else if useAudio}
       {#if thumbUrl && !imgFailed}
         <img class="previmg" src={thumbUrl} alt={media.name} on:error={() => (imgFailed = true)} />
@@ -667,7 +684,15 @@
   .previmg { width: 100%; height: 100%; object-fit: cover; display: block; }
   /* the real player: contain (don't crop footage) on black; audio sits at the bottom */
   video.previmg { object-fit: contain; background: #000; }
-  .prevaudio { position: absolute; left: 12px; right: 12px; bottom: 12px; width: auto; }
+  /* The native control bar renders light-on-white by default, which in this
+     dark inspector reads as a broken white box rather than a play control
+     (#420). `color-scheme` is what tells the engine to draw its own widgets
+     dark — restyling the bar by hand would mean rebuilding play/scrub/time. */
+  .prevaudio { position: absolute; left: 12px; right: 12px; bottom: 12px; width: auto; color-scheme: dark; }
+  .playfail {
+    position: absolute; inset: 0; display: flex; flex-direction: column;
+    align-items: center; justify-content: center; gap: 10px; background: #000;
+  }
   .panoload { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; background: var(--surface-2); }
   .scrim {
     position: absolute; left: 0; right: 0; bottom: 0; height: 40%;

--- a/routers/misc.py
+++ b/routers/misc.py
@@ -144,17 +144,35 @@ def stream_media(media_id: int, _tok: dict = Depends(require_scopes("videos_read
                         conn.execute("UPDATE media SET codec=? WHERE id=?", (stored_codec, media_id))
                 except Exception:
                     pass  # backfill is best-effort; playback must not fail on it
-    if stored_codec and stored_codec in codec.PROXY_CODECS:
-        return JSONResponse(
-            status_code=409,
-            content={
-                "need_proxy": True,
-                "media_id": media_id,
-                "filename": rec.get("filename"),
-                "reason": "browser-incompatible codec (HEVC/ProRes); proxy required for playback",
-                "hint": "POST /api/proxy/build to queue proxy generation",
-            },
-        )
+    # 🔴 Only video files get the codec gate (issue #420). The question "can a
+    # browser play this codec" is meaningless for the other two kinds and
+    # actively harmful to ask:
+    #   a JPEG still probes as `mjpeg`  → a 409 would break every image preview
+    #   an MP3 probes as `mp3`          → a 409 would break every audio preview
+    # Gating on VIDEO_EXT rather than on "not an image" covers both; the audio
+    # half is easy to miss because images are the case people remember.
+    if file_path.suffix.lower() in mediatypes.VIDEO_EXT and stored_codec:
+        playable = codec.is_browser_playable_video(stored_codec)
+        # None = ffprobe could not tell us. Fall through and let the browser try,
+        # exactly as before — a 409 there would blame the codec for a probe that
+        # never ran.
+        if playable is False:
+            in_proxy_set = stored_codec in codec.PROXY_CODECS
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "need_proxy": True,
+                    "media_id": media_id,
+                    "filename": rec.get("filename"),
+                    "reason": (
+                        "browser-incompatible codec (HEVC/ProRes); proxy required for playback"
+                        if in_proxy_set else
+                        "browser cannot decode this codec ({0}); proxy required for playback".format(
+                            stored_codec)
+                    ),
+                    "hint": "POST /api/proxy/build to queue proxy generation",
+                },
+            )
 
     mime, _ = mimetypes.guess_type(str(file_path))
     if not mime:

--- a/tests/test_stream_codec_gate.py
+++ b/tests/test_stream_codec_gate.py
@@ -1,0 +1,185 @@
+"""`/api/stream` refuses any codec a browser cannot decode, not just two of them.
+
+Issue #420. The gate compared against `PROXY_CODECS` — `{hevc, prores, …}` — which
+is the list of formats the proxy BUILDER knows how to transcode, not the list a
+browser can show. Anything outside it (mjpeg, qtrle, dnxhd, cinepak, rawvideo…)
+was handed over raw: black pane, no error, no way to ask for a proxy. The same
+failure the `REMUX_CONTAINERS` comment already describes for containers — the
+codec half of it was never closed.
+
+The fix is an ALLOW-list, because the set of codecs browsers play is short and
+slow-moving while the set they refuse is unbounded.
+
+🔴 Two traps, both of which turn a fix into a regression:
+
+  a JPEG still probes as `mjpeg`  → 409 would break every image preview
+  an MP3 probes as `mp3`          → 409 would break every audio preview
+
+Gating on VIDEO_EXT covers both. Gating on "not an image" — the obvious guard,
+and the one the issue proposes — covers only the first, and the audio half is
+easy to miss because images are the case people remember.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import codec
+import pathres
+
+
+# ── the helper on its own ────────────────────────────────────────────────────
+@pytest.mark.parametrize("name", ["h264", "avc1", "vp9", "av1", "av01", "H264", " h264 "])
+def test_playable_codecs(name):
+    assert codec.is_browser_playable_video(name) is True
+
+
+@pytest.mark.parametrize("name", ["mjpeg", "qtrle", "dnxhd", "cinepak", "rawvideo",
+                                  "hevc", "prores"])
+def test_unplayable_codecs(name):
+    assert codec.is_browser_playable_video(name) is False
+
+
+@pytest.mark.parametrize("name", [None, "", "   "])
+def test_unknown_is_none_not_false(name):
+    """None means the probe failed, and that must not become a 409 telling the
+    user to build a proxy for a file we could not read."""
+    assert codec.is_browser_playable_video(name) is None
+
+
+def test_proxy_codecs_are_a_subset_of_the_unplayable_ones():
+    """The two lists answer different questions — what the builder can transcode
+    vs what a browser can show — but every codec we build a proxy FOR must be one
+    a browser cannot show, or we would be transcoding for no reason."""
+    for c in codec.PROXY_CODECS:
+        assert codec.is_browser_playable_video(c) is False, c
+
+
+# ── through the endpoint ─────────────────────────────────────────────────────
+@pytest.fixture
+def clip(tmp_path):
+    src = tmp_path / "cam" / "A001.mov"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_bytes(b"\x00" * 16)
+    return src
+
+
+def _seed(db, sample_record, src, **over):
+    rec = dict(path=str(src), filename=src.name, ext=src.suffix,
+               duration_s=12.0, fps=30.0, has_audio=1)
+    rec.update(over)
+    db.upsert(sample_record(**rec))
+    return 1
+
+
+@pytest.mark.parametrize("bad", ["mjpeg", "qtrle", "dnxhd"])
+def test_a_browser_incompatible_video_gets_409(
+    fastapi_client, server_module, sample_record, clip, monkeypatch, bad
+):
+    db = importlib.import_module("db")
+    mid = _seed(db, sample_record, clip, codec=bad)
+    monkeypatch.setattr(pathres, "_probe_duration", lambda path: 12.0)
+
+    r = fastapi_client.get("/api/stream/%d" % mid)
+
+    assert r.status_code == 409
+    body = r.json()
+    assert body["need_proxy"] is True
+    assert bad in body["reason"], "the reason should name the codec that failed"
+
+
+def test_hevc_keeps_its_original_wording(
+    fastapi_client, server_module, sample_record, clip, monkeypatch
+):
+    """The pre-existing HEVC/ProRes message is what the UI already renders; a
+    wider gate must not quietly reword the case that already worked."""
+    db = importlib.import_module("db")
+    mid = _seed(db, sample_record, clip, codec="hevc")
+    monkeypatch.setattr(pathres, "_probe_duration", lambda path: 12.0)
+
+    r = fastapi_client.get("/api/stream/%d" % mid)
+
+    assert r.status_code == 409
+    assert "HEVC/ProRes" in r.json()["reason"]
+
+
+def test_h264_still_streams(
+    fastapi_client, server_module, sample_record, clip, monkeypatch
+):
+    db = importlib.import_module("db")
+    mid = _seed(db, sample_record, clip, codec="h264")
+    monkeypatch.setattr(pathres, "_probe_duration", lambda path: 12.0)
+
+    assert fastapi_client.get("/api/stream/%d" % mid).status_code == 200
+
+
+def test_an_unprobeable_video_falls_through_instead_of_409(
+    fastapi_client, server_module, sample_record, clip, monkeypatch
+):
+    """ffprobe missing / NAS unreachable keeps the old behaviour: hand over the
+    bytes and let the browser decide."""
+    db = importlib.import_module("db")
+    mid = _seed(db, sample_record, clip, codec=None)
+    monkeypatch.setattr(pathres, "_probe_duration", lambda path: 12.0)
+    monkeypatch.setattr(codec, "probe_codec", lambda path, **k: None)
+
+    assert fastapi_client.get("/api/stream/%d" % mid).status_code == 200
+
+
+def test_a_codec_we_cannot_judge_falls_through(
+    fastapi_client, server_module, sample_record, clip, monkeypatch
+):
+    """The `None` branch, reached directly.
+
+    The test above exercises the outer `and stored_codec` guard instead: with no
+    codec at all the gate is skipped before the verdict is consulted, so
+    `playable is None` is never evaluated. (A mutation flipping `is False` to
+    `is not True` survived the whole suite until this existed — an equivalent
+    mutant only because the branch was unreachable as written, which is worth
+    knowing rather than assuming.)
+    """
+    db = importlib.import_module("db")
+    mid = _seed(db, sample_record, clip, codec="some-future-codec")
+    monkeypatch.setattr(pathres, "_probe_duration", lambda path: 12.0)
+    monkeypatch.setattr(codec, "is_browser_playable_video", lambda c: None)
+
+    assert fastapi_client.get("/api/stream/%d" % mid).status_code == 200
+
+
+# ── 🔴 the two regressions this gate could cause ─────────────────────────────
+def test_a_jpeg_still_is_not_refused_for_being_mjpeg(
+    fastapi_client, server_module, sample_record, tmp_path, monkeypatch
+):
+    """A JPEG's codec IS `mjpeg`. Asking "can a browser play this video codec"
+    about a photograph and acting on the answer breaks every image preview."""
+    db = importlib.import_module("db")
+    img = tmp_path / "stills" / "shot.jpg"
+    img.parent.mkdir(parents=True, exist_ok=True)
+    img.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 32)
+    mid = _seed(db, sample_record, img, codec="mjpeg", duration_s=0.04,
+                fps=25.0, has_audio=0)
+    monkeypatch.setattr(pathres, "_probe_duration", lambda path: 0.04)
+
+    r = fastapi_client.get("/api/stream/%d" % mid)
+
+    assert r.status_code == 200, "image preview must not be gated on video codecs"
+
+
+def test_an_audio_file_is_not_refused_for_not_being_video(
+    fastapi_client, server_module, sample_record, tmp_path, monkeypatch
+):
+    """🔴 The half that gating on "not an image" would miss. An MP3 is not an
+    image and `mp3` is not a browser-playable VIDEO codec, so that guard hands
+    it a 409 and audio preview dies."""
+    db = importlib.import_module("db")
+    snd = tmp_path / "audio" / "take.mp3"
+    snd.parent.mkdir(parents=True, exist_ok=True)
+    snd.write_bytes(b"ID3" + b"\x00" * 32)
+    mid = _seed(db, sample_record, snd, codec="mp3", duration_s=30.0,
+                fps=0.0, has_audio=1)
+    monkeypatch.setattr(pathres, "_probe_duration", lambda path: 30.0)
+
+    r = fastapi_client.get("/api/stream/%d" % mid)
+
+    assert r.status_code == 200, "audio preview must not be gated on video codecs"


### PR DESCRIPTION
Closes #420.

`/api/stream` 的閘門比對的是 `PROXY_CODECS` = `{hevc, hev1, prores, ap4h, …}`。那份清單回答的是「**proxy builder 會轉哪些格式**」，不是「**瀏覽器能顯示哪些格式**」。清單之外的東西（mjpeg、qtrle、dnxhd、cinepak、rawvideo⋯）一律原樣送出：**黑畫面、沒有錯誤、也沒有任何地方可以要求建 proxy**。

`codec.py` 對 `REMUX_CONTAINERS` 的註解早就描述過同一個失效形狀 —— *"The user sees a black player and no error"*。容器那一側想到了，codec 這側沒有。

## 白名單，不是黑名單

新增 `BROWSER_PLAYABLE_VIDEO` 與 `is_browser_playable_video()`。瀏覽器能播的 codec 是短而穩定的集合，不能播的是無窮的 —— 而 `PROXY_CODECS` 正是那份無窮清單，所以它只寫得出「已經有人被咬過」的那兩種。

回傳**三態**：`True` / `False` / **`None`（不知道）**。ffprobe 掛掉、binary 不在、NAS 連不上都必須維持既有的 fall-through，而不是變成一個「請去建 proxy」的 409 —— 那是拿讀都讀不到的檔案去怪罪 codec。

## 🔴 閘門只對 `VIDEO_EXT` 生效，因為有兩個陷阱

```
JPEG 靜態圖的 codec 是 mjpeg  → 409 會打爆每一張圖片預覽
MP3 的 codec 是 mp3          → 409 會打爆每一個音訊預覽
```

issue 建議的守衛是 `if not is_image`。**那只擋得住第一個。** MP3 既不是圖片、`mp3` 也不在可播影片白名單裡，於是每個音訊檔拿到 409。改用副檔名落在 `VIDEO_EXT` 當閘門，兩個一起免疫。圖片是大家記得的案例，音訊那一半很容易漏掉 —— 兩支測試都寫了。

## 前端把 409 變成看得見的東西

`<video>` 沒有 `on:error`，所以就算後端回了 409 JSON，瀏覽器也只是載入失敗、留下一片黑 —— **409 是隱形的**，那支素材看起來像壞掉而不是像差一個點擊。加上 `on:error` 後改顯示提示＋一顆走既有 `onReprocess('proxy')` 的按鈕。狀態隨 `media` 重置，否則上一支的失敗會黏在下一支上。

音訊的原生控制列在深色 Inspector 裡是一條白帶。加 `color-scheme: dark` 讓引擎自己畫深色 —— **刻意不重寫成自訂控制列**：那要重做播放狀態、進度條、時間顯示，還會動到已經在運作的波形與 IN／OUT 整合，為了一條色帶不值得。

## 測試

`tests/test_stream_codec_gate.py` 27 支。五組 mutation 全數被抓：

| Mutation | 結果 |
|---|---|
| M1 空白字串當成「不能播」而非「不知道」 | 1 紅 |
| M2 白名單漏掉 vp9 | 1 紅 |
| **M3 閘門改成「不是圖片」（漏掉音訊）** | **1 紅** |
| M4 閘門回到只比對 `PROXY_CODECS` | 3 紅 |
| M5 未知 codec 也回 409 | 1 紅 |

⚠️ **M5 第一輪是存活的。** 查出來不是測試缺口而是**等價 mutant**：外層的 `and stored_codec` 已經把 None 擋掉，而 `stored_codec` 經過 `.strip() or None` 之後只可能是 None 或非空字串，所以 `playable is None` 那條分支照現在的寫法根本到不了。補一支直接 monkeypatch helper 回 `None` 的測試把分支打通 —— **分支到不了這件事本身值得知道**，而不是假設它有被覆蓋。

全套 **1884 passed / 11 skipped**，svelte-check **0 錯 0 警告**，前端 build 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BznCya8zniew2fVKvPXJrP