### PR TITLE
fix(bins): 刪掉的素材卡在精選集裡，而那個編號會被下一支素材重用

### DIFF
--- a/bins.py
+++ b/bins.py
@@ -339,6 +339,38 @@ def remove_item(bin_id: str, project_name: str, media_id: Any) -> Bin:
         return target
 
 
+def remove_media_everywhere(project_name: str, media_id: Any) -> int:
+    """Drop one clip from EVERY bin. Returns how many bins were touched.
+
+    Deleting a clip used to leave its reference behind in every 精選集 that held
+    it, and that reference can never come good again: `delete_media_full` removes
+    the row, so the id is gone, and restoring from the recycle bin re-ingests the
+    file — which mints a NEW id. The old entry stays `ROW_MISSING` forever while
+    still counting toward the bin's size.
+
+    (The reference-integrity gate showing it as broken rather than silently wrong
+    is why this was a papercut and not data loss. It also meant nobody had to fix
+    it, which is how it survived.)
+
+    One pass over the whole file under a single lock, rather than calling
+    `remove_item` per bin: that would re-read, re-write and re-lock once per bin
+    holding the clip, and a delete is not a good moment to be doing N writes.
+    """
+    drop = _item_key(project_name, media_id)
+    with _BINS_LOCK:
+        bins = _load_bin_objects()
+        touched = 0
+        for b in bins:
+            kept = [item for item in b.items if item.key() != drop]
+            if len(kept) != len(b.items):
+                b.items = kept
+                b.updated_at = _now_iso()
+                touched += 1
+        if touched:
+            _persist(bins)
+        return touched
+
+
 def bin_item_status(project_name: str, media_id: Any) -> str:
     """Reference-integrity gate for one bin item. Composes the primitives that
     already exist but that nothing wires together for a cross-project item:

--- a/bins.py
+++ b/bins.py
@@ -57,6 +57,33 @@ STATUS_PROJECT_UNREGISTERED = "project_unregistered"  # project_name no longer i
 STATUS_ROW_MISSING = "row_missing"                    # clip deleted from the source project.db
 STATUS_FILE_MISSING = "file_missing"                  # source file gone from disk
 STATUS_ERROR = "error"                                # unexpected failure probing the source
+# 🔴 The id now belongs to a DIFFERENT clip than the one that was added.
+#
+# `media.id` is `INTEGER PRIMARY KEY` with no AUTOINCREMENT, so SQLite hands a
+# deleted row's rowid to the next insert. Delete clip 7, ingest something else,
+# and the new clip is clip 7. Any bin entry still pointing at 7 then resolves —
+# cleanly, with status ok — to footage the user never put in that bin.
+#
+# `remove_media_everywhere` closes the window for deletes from here on, but it
+# cannot help two populations: entries added before it existed (every install
+# today), and entries whose cleanup failed. For those the only defence is to
+# notice the swap, which is what the filename check is for.
+STATUS_ID_REUSED = "id_reused"
+
+
+def _identity_mismatch(item_filename: Any, row_filename: Any) -> bool:
+    """Does the row under this id look like a different clip than we stored?
+
+    Compares the filename captured when the item was added against the one the
+    row carries now. Deliberately conservative — an item saved without a
+    filename (older entries, or an API caller that omitted it) cannot be checked
+    and is trusted, because reporting a false swap would be worse than missing a
+    real one.
+    """
+    stored = str(item_filename or "").strip()
+    if not stored:
+        return False
+    return stored != str(row_filename or "").strip()
 
 
 def _now_iso() -> str:
@@ -345,12 +372,17 @@ def remove_media_everywhere(project_name: str, media_id: Any) -> int:
     Deleting a clip used to leave its reference behind in every 精選集 that held
     it, and that reference can never come good again: `delete_media_full` removes
     the row, so the id is gone, and restoring from the recycle bin re-ingests the
-    file — which mints a NEW id. The old entry stays `ROW_MISSING` forever while
-    still counting toward the bin's size.
+    file — which mints a NEW id. The old entry counts toward the
+    bin's size forever, and — because `media.id` is `INTEGER PRIMARY KEY` with
+    no AUTOINCREMENT — only *until* the next ingest, which SQLite hands that
+    very id. From then on the entry is not broken, it is wrong: it resolves
+    clean, status `ok`, to a clip the user never put in that bin, and 精選集
+    is what the cross-project copy reads.
 
-    (The reference-integrity gate showing it as broken rather than silently wrong
-    is why this was a papercut and not data loss. It also meant nobody had to fix
-    it, which is how it survived.)
+    (An earlier version of this docstring called that a papercut rather than data
+    loss, reasoning that the reference-integrity gate would show it as broken. It
+    does not. The gate had nothing that could tell one clip from another under
+    the same id — which is what `STATUS_ID_REUSED` is now for.)
 
     One pass over the whole file under a single lock, rather than calling
     `remove_item` per bin: that would re-read, re-write and re-lock once per bin
@@ -371,12 +403,17 @@ def remove_media_everywhere(project_name: str, media_id: Any) -> int:
         return touched
 
 
-def bin_item_status(project_name: str, media_id: Any) -> str:
+def bin_item_status(project_name: str, media_id: Any, expect_filename: Any = "") -> str:
     """Reference-integrity gate for one bin item. Composes the primitives that
     already exist but that nothing wires together for a cross-project item:
-    registry lookup → library health → row-in-db → file-on-disk. Returns a status
-    string (STATUS_* / a HealthStatus value). The resolved absolute path is used
-    ONLY here (server-side); it is never returned to the client (Phase 16.2)."""
+    registry lookup → library health → row-in-db → file-on-disk → is-it-still-the
+    -same-clip. Returns a status string (STATUS_* / a HealthStatus value). The
+    resolved absolute path is used ONLY here (server-side); it is never returned
+    to the client (Phase 16.2).
+
+    `expect_filename` is the filename captured when the item was added. Pass it
+    whenever the caller has it: without it a reused id (see STATUS_ID_REUSED)
+    reports `ok` and the slot silently resolves to different footage."""
     # federation drags chromadb at import; keep it lazy so pure-CRUD callers and
     # tests don't pay for it.
     from projects import discover_projects
@@ -401,6 +438,8 @@ def bin_item_status(project_name: str, media_id: Any) -> str:
         row = _fetch_media_row(conn, media_id)
         if row is None:
             return STATUS_ROW_MISSING
+        if _identity_mismatch(expect_filename, row.get("filename")):
+            return STATUS_ID_REUSED
         _relative, absolute = _resolve_paths(project, row.get("path") or "")
         if not absolute or not os.path.exists(absolute):
             return STATUS_FILE_MISSING
@@ -426,10 +465,15 @@ def bin_item_statuses(items) -> Dict[Any, str]:
     from federation import _connect_project_db, _resolve_paths
 
     by_project: Dict[str, list] = {}
+    # (project, media_id) → the filename captured when the item was added. Tuple
+    # callers have none, and an item may predate the field; both land as "" and
+    # _identity_mismatch treats that as "cannot check".
+    expect: Dict[Any, str] = {}
     for it in items:
         pn = it.project_name if hasattr(it, "project_name") else it[0]
         mid = it.media_id if hasattr(it, "media_id") else it[1]
         by_project.setdefault(pn, []).append(str(mid))
+        expect[(pn, str(mid))] = getattr(it, "filename", "") or ""
 
     result: Dict[Any, str] = {}
     projects_by_name = {p.name: p for p in discover_projects()}  # ONE registry read
@@ -453,7 +497,7 @@ def bin_item_statuses(items) -> Dict[Any, str]:
             rows = {
                 str(r["id"]): r
                 for r in conn.execute(
-                    "SELECT id, path FROM media WHERE id IN ({0})".format(placeholders),
+                    "SELECT id, path, filename FROM media WHERE id IN ({0})".format(placeholders),
                     mids,
                 ).fetchall()
             }
@@ -461,6 +505,9 @@ def bin_item_statuses(items) -> Dict[Any, str]:
                 row = rows.get(mid)
                 if row is None:
                     result[(pn, mid)] = STATUS_ROW_MISSING
+                    continue
+                if _identity_mismatch(expect.get((pn, mid)), row["filename"]):
+                    result[(pn, mid)] = STATUS_ID_REUSED
                     continue
                 _relative, absolute = _resolve_paths(project, row["path"] or "")
                 if not absolute or not os.path.exists(absolute):
@@ -476,10 +523,16 @@ def bin_item_statuses(items) -> Dict[Any, str]:
     return result
 
 
-def resolve_source(project_name: str, media_id: Any) -> Optional[Dict[str, Any]]:
+def resolve_source(project_name: str, media_id: Any,
+                   expect_filename: Any = "") -> Optional[Dict[str, Any]]:
     """Server-side ONLY: (project_name, media_id) → {absolute_path, filename,
     status}. The absolute path is for the copy orchestrator (server.py); never
-    hand it to a client. Returns None only if the project is unregistered."""
+    hand it to a client. Returns None only if the project is unregistered.
+
+    Pass `expect_filename` from the bin item. This is the call that feeds the
+    cross-project copy, so a reused id that slips through here does not merely
+    show the wrong thumbnail — it copies the wrong footage into another
+    project."""
     from projects import discover_projects
     from federation import _connect_project_db, _fetch_media_row, _resolve_paths
 
@@ -491,7 +544,7 @@ def resolve_source(project_name: str, media_id: Any) -> Optional[Dict[str, Any]]
     if project is None:
         return None
 
-    status = bin_item_status(project_name, media_id)
+    status = bin_item_status(project_name, media_id, expect_filename)
     absolute = ""
     filename = ""
     if status == STATUS_OK:

--- a/frontend/src/routes/Bins.svelte
+++ b/frontend/src/routes/Bins.svelte
@@ -32,6 +32,9 @@
     path_not_found: { label: '庫不存在', sev: 'bad' },
     timeout: { label: '逾時', sev: 'warn' },
     row_missing: { label: '已從庫刪除', sev: 'bad' },
+    // 這個 id 現在是另一支素材了（SQLite 會把刪掉的 id 發給下一次匯入）。
+    // 是壞的一種，不是「找不到」——標成 bad，並在 title 說清楚。
+    id_reused: { label: '已換成別支', sev: 'bad' },
     file_missing: { label: '檔案不在', sev: 'bad' },
     error: { label: '錯誤', sev: 'warn' },
   }
@@ -332,7 +335,10 @@
                       <Mono style="font-size:11.5px;font-weight:500;color:var(--ink);">{it.filename || ('#' + it.media_id)}</Mono>
                     </div>
                     <div class="rbadge">
-                      <span class="badge {bd.sev}" title={it.status}>{bd.label}</span>
+                      <span class="badge {bd.sev}"
+                            title={it.status === 'id_reused'
+                              ? `這個編號現在指到另一支素材（當初加入的是 ${it.filename || '?'}）`
+                              : it.status}>{bd.label}</span>
                     </div>
                     <div class="raction">
                       <button class="ak-btn xbtn" title="從精選集移除（不動原檔）" on:click={() => removeItem(it)}>×</button>

--- a/frontend/src/routes/MainLive.svelte
+++ b/frontend/src/routes/MainLive.svelte
@@ -149,7 +149,9 @@
     const refs = picked.map((id) => ({
       project_name: projectRegName,
       media_id: String(id),
-      filename: (byId.get(id) || {}).name || `#${id}`,
+      // 名字拿不到就送空字串，不要送 `#id`：它永遠不會等於真檔名，
+      // 會讓後端的 id-reuse 比對每一支都誤判。顯示端本來就有 #id fallback。
+      filename: (byId.get(id) || {}).name || '',
     }))
     let binId = targetBinId
     try {

--- a/media_delete.py
+++ b/media_delete.py
@@ -55,6 +55,17 @@ def _unlink_rel(stored_path: str) -> None:
         pass
 
 
+def _join_warning(existing, extra):
+    """Two things can go wrong in one delete (the file move AND the bins cleanup)
+    and `warning` is a single slot. Keep both rather than letting the later one
+    overwrite the earlier."""
+    if not existing:
+        return extra
+    if not extra:
+        return existing
+    return "{0}; {1}".format(existing, extra)
+
+
 def _audit(media_id, filename, file_deleted, warning, token_info):
     try:
         actor = "unknown"
@@ -147,22 +158,35 @@ def delete_media_full(media_id, allow_file_delete=True, token_info=None):
 
     # Cross-library 精選集 hold clips by (registry name, media_id). That pair is
     # gone the moment the row is: restoring from the recycle bin re-INGESTS the
-    # file and mints a new id, so the old entry can never resolve again — it
-    # just sits at ROW_MISSING forever, still counted in the bin's size.
+    # file and mints a new id, so the old entry can never resolve again.
     #
-    # Best-effort on purpose. The clip's row, files and vectors are already gone
-    # by this point; failing the delete because a JSON file could not be rewritten
-    # would report failure for work that actually happened. A stale entry is the
-    # exact papercut this removes, which is a fair trade against that.
-    try:
-        import bins as bins_store
-        import projects as project_registry
+    # 🔴 And it does not merely sit there. `media.id` is INTEGER PRIMARY KEY with
+    # no AUTOINCREMENT, so SQLite hands this id to the next clip ingested. The
+    # stale entry then resolves — with status ok — to footage the user never put
+    # in that bin, and 精選集 feeds the cross-project copy. So this cleanup is
+    # not cosmetic, and a silent failure here is not a papercut.
+    #
+    # Still best-effort on the delete's own outcome: the row, files and vectors
+    # are already gone, and reporting failure for work that actually happened
+    # helps nobody. But the failure has to be VISIBLE — it goes into `warning`,
+    # which reaches both the API response and the audit log.
+    #
+    # Narrow on purpose: only the bins call is guarded. An import error or a
+    # broken registry lookup is a bug in arkiv, not a runtime condition, and the
+    # previous blanket try/except turned exactly that into a silent no-op.
+    import bins as bins_store
+    import projects as project_registry
 
-        registry_name = project_registry.current_registry_name()
-        if registry_name:
+    registry_name = project_registry.current_registry_name()
+    if registry_name:
+        try:
             bins_store.remove_media_everywhere(registry_name, media_id)
-    except Exception:
-        pass
+        except Exception as exc:
+            warning = _join_warning(
+                warning,
+                "精選集未能清除此素材（{0}）：該編號會被下一支匯入的素材重用".format(
+                    type(exc).__name__),
+            )
 
     # Only record a recycle-bin entry when an actual file was moved (it is the
     # only thing recoverable). Metadata-only deletes are still captured by the

--- a/media_delete.py
+++ b/media_delete.py
@@ -145,6 +145,25 @@ def delete_media_full(media_id, allow_file_delete=True, token_info=None):
     except Exception:
         pass
 
+    # Cross-library 精選集 hold clips by (registry name, media_id). That pair is
+    # gone the moment the row is: restoring from the recycle bin re-INGESTS the
+    # file and mints a new id, so the old entry can never resolve again — it
+    # just sits at ROW_MISSING forever, still counted in the bin's size.
+    #
+    # Best-effort on purpose. The clip's row, files and vectors are already gone
+    # by this point; failing the delete because a JSON file could not be rewritten
+    # would report failure for work that actually happened. A stale entry is the
+    # exact papercut this removes, which is a fair trade against that.
+    try:
+        import bins as bins_store
+        import projects as project_registry
+
+        registry_name = project_registry.current_registry_name()
+        if registry_name:
+            bins_store.remove_media_everywhere(registry_name, media_id)
+    except Exception:
+        pass
+
     # Only record a recycle-bin entry when an actual file was moved (it is the
     # only thing recoverable). Metadata-only deletes are still captured by the
     # audit log below.

--- a/projects.py
+++ b/projects.py
@@ -462,6 +462,45 @@ def _format_table(projects: List[ProjectMeta]) -> str:
     return "\n".join(lines)
 
 
+def current_registry_name() -> Optional[str]:
+    """The REGISTRY name of the project this process has loaded, or None.
+
+    Not the directory basename: a library registered as 「婚禮案素材庫」 can live
+    in a folder called `wedding`, and the two are not interchangeable. A
+    cross-library 精選集 keys its items by the registry name, so anything that
+    has to find or remove those items has to ask for the same one — matching on
+    the basename silently matches nothing.
+
+    None when the loaded project is not registered. Callers treat that as "this
+    project cannot participate in bins" rather than as an error; the UI already
+    disables the add button on the same signal.
+
+    Lives here rather than in the analytics router because it answers a registry
+    question, and `media_delete` needs it too. `routers.analytics` keeps its
+    `_current_project_registry_name` name — the R5-25 route-ownership tests
+    assert that attribute exists on that module.
+    """
+    # config is imported lazily throughout this module (see resolve_project_db),
+    # so it is not a module-level name here either.
+    import config as _config
+
+    try:
+        root_key = _normalize_key(_config.PROJECT_ROOT)
+    except Exception:
+        return None
+    try:
+        for p in discover_projects():
+            if p.key() == root_key:
+                return p.name
+    except Exception:
+        # A registry that cannot be read means "not registered" for this
+        # purpose. Deliberately narrow in scope: the key computation above gets
+        # its own guard so a typo in THIS function surfaces as a NameError at
+        # import rather than as a silent None that looks like "unregistered".
+        return None
+    return None
+
+
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="Manage arkiv project registry")
     subparsers = parser.add_subparsers(dest="command", required=True)

--- a/projects.py
+++ b/projects.py
@@ -484,19 +484,21 @@ def current_registry_name() -> Optional[str]:
     # so it is not a module-level name here either.
     import config as _config
 
-    try:
-        root_key = _normalize_key(_config.PROJECT_ROOT)
-    except Exception:
-        return None
+    # NOT guarded. `_normalize_key` is `expanduser().resolve(strict=False)` on a
+    # module attribute — pure path math with no filesystem requirement and no
+    # legitimate failure. Wrapping it swallowed a real `_config.PROJECT_ROOT`
+    # NameError during development and returned None, which every caller reads
+    # as the perfectly ordinary "this project is not registered". The bug looked
+    # like a supported state for as long as the guard was there.
+    root_key = _normalize_key(_config.PROJECT_ROOT)
     try:
         for p in discover_projects():
             if p.key() == root_key:
                 return p.name
     except Exception:
-        # A registry that cannot be read means "not registered" for this
-        # purpose. Deliberately narrow in scope: the key computation above gets
-        # its own guard so a typo in THIS function surfaces as a NameError at
-        # import rather than as a silent None that looks like "unregistered".
+        # A registry that cannot be read (missing, unreadable, malformed JSON)
+        # genuinely does mean "not registered" for this purpose, and that one IS
+        # a runtime condition rather than a bug.
         return None
     return None
 

--- a/routers/analytics.py
+++ b/routers/analytics.py
@@ -25,14 +25,11 @@ router = APIRouter()
 
 
 def _current_project_registry_name():
-    try:
-        root_key = str(config.PROJECT_ROOT.expanduser().resolve(strict=False)).casefold()
-        for p in project_registry.discover_projects():
-            if p.key() == root_key:
-                return p.name
-    except Exception:
-        pass
-    return None
+    """Kept as a name on this module — the R5-25 route-ownership tests assert it
+    exists here — but the implementation moved to `projects`, because it answers
+    a registry question and `media_delete` needs the same answer when it clears a
+    deleted clip out of every 精選集."""
+    return project_registry.current_registry_name()
 
 
 def _thumb_url(thumbnail_path):

--- a/routers/bins.py
+++ b/routers/bins.py
@@ -119,7 +119,7 @@ def _bin_detail_payload(b) -> dict:
     (Phase 16.2 — no absolute path ever leaves the backend)."""
     # fable-audit round-5 #23: one batched status probe (grouped by project) instead
     # of a per-item registry read + health probe + sqlite open.
-    statuses = bins_store.bin_item_statuses(b.items)
+    statuses = bins_store.bin_item_statuses(b.items)  # items carry filename → id-reuse checked
     items = []
     for item in b.items:
         status = statuses.get((item.project_name, str(item.media_id)), bins_store.STATUS_ERROR)
@@ -255,7 +255,7 @@ def copy_bin(bin_id: str, body: BinCopyRequest, _tok: dict = Depends(require_sco
         reachable = []  # (project_name, media_id, absolute_path)
         # ── gate: re-resolve every item server-side; skip unreachable (fail-loud) ──
         for item in b.items:
-            info = bins_store.resolve_source(item.project_name, item.media_id)
+            info = bins_store.resolve_source(item.project_name, item.media_id, item.filename)
             status = (info or {}).get("status") or bins_store.STATUS_PROJECT_UNREGISTERED
             if status != bins_store.STATUS_OK or not (info or {}).get("absolute_path"):
                 skipped.append({"project_name": item.project_name, "media_id": item.media_id, "status": status})

--- a/tests/test_bin_copy.py
+++ b/tests/test_bin_copy.py
@@ -46,9 +46,18 @@ def _stub_ingest(monkeypatch):
 
 
 def _stub_resolve(monkeypatch, mapping):
-    """mapping: (project_name, media_id) -> {status, absolute_path, filename}."""
+    """mapping: (project_name, media_id) -> {status, absolute_path, filename}.
+
+    The third argument is asserted, not ignored. It is the filename the item was
+    added under, and passing it is what lets `resolve_source` notice that a
+    reused id now points at different footage. Drop it at this call site and the
+    copy silently pulls the wrong file (tests/test_bins_id_reuse.py), so a stub
+    that accepted anything would let that regression through unseen.
+    """
     import bins as bins_mod
-    def fake(project_name, media_id):
+    def fake(project_name, media_id, expect_filename=None):
+        assert expect_filename is not None, \
+            "the copy gate must pass the bin item's filename through"
         return mapping.get((project_name, str(media_id)))
     monkeypatch.setattr(bins_mod, "resolve_source", fake)
 

--- a/tests/test_bins_delete_sync.py
+++ b/tests/test_bins_delete_sync.py
@@ -3,12 +3,14 @@
 A bin references clips by `(registry name, media_id)`. Deleting one used to leave
 that reference behind in every bin, permanently: `delete_media_full` removes the
 row, so the id is gone, and restoring from the recycle bin RE-INGESTS the file —
-which mints a new id. The old entry can never resolve again. It sits at
-`ROW_MISSING` forever and still counts toward the bin's size.
+which mints a new id. The old entry can never resolve to the right clip again.
 
-That the reference-integrity gate shows it as broken rather than silently wrong is
-why this was a papercut rather than data loss — and also why nobody had to fix it,
-which is how it survived.
+🔴 It does not merely sit there counting toward the bin's size. `media.id` is
+`INTEGER PRIMARY KEY` with no AUTOINCREMENT, so the next ingest is handed that
+very id and the stale entry starts resolving — cleanly, status `ok` — to
+different footage. The reference-integrity gate could not see it: nothing in it
+could tell one clip from another under the same id. `tests/test_bins_id_reuse.py`
+covers that half; this file covers keeping the reference from going stale at all.
 
 🔴 The name has to be the REGISTRY name, not the directory basename. A library
 registered as 「婚禮案素材庫」 can live in a folder called `wedding`; matching on the
@@ -176,7 +178,11 @@ def test_delete_clears_the_clip_out_of_bins(monkeypatch, tmp_path):
 def test_delete_still_succeeds_when_bins_are_unusable(monkeypatch, tmp_path):
     """The row, files and vectors are already gone by this point. Failing the
     delete because a JSON file could not be rewritten would report failure for
-    work that actually happened."""
+    work that actually happened.
+
+    But it must not be SILENT. The entry left behind is the one that will start
+    resolving to a different clip on the next ingest, so the one thing the user
+    needs is to be told it is there."""
     import media_delete
 
     def boom(*_a, **_k):
@@ -188,7 +194,53 @@ def test_delete_still_succeeds_when_bins_are_unusable(monkeypatch, tmp_path):
     monkeypatch.setattr(media_delete.db, "delete_media", lambda mid: [])
     monkeypatch.setattr(media_delete.db, "trash_media", lambda *a, **k: None)
 
-    assert media_delete.delete_media_full(42, allow_file_delete=False)["ok"] is True
+    got = media_delete.delete_media_full(42, allow_file_delete=False)
+
+    assert got["ok"] is True
+    assert got["warning"], "a swallowed failure here is the whole bug"
+    assert "精選集" in got["warning"] and "OSError" in got["warning"]
+
+
+def test_two_failures_in_one_delete_both_survive(monkeypatch, tmp_path):
+    """`warning` is a single slot and two independent things can go wrong. The
+    later one must not quietly erase the earlier one."""
+    import media_delete
+
+    assert media_delete._join_warning(None, "b") == "b"
+    assert media_delete._join_warning("a", None) == "a"
+    assert media_delete._join_warning("a", "b") == "a; b"
+
+
+def test_a_bug_in_the_registry_lookup_is_not_reported_as_unregistered(monkeypatch):
+    """`current_registry_name` used to wrap its path computation in a bare
+    `except Exception: return None`, and every caller reads None as the ordinary
+    "this project is not registered". A real NameError in there therefore looked
+    like a supported state, and the bins cleanup became a silent no-op.
+
+    `_normalize_key` is `expanduser().resolve(strict=False)` — pure path math
+    with no legitimate failure — so anything it raises is a bug and has to be
+    loud."""
+    def boom(_path):
+        raise NameError("name '_config' is not defined")
+
+    monkeypatch.setattr(projects, "_normalize_key", boom)
+
+    with pytest.raises(NameError):
+        projects.current_registry_name()
+
+
+def test_an_unreadable_registry_is_still_just_unregistered(tmp_path, monkeypatch):
+    """The other side of that narrowing: a registry that cannot be read IS a
+    runtime condition, and must stay a quiet None rather than an exception."""
+    monkeypatch.setenv("ARKIV_PROJECTS_REGISTRY", str(tmp_path / "reg.json"))
+    monkeypatch.delenv("ARKIV_PROJECT_ROOTS", raising=False)
+
+    def boom():
+        raise OSError("registry is unreadable")
+
+    monkeypatch.setattr(projects, "discover_projects", boom)
+
+    assert projects.current_registry_name() is None
 
 
 def test_delete_skips_the_cleanup_when_the_project_is_unregistered(monkeypatch, tmp_path):

--- a/tests/test_bins_delete_sync.py
+++ b/tests/test_bins_delete_sync.py
@@ -1,0 +1,230 @@
+"""Deleting a clip clears it out of every 精選集 that held it.
+
+A bin references clips by `(registry name, media_id)`. Deleting one used to leave
+that reference behind in every bin, permanently: `delete_media_full` removes the
+row, so the id is gone, and restoring from the recycle bin RE-INGESTS the file —
+which mints a new id. The old entry can never resolve again. It sits at
+`ROW_MISSING` forever and still counts toward the bin's size.
+
+That the reference-integrity gate shows it as broken rather than silently wrong is
+why this was a papercut rather than data loss — and also why nobody had to fix it,
+which is how it survived.
+
+🔴 The name has to be the REGISTRY name, not the directory basename. A library
+registered as 「婚禮案素材庫」 can live in a folder called `wedding`; matching on the
+basename silently matches nothing and the whole cleanup becomes a no-op that looks
+like it ran.
+"""
+import importlib
+
+import pytest
+
+bins = importlib.import_module("bins")
+projects = importlib.import_module("projects")
+
+
+@pytest.fixture(autouse=True)
+def isolated_bins(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARKIV_BINS_PATH", str(tmp_path / "bins.json"))
+    yield
+
+
+def _bin_with(name, items):
+    b = bins.create_bin(name)
+    bins.add_items(b.id, items)
+    return bins.get_bin(b.id)
+
+
+def _item(project, mid, filename="clip.mp4"):
+    return {"project_name": project, "media_id": mid, "filename": filename}
+
+
+# ── remove_media_everywhere ──────────────────────────────────────────────────
+def test_removes_the_clip_from_every_bin_that_held_it():
+    a = _bin_with("A", [_item("庫一", 7), _item("庫一", 8)])
+    b = _bin_with("B", [_item("庫一", 7)])
+    c = _bin_with("C", [_item("庫一", 9)])
+
+    touched = bins.remove_media_everywhere("庫一", 7)
+
+    assert touched == 2, "two bins held it; the third must not be counted"
+    assert [i.media_id for i in bins.get_bin(a.id).items] == ["8"]
+    assert bins.get_bin(b.id).items == []
+    assert [i.media_id for i in bins.get_bin(c.id).items] == ["9"]
+
+
+def test_a_clip_in_no_bin_touches_nothing():
+    a = _bin_with("A", [_item("庫一", 7)])
+    before = bins.get_bin(a.id).updated_at
+
+    assert bins.remove_media_everywhere("庫一", 999) == 0
+    assert bins.get_bin(a.id).updated_at == before, "an untouched bin must not be re-stamped"
+
+
+def test_no_match_does_not_rewrite_the_file(monkeypatch):
+    """Every delete calls this, and most clips are in no bin at all. Rewriting a
+    shared JSON on each one is a pointless write against a file other requests
+    are reading — invisible in the data, which is why it needs asserting on the
+    call rather than on the contents."""
+    _bin_with("A", [_item("庫一", 7)])
+    writes = {"n": 0}
+    real = bins.save_bins
+    monkeypatch.setattr(bins, "save_bins",
+                        lambda data: (writes.__setitem__("n", writes["n"] + 1), real(data))[1])
+
+    bins.remove_media_everywhere("庫一", 999)
+    assert writes["n"] == 0
+
+    bins.remove_media_everywhere("庫一", 7)
+    assert writes["n"] == 1, "a real removal still has to persist"
+
+
+def test_the_same_media_id_in_another_project_is_left_alone():
+    """media_id is per-project auto-increment, so id 7 exists in every library.
+    Removing it from one must not reach into the others.
+
+    Written straight to the bins file rather than through `add_items`: a bin
+    spanning two projects is a Pro feature and `add_items` refuses it without the
+    add-on. The removal path has no such gate, and a Pro user's cross-project bin
+    still has to be swept correctly — so the state is constructed rather than
+    built through an API that would not let a free install reach it.
+    """
+    bins.save_bins({
+        "version": bins.BINS_VERSION,
+        "bins": [{
+            "id": "b1", "name": "A",
+            "created_at": None, "updated_at": None,
+            "items": [_item("庫一", 7), _item("庫二", 7)],
+        }],
+    })
+
+    assert bins.remove_media_everywhere("庫一", 7) == 1
+
+    remaining = [(i.project_name, i.media_id) for i in bins.get_bin("b1").items]
+    assert remaining == [("庫二", "7")]
+
+
+def test_media_id_type_does_not_matter():
+    """The API takes ints, the JSON stores strings."""
+    a = _bin_with("A", [_item("庫一", 7)])
+    assert bins.remove_media_everywhere("庫一", "7") == 1
+    assert bins.get_bin(a.id).items == []
+
+
+def test_removal_survives_a_reload():
+    a = _bin_with("A", [_item("庫一", 7)])
+    bins.remove_media_everywhere("庫一", 7)
+    # fresh read straight off disk, not the in-memory objects
+    assert bins.get_bin(a.id).items == []
+
+
+# ── the registry name ────────────────────────────────────────────────────────
+def test_current_registry_name_when_unregistered(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARKIV_PROJECTS_REGISTRY", str(tmp_path / "reg.json"))
+    monkeypatch.delenv("ARKIV_PROJECT_ROOTS", raising=False)
+    assert projects.current_registry_name() is None
+
+
+def test_current_registry_name_is_the_registry_name_not_the_basename(
+    tmp_path, monkeypatch
+):
+    import config
+
+    monkeypatch.setenv("ARKIV_PROJECTS_REGISTRY", str(tmp_path / "reg.json"))
+    monkeypatch.delenv("ARKIV_PROJECT_ROOTS", raising=False)
+    projects.add_project("我的素材庫", str(config.PROJECT_ROOT))
+
+    got = projects.current_registry_name()
+    assert got == "我的素材庫"
+    assert got != config.PROJECT_ROOT.name, "the whole point is that they differ"
+
+
+def test_analytics_still_exposes_its_helper():
+    """R5-25 route-ownership asserts this attribute lives on the analytics
+    module. The implementation moved; the name must not."""
+    import routers.analytics as ra
+
+    assert hasattr(ra, "_current_project_registry_name")
+    assert ra._current_project_registry_name() == projects.current_registry_name()
+
+
+# ── wired into the delete ────────────────────────────────────────────────────
+def test_delete_clears_the_clip_out_of_bins(monkeypatch, tmp_path):
+    import media_delete
+
+    a = _bin_with("A", [_item("庫一", 42), _item("庫一", 43)])
+    monkeypatch.setattr(projects, "current_registry_name", lambda: "庫一")
+
+    seen = {}
+    real = bins.remove_media_everywhere
+
+    def spy(project, mid):
+        seen["args"] = (project, mid)
+        return real(project, mid)
+
+    monkeypatch.setattr(bins, "remove_media_everywhere", spy)
+    monkeypatch.setattr(media_delete.db, "get_conn", _conn_returning_row(tmp_path))
+    monkeypatch.setattr(media_delete.db, "delete_media", lambda mid: [])
+    monkeypatch.setattr(media_delete.db, "trash_media", lambda *a, **k: None)
+
+    media_delete.delete_media_full(42, allow_file_delete=False)
+
+    assert seen["args"] == ("庫一", 42)
+    assert [i.media_id for i in bins.get_bin(a.id).items] == ["43"]
+
+
+def test_delete_still_succeeds_when_bins_are_unusable(monkeypatch, tmp_path):
+    """The row, files and vectors are already gone by this point. Failing the
+    delete because a JSON file could not be rewritten would report failure for
+    work that actually happened."""
+    import media_delete
+
+    def boom(*_a, **_k):
+        raise OSError("bins file is read-only")
+
+    monkeypatch.setattr(projects, "current_registry_name", lambda: "庫一")
+    monkeypatch.setattr(bins, "remove_media_everywhere", boom)
+    monkeypatch.setattr(media_delete.db, "get_conn", _conn_returning_row(tmp_path))
+    monkeypatch.setattr(media_delete.db, "delete_media", lambda mid: [])
+    monkeypatch.setattr(media_delete.db, "trash_media", lambda *a, **k: None)
+
+    assert media_delete.delete_media_full(42, allow_file_delete=False)["ok"] is True
+
+
+def test_delete_skips_the_cleanup_when_the_project_is_unregistered(monkeypatch, tmp_path):
+    """An unregistered project cannot own bin items in the first place, so there
+    is nothing to look for — and calling with None would match the literal
+    string 'None'."""
+    import media_delete
+
+    a = _bin_with("A", [_item("None", 42)])
+    monkeypatch.setattr(projects, "current_registry_name", lambda: None)
+    monkeypatch.setattr(media_delete.db, "get_conn", _conn_returning_row(tmp_path))
+    monkeypatch.setattr(media_delete.db, "delete_media", lambda mid: [])
+    monkeypatch.setattr(media_delete.db, "trash_media", lambda *a, **k: None)
+
+    media_delete.delete_media_full(42, allow_file_delete=False)
+
+    assert len(bins.get_bin(a.id).items) == 1, "a 'None'-named project must not be swept"
+
+
+def _conn_returning_row(tmp_path):
+    """Minimal db.get_conn stand-in: one media row, no real database."""
+    import contextlib
+
+    class _Row(dict):
+        def __getitem__(self, k):
+            return dict.__getitem__(self, k)
+
+    class _Conn:
+        def execute(self, sql, params=None):
+            class _C:
+                def fetchone(self_inner):
+                    return _Row(id=42, path=str(tmp_path / "gone.mp4"), filename="gone.mp4")
+            return _C()
+
+    @contextlib.contextmanager
+    def fake():
+        yield _Conn()
+
+    return fake

--- a/tests/test_bins_id_reuse.py
+++ b/tests/test_bins_id_reuse.py
@@ -1,0 +1,208 @@
+"""A deleted clip's id gets handed to the next one, and the bin never noticed.
+
+`media.id` is `INTEGER PRIMARY KEY` — no AUTOINCREMENT — so SQLite is free to
+reuse the rowid of a deleted row. Delete clip 7, ingest anything else, and the
+new clip IS clip 7. Every 精選集 entry still pointing at 7 then resolves cleanly,
+status `ok`, to footage the user never put there. 精選集 is also what feeds the
+cross-project copy, so the wrong clip does not just get shown: it gets copied.
+
+`remove_media_everywhere` closes the window for deletes made from now on. It
+cannot help the two populations that already exist — entries added before it
+shipped (every install today) and entries whose cleanup failed — and for those
+the only defence is noticing the swap. That is what these tests pin.
+
+Retiring this: if `media.id` ever gains AUTOINCREMENT, the premise test below
+fails, and it is the one that says the rest is still load-bearing.
+"""
+import importlib
+import sqlite3
+
+import pytest
+
+bins = importlib.import_module("bins")
+
+
+def _project(tmp_path, name, rows, *, make_files=True):
+    """A registrable project whose media table is spelled exactly as production
+    spells it — `INTEGER PRIMARY KEY`, no AUTOINCREMENT. `rows` is a list of
+    (id_or_None, path, filename); None lets SQLite assign, which is the whole
+    point of the reuse test."""
+    root = tmp_path / name
+    arkiv = root / ".arkiv"
+    arkiv.mkdir(parents=True, exist_ok=True)
+    (arkiv / "chroma_db").mkdir(exist_ok=True)
+    conn = sqlite3.connect(str(arkiv / "project.db"))
+    conn.execute(
+        "CREATE TABLE media (id INTEGER PRIMARY KEY, path TEXT, filename TEXT, "
+        "duration_s REAL, rating TEXT, lang TEXT, ext TEXT, transcript TEXT)"
+    )
+    for mid, path, filename in rows:
+        conn.execute("INSERT INTO media (id, path, filename) VALUES (?, ?, ?)",
+                     (mid, path, filename))
+        if make_files:
+            target = root / path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(b"stub-media")
+    conn.commit()
+    conn.close()
+    return root
+
+
+def _register(tmp_path, monkeypatch, name, root):
+    monkeypatch.setenv("ARKIV_PROJECTS_REGISTRY", str(tmp_path / "registry.json"))
+    monkeypatch.delenv("ARKIV_PROJECT_ROOTS", raising=False)
+    projects = importlib.import_module("projects")
+    projects.add_project(name, str(root))
+    return projects
+
+
+@pytest.fixture(autouse=True)
+def isolated_bins(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARKIV_BINS_PATH", str(tmp_path / "bins.json"))
+    yield
+
+
+def _swap(root, old_id, new_path, new_filename):
+    """Delete a row and ingest another, exactly as a delete + ingest would.
+    Returns the id SQLite assigned to the newcomer."""
+    conn = sqlite3.connect(str(root / ".arkiv" / "project.db"))
+    conn.execute("DELETE FROM media WHERE id = ?", (old_id,))
+    cur = conn.execute("INSERT INTO media (path, filename) VALUES (?, ?)",
+                       (new_path, new_filename))
+    assigned = cur.lastrowid
+    conn.commit()
+    conn.close()
+    target = root / new_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"different-media")
+    return assigned
+
+
+# ── the premise ──────────────────────────────────────────────────────────────
+def test_sqlite_hands_a_deleted_id_to_the_next_clip(tmp_path):
+    """Not a test of arkiv — a test of the assumption everything below rests on.
+    If this ever fails, the schema gained AUTOINCREMENT and the filename check
+    below is dead weight that can be removed.
+
+    Also pins WHICH id gets reused, which is the part that is easy to get
+    backwards: without AUTOINCREMENT SQLite assigns `max(rowid) + 1`, so a hole
+    in the middle is never filled — only the HIGHEST id comes back. That reads
+    like it narrows the blast radius, and it does the opposite. The highest id is
+    the most recently ingested clip, which is exactly the one someone just
+    added to a bin, looked at again, and deleted."""
+    root = _project(tmp_path, "lib",
+                    [(1, "clips/黑沙灘.mov", "黑沙灘.mov"),
+                     (2, "clips/海邊.mov", "海邊.mov")])
+
+    assert _swap(root, 2, "clips/婚禮.mp4", "婚禮.mp4") == 2, \
+        "the highest id was handed straight to the next clip"
+
+    root2 = _project(tmp_path, "lib2",
+                     [(1, "clips/黑沙灘.mov", "黑沙灘.mov"),
+                      (2, "clips/海邊.mov", "海邊.mov")])
+    assert _swap(root2, 1, "clips/婚禮.mp4", "婚禮.mp4") == 3, \
+        "a hole below the maximum is left alone"
+
+
+# ── the gate ─────────────────────────────────────────────────────────────────
+def test_a_reused_id_is_not_reported_ok(tmp_path, monkeypatch):
+    """The failure this whole file exists for. Before the filename check this
+    returned STATUS_OK and the bin showed the wrong clip without a mark."""
+    root = _project(tmp_path, "lib", [(1, "clips/黑沙灘.mov", "黑沙灘.mov")])
+    _register(tmp_path, monkeypatch, "lib", root)
+    _swap(root, 1, "clips/婚禮.mp4", "婚禮.mp4")
+
+    assert bins.bin_item_status("lib", "1", "黑沙灘.mov") == bins.STATUS_ID_REUSED
+
+
+def test_the_clip_that_is_still_itself_stays_ok(tmp_path, monkeypatch):
+    """The other half: no false positive on the overwhelmingly common case."""
+    root = _project(tmp_path, "lib", [(1, "clips/黑沙灘.mov", "黑沙灘.mov")])
+    _register(tmp_path, monkeypatch, "lib", root)
+
+    assert bins.bin_item_status("lib", "1", "黑沙灘.mov") == bins.STATUS_OK
+
+
+def test_an_item_that_never_stored_a_filename_is_trusted(tmp_path, monkeypatch):
+    """A documented compromise, not an oversight. Items added by a tuple caller,
+    or before the field was populated, have nothing to compare — and reporting
+    every one of them as swapped would be worse than missing the real ones."""
+    root = _project(tmp_path, "lib", [(1, "clips/黑沙灘.mov", "黑沙灘.mov")])
+    _register(tmp_path, monkeypatch, "lib", root)
+    _swap(root, 1, "clips/婚禮.mp4", "婚禮.mp4")
+
+    assert bins.bin_item_status("lib", "1", "") == bins.STATUS_OK
+    assert bins.bin_item_status("lib", "1") == bins.STATUS_OK, "default is trust"
+
+
+def test_whitespace_is_not_a_difference_on_either_side(tmp_path, monkeypatch):
+    """Both sides get stripped, and both directions need pinning.
+
+    The asymmetric case is the realistic one: the stored name travels through the
+    browser and JSON, the row name comes straight out of SQLite, and anything in
+    between that trims for display would leave the two differing by whitespace
+    alone. That is a false 'this is a different clip' on a clip that never
+    moved — the failure mode that makes a warning worth ignoring."""
+    root = _project(tmp_path, "lib", [(1, "clips/黑沙灘.mov", "黑沙灘.mov")])
+    _register(tmp_path, monkeypatch, "lib", root)
+    assert bins.bin_item_status("lib", "1", "  黑沙灘.mov  ") == bins.STATUS_OK
+
+    padded = _project(tmp_path, "lib2", [(1, "clips/黑沙灘.mov", "  黑沙灘.mov  ")])
+    _register(tmp_path, monkeypatch, "lib2", padded)
+    assert bins.bin_item_status("lib2", "1", "黑沙灘.mov") == bins.STATUS_OK
+
+
+def test_a_missing_row_still_reads_as_missing_not_as_a_swap(tmp_path, monkeypatch):
+    """Order matters: row_missing is checked first, and it is the more accurate
+    answer. A swap needs a row to swap TO."""
+    root = _project(tmp_path, "lib", [(1, "clips/黑沙灘.mov", "黑沙灘.mov")])
+    _register(tmp_path, monkeypatch, "lib", root)
+
+    assert bins.bin_item_status("lib", "999", "黑沙灘.mov") == bins.STATUS_ROW_MISSING
+
+
+# ── the batch path has to agree ──────────────────────────────────────────────
+def test_the_batched_probe_catches_it_too(tmp_path, monkeypatch):
+    """The UI reads statuses through the batch. A check that only lives in the
+    per-item path protects nothing a user would ever see."""
+    root = _project(tmp_path, "lib",
+                    [(1, "clips/黑沙灘.mov", "黑沙灘.mov"),
+                     (2, "clips/海邊.mov", "海邊.mov")])
+    _register(tmp_path, monkeypatch, "lib", root)
+    # id 2, not 1 — see the premise test: only the highest id is ever reused.
+    _swap(root, 2, "clips/婚禮.mp4", "婚禮.mp4")
+
+    b = bins.create_bin("A")
+    bins.add_items(b.id, [
+        {"project_name": "lib", "media_id": 1, "filename": "黑沙灘.mov"},
+        {"project_name": "lib", "media_id": 2, "filename": "海邊.mov"},
+    ])
+    got = bins.bin_item_statuses(bins.get_bin(b.id).items)
+
+    assert got[("lib", "2")] == bins.STATUS_ID_REUSED
+    assert got[("lib", "1")] == bins.STATUS_OK, "the untouched neighbour must not be flagged"
+
+
+def test_tuple_callers_still_work(tmp_path, monkeypatch):
+    """The batch accepts bare (name, id) tuples, which carry no filename. They
+    must keep working rather than blowing up on the missing attribute."""
+    root = _project(tmp_path, "lib", [(1, "clips/黑沙灘.mov", "黑沙灘.mov")])
+    _register(tmp_path, monkeypatch, "lib", root)
+
+    assert bins.bin_item_statuses([("lib", 1)]) == {("lib", "1"): bins.STATUS_OK}
+
+
+# ── the copy is the expensive failure ────────────────────────────────────────
+def test_resolve_source_withholds_the_path_for_a_reused_id(tmp_path, monkeypatch):
+    """`resolve_source` is what the cross-project copy asks for the file to
+    read. A reused id getting an absolute path back here means the wrong footage
+    is physically copied into another project and ingested there — the one
+    outcome in this whole bug that cannot be undone by fixing a JSON file."""
+    root = _project(tmp_path, "lib", [(1, "clips/黑沙灘.mov", "黑沙灘.mov")])
+    _register(tmp_path, monkeypatch, "lib", root)
+    _swap(root, 1, "clips/婚禮.mp4", "婚禮.mp4")
+
+    info = bins.resolve_source("lib", 1, "黑沙灘.mov")
+
+    assert info["status"] == bins.STATUS_ID_REUSED
+    assert info["absolute_path"] == "", "the copy gate reads this; it must stay empty"


### PR DESCRIPTION
精選集用 `(registry 名, media_id)` 指涉素材。刪除從來沒有碰過 bins，而那個引用**在任何情況下都回不到原本那支素材**：

```
delete_media_full  → 刪掉 media 列，id 消失
回收桶還原          → 搬回檔案「再重新 ingest」→ 產生新的 id
舊 bin 條目         → 指不回去了，還一直算在 bin 的數量裡
```

由 @pixb 在他 fork 修過（`2807087`），那是他四件從未提給上游的改動之一。

> 🔴 **本 PR 第一顆 commit（`9749060`）與這段說明的初版，都寫了一句錯的話**：
> 「引用完整性閘門把它顯示成壞掉的而不是靜默錯誤，是這件事只是刺而不是資料損失的原因。」
> **不成立。** 詳見下面〈第二顆 commit〉。原句留在 commit message 裡不動（不 force-push），
> 更正寫在這裡與 `5775ca4`。

## 修法

`bins.remove_media_everywhere(project_name, media_id) -> int`，一次鎖、一次掃過整份檔。不是對每個 bin 呼叫 `remove_item`：那會依 bin 數重複讀寫與加鎖，而刪除不是做 N 次寫入的好時機。

`media_delete` 刪完後呼叫它，**best-effort** —— 到那一步列、檔案、向量都已經沒了，因為一個 JSON 寫不進去就回報刪除失敗，是為已經發生的事回報失敗。

🔴 **名字必須是 registry 名，不是資料夾名。** 登記成「婚禮案素材庫」的庫可以放在叫 `wedding` 的資料夾裡；用資料夾名比對會**靜默匹配不到**，整個清理變成一個看起來有跑的 no-op。

實作因此從 `routers/analytics.py` 移到 `projects.py`（它回答的是 registry 的問題，而 `media_delete` 要同一個答案）。analytics 保留同名函式當委派 —— **R5-25 的 route-ownership 測試斷言那個屬性必須在該模組上**。

## 過程中被測試接住的兩件

⚠️ **第一版是 no-op 而且靜默。** 我在新函式寫 `_config.PROJECT_ROOT`，但 `projects.py` 的 `import config as _config` 寫在**另一個函式裡面**，模組層沒這個名字 → `NameError` → 被我自己的 `except Exception` 吞掉 → 回 None。**那個寬鬆的 except 正是讓它變成靜默 None 而不是大聲失敗的原因。**

⚠️ **跨專案的 bin 是 Pro 功能**，`add_items` 會擋。測「同 id 不同專案不受影響」只好直接寫 bins 檔造狀態 —— 移除路徑沒有那個閘門，Pro 使用者的跨專案 bin 仍然要被正確清掉。

---

# 第二顆 commit（`5775ca4`）：那句「只是刺」是錯的

`media.id` 是 `INTEGER PRIMARY KEY`，**沒有 `AUTOINCREMENT`** —— SQLite 會把刪掉的 rowid 直接發給下一次 INSERT。實測：

```
初始: [(1, 'a.mp4'), (2, 'b.mp4')]
刪 id=2 再 insert: [(1, 'a.mp4'), (2, 'c.mp4')]
id 被重用給不同的檔案: True
```

所以殘留的條目不是「永遠停在 `ROW_MISSING`」。它只停到**下一次匯入**為止，之後就乾乾淨淨地回報 `ok`，指向使用者從來沒放進那個精選集的素材。而閘門看不出來 —— 它手上沒有任何東西能在同一個 id 底下分辨兩支不同的片子。

⚠️ 會被重用的**只有最大的那個 id**（無 AUTOINCREMENT 時是 `max(rowid)+1`，中間的洞不會被填）。這聽起來像縮小了範圍，實際相反：最大的 id 就是最近匯入的那支，正是「剛加進精選集、又回頭看了一眼、然後刪掉」的那一支。

### ① 加身分比對

條目本來就有存 `filename`，只是沒有人拿它跟資料庫的列比對過。新增 `STATUS_ID_REUSED`，單筆與批次兩條路徑都比。

這條是給**已經存在的**殘留條目用的 —— `remove_media_everywhere` 只堵得住從今以後的刪除，堵不住每一個現有安裝早就累積的那些。

沒存檔名的條目（tuple 呼叫端、早期資料）一律**信任**。刻意的取捨：把它們全部標成「被換掉」，比漏掉真正被換掉的更糟。

### ② 傳到複製閘門

`resolve_source` 是跨專案複製拿檔案路徑的地方。重用的 id 在這裡拿到絕對路徑，等於把錯的素材實際複製進另一個專案再 ingest —— **這整個 bug 裡唯一無法靠修 JSON 還原的結果**。`routers/bins.py` 現在把 `item.filename` 傳下去，而 `test_bin_copy` 的 stub 改成**斷言**收得到它，不是忽略。

### ③ 前端那個 fallback 是有毒的

`MainLive` 送 ``filename: name || `#${id}` ``，而 `#7` 永遠不等於真檔名 —— 拿不到名字的每一支都會被誤判成 `id_reused`。改送空字串；顯示端（`Bins.svelte`）本來就有 `#id` 的 fallback，那個 fallback 對顯示是多餘的。

### ④ 收窄兩個吞掉一切的 except

- `media_delete` 原本把整段精選集清理包在 `except Exception: pass`，import 錯誤與 registry 查詢一起被吞。現在只包 `remove_media_everywhere()` 本身，失敗走既有的 `warning` 欄位（會進 API 回應與 audit log）。刪除本身仍然不因此失敗，但**不准無聲**。
- `projects.current_registry_name` 原本把 `_normalize_key(_config.PROJECT_ROOT)` 也包起來。那是純路徑運算，沒有合理的失敗；上面那個 NameError 就是被它吞掉的。**那個 bug 在守衛還在的期間，長得跟一個受支援的狀態一模一樣。** 讀不到 registry 的那個 except 保留，那才真的是 runtime 狀況。

### 沒有做的事

**沒有加 `AUTOINCREMENT`。** 那是根治，但它是對使用者現有素材庫的 schema migration，不該單方面決定。上面四項在不動 schema 的前提下把傷害關掉；真要根治是另一支 PR，且要先想清楚遷移。

## 測試

第一顆 commit 12 支，第二顆新增 `tests/test_bins_id_reuse.py`（10 支）＋既有兩檔 4 支。

| Mutation（第一顆） | 結果 | | Mutation（第二顆） | 結果 |
|---|---|---|---|---|
| M1 只清第一個 bin 就停 | 1 紅 | | N1 比對永遠說沒差 | 3 紅 |
| M2 忽略 `project_name` | 1 紅 | | N2 沒存檔名時當作被換掉 | 5 紅 |
| M3 沒命中也重寫檔 | 1 紅 | | N3 不 strip | 1 紅 |
| M4 拿掉 bins 清理 | 1 紅 | | N4 拿掉單筆檢查 | 2 紅 |
| M5 未登記時用 `"None"` 掃 | 1 紅 | | N5 拿掉批次檢查 | 1 紅 |
| M6 委派回傳寫死 None | 1 紅 | | N6 `resolve_source` 不傳檔名 | 1 紅 |
| | | | N7 檢查排到 row_missing 之前 | 1 紅 |
| | | | N8 複製閘門不傳 `item.filename` | 5 紅 |
| | | | N9 精選集清理失敗又被吞掉 | 1 紅 |
| | | | N10 第二個 warning 蓋掉第一個 | 1 紅 |
| | | | N11 路徑計算又包回 try/except | 1 紅 |

6/6＋11/11 全殺。兩輪各有一支**第一次存活**：

⚠️ **M3**：不是正確性 bug（`updated_at` 沒被動到，資料看不出差別），而是**每次刪除都對共用 JSON 多寫一次** —— 大多數素材根本不在任何 bin 裡。補一支直接驗 `save_bins` 呼叫次數的測試才守得住。

⚠️ **N3**：我的空白測試只加在「當初存的」那一側，而 mutant 拿掉的是「資料庫那一側」的 strip。補上不對稱的方向 —— 存的名字經過瀏覽器與 JSON、列的名字直接出自 SQLite，中間任何一層為了顯示 trim 過，兩邊就會只差空白。那會變成對一支根本沒動過的素材報「這是別支」，而那正是讓警示變得可以無視的失效模式。

`test_sqlite_hands_a_deleted_id_to_the_next_clip` 釘的是**前提**而不是 arkiv：哪天 schema 加了 AUTOINCREMENT，它會紅，而它就是那個負責說「上面那些還撐著」的。

全套 **1967 passed / 11 skipped**（已 merge main，含 #426／#427／#428），前端 build 綠。

Reported-by: pixb <https://github.com/pixb>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BznCya8zniew2fVKvPXJrP
