### PR TITLE
fix(mcp): 任何 token 都能讀全庫，而我加的 :ro 把語意搜尋弄死了

### DIFF
--- a/docker-compose.remote-ollama.yml
+++ b/docker-compose.remote-ollama.yml
@@ -86,9 +86,25 @@ services:
     ports:
       - "8502:8502"
     volumes:
-      # Read-only: MCP exposes queries, never ingest or delete.
+      # 🔴 chroma_db is NOT :ro. chromadb 1.5.5 cannot open a read-only persist
+      # dir — it raises `attempt to write a readonly database` — and
+      # mcp_server's search falls through a blanket `except Exception` to a SQL
+      # LIKE scan with NO search_degraded flag (only a dimension mismatch sets
+      # that). Semantic search over MCP would be dead on arrival and look
+      # perfectly healthy. Measured 2026-09-05. The read-only guarantee comes
+      # from the tool surface — all seven tools only read — not from the mount.
+      - ./chroma_db:/app/chroma_db
+      # ⚠️ Single-FILE bind mount hides the host's WAL. SQLite keeps `-wal` /
+      # `-shm` as siblings of the db file; mounting only the file gives this
+      # container its own, so it reads the last CHECKPOINT rather than what
+      # arkiv has committed. Measured with the writer connection held open:
+      #     single-file mount → 1 of 2 rows      directory mount → 2 of 2
+      # The arkiv service has always mounted it this way; with one container it
+      # did not matter, because that container owned the only WAL. A second
+      # container makes it live. Fixing it properly means moving media.db under
+      # a mounted DIRECTORY, which relocates existing users' data — a breaking
+      # change, not a 3am one. Until then: MCP may serve a slightly stale view.
       - ./media.db:/app/media.db:ro
-      - ./chroma_db:/app/chroma_db:ro
       - ./thumbnails:/app/thumbnails:ro
       - ${ARKIV_MEDIA_DIR:-./media}:/media:ro
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,10 +137,25 @@ services:
     ports:
       - "8502:8502"
     volumes:
-      # Read-only: MCP exposes queries, never ingest or delete. The mount being
-      # ro is a second lock behind that, not a substitute for it.
+      # 🔴 chroma_db is NOT :ro. chromadb 1.5.5 cannot open a read-only persist
+      # dir — it raises `attempt to write a readonly database` — and
+      # mcp_server's search falls through a blanket `except Exception` to a SQL
+      # LIKE scan with NO search_degraded flag (only a dimension mismatch sets
+      # that). Semantic search over MCP would be dead on arrival and look
+      # perfectly healthy. Measured 2026-09-05. The read-only guarantee comes
+      # from the tool surface — all seven tools only read — not from the mount.
+      - ./chroma_db:/app/chroma_db
+      # ⚠️ Single-FILE bind mount hides the host's WAL. SQLite keeps `-wal` /
+      # `-shm` as siblings of the db file; mounting only the file gives this
+      # container its own, so it reads the last CHECKPOINT rather than what
+      # arkiv has committed. Measured with the writer connection held open:
+      #     single-file mount → 1 of 2 rows      directory mount → 2 of 2
+      # The arkiv service has always mounted it this way; with one container it
+      # did not matter, because that container owned the only WAL. A second
+      # container makes it live. Fixing it properly means moving media.db under
+      # a mounted DIRECTORY, which relocates existing users' data — a breaking
+      # change, not a 3am one. Until then: MCP may serve a slightly stale view.
       - ./media.db:/app/media.db:ro
-      - ./chroma_db:/app/chroma_db:ro
       - ./thumbnails:/app/thumbnails:ro
       - ${ARKIV_MEDIA_DIR:-./media}:/media:ro
     environment:

--- a/mcp_http_server.py
+++ b/mcp_http_server.py
@@ -30,12 +30,15 @@ Env:
 from __future__ import annotations
 
 import json
+import logging
 import os
 
 from fastapi import HTTPException
 
 import auth
 import mcp_server
+
+_LOGGER = logging.getLogger(__name__)
 
 # 127.0.0.1, not 0.0.0.0. Running this file directly is the "I am on the box"
 # case and should not silently publish an MCP endpoint to the network. The
@@ -119,29 +122,61 @@ def _extract_token(scope) -> str:
     return ""
 
 
+# The scope every tool on this transport needs. All seven read media rows,
+# transcripts, frames or the vector index — the same thing `routers/media.py`
+# guards with `require_scopes("videos_read")`.
+REQUIRED_SCOPE = "videos_read"
+
+
 async def token_gate(app, scope, receive, send):
-    """ASGI middleware: reject anything without a valid arkiv token.
+    """ASGI middleware: reject anything without a valid, SUFFICIENTLY SCOPED token.
 
     Reuses `auth.resolve_raw_token`, so this endpoint inherits the same token
     store, IP allow-list and expiry as the HTTP API — an existing token works
     here unchanged, and revoking one revokes it everywhere.
+
+    🔴 Resolving the token is not the same as authorising it. The first version
+    of this file called `resolve_raw_token` and threw the result away, so ANY
+    valid token reached every tool: a `chat_read`-only token, an ingest bot's
+    token, even a zero-scope one, all read the whole library over the LAN, while
+    the REST API refused those same tokens with 403. Every narrow token ever
+    minted was a full read key the moment this transport shipped.
     """
     if scope["type"] in ("http", "websocket"):
         client_ip = (scope.get("client") or ("", 0))[0]
         try:
-            auth.resolve_raw_token(_extract_token(scope), client_ip)
+            tok = auth.resolve_raw_token(_extract_token(scope), client_ip)
         except HTTPException as exc:
-            await _refuse(send, getattr(exc, "status_code", 401), str(exc.detail))
+            await _refuse(send, scope, getattr(exc, "status_code", 401), str(exc.detail))
             return
         except Exception:
-            # Never leak the internals of an auth failure to an unauthenticated
-            # caller; the server log already has the traceback.
-            await _refuse(send, 401, "unauthorized")
+            # Never hand an unauthenticated caller the internals of an auth
+            # failure — but do log it, or a fleet-wide 401 (missing table, locked
+            # DB, unreadable token store) is undebuggable from the outside.
+            _LOGGER.exception("MCP token resolution failed")
+            await _refuse(send, scope, 401, "unauthorized")
+            return
+        if REQUIRED_SCOPE not in (tok or {}).get("scopes", ()):
+            await _refuse(
+                send, scope, 403,
+                "Insufficient scope: MCP needs {0}".format(REQUIRED_SCOPE),
+            )
             return
     await app(scope, receive, send)
 
 
-async def _refuse(send, status: int, detail: str) -> None:
+async def _refuse(send, scope, status: int, detail: str) -> None:
+    """Refuse in the protocol the caller is actually speaking.
+
+    A websocket scope cannot be answered with `http.response.start`: uvicorn
+    raises RuntimeError and turns a clean rejection into a 500 plus a traceback
+    per attempt. There are no websocket routes here, so the only thing that
+    reaches this branch is someone probing — and letting them fill the log is
+    the one thing an unauthenticated neighbour could otherwise do.
+    """
+    if scope.get("type") == "websocket":
+        await send({"type": "websocket.close", "code": 1008})
+        return
     body = json.dumps({"error": detail}).encode("utf-8")
     await send({
         "type": "http.response.start",
@@ -173,7 +208,16 @@ def build_app():
 def main() -> None:
     mcp_server._prewarm_vectordb()
     import uvicorn
-    uvicorn.run(build_app(), host=BIND, port=PORT)
+
+    # 🔴 proxy_headers defaults to True, and with no `forwarded_allow_ips` uvicorn
+    # trusts 127.0.0.1. BIND also defaults to 127.0.0.1, so in host-run mode EVERY
+    # peer is loopback and therefore trusted: a token whose IP allow-list says
+    # 10.0.0.0/8 is refused from localhost, then accepted by adding
+    # `X-Forwarded-For: 10.1.1.1` — and the audit trail records the spoofed IP.
+    # The same hole is open behind any tunnel that does not set XFF itself
+    # (`ssh -L`, socat). arkiv terminates its own connections; nothing here sits
+    # behind a reverse proxy, so the header has no legitimate reading.
+    uvicorn.run(build_app(), host=BIND, port=PORT, proxy_headers=False)
 
 
 if __name__ == "__main__":

--- a/tests/test_compose_deploy.py
+++ b/tests/test_compose_deploy.py
@@ -183,12 +183,34 @@ def test_mcp_service_exists_and_runs_the_http_server(compose):
 
 
 @pytest.mark.parametrize("compose", [SINGLE_HOST, SPLIT_HOST], ids=["single", "split"])
-def test_mcp_mounts_are_read_only(compose):
-    """MCP exposes queries, never ingest or delete. `:ro` is a second lock behind
-    the tool surface, not a substitute for it — a bug that let a write through
-    would still hit a read-only filesystem."""
+def test_mcp_mounts_are_read_only_except_the_one_that_cannot_be(compose):
+    """`:ro` was meant as a second lock behind a tool surface that only reads.
+
+    🔴 On `chroma_db` it is not a lock, it is a break. chromadb 1.5.5 cannot open
+    a read-only persist dir (`attempt to write a readonly database`), and
+    `mcp_server`'s search swallows that in a blanket `except Exception` and
+    degrades to a SQL LIKE scan — with no `search_degraded` flag, because only a
+    dimension mismatch sets one. Semantic search over MCP would be dead and look
+    healthy. Measured 2026-09-05.
+
+    The read-only guarantee has to come from the tools, which is where it
+    actually lives; the mount was belt-and-braces that strangled the wearer.
+    """
+    writable = [v for v in _mcp(compose)["volumes"] if not v.endswith(":ro")]
+    assert writable == ["./chroma_db:/app/chroma_db"], (
+        "only chroma_db may be writable on the MCP service, got: {0}".format(writable)
+    )
+
+
+@pytest.mark.parametrize("compose", [SINGLE_HOST, SPLIT_HOST], ids=["single", "split"])
+def test_chroma_is_not_mounted_read_only(compose):
+    """Stated on its own so a future tidy-up that "fixes the inconsistency" by
+    adding `:ro` back fails here instead of silently killing semantic search."""
     for entry in _mcp(compose)["volumes"]:
-        assert entry.endswith(":ro"), "writable mount on the MCP service: " + entry
+        if "/app/chroma_db" in entry:
+            assert not entry.endswith(":ro"), (
+                "chromadb cannot open a read-only dir; see the compose comment"
+            )
 
 
 @pytest.mark.parametrize("compose", [SINGLE_HOST, SPLIT_HOST], ids=["single", "split"])

--- a/tests/test_mcp_http_server.py
+++ b/tests/test_mcp_http_server.py
@@ -172,6 +172,75 @@ def test_no_token_is_refused(monkeypatch):
     assert sent[0]["status"] == 401
 
 
+# ── scope, not just identity ─────────────────────────────────────────────────
+@pytest.mark.parametrize("scopes", [[], ["chat_read"], ["ingest_write"], ["admin"]])
+def test_a_valid_token_without_videos_read_is_refused(monkeypatch, scopes):
+    """🔴 The audit finding. The first version resolved the token and discarded
+    the result, so ANY valid token — a chat widget's, an ingest bot's, a
+    zero-scope one — read the entire library over the LAN, while REST answered
+    403 to those same tokens. Note `admin` is in this list on purpose: arkiv's
+    scopes are a flat set, not a hierarchy, and REST does not treat admin as a
+    superset either."""
+    reached, sent = _run_gate(
+        monkeypatch,
+        _scope([(b"authorization", b"Bearer tok")]),
+        lambda raw, ip: {"scopes": scopes},
+    )
+    assert reached is False
+    assert sent[0]["status"] == 403
+
+
+def test_videos_read_gets_through(monkeypatch):
+    reached, _ = _run_gate(
+        monkeypatch,
+        _scope([(b"authorization", b"Bearer tok")]),
+        lambda raw, ip: {"scopes": ["chat_read", "videos_read"]},
+    )
+    assert reached is True
+
+
+def test_a_resolver_returning_none_is_refused(monkeypatch):
+    """Defensive: a token store that answers None must not be read as
+    "unrestricted"."""
+    reached, sent = _run_gate(
+        monkeypatch, _scope([(b"authorization", b"Bearer tok")]), lambda raw, ip: None)
+    assert reached is False
+    assert sent[0]["status"] == 403
+
+
+def test_the_required_scope_matches_what_rest_asks_for():
+    """If REST's media routes ever move off videos_read, this transport must
+    move with them rather than quietly becoming the looser door."""
+    rest = (ROOT_MEDIA_ROUTER := importlib.import_module("routers.media"))
+    src = open(rest.__file__, encoding="utf-8").read()
+    assert 'require_scopes("{0}")'.format(mcp_http_server.REQUIRED_SCOPE) in src
+
+
+# ── refusing in the right protocol ───────────────────────────────────────────
+def test_a_websocket_is_closed_not_answered_with_http(monkeypatch):
+    """🔴 `http.response.start` on a websocket scope makes uvicorn raise
+    RuntimeError — a clean rejection becomes a 500 and a traceback per attempt.
+    There are no ws routes here, so the only caller is someone probing, and
+    filling the log is the one thing an unauthenticated neighbour could do."""
+    scope = dict(_scope(), type="websocket")
+    reached, sent = _run_gate(monkeypatch, scope, lambda raw, ip: (_ for _ in ()).throw(Exception()))
+    assert reached is False
+    assert sent[0]["type"] == "websocket.close"
+    assert not any(m["type"].startswith("http.") for m in sent)
+
+
+def test_auth_failure_is_logged(monkeypatch, caplog):
+    """The comment used to claim "the server log already has the traceback".
+    Nothing logged. A fleet-wide 401 (missing table, locked DB) was then
+    undebuggable from outside."""
+    import logging
+
+    with caplog.at_level(logging.ERROR):
+        _run_gate(monkeypatch, _scope(),
+                  lambda raw, ip: (_ for _ in ()).throw(RuntimeError("token store locked")))
+    assert any("token" in r.message.lower() for r in caplog.records)
+
+
 def test_valid_token_reaches_the_app(monkeypatch):
     seen = {}
 


### PR DESCRIPTION
fix(mcp): 任何 token 都能讀全庫，而我加的 :ro 把語意搜尋弄死了

Fable 對 #427 做的對抗式審計，五項我逐條自己驗過才修。

## 🔴 F1 — scope 根本沒有被強制（HIGH）

`token_gate` 呼叫 `auth.resolve_raw_token` 之後**把回傳值丟掉**。REST 用
`require_scopes("videos_read")` 比對 `tok["scopes"]`，MCP 沒有。所以：

    零 scope 的 token   → REST 403，MCP 拿到全部 7 個工具
    chat_read 的 token  → REST 403，MCP 拿到全部
    ingest bot 的 token → REST 403，MCP 拿到全部

**每一張為了窄用途發出去的 token，在這個 transport 上線的那一刻都變成整個素材庫
的讀取金鑰**，而且是走區網。現在要求 `videos_read`，跟 `routers/media.py` 同一個。

⚠️ **`admin` 沒有被當成萬用**：arkiv 的 scope 是平的集合不是階層，REST 也不把
admin 視為超集。有一支 mutation 專門釘這件事。

## 🔴 F5b — 我加的 `:ro` 讓語意搜尋靜默死掉（CORRECTNESS）

chromadb 1.5.5 **開不了唯讀的 persist 目錄**：`attempt to write a readonly
database`（2026-09-05 實測）。而 `mcp_server` 的搜尋只有
`EmbeddingDimensionMismatch` 會設 `search_degraded`，chromadb 的 `InternalError`
落進下面那個 blanket `except Exception` → **靜默降級成 SQL LIKE，沒有警告、沒有
旗標**。

也就是說：我為了「縱深防禦」加的那個 `:ro`，把 MCP 的語意搜尋整個弄死，而且死得
跟我整晚在修的那些 bug 一模一樣 —— 看起來很健康。唯讀的保證本來就該來自工具面
（七個工具全部只讀，Fable 逐個掃過原始碼確認），不是來自掛載。

## F3 — `X-Forwarded-For` 可以偽造 IP allow-list（LOW）

uvicorn 的 `proxy_headers` 預設 True，`forwarded_allow_ips` 未設時信任
127.0.0.1；而 `ARKIV_MCP_BIND` 預設就是 127.0.0.1，**於是每個 peer 都是 loopback
都被信任**。allow-list 寫 10.0.0.0/8 的 token 從 localhost 會被拒，加一個
`X-Forwarded-For: 10.1.1.1` 就過，而且稽核紀錄會記下那個假 IP。arkiv 自己終結連線，
前面沒有 reverse proxy，這個標頭沒有任何正當讀法 → `proxy_headers=False`。

## F6 — 兩個誠實問題

**websocket scope 走 `_refuse` 會炸。** `http.response.start` 送進 websocket
scope 會讓 uvicorn 拋 RuntimeError，一次乾淨的拒絕變成 500 加一整段 traceback。
沒有 ws 路由，所以唯一會走到那裡的是在探測的人 —— 而**填滿 log 正是未持有 token
的鄰居唯一做得到的事**。改成 `websocket.close`。

**那句「the server log already has the traceback」是我寫的，而根本沒有東西在 log。**
補上 `_LOGGER.exception`，否則整批 401（表不存在、DB 被鎖、token store 讀不到）
從外面完全無法除錯。

## ⚠️ F5a — 量到了但這支不修：單檔 bind mount 會漏掉 WAL

SQLite 的 `-wal` / `-shm` 是 db 檔的兄弟檔；只掛那一個檔，容器就有自己的一份，
讀到的是**上一次 checkpoint** 而不是 arkiv 已提交的內容。在寫入端連線仍開著時實測：

    single-file mount → 2 筆只讀到 1 筆
    directory mount   → 2 筆讀到 2 筆

arkiv 服務從一開始就是這樣掛的。單一容器時無所謂 —— 那個容器擁有唯一的 WAL；
**是我加的第二個容器把它變成活的問題**。正確修法是把 media.db 移到一個被掛載的
目錄底下，那會搬動既有使用者的資料，是破壞性變更，不該由我在凌晨自己決定。
量測與取捨已寫進 compose 註解，等 Hevin 拍板。

## 測試

66 支（新增 10 支）。六組 mutation 全數被抓：

    M1 丟掉 scope 檢查（回到審計前）    5 紅
    M2 把 admin 當成萬用 scope       1 紅
    M3 None token 當成放行           1 紅
    M4 websocket 仍回 HTTP response  1 紅
    M5 拿掉例外的 logging             1 紅
    M6 chroma_db 加回 :ro            2 紅

全套 1954 passed / 11 skipped，兩份 compose 都通過 `docker compose config`。

Audited-by: Fable 5.1
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BznCya8zniew2fVKvPXJrP
