### PR TITLE
fix(vectordb,subtitle): 清快取的動作自己製造了下一次清快取的理由

### DIFF
--- a/subtitle.py
+++ b/subtitle.py
@@ -379,15 +379,39 @@ def _apply_timing(cues: List[Cue], policy: TimingPolicy) -> List[Cue]:
     i = 0
     while i < len(out):
         s, e, lines = out[i]
-        if (e - s) < policy.min_dur and i + 1 < len(out):
+        if _is_too_short(s, e, policy) and i + 1 < len(out):
             ns, ne, nlines = out[i + 1]
-            if len(lines) + len(nlines) <= 2 and (ne - s) <= policy.max_dur:
+            # 🔴 A merge shows the absorbed cue's text from the EARLIER cue's
+            # start, i.e. before those words are spoken. That is tolerable only
+            # because a cue reaching this point had no room to grow, which bounds
+            # the lead at min_dur + min_gap. Assert the bound rather than trust
+            # it: a float slip upstream once let a cue that HAD room merge here,
+            # and the lead was then capped by nothing but max_dur — 5.7 seconds
+            # of the next sentence on screen early, in a pass whose whole promise
+            # is that text never precedes its words.
+            lead_ok = (ns - s) <= policy.min_dur + policy.min_gap + 1e-9
+            if (lead_ok
+                    and len(lines) + len(nlines) <= 2
+                    and (ne - s) <= policy.max_dur):
                 merged.append((s, ne, lines + nlines))
                 i += 2
                 continue
         merged.append((s, e, lines))
         i += 1
     return merged
+
+
+def _is_too_short(start: float, end: float, policy: TimingPolicy) -> bool:
+    """Is this cue still under `min_dur` after the extend pass had its go?
+
+    🔴 The epsilon is the whole point. `(37.259 + 0.8) - 37.259` is
+    `0.7999999999999972`, so a cue the extend pass had just lifted to exactly
+    `min_dur` measured as *short* and got merged into its neighbour — showing
+    that neighbour's text up to 5.7 s early. It held for 31.6% of three-decimal
+    start times and 102 of the 312 starts in the reference library; every test
+    started a cue at 0.0, where `0.0 + 0.8` is exact, so nothing caught it.
+    """
+    return (end - start) < policy.min_dur - 1e-9
 
 
 def _render_lines(lines: List[str], restrict_punct: bool) -> List[str]:

--- a/tests/test_chroma_staleness_thrash.py
+++ b/tests/test_chroma_staleness_thrash.py
@@ -1,0 +1,118 @@
+"""The staleness check must not treat its own cache drop as somebody else's write.
+
+#421 added an mtime check so a write from another process (embed.py, MCP, an
+ingest subprocess) invalidates this process's HNSW index. It fed itself:
+
+    check sees a newer mtime  →  drops the System cache
+    → next PersistentClient(path) has to rebuild from disk
+    → that rebuild WRITES to chroma.sqlite3, moving the mtime
+    → next call sees a newer file, drops again, forever
+
+Measured on the real chromadb before the fix: six `get_collection()` calls with
+no external write at all produced SIX drops, each reloading the whole index.
+After: one. An external write is still caught.
+
+The tests below do not need real chromadb (conftest stubs it). They reproduce
+the loop directly: a client whose construction touches the file, which is exactly
+what the rebuild does.
+"""
+import importlib
+
+import pytest
+
+vectordb = importlib.import_module("vectordb")
+
+
+@pytest.fixture
+def chroma_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(vectordb, "CHROMA_PATH", tmp_path)
+    monkeypatch.setattr(vectordb, "_CHROMA_DB_MTIME", 0.0)
+    db = tmp_path / "chroma.sqlite3"
+    db.write_text("seed")
+    return db
+
+
+def _count_drops(monkeypatch, succeeds=True):
+    calls = {"n": 0}
+
+    def fake():
+        calls["n"] += 1
+        return succeeds
+
+    monkeypatch.setattr(vectordb, "_drop_chroma_system_cache", fake)
+    return calls
+
+
+def _touch(db, offset):
+    import os
+    st = db.stat()
+    os.utime(db, (st.st_atime, st.st_mtime + offset))
+
+
+# ── the loop itself ──────────────────────────────────────────────────────────
+def test_recording_after_the_rebuild_absorbs_our_own_write(chroma_dir, monkeypatch):
+    """🔴 The regression. Simulate one full round: check, then the rebuild
+    writes, then we record. The next check must see nothing new."""
+    calls = _count_drops(monkeypatch)
+
+    vectordb._check_chroma_staleness()      # first sight of the file
+    assert calls["n"] == 1
+    _touch(chroma_dir, 5)                   # the rebuild's own write
+    vectordb._record_chroma_mtime()
+
+    vectordb._check_chroma_staleness()      # a second, idle call
+    assert calls["n"] == 1, "our own rebuild write must not read as staleness"
+
+
+def test_many_idle_rounds_drop_once(chroma_dir, monkeypatch):
+    calls = _count_drops(monkeypatch)
+    for i in range(6):
+        vectordb._check_chroma_staleness()
+        _touch(chroma_dir, 5 * (i + 1))     # every rebuild moves the file
+        vectordb._record_chroma_mtime()
+    assert calls["n"] == 1, "six idle calls dropped {0} times".format(calls["n"])
+
+
+def test_a_real_external_write_is_still_caught(chroma_dir, monkeypatch):
+    calls = _count_drops(monkeypatch)
+    vectordb._check_chroma_staleness()
+    _touch(chroma_dir, 5)
+    vectordb._record_chroma_mtime()
+
+    _touch(chroma_dir, 100)                 # another process writes
+    vectordb._check_chroma_staleness()
+    assert calls["n"] == 2
+
+
+# ── the pieces on their own ──────────────────────────────────────────────────
+def test_record_is_a_noop_when_the_file_is_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr(vectordb, "CHROMA_PATH", tmp_path)
+    monkeypatch.setattr(vectordb, "_CHROMA_DB_MTIME", 7.0)
+    vectordb._record_chroma_mtime()
+    assert vectordb._CHROMA_DB_MTIME == 7.0, "a missing file must not reset the mark"
+
+
+def test_a_failed_drop_is_still_retried(chroma_dir, monkeypatch):
+    """The ordering #421 argued for, which the thrash made unreachable in
+    production: a drop that fails must not consume the mtime."""
+    calls = _count_drops(monkeypatch, succeeds=False)
+    vectordb._check_chroma_staleness()
+    assert vectordb._CHROMA_DB_MTIME == 0.0
+    vectordb._check_chroma_staleness()
+    assert calls["n"] == 2
+
+
+def test_get_collection_records_the_mark_inside_the_lock(monkeypatch):
+    """The re-read has to happen while the lock is still held, or a concurrent
+    caller can slip a drop in between the rebuild and the record."""
+    import inspect
+
+    src = inspect.getsource(vectordb.get_collection)
+    body = src.split("with _CHROMA_LOCK:")[1]
+    record_line = next(i for i, l in enumerate(body.splitlines())
+                       if "_record_chroma_mtime()" in l)
+    dedented = [l for l in body.splitlines()[:record_line]
+                if l.strip() and not l.strip().startswith("#")]
+    assert dedented, "expected the client build to precede the record"
+    assert "_assert_collection_compatible" not in "\n".join(
+        body.splitlines()[:record_line]), "record must come before leaving the lock"

--- a/tests/test_subtitle_timing.py
+++ b/tests/test_subtitle_timing.py
@@ -39,11 +39,19 @@ def durs(cues):
     [seg(1.5, 9.0, "一段很長的旁白" * 6)],
 ])
 def test_no_cue_starts_before_its_words(segments):
-    """Every emitted start must be one of the segment starts we were given."""
-    allowed = {s["start"] for s in segments}
+    """Every emitted start is a segment start, or lies strictly inside one.
+
+    The first version of this asserted `any(start == a or start > a for a in
+    allowed)`, which is true for ANY value past the earliest segment start — 0.15
+    and 3.0 both "passed" for allowed={0.0, 0.3}. It was checking almost nothing.
+    A split chunk legitimately starts mid-segment, so that is the shape to state:
+    inside SOME segment's own span.
+    """
+    spans = [(s["start"], s["end"]) for s in segments]
     for start, _end, _lines in sub.layout_cues(segments):
-        assert any(abs(start - a) < 1e-6 or start > a for a in allowed)
-        assert start >= min(allowed) - 1e-9
+        assert any(a - 1e-9 <= start <= b + 1e-9 for a, b in spans), (
+            "cue starts at {0}, outside every segment span {1}".format(start, spans)
+        )
 
 
 @pytest.mark.parametrize("segments", [
@@ -215,3 +223,80 @@ def test_srt_output_has_a_real_gap_at_millisecond_precision():
     srt = sub.segments_to_srt([seg(0.0, 2.0, "第一句"), seg(2.0, 4.0, "第二句")])
     assert "00:00:00,000 --> 00:00:01,920" in srt
     assert "00:00:02,000 --> 00:00:04,000" in srt
+
+
+# ── the float flip (audit round 2) ───────────────────────────────────────────
+def test_a_cue_that_reached_min_dur_is_not_merged_away():
+    """🔴 The bug every earlier test missed by starting cues at 0.0.
+
+    `(37.259 + 0.8) - 37.259` is `0.7999999999999972`. The extend pass lifts a
+    short cue to exactly `min_dur`, the merge pass measures it back as SHORT, and
+    absorbs it — putting the next sentence on screen early.
+
+    The next cue starts at exactly `min_dur + min_gap`, which is the only place
+    the two guards separate: any closer and the cue genuinely cannot reach
+    `min_dur` (so merging is right), any further and the lead check refuses the
+    merge for its own reasons. Here the epsilon is the sole thing deciding, which
+    is what makes this a test OF the epsilon rather than of the pair.
+    """
+    P = sub.DEFAULT_TIMING
+    start = 37.259                                  # a start where the flip fires
+    nxt = start + P.min_dur + P.min_gap
+    assert (start + P.min_dur) - start < P.min_dur, "premise: this start flips"
+
+    cues = sub.layout_cues([seg(start, start + 0.265, "講感開們到節"),
+                            seg(nxt, nxt + 2.0, "每")])
+
+    assert len(cues) == 2, "it reached min_dur; only the float said otherwise"
+    assert cues[0][1] == pytest.approx(start + P.min_dur)
+
+
+@pytest.mark.parametrize("start", [0.001, 12.345, 99.999, 601.237, 37.259])
+def test_the_boundary_holds_at_many_starts(start):
+    """The same construction across starts that flip and starts that do not."""
+    P = sub.DEFAULT_TIMING
+    nxt = start + P.min_dur + P.min_gap
+    cues = sub.layout_cues([seg(start, start + 0.265, "真的"),
+                            seg(nxt, nxt + 2.0, "然後我們就去了")])
+    assert len(cues) == 2, "start={0} merged a cue that had room".format(start)
+
+
+def test_the_lead_a_merge_introduces_stays_within_the_bound():
+    """A merge shows the absorbed text from the earlier start — before those
+    words are spoken. That is tolerable only because a cue reaching the merge
+    pass had no room to grow, which bounds the lead at min_dur + min_gap.
+
+    ⚠️ The `lead_ok` guard in the merge cannot fire under any self-consistent
+    policy, and this test does not pretend to make it. A cue is still short after
+    the extend pass only when the next one starts within min_dur + min_gap, so
+    the lead is inside the bound by construction; raising max_dur to let a wider
+    merge through also lets the extend reach min_dur, and lowering it makes
+    `(ne - s) <= max_dur` refuse the merge first. A mutation removing `lead_ok`
+    survives the suite, and that is correct rather than a gap.
+
+    It is kept because it was NOT unreachable while the float flip was live: a
+    cue that had reached min_dur measured as short, and the lead was then bounded
+    by max_dur alone. The guard is what turns a repeat of that into a refused
+    merge rather than 5.7 seconds of early text.
+
+    What this test does is check the bound empirically across the space, which is
+    what would catch a future change that makes merging reachable from further
+    away.
+    """
+    P = sub.DEFAULT_TIMING
+    bound = P.min_dur + P.min_gap + 1e-9
+    starts = [0.0, 0.001, 12.345, 37.259, 99.999, 601.237]
+    gaps = [0.0, 0.01, 0.05, 0.2, 0.5, 0.8, 0.87, 0.88, 0.9, 1.604, 5.741]
+    merges = 0
+    for s0 in starts:
+        for gap in gaps:
+            cues = sub.layout_cues([seg(s0, s0 + 0.265, "真的"),
+                                    seg(s0 + gap, s0 + gap + 2.0, "然後我們就去了")])
+            if len(cues) == 1:
+                merges += 1
+                lead = (s0 + gap) - cues[0][0]
+                assert lead <= bound, (
+                    "start={0} gap={1}: merged text leads its words by "
+                    "{2:.4f}s, bound {3:.4f}".format(s0, gap, lead, bound)
+                )
+    assert merges, "the sweep must actually produce merges or it proves nothing"

--- a/vectordb.py
+++ b/vectordb.py
@@ -270,15 +270,47 @@ def _check_chroma_staleness() -> None:
     stays stale until the process restarts.
     """
     global _CHROMA_DB_MTIME
-    try:
-        current = (CHROMA_PATH / "chroma.sqlite3").stat().st_mtime
-    except OSError:
+    current = _chroma_db_mtime()
+    if current is None:
         # No DB on disk yet (fresh install, or a pg backend that never writes
         # one). Nothing to be stale against.
         return
     if current == _CHROMA_DB_MTIME:
         return
     if _drop_chroma_system_cache():
+        _CHROMA_DB_MTIME = current
+
+
+def _chroma_db_mtime():
+    """`chroma.sqlite3`'s mtime, or None when it is not there yet."""
+    try:
+        return (CHROMA_PATH / "chroma.sqlite3").stat().st_mtime
+    except OSError:
+        return None
+
+
+def _record_chroma_mtime() -> None:
+    """Re-read the mtime AFTER the client has been rebuilt, and treat that as the
+    high-water mark.
+
+    🔴 Without this the staleness check feeds itself. Dropping the System cache
+    forces the next `PersistentClient(path)` to rebuild from disk, and that
+    rebuild WRITES to chroma.sqlite3 — after `_check_chroma_staleness` recorded
+    the old mtime. So the next call sees a newer file, drops again, rebuilds
+    again, writes again. Measured: six `get_collection()` calls with no external
+    write at all produced six cache drops, each one reloading the whole HNSW
+    index; with this, six calls produce one.
+
+    The check was written to catch someone ELSE's write. It could not tell that
+    write apart from the one it had just caused.
+
+    A genuine external write landing between the check and this re-read is
+    recorded here as already-seen — a one-call window, closed by that writer's
+    next write. That is the trade for not thrashing on every single search.
+    """
+    global _CHROMA_DB_MTIME
+    current = _chroma_db_mtime()
+    if current is not None:
         _CHROMA_DB_MTIME = current
 
 
@@ -311,6 +343,10 @@ def get_collection(reset: bool = False):
             # on 1.5.x), so the stamp only lands when the collection is created/reset.
             metadata={"hnsw:space": "cosine", "embed_model": EMBED_MODEL, "embed_dim": EMBED_DIM},
         )
+        # Still inside the lock: the rebuild above may have written to
+        # chroma.sqlite3, and if that write is not folded into the high-water
+        # mark now, the next call reads it as somebody else's change.
+        _record_chroma_mtime()
     _assert_collection_compatible(col)
     return col
 


### PR DESCRIPTION
fix(vectordb,subtitle): 清快取的動作自己製造了下一次清快取的理由

Fable 對已併入 main 的 #421 與 #426 做的對抗式審計，兩條都自己驗過機制才修。

## #421 —— staleness 檢查自我延續，每次搜尋都在重載索引

    1. 檢查看到 mtime 變了 → 清掉 System 快取
    2. 下一個 PersistentClient(path) 因為快取被清而從磁碟重建 → 寫入 chroma.sqlite3
    3. 而 mtime 是在步驟 1 之前記錄的 → 下一次呼叫看到更新的檔案 → 再清一次

**是「清快取」本身製造了下一次清快取的理由。** 實測：六次 `get_collection()`、
零外部寫入 → **六次清快取**，每一次都把整個 HNSW 索引從磁碟重載。

⚠️ Fable 把成因指向「`PersistentClient()` 建構時會寫檔」。我逐步量過，
單獨呼叫 `PersistentClient()` 與 `get_or_create_collection()` 都 **不會**移動 mtime
（ns 精度）。真正的條件是「快取被清之後的那次重建」才寫 —— 所以先前的逐步測試
複現不出來，因為那時快取是熱的。症狀對，機制要自己找。

修法：`_record_chroma_mtime()` 在 client 建好之後、**仍在同一個鎖內**重讀一次
mtime，把我們自己造成的寫入折進高水位。實測 6 次呼叫 → 1 次清；子行程寫入後
仍偵測得到（清 1 次、count 正確）；之後 4 次閒置 → 0 次清。

代價寫在註解裡：外部寫入若剛好落在檢查與重讀之間，會被記成已看過 —— 一次呼叫的
窗口，由那個寫入者的下一次寫入關閉。用它換掉每一次搜尋都 thrash。

## #426 —— 浮點翻轉讓已達 min_dur 的 cue 仍被合併

`(37.259 + 0.8) - 37.259` 是 `0.7999999999999972`。extend pass 把短 cue 拉到剛好
`min_dur`，merge pass 量回來卻判定為「短」，於是把下一句吸收進來 —— 那句話的字
提前出現在螢幕上，而**上限只剩 `max_dur`：最多 5.7 秒**。

在整個 pass 的核心承諾是「字不會早於話」的地方，這是最壞的一種失效。

適用範圍：三位小數的起始時間有 31.6% 會翻轉，參考庫 312 個起始裡有 102 個。
**我所有的測試都從 `0.0` 開始，而 `0.0 + 0.8` 是精確的**，所以一支都沒抓到。

修法：`_is_too_short()` 用 `< min_dur - 1e-9`，另加一道 `lead_ok` 斷言把
「合併引入的提前量不得超過 min_dur + min_gap」寫成程式而不是註解。

## 順便修掉一支我自己的假強度測試

`test_no_cue_starts_before_its_words` 原本斷言
`any(abs(start-a) < 1e-6 or start > a for a in allowed)` —— 那對**任何**大於最早
起始的值都成立（allowed={0.0, 0.3} 時 0.15 和 3.0 都會過）。實際只等於
`start >= min(allowed)`。改成「落在某個 segment 自己的 span 內」，那才是切割
產生的 cue 該滿足的形狀。

## 測試與 mutation

新增 `tests/test_chroma_staleness_thrash.py`（6 支）＋ 字幕 3 支。

    M1 拿掉 epsilon（回到浮點翻轉）        4 紅
    M2 拿掉 lead 上限斷言                 存活（見下）
    M3 epsilon 方向寫反                   6 紅
    M4 不在建完後重記 mtime（回到 thrash）  1 紅
    M5 檔案不存在時把 mark 清成 0           1 紅
    M6 失敗的 drop 也吃掉 mtime            1 紅

⚠️ **第一輪 M1／M2／M3 全部存活**，原因是兩個修法互相遮蔽：`lead_ok` 在 M1 的
案例裡先擋下合併，所以拿掉 epsilon 看不出差別，反之亦然。改成把下一句放在
**恰好 `min_dur + min_gap`** —— 那是兩道守衛唯一分離的位置：再近一點 cue 就真的
到不了 min_dur（合併是對的），再遠一點 lead 檢查會用它自己的理由拒絕。

⚠️ **M2 是真正的等價 mutant，不是測試缺口。** 任何自洽的設定下，cue 在 extend
之後仍短 ⟹ 下一句在 `min_dur + min_gap` 之內 ⟹ lead 必在界內。放寬 max_dur 讓
更遠的合併通過，也就讓 extend 到得了 min_dur；收緊 max_dur 則是
`(ne - s) <= max_dur` 先拒絕。**但它在浮點翻轉還活著的時候並非不可達** —— 那正是
它存在的理由。測試改成在整個空間上實證那個界限，並把這件事寫在 docstring 裡，
而不是假裝有測到。

全套 1956 passed / 11 skipped。真素材量測與修法前相同（290 cue、違規 1.7%）——
參考庫裡那三個候選剛好都沒翻轉，所以這次修的是還沒發生的傷害。

Audited-by: Fable 5.1
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BznCya8zniew2fVKvPXJrP
