### PR TITLE
fix(frames): 動態 GIF 被當成靜圖，30 格的片子只被看見第一格

### DIFF
--- a/frames.py
+++ b/frames.py
@@ -67,6 +67,46 @@ def _frame_vf_args(video_path: str) -> List[str]:
     return ["-vf", _NORMAL_SCALE]
 
 
+_animated_gif_cache: dict = {}
+
+
+def _is_animated_gif(video_path: str) -> bool:
+    """True for a `.gif` carrying more than one frame.
+
+    `.gif` is the one extension in STILL_RASTER_EXT that does not decide the
+    question. png/jpg/webp are stills; a gif is a still or a short silent movie
+    and only the file knows which. Same shape as `_is_360_dualfisheye`: ext gate,
+    then ffprobe, cached by (path, mtime, size) so a replaced file re-probes and a
+    failed probe is not cached.
+
+    Falls back to "not animated" on any probe failure — that is the old
+    behaviour, so a broken ffprobe degrades to the single-frame path instead of
+    seeking into something that might not support it.
+    """
+    if Path(video_path).suffix.lower() != ".gif":
+        return False
+    try:
+        st = os.stat(video_path)
+        key = (os.path.abspath(video_path), st.st_mtime_ns, st.st_size)
+    except OSError:
+        return False
+    if key in _animated_gif_cache:
+        return _animated_gif_cache[key]
+    try:
+        out = subprocess.run(
+            [config.FFPROBE_PATH, "-v", "error", "-select_streams", "v:0",
+             "-count_frames", "-show_entries", "stream=nb_read_frames",
+             "-of", "csv=p=0", video_path],
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=30)
+        if out.returncode != 0:
+            return False  # transient/failed probe — don't cache, retry next time
+        animated = int((out.stdout.strip() or "0").splitlines()[0]) > 1
+    except Exception:
+        return False  # don't cache transient failure
+    _animated_gif_cache[key] = animated
+    return animated
+
+
 def _is_still_raster(video_path: str) -> bool:
     """True for a single-frame raster still (png/jpg/jpeg/webp/gif), which must be
     read whole rather than seeked into.
@@ -75,8 +115,18 @@ def _is_still_raster(video_path: str) -> bool:
     back `duration=0.040000` for a `.jpg` (mjpeg, one frame at an assumed 25fps)
     and `N/A` → 0.0 for `.png` / `.webp`, so the old `duration_s <= 0` test called
     every JPEG a video.
+
+    🔴 With one carve-out. The extension answers the question for every member of
+    the set except `.gif`, and treating an ANIMATED gif as a still collapsed it to
+    a single frame at t=0 — one thumbnail, one visual-tag pass, and a 30-frame
+    clip indexed as though it were its own first frame. Measured: `-ss` works
+    perfectly well on an animated gif (three seek positions, three different
+    frames), so nothing about gif ever needed this path. The original defect was
+    mjpeg-specific; `.gif` was swept in with it.
     """
-    return Path(video_path).suffix.lower() in mediatypes.STILL_RASTER_EXT
+    if Path(video_path).suffix.lower() not in mediatypes.STILL_RASTER_EXT:
+        return False
+    return not _is_animated_gif(video_path)
 
 
 def _safe_stem(video_path: str) -> str:

--- a/tests/test_still_raster_frames.py
+++ b/tests/test_still_raster_frames.py
@@ -194,3 +194,125 @@ def test_jpeg_really_does_report_a_nonzero_duration(tmp_path):
     """Pin the premise. If this ever fails, the fix's rationale changed, not the fix."""
     assert _probed_duration(_synth(tmp_path, "still.jpg")) > 0
     assert _probed_duration(_synth(tmp_path, "still.png")) == 0.0
+
+
+# ── the carve-out: .gif is the one extension that does not decide ───────────
+#
+# 🔴 A regression this file's own fix introduced. `.gif` came along with the
+# raster set, so an ANIMATED gif was read as a still: one frame at t=0, one
+# visual-tag pass, and a 30-frame clip indexed as though it were its own first
+# frame. Measured 2026-09-05 — before the carve-out, a 30-frame gif yielded
+# exactly 1 frame; `-ss` at 0 / 1.5 / 2.8 on that same file yields three
+# genuinely different images, so nothing about gif ever needed the still path.
+# The original defect was mjpeg-specific; gif was swept in with it.
+
+
+def _synth_gif(tmp_path, name, n_frames):
+    """A gif written the ordinary way, by Pillow.
+
+    Colour changes per frame so "did we get more than one frame" and "are they
+    different pictures" are separate questions — a fix that returns three copies
+    of frame 0 would pass the first and fail the second.
+    """
+    from PIL import Image
+
+    imgs = [Image.new("RGB", (640, 360), ((10 + i * 60) % 240, 40, (200 - i * 50) % 180))
+            for i in range(n_frames)]
+    out = tmp_path / name
+    if n_frames == 1:
+        imgs[0].save(out)
+    else:
+        imgs[0].save(out, save_all=True, append_images=imgs[1:], duration=100, loop=0)
+    return out
+
+
+@_needs_ffmpeg
+def test_seeking_an_animated_gif_works_at_all(tmp_path):
+    """Pin the premise, like the JPEG duration test above does for the other half.
+
+    The still path exists because a seek on single-frame mjpeg encodes nothing.
+    If that were also true of gif, the carve-out would be wrong rather than
+    merely unnecessary. It is not: three seeks, three different frames."""
+    src = _synth_gif(tmp_path, "motion.gif", 30)
+    digests = set()
+    for i, t in enumerate((0.0, 1.5, 2.8)):
+        out = tmp_path / "s{0}.png".format(i)
+        subprocess.run(["ffmpeg", "-y", "-v", "error", "-ss", str(t), "-i", str(src),
+                        "-frames:v", "1", str(out)], capture_output=True)
+        assert out.exists() and out.stat().st_size > 0, \
+            "seek to {0}s produced nothing".format(t)
+        digests.add(out.read_bytes())
+    assert len(digests) == 3, "the seeks all landed on the same frame"
+
+
+@_needs_ffmpeg
+def test_a_single_frame_gif_is_still_a_still(tmp_path):
+    assert frames._is_still_raster(str(_synth_gif(tmp_path, "one.gif", 1))) is True
+
+
+@_needs_ffmpeg
+def test_an_animated_gif_is_not_a_still(tmp_path):
+    assert frames._is_still_raster(str(_synth_gif(tmp_path, "motion.gif", 30))) is False
+
+
+def test_a_gif_that_cannot_be_probed_falls_back_to_still():
+    """`a.gif` in the parametrized set above passes through this path — the file
+    does not exist, os.stat raises, and we choose the old behaviour. Asserted
+    here so that it is a decision rather than an accident: an unreadable file
+    must not be sent down a path that assumes seeking works."""
+    assert frames._is_animated_gif("/nope/missing.gif") is False
+    assert frames._is_still_raster("/nope/missing.gif") is True
+
+
+@_needs_ffmpeg
+def test_probe_failure_does_not_poison_the_cache(tmp_path, monkeypatch):
+    """A transient ffprobe failure must not pin the answer for the life of the
+    process — same rule as _is_360_dualfisheye."""
+    src = _synth_gif(tmp_path, "motion.gif", 30)
+    frames._animated_gif_cache.clear()
+
+    monkeypatch.setattr(frames.config, "FFPROBE_PATH", "/definitely/not/ffprobe")
+    assert frames._is_animated_gif(str(src)) is False
+    assert not frames._animated_gif_cache, "a failed probe must not be cached"
+
+    monkeypatch.undo()
+    assert frames._is_animated_gif(str(src)) is True
+
+
+@_needs_ffmpeg
+def test_replacing_the_file_re_probes(tmp_path):
+    """Cache key is (path, mtime, size): overwrite a still gif with an animated
+    one at the same path and the answer has to change."""
+    frames._animated_gif_cache.clear()
+    src = _synth_gif(tmp_path, "same-name.gif", 1)
+    assert frames._is_animated_gif(str(src)) is False
+
+    animated = _synth_gif(tmp_path, "other.gif", 30)
+    src.write_bytes(animated.read_bytes())
+    assert frames._is_animated_gif(str(src)) is True
+
+
+@_needs_ffmpeg
+def test_real_ffmpeg_frames_across_an_animated_gif(tmp_path, monkeypatch):
+    """The end-to-end shape of the regression: more than one frame, and more than
+    one PICTURE."""
+    monkeypatch.setattr(frames, "THUMBNAILS_DIR", tmp_path / "thumbs")
+    src = _synth_gif(tmp_path, "motion.gif", 30)
+    res = frames.extract_frames(str(src), 3.0, 10.0, force=True)
+
+    assert len(res) > 1, "an animated gif collapsed to a single frame"
+    assert [r["timestamp_s"] for r in res] != [0.0] * len(res)
+    pictures = {pathlib.Path(r["thumbnail_path"]).read_bytes() for r in res}
+    assert len(pictures) == len(res), "the frames are all the same picture"
+
+
+@_needs_ffmpeg
+def test_a_static_gif_still_collapses_to_one_frame(tmp_path, monkeypatch):
+    """The other side: the carve-out must not drag ordinary stills back onto the
+    seek path."""
+    monkeypatch.setattr(frames, "THUMBNAILS_DIR", tmp_path / "thumbs")
+    src = _synth_gif(tmp_path, "one.gif", 1)
+    res = frames.extract_frames(str(src), _probed_duration(src), 25.0, force=True)
+
+    assert len(res) == 1
+    assert res[0]["timestamp_s"] == 0.0


### PR DESCRIPTION
#419 修好了「單格 mjpeg 不能 seek」，但把 `.gif` 一起掃進靜圖集合裡 ——
而 `.gif` 是那個集合裡**唯一一個副檔名不能決定答案**的成員。png/jpg/webp 是靜圖；
gif 是靜圖**或是一支沒有聲音的短片**，只有檔案自己知道。

## 實測

    ffprobe: codec_name=gif  nb_frames=30
    _is_still_raster('.gif') = True
    extract_frames 取到 1 格，timestamps = [0.0]
    相異畫面數: 1

一支 30 格的 GIF 只拿到一格。而那一格就是它的全部 —— 縮圖、視覺標籤、內容搜尋
都只認得第一格。**不是壞掉，是被看小了**，所以沒有任何錯誤訊息。

## 而 gif 從來就不需要那條路

    -ss 0    → 6371 bytes
    -ss 1.5  → 6603 bytes
    -ss 2.8  → 6294 bytes   三個不同的雜湊

`-ss` 對動態 GIF 完全正常。單格 GIF 用 `-ss 0` 也正常（6371 bytes）。
**原本的缺陷是 mjpeg 專屬的**（單格 mjpeg 即使 `-ss 0` 也編不出東西，exit 0 但
「Output file is empty」），gif 只是跟著被掃進去。

## 修法

不動 `mediatypes.STILL_RASTER_EXT` —— `ingest.py` 拿它分類影像素材，那個語意沒錯：
一支 GIF 確實是 raster image。要動的是 frames 這一側的 **seek 判定**。

新增 `_is_animated_gif()`，形狀逐字照抄同檔既有的 `_is_360_dualfisheye`：
副檔名閘門 → ffprobe → 以 `(path, mtime_ns, size)` 快取、**失敗不快取**。
探測失敗一律退回「不是動態的」，也就是舊行為 —— ffprobe 壞掉時降級成單格路徑，
而不是把檔案送進一條假設 seek 可行的路。

## 測試

`tests/test_still_raster_frames.py` 新增 8 支（該檔原本就是 #419 的測試檔）：

- `test_seeking_an_animated_gif_works_at_all` —— **釘前提**，跟該檔既有的
  `test_jpeg_really_does_report_a_nonzero_duration` 同一個角色。靜圖路徑存在的理由
  是「單格 mjpeg 的 seek 會編不出東西」；如果 gif 也是這樣，這支修法就是錯的而不只是
  多餘的。三個 seek、三個不同畫面 → 不是。
- 動態 GIF 端到端拿到多格，而且**是多張不同的圖**（回傳三份第一格的修法會過第一個
  斷言、死在第二個）。
- 單格 GIF 仍然塌成一格 t=0 —— 這條防的是修法把一般靜圖拖回 seek 路徑。
- 探測失敗不毒化快取；同路徑換檔（1 格覆寫成 30 格）會重新探測。
- 檔案不存在的 `.gif` 退回靜圖 —— 該檔原本的 `a.gif` 參數化案例走的就是這條，
  現在把它寫成**決定**而不是巧合。

34 passed（該檔）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BznCya8zniew2fVKvPXJrP
