### PR TITLE
fix(codec): theora 與 mpeg4 不是「播得動」，是我們記錯了

### DIFF
--- a/codec.py
+++ b/codec.py
@@ -30,12 +30,30 @@ PROXY_CODECS = frozenset({
 #
 # PROXY_CODECS stays as it is: it names the codecs the proxy BUILDER knows how
 # to transcode, which is a different question from what a browser can show.
+#
+# 🔴 Measured, not remembered. Two entries sat here on the strength of what
+# browsers used to do, and a real Chrome 152 disagrees with both:
+#
+#     canPlayType('video/mp4; codecs="avc1.42E01E"')   → "probably"
+#     canPlayType('video/webm; codecs="vp9"')          → "probably"
+#     canPlayType('video/mp4; codecs="av01.0.05M.08"') → "probably"
+#     canPlayType('video/ogg; codecs="theora"')        → ""   ← cannot
+#     canPlayType('video/mp4; codecs="mp4v.20.8"')     → ""   ← cannot
+#
+# Theora decoding was dropped from Chrome; MPEG-4 Part 2 (DivX/Xvid) was never
+# in it. Listing them was worse than omitting them: this gate exists to send an
+# unplayable codec down the proxy path, so a wrong "playable" hands the raw bytes
+# to a player that shows a black pane and no error — the exact symptom issue #420
+# was opened about, arrived at by the code meant to prevent it.
+#
+# ⚠️ `video/ogg` with no codec string answers "maybe", but that is the CONTAINER
+# — Chrome plays Ogg *audio* (Vorbis/Opus). It is not evidence for Theora video,
+# and asking the bare-container question is how this gets believed again. Ask
+# with the codec.
 BROWSER_PLAYABLE_VIDEO = frozenset({
     "h264", "avc1",          # the overwhelming majority of everything
     "vp8", "vp9",
     "av1", "av01",
-    "theora",                # Firefox-era, still decoded
-    "mpeg4",                 # Simple Profile in MP4 — Safari and Chrome do play it
 })
 
 

--- a/tests/test_stream_codec_gate.py
+++ b/tests/test_stream_codec_gate.py
@@ -36,8 +36,28 @@ def test_playable_codecs(name):
 
 
 @pytest.mark.parametrize("name", ["mjpeg", "qtrle", "dnxhd", "cinepak", "rawvideo",
-                                  "hevc", "prores"])
+                                  "hevc", "prores", "theora", "mpeg4"])
 def test_unplayable_codecs(name):
+    assert codec.is_browser_playable_video(name) is False
+
+
+@pytest.mark.parametrize("name", ["theora", "mpeg4"])
+def test_the_two_that_were_wrong(name):
+    """Measured in a real Chrome 152, 2026-09-05:
+
+        canPlayType('video/ogg; codecs="theora"')    → ""
+        canPlayType('video/mp4; codecs="mp4v.20.8"') → ""
+
+    Both shipped in the allow-list on the strength of what browsers used to do.
+    Theora decoding was dropped from Chrome; MPEG-4 Part 2 (DivX/Xvid) was never
+    in it. A wrong 'playable' is the worse direction of error — it hands raw
+    bytes to a player that shows a black pane and no error, which is the exact
+    symptom this gate was built to stop.
+
+    Kept separate from the list above so the reason survives: if a future Chrome
+    brings either back, this is the test whose docstring says what to re-measure
+    rather than a name silently deleted from a parametrize list."""
+    assert name not in codec.BROWSER_PLAYABLE_VIDEO
     assert codec.is_browser_playable_video(name) is False
 
 


### PR DESCRIPTION
#428 建了 allow-list 來擋「瀏覽器播不動的編碼」。清單本身是對的做法，
但裡面有兩個成員是憑印象放進去的。拿真的 Chrome 152 問：

    canPlayType('video/mp4; codecs="avc1.42E01E"')   → "probably"
    canPlayType('video/webm; codecs="vp9"')          → "probably"
    canPlayType('video/mp4; codecs="av01.0.05M.08"') → "probably"
    canPlayType('video/ogg; codecs="theora"')        → ""   ← 播不動
    canPlayType('video/mp4; codecs="mp4v.20.8"')     → ""   ← 播不動

Theora 的解碼已經從 Chrome 移除；**MPEG-4 Part 2（DivX／Xvid）從來就不在裡面** ——
而原本的註解寫的是「Safari 和 Chrome 都播得動」。

## 為什麼這個方向的錯比較嚴重

這道閘門存在的唯一理由，是把播不動的編碼**送去 proxy 路徑**。
所以「誤判成播不動」只是多轉一次檔；**「誤判成播得動」是把原始 bytes 直接交給播放器**，
使用者看到一片黑、沒有錯誤訊息、也沒有辦法要求 proxy ——
那正是 issue #420 當初開單的症狀。**由那支要防止它的程式碼自己製造出來。**

⚠️ 註解裡留了一條給下一個人的警告：`video/ogg` 不帶 codec 字串問，會回 `"maybe"`。
那是**容器層**的答案（Chrome 播得動 Ogg 的**音訊**：Vorbis／Opus），不是 Theora
影像的證據。用容器去問，就是這件事會被再相信一次的方式。

## 測試

`theora` / `mpeg4` 加進既有的 `test_unplayable_codecs` 參數化，另加一支
`test_the_two_that_were_wrong` 單獨釘它們。**刻意分開寫**：如果日後哪個 Chrome
把其中一個帶回來，這支測試的 docstring 會告訴人要重新量什麼，
而不是在 parametrize 清單裡默默少掉一個名字。

既有的 `test_proxy_codecs_are_a_subset_of_the_unplayable_ones` 不受影響
（`PROXY_CODECS` 本來就沒有這兩個）。

全套 1982 passed / 11 skipped。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BznCya8zniew2fVKvPXJrP
