### PR TITLE
fix(offload): 拷完不等於過卡完成 —— 而那兩趟雜湊既不出聲，又已經把狀態寫成 done

### DIFF
--- a/frontend/src/routes/Offload.svelte
+++ b/frontend/src/routes/Offload.svelte
@@ -37,6 +37,11 @@
 
   // run progress
   let curDst = ''
+  // Which post-copy pass is running. The copy bar hits N/N long before the
+  // offload is finished — the MHL write and verify each re-read every byte
+  // and emit nothing of their own, so without this the UI looks hung.
+  let stage = '' // '' | 'mhl_write' | 'mhl_verify'
+  let stageFiles = 0
   let pTotal = 0
   let pDone = 0
   let pFailed = 0
@@ -134,6 +139,7 @@
     if (missing.length) { pushToast(`無法開始複製 — 缺少：${missing.join('、')}`, 'error'); return }
     err = ''; phase = 'running'; stopped = false
     curDst = ''; pTotal = 0; pDone = 0; pFailed = 0; recent = []; summary = null; doneCode = null
+    stage = ''; stageFiles = 0
     abortCtl = new AbortController()
     try {
       const res = await api.offloadRun({
@@ -158,7 +164,10 @@
             pDone++
             if (ev.status === 'failed') pFailed++
             recent = [{ name: ev.name, status: ev.status }, ...recent].slice(0, 8)
+          } else if (ev.type === 'phase') {
+            stage = ev.phase; stageFiles = ev.files || 0
           } else if (ev.type === 'done') {
+            stage = ''
             doneCode = ev.code
             summary = ev.summary || {}
             phase = 'done'
@@ -316,6 +325,16 @@
           {#if curDst}<Mono dim style="font-size:10px;">→ {curDst}</Mono>{/if}
           <div class="bar"><div class="barfill" class:fail={anyFailed} style="width:{phase === 'done' ? 100 : pct}%;"></div></div>
           <Mono dim style="font-size:10.5px;">{pDone}{pTotal ? `/${pTotal}` : ''} files{pFailed ? ` · ${pFailed} failed` : ''}</Mono>
+          {#if stage}
+            <div class="stagerow">
+              <span class="spin"></span>
+              <Mono style="font-size:10.5px;">
+                {stage === 'mhl_write' ? 'Writing MHL manifest' : 'Verifying MHL manifest'}
+                — hashing {stageFiles} files again. No per-file progress here; this
+                pass re-reads every byte and can take as long as the copy did.
+              </Mono>
+            </div>
+          {/if}
 
           <div class="rowsbox">
             {#each recent as r}
@@ -392,6 +411,10 @@
   .seg:disabled { opacity: 0.4; cursor: not-allowed; }
 
   .empty { padding: 24px 0; }
+  .stagerow { display: flex; align-items: center; gap: 6px; margin-top: 6px; }
+  .spin { width: 8px; height: 8px; border-radius: 50%; background: currentColor;
+          opacity: .35; animation: pulse 1.2s ease-in-out infinite; flex: none; }
+  @keyframes pulse { 0%, 100% { opacity: .2 } 50% { opacity: .8 } }
   .rowsbox { flex: 1; min-height: 0; overflow: auto; border-top: 1px solid var(--rule); margin-top: 2px; }
   .prow { display: grid; grid-template-columns: 1fr auto 1.1fr auto; gap: 8px; align-items: baseline; padding: 4px 0; border-bottom: 1px solid var(--surface-2); }
   .prow.file { grid-template-columns: 1fr auto; }

--- a/offload.py
+++ b/offload.py
@@ -585,18 +585,34 @@ def run_offload(src, dsts, hash_algo=DEFAULT_HASH, include_heic=False, resume=No
 
         dst_state["verified_files"] = len(verified_rel_paths)
         dst_state["failed_files"] = failed
-        dst_state["status"] = "done" if failed == 0 else "partial"
+        # The copy is done; the CARD is not. `status` stays "running" through the
+        # MHL passes below — writing "done" here is what let a run cancelled during
+        # those passes persist a state that says finished with `mhl_path: null`,
+        # which is indistinguishable from a real completion. For a DIT the manifest
+        # IS the deliverable (chain of custody), so "copied" must not read as "done".
+        final_status = "done" if failed == 0 else "partial"
         _save_state(state_path, state)
 
         mhl_path = None
         if emit_mhl and verified_rel_paths:
+            # Two full re-reads of every byte happen below (write, then verify) and
+            # neither emits anything on its own. Without these markers the UI sits
+            # on "file N/N" for as long as the hashing takes — 35 minutes for 89 GB
+            # in the 2026-09-06 field run — and looks hung while it is working.
+            _emit(progress, {"type": "phase", "dst": dst_key, "phase": "mhl_write",
+                             "files": len(verified_rel_paths)})
             mhl_path = _write_mhl(dst_root, hash_algo, op="offload")
             dst_state["mhl_path"] = str(mhl_path)
             _save_state(state_path, state)
             if verify:
+                _emit(progress, {"type": "phase", "dst": dst_key, "phase": "mhl_verify",
+                                 "files": len(verified_rel_paths)})
                 verify_result = _verify_emitted_mhl(dst_root, mhl_path)
                 if verify_result is not None and verify_result != 0:
                     raise RuntimeError("mhl verify failed for {0}: exit code {1}".format(mhl_path, verify_result))
+
+        dst_state["status"] = final_status
+        _save_state(state_path, state)
 
         summary[dst_key] = {
             "verified_files": len(verified_rel_paths),

--- a/tests/test_offload_mhl_phase.py
+++ b/tests/test_offload_mhl_phase.py
@@ -1,0 +1,130 @@
+"""拷卡完成之後、done 之前的那兩趟雜湊 —— 它們的可見性與狀態語意。
+
+2026-09-06 實地跑 200 支／89 GB：進度條在 00:55 走到 200/200，`done` 事件
+01:30 才出現。中間 35 分鐘是 MHL 寫入 + 驗證各讀完一次全部位元組，而兩者
+都不發任何事件 —— 畫面上「還在跑」與「當掉了」完全同形。
+
+更嚴重的是狀態語意：`status` 原本在 MHL 之前就寫成 "done"。在那 35 分鐘裡
+按取消，state 會留下一筆 `status: "done"` 且 `mhl_path: null` 的紀錄 ——
+跟真正完成的紀錄無法區分，而 MHL 正是 DIT 的保管鏈交付物。
+"""
+import importlib
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GIT = ["git", "-c", "safe.directory={0}".format(ROOT), "-C", str(ROOT)]
+
+
+def _bootstrap_mhl(tmp_path, monkeypatch):
+    mhl_src = subprocess.run(
+        GIT + ["show", "HEAD:mhl.py"], check=True, capture_output=True, text=True
+    ).stdout
+    module_dir = tmp_path / "bootstrap"
+    module_dir.mkdir(parents=True, exist_ok=True)
+    (module_dir / "mhl.py").write_text(mhl_src, encoding="utf-8")
+    monkeypatch.syspath_prepend(str(module_dir))
+    sys.modules.pop("mhl", None)
+    sys.modules.pop("offload", None)
+    return importlib.import_module("offload")
+
+
+@pytest.fixture
+def scratch():
+    temp_root = ROOT / "temp"
+    temp_root.mkdir(parents=True, exist_ok=True)
+    root = Path(tempfile.mkdtemp(prefix="arkiv-mhlphase-", dir=str(temp_root)))
+    yield root
+    shutil.rmtree(root, ignore_errors=True)
+
+
+def _src(root):
+    src = root / "src"
+    (src / "A001").mkdir(parents=True, exist_ok=True)
+    (src / "A001" / "clip_001.mp4").write_bytes(b"alpha")
+    (src / "A001" / "clip_002.mp4").write_bytes(b"bravo")
+    return src
+
+
+def _events(capsys):
+    out = []
+    for line in capsys.readouterr().out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except ValueError:
+            pass
+    return out
+
+
+def test_mhl_write_and_verify_each_announce_themselves(scratch, monkeypatch, capsys):
+    """兩趟雜湊各自要有事件，且要落在最後一個 file 與 done 之間。"""
+    offload = _bootstrap_mhl(scratch, monkeypatch)
+    monkeypatch.chdir(scratch)
+    code, _summary, _sp = offload.run_offload(
+        _src(scratch), [scratch / "dst"], verify=True, emit_mhl=True, progress="json")
+    assert code == 0
+
+    evs = _events(capsys)
+    kinds = [e.get("type") for e in evs]
+    phases = [e for e in evs if e.get("type") == "phase"]
+    assert [p["phase"] for p in phases] == ["mhl_write", "mhl_verify"], kinds
+    # 檔案數要帶上 —— 使用者要知道這一趟在雜湊幾個檔，否則「還要多久」無從估計
+    assert all(p["files"] == 2 for p in phases), phases
+
+    last_file = max(i for i, k in enumerate(kinds) if k == "file")
+    first_phase = min(i for i, k in enumerate(kinds) if k == "phase")
+    assert first_phase > last_file, "phase 必須在最後一個 file 之後（那正是靜默期的起點）"
+
+
+def test_phase_events_stay_silent_in_tui_mode(scratch, monkeypatch, capsys):
+    """負向：tui 模式不該吐 JSON —— 否則會汙染人看的輸出。"""
+    offload = _bootstrap_mhl(scratch, monkeypatch)
+    monkeypatch.chdir(scratch)
+    offload.run_offload(_src(scratch), [scratch / "dst"], verify=True,
+                        emit_mhl=True, progress="tui")
+    assert not [e for e in _events(capsys) if e.get("type") == "phase"]
+
+
+def test_status_is_not_done_when_mhl_write_fails(scratch, monkeypatch):
+    """🔴 本檔的核心：MHL 沒寫成，state 就不可以說 done。
+
+    這是「取消在那 35 分鐘裡」的可測代理 —— 兩者都是「拷完了但 manifest 沒有」。
+    """
+    offload = _bootstrap_mhl(scratch, monkeypatch)
+    monkeypatch.chdir(scratch)
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("simulated: interrupted during manifest write")
+    monkeypatch.setattr(offload, "_write_mhl", _boom)
+
+    with pytest.raises(RuntimeError):
+        offload.run_offload(_src(scratch), [scratch / "dst"], verify=True,
+                            emit_mhl=True, resume=str(scratch / "st.json"))
+
+    st = json.loads((scratch / "st.json").read_text(encoding="utf-8"))
+    dst_state = st["destinations"][str((scratch / "dst").resolve())]
+    assert dst_state["status"] != "done", "檔案拷完不等於過卡完成 —— manifest 才是交付物"
+    assert not dst_state.get("mhl_path")
+
+
+def test_status_done_always_carries_an_mhl_path(scratch, monkeypatch):
+    """正向配對：成功時 done 與 mhl_path 必須同時成立，不可只有其一。"""
+    offload = _bootstrap_mhl(scratch, monkeypatch)
+    monkeypatch.chdir(scratch)
+    _code, summary, state_path = offload.run_offload(
+        _src(scratch), [scratch / "dst"], verify=True, emit_mhl=True)
+    st = json.loads(Path(state_path).read_text(encoding="utf-8"))
+    key = str((scratch / "dst").resolve())
+    assert st["destinations"][key]["status"] == "done"
+    assert st["destinations"][key]["mhl_path"]
+    assert Path(summary[key]["mhl_path"]).exists()


### PR DESCRIPTION
2026-09-06 實地跑 200 支／89 GB 時撞到：進度條 **00:55** 就走到 200/200，
`done` 事件 **01:30** 才出現。使用者在中間按了取消，再確認一次才顯示完成。

## 兩個獨立的缺陷，在同一段程式碼裡

### ① 35 分鐘完全沒有回饋

`offload.py` 吐完最後一個 `file` 事件之後：

| 行 | 動作 | 事件 |
|---|---|---|
| 583 | 最後一支 `file 200/200` | 有 |
| 593 | `_write_mhl()` 把每個檔重新雜湊一次 | **無** |
| 597 | `_verify_emitted_mhl()` 再雜湊驗證一次 | **無** |
| 820 | `done` | 有 |

畫面停在 `file N/N` —— 「還在跑」跟「當掉了」在輸出上完全同形。

**修法**：兩趟各發 `{"type": "phase", "phase": "mhl_write"|"mhl_verify", "files": N}`，
前端顯示「正在雜湊 N 個檔、這一趟沒有逐檔進度」。
**刻意不假裝有進度條** —— `mhl.create_manifest` 是函式庫呼叫，拿不到它的內圈；
編一個會動的百分比比誠實的靜止更糟。

### ② `status` 在 MHL 產出之前就寫成 `"done"`

於是在那 35 分鐘裡取消，state 會留下：

```json
{ "status": "done", "mhl_path": null }
```

**跟真正完成的紀錄無法區分** —— 而 MHL 是 DIT 的保管鏈交付物，不是附屬品。
這次現場沒出事，是因為取消得夠晚（manifest 已寫完），不是因為有防護。

**修法**：算出 `final_status` 但等 MHL 寫完並驗過才寫進去。
續傳不受影響 —— 它讀的是逐檔的 `file_state["status"]`，不是這個欄位。

## 驗證

新測試 4 條。**先確認它們抓得到原本的 bug**（恆綠的測試比沒有還糟）：

| | 未修版 | 已修版 |
|---|---|---|
| `tests/test_offload_mhl_phase.py` | **2 failed** / 2 passed | 4 passed |

另 2 條是既有不變量（tui 模式不吐 JSON、`done` 必帶 `mhl_path`），兩版皆綠 —— 它們是配對驗，不是湊數。

| 檢查 | 結果 |
|---|---|
| `pytest -q` | 2006 → **2010 passed**, 8 skipped |
| `npm run check` | 41 檔 **0 errors 0 warnings** |
| `npm run test` | **24 pass 0 fail** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4bk97WfFTpK1xQCWuvZPg