### PR TITLE
feat(ingest): 30 分鐘死線同時錯兩個方向 —— 拆成「靜默多久」與「總共多久」

### DIFF
--- a/config.py
+++ b/config.py
@@ -611,3 +611,17 @@ if VECTOR_BACKEND == "pg" and not ARKIV_PG_DSN:
         "ARKIV_VECTOR_BACKEND=pg requires ARKIV_PG_DSN "
         "(e.g. postgresql://rag:PASSWORD@100.64.0.10:5433/rag)"
     )
+
+# ── Ingest 的兩道截止線（見 ingest_budget.py 的完整推導）─────────────────────
+# 係數來自 2026-09-06 的 200 支現場實測迴歸（n=33）：單檔秒 ≈ 5.0 + 5.6 × 幀數，
+# R² = 0.88。⚠️ M2 Max + qwen2.5vl:7b 上量的，換機器要重新量 —— 所以可用環境變數覆寫。
+INGEST_PER_FILE_SECONDS = float(os.getenv("ARKIV_INGEST_PER_FILE_SECONDS", "5.0"))
+INGEST_PER_FRAME_SECONDS = float(os.getenv("ARKIV_INGEST_PER_FRAME_SECONDS", "5.6"))
+# 預算 = 估值 × 這個係數。估值不是死線，這個乘積才是。
+INGEST_BUDGET_FACTOR = float(os.getenv("ARKIV_INGEST_BUDGET_FACTOR", "2.0"))
+# 下限：模型暖機一次就 ~100 秒，沒有下限的話最小的匯入反而最容易被誤殺。
+INGEST_BUDGET_FLOOR_SECONDS = float(os.getenv("ARKIV_INGEST_BUDGET_FLOOR", "1800"))
+# 可以沉默多久才算卡住。whisper 解碼期間完全不出聲，而最慢的路徑
+# （faster-whisper large-v3 在 CPU 上）實測 RTF 1.22 —— 門檻要隨最長的素材放大。
+INGEST_STALL_FLOOR_SECONDS = float(os.getenv("ARKIV_INGEST_STALL_FLOOR", "600"))
+INGEST_STALL_RTF = float(os.getenv("ARKIV_INGEST_STALL_RTF", "1.3"))

--- a/frontend/src/routes/IngestLive.svelte
+++ b/frontend/src/routes/IngestLive.svelte
@@ -39,6 +39,10 @@
   let files = {} // index → {filename, status, stage}
   let stageCounts = {} // aggregate per-stage tally from the backend (counts dict)
   let complete = null // {ok, skipped, failed}
+  // Set when the server's watchdog stopped the run. Two kinds, and they need
+  // different words: 'stall' = no output for the threshold, probably wedged;
+  // 'budget' = still talking but past the estimated cap, probably just slow.
+  let halted = null // {reason, idle_s, elapsed_s, stall_s, budget_s}
   let log = [] // [{t, stage, text}]
   let busy = false
   let rebuilding = false
@@ -126,9 +130,17 @@
         files = files // trigger reactivity
         if (msg.counts) stageCounts = msg.counts
         pushLog(`${msg.filename}`, msg.stage)
+      } else if (msg.type === 'halted') {
+        halted = msg
+        pushLog(msg.reason === 'stall'
+          ? `HALTED · 已 ${Math.round(msg.idle_s / 60)} 分鐘沒有進度（門檻 ${Math.round(msg.stall_s / 60)} 分）`
+          : `HALTED · 已跑 ${Math.round(msg.elapsed_s / 60)} 分，超過上限 ${Math.round(msg.budget_s / 60)} 分`)
       } else if (msg.type === 'complete') {
         complete = { ok: msg.ok, skipped: msg.skipped, failed: msg.failed }
         busy = false
+        // A late-joining client never saw the 'halted' event; without this it
+        // would read a cut-short run as a finished one.
+        if (msg.halted && !halted) halted = { reason: msg.halted }
         pushLog(`complete · ok=${msg.ok} skipped=${msg.skipped} failed=${msg.failed}`)
       }
     }
@@ -140,6 +152,7 @@
     busy = true
     files = {}
     stageCounts = {}
+    halted = null
     complete = null
     try {
       // Through the authenticated API layer (adds the Bearer token when set) —
@@ -301,6 +314,31 @@
         {/if}
         {#if err}<Mono style="font-size:11px;color:var(--cyan);margin-top:8px;display:block;">{err}</Mono>{/if}
 
+        {#if halted}
+          <!-- The run was stopped by the server-side watchdog. This has to be
+               loud: the previous behaviour was that a wedged import simply sat
+               there, and "still working" looked exactly like "dead". -->
+          <div class="haltbox" role="alert">
+            <div class="halthead">
+              <Mono style="font-size:11px;font-weight:600;">
+                {halted.reason === 'stall' ? '匯入已停止 · 研判卡住' : '匯入已停止 · 超過預估上限'}
+              </Mono>
+            </div>
+            <Mono dim style="font-size:10.5px;line-height:1.65;display:block;">
+              {#if halted.reason === 'stall'}
+                已 {Math.round((halted.idle_s || 0) / 60)} 分鐘沒有任何進度輸出（門檻
+                {Math.round((halted.stall_s || 0) / 60)} 分鐘），整個處理程序已被停止。
+                可能是 ffmpeg 或視覺模型沒有回應 —— 先確認 ollama 還活著再重跑。
+              {:else}
+                已跑 {Math.round((halted.elapsed_s || 0) / 60)} 分鐘，超過本次的上限
+                {Math.round((halted.budget_s || 0) / 60)} 分鐘。它當時仍在輸出進度，
+                所以多半只是估值偏低而不是卡住。
+              {/if}
+              <br/><b>已完成的素材都已寫進素材庫，重跑會從中斷處接續。</b>
+            </Mono>
+          </div>
+        {/if}
+
         <div class="aggwrap">
           <div class="aggrow"><Mono dim style="font-size:10px;">AGGREGATE</Mono><Mono style="font-size:11px;font-weight:600;color:var(--cyan);">{pct}%</Mono></div>
           <div class="aggbar"><div class="aggfill" style="width:{pct}%;"></div><div class="aggmark" style="left:{pct}%;"></div></div>
@@ -384,6 +422,9 @@
   .pathinput { font-size: 12px; }
   .triggerrow { display: flex; gap: 8px; align-items: center; }
   .limitinput { width: 70px; font-size: 12px; }
+  .haltbox { margin-top: 10px; padding: 10px 12px; border-radius: 6px;
+             border: 1px solid var(--cyan); background: color-mix(in srgb, var(--cyan) 8%, transparent); }
+  .halthead { margin-bottom: 4px; }
   .aggwrap { margin-top: 22px; }
   .aggrow { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 6px; }
   .aggbar { height: 4px; background: var(--surface-3); position: relative; }

--- a/frontend/src/routes/IngestSetup.svelte
+++ b/frontend/src/routes/IngestSetup.svelte
@@ -38,9 +38,18 @@
 
   let manifest = null      // {video,audio,unsupported,total_size_mb}
   let total = 0, fresh = 0
+  // From /api/ingest/scan: {seconds, budget_s, stall_s, probed, of}.
+  // `seconds` is advisory — nothing is killed on it. What actually bounds
+  // the run is budget_s plus a stall watchdog the UI cannot see.
+  let estimate = null
   let scanning = false, starting = false, err = '', notice = ''
 
   $: gb = manifest ? (manifest.total_size_mb / 1024).toFixed(1) : null
+  const hhmm = (s) => {
+    if (!s || s < 60) return `${Math.max(1, Math.round(s || 0))} 秒`
+    const m = Math.round(s / 60)
+    return m < 60 ? `${m} 分` : `${Math.floor(m / 60)} 小時 ${m % 60} 分`
+  }
 
   // The header button has read "ESC · CANCEL" since this screen shipped, but the
   // key was never wired. Same fix as Offload's, minus its running-copy guard:
@@ -78,10 +87,10 @@
       pushToast('請先填來源資料夾路徑（Source · folder）', 'error')
       return
     }
-    err = ''; notice = ''; scanning = true; manifest = null
+    err = ''; notice = ''; scanning = true; manifest = null; estimate = null
     try {
       const d = await api.scanMedia(path.trim())
-      manifest = d.manifest; total = d.total; fresh = d.new
+      manifest = d.manifest; total = d.total; fresh = d.new; estimate = d.estimate || null
       if (total === 0) notice = '這個資料夾沒有可匯入的媒體檔。'
     } catch (e) { err = e.message } finally { scanning = false }
   }
@@ -250,7 +259,21 @@
           {#if manifest.unsupported.count}
             <div class="mrow skip"><span>Unsupp.</span><Mono dim>{manifest.unsupported.count}</Mono><Mono dim>skipped</Mono></div>
           {/if}
-          <div class="estimated"><Eyebrow>Estimated</Eyebrow><span class="pend">timing pending · brick 4</span></div>
+          <div class="estimated">
+            <Eyebrow>Estimated</Eyebrow>
+            {#if estimate}
+              <div class="estrow"><span>約需</span><Mono>{hhmm(estimate.seconds)}</Mono></div>
+              <div class="estrow dim"><span>上限</span><Mono dim>{hhmm(estimate.budget_s)}</Mono></div>
+              <Mono dim style="font-size:9.5px;line-height:1.5;display:block;margin-top:4px;">
+                依 {estimate.probed}/{estimate.of} 支的實際時長推算（成本由視覺分析的
+                幀數決定，不是由檔案數）。超過上限或連續
+                {hhmm(estimate.stall_s)}沒有進度會停止並告知原因；
+                已完成的素材都會留在庫裡，重跑接續。
+              </Mono>
+            {:else}
+              <span class="pend">掃描後顯示</span>
+            {/if}
+          </div>
         {/if}
         <div class="noticebox">
           <Mono dim style="font-size:10px;">◇ Notice<br/>Files are processed locally. Nothing leaves this machine. Offload never deletes the source.</Mono>
@@ -306,6 +329,9 @@
   .mtotal { padding-bottom: 8px; border-bottom: 1px solid var(--rule); margin-bottom: 4px; }
   .mrow { display: grid; grid-template-columns: 1fr auto auto; gap: 14px; padding: 5px 0; font-size: 12px; align-items: baseline; }
   .mrow.skip { color: var(--quiet); }
+  .estrow { display: flex; justify-content: space-between; align-items: baseline;
+            gap: 8px; font-size: 11px; margin-top: 2px; }
+  .estrow.dim { opacity: .65; }
   .estimated { margin-top: 10px; }
   .noticebox { margin-top: auto; border: 1px dashed var(--rule-hi); padding: 12px; line-height: 1.5; }
 

--- a/ingest_budget.py
+++ b/ingest_budget.py
@@ -1,0 +1,87 @@
+"""匯入要跑多久 —— 以及兩道截止線各自該設多少。
+
+## 為什麼不是一個固定秒數
+
+`routers/ingest.py` 原本寫死 `timeout=1800`。2026-09-06 拿 200 支現場素材實測，
+整批需要 **94 分鐘** —— 那個上限撐不到第 60 支，而且它是硬殺整棵行程樹。
+把上限調大又會讓「真的卡死」變成無限等待。所以拆成兩道：
+
+  stall   子行程可以沉默多久   →  抓「卡住了」
+  budget  整批總共可以跑多久   →  抓「估錯了」
+
+## 係數怎麼來的
+
+拿那次跑掛的 log 逐檔耗時（n=33）做迴歸。**用素材時長當自變數 R² 只有 0.39，
+用幀數是 0.88** —— 成本由 vision 的幀數驅動，不是由片長驅動：
+
+    單檔處理秒 ≈ 5.0 + 5.6 × 幀數        (R² = 0.88, n=33)
+
+    幀數 3 → 中位 21.8s（每幀 7.3s）
+    幀數 5 → 中位 32.7s（每幀 6.5s）
+
+⚠️ 這兩個係數是 **M2 Max + qwen2.5vl:7b** 量到的，換機器會漂。所以它們是
+`config` 的常數（可覆寫），而預算再乘一個安全係數 —— 估值本身不是死線，
+`budget` 才是，而 `budget = 估值 × 2`。
+
+⚠️ 幀數一律走 `frames._adaptive_frame_count`，**不在這裡重抄一份**：
+兩份會漂，而漂掉之後預算會安靜地變錯。
+"""
+from __future__ import annotations
+
+from typing import Iterable, List, Optional
+
+import config
+
+
+def _frames_for(duration_s: float) -> int:
+    from frames import _adaptive_frame_count
+    return _adaptive_frame_count(duration_s)
+
+
+def estimate_seconds(durations: Iterable[Optional[float]], n_files: Optional[int] = None) -> float:
+    """預估整批要跑多久（秒）。
+
+    `durations` 是每支素材的時長；`None`／0（探測不到）的用其餘檔案的中位時長
+    代入 —— **不可以當成 0**，那會讓預算偏小，而偏小的預算會殺掉正常的匯入。
+    """
+    ds: List[Optional[float]] = [d for d in durations]
+    known = sorted(d for d in ds if d and d > 0)
+    if n_files is None:
+        n_files = len(ds)
+    if not known:
+        # 全部探不到 → 只能用檔案數 × 一支的平均成本（幀數取中間值 3）
+        per_file = config.INGEST_PER_FILE_SECONDS + 3 * config.INGEST_PER_FRAME_SECONDS
+        return float(n_files) * per_file
+    median = known[len(known) // 2]
+    total_frames = 0
+    for d in ds:
+        total_frames += _frames_for(d if d and d > 0 else median)
+    # ds 短於 n_files（例如只抽樣探測了一部分）→ 其餘用中位數補齊
+    missing = max(0, n_files - len(ds))
+    total_frames += missing * _frames_for(median)
+    return (n_files * config.INGEST_PER_FILE_SECONDS
+            + total_frames * config.INGEST_PER_FRAME_SECONDS)
+
+
+def budget_seconds(estimate_s: float) -> float:
+    """總預算 —— 估值乘安全係數，並有下限。
+
+    下限存在的理由：小批次的估值可能只有幾十秒，而模型暖機一次就要 ~100 秒。
+    沒有下限的話，最小的匯入反而最容易被誤殺。
+    """
+    return max(config.INGEST_BUDGET_FLOOR_SECONDS,
+               estimate_s * config.INGEST_BUDGET_FACTOR)
+
+
+def stall_seconds(max_duration_s: Optional[float]) -> float:
+    """可以沉默多久才算卡住。
+
+    不能是死的 10 分鐘：**whisper 的解碼是「一支檔一次不透明呼叫」**
+    （`transcribe.py` 自己的註解），長片在解碼期間完全不出聲。最慢的解碼路徑
+    是 faster-whisper large-v3 在 CPU 上（Mac 沒有 Metal 加速），實測 RTF 1.22
+    —— 也就是一支片可能靜默到「比它自己還久」。所以門檻要隨最長的那支放大。
+    """
+    floor = config.INGEST_STALL_FLOOR_SECONDS
+    if not max_duration_s or max_duration_s <= 0:
+        return float(floor)
+    return float(max(floor, max_duration_s * config.INGEST_STALL_RTF))

--- a/proctree.py
+++ b/proctree.py
@@ -16,7 +16,22 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+import time
 from typing import Mapping, Optional, Sequence
+
+
+def _kill_tree(proc) -> None:
+    """Kill the child AND its descendants. Extracted so the timeout path and the
+    watchdog path cannot drift apart — the Windows branch in particular is easy to
+    fix on one side only."""
+    if os.name == "posix":
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            proc.kill()
+    else:
+        subprocess.run(["taskkill", "/F", "/T", "/PID", str(proc.pid)], capture_output=True)
+        proc.kill()
 
 
 def run_tree(
@@ -58,17 +73,134 @@ def run_tree(
     try:
         out, err = proc.communicate(timeout=timeout)
     except subprocess.TimeoutExpired:
-        if os.name == "posix":
-            try:
-                os.killpg(proc.pid, signal.SIGKILL)
-            except (ProcessLookupError, PermissionError):
-                proc.kill()
-        else:
-            subprocess.run(["taskkill", "/F", "/T", "/PID", str(proc.pid)], capture_output=True)
-            proc.kill()
+        _kill_tree(proc)
         try:
             out, err = proc.communicate(timeout=10)
         except Exception:
             out, err = ("" if text else b""), ("" if text else b"")
         raise subprocess.TimeoutExpired(list(cmd), timeout, output=out, stderr=err)
     return subprocess.CompletedProcess(list(cmd), proc.returncode, out, err)
+
+
+class TreeTimeout(subprocess.TimeoutExpired):
+    """A `run_tree_watched` kill, carrying WHICH limit fired.
+
+    Subclasses TimeoutExpired so existing `except subprocess.TimeoutExpired`
+    handlers keep working; `kind` is what lets a caller tell the user the two
+    apart, and they need different words:
+
+      "stall"  — the child produced no output for `stall_timeout` seconds. It is
+                 probably wedged (a hung ffmpeg, an ollama that stopped answering).
+      "budget" — the child is still talking, just far past the estimated total. It
+                 may well finish; the cap exists so a wrong estimate cannot run
+                 forever.
+    """
+
+    def __init__(self, cmd, timeout, kind, output=None, stderr=None,
+                 elapsed=None, idle=None):
+        super().__init__(cmd, timeout, output=output, stderr=stderr)
+        self.kind = kind
+        self.elapsed = elapsed
+        self.idle = idle
+
+
+def run_tree_watched(
+    cmd: Sequence[str],
+    stall_timeout: float,
+    total_timeout: float,
+    cwd: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
+    on_line=None,
+) -> "subprocess.CompletedProcess":
+    """`run_tree` with two independent deadlines instead of one wall-clock cap.
+
+    Why two: a single fixed timeout has to be either too small for a big library
+    (30 minutes could not finish a 200-clip ingest — measured 94 minutes) or too
+    large to catch anything wedged. Splitting them lets each be right:
+
+      stall_timeout  bounds how long the child may stay SILENT.
+      total_timeout  bounds the whole run, as a backstop for a bad estimate.
+
+    stdout and stderr are merged so that any byte counts as liveness — ingest.py
+    flushes a marker at every stage (`probe`/`transcribe`/`thumbnail`/`frames`/
+    `vision`), so silence really does mean "not progressing" rather than "buffered".
+
+    `on_line(str)` is called for each line as it arrives (used to broadcast live
+    progress); exceptions from it are swallowed so a bad consumer cannot kill the
+    ingest.
+    """
+    import threading
+
+    popen_kwargs: dict = {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.STDOUT,   # merged: any output is liveness
+        "text": True,
+        "bufsize": 1,
+    }
+    if cwd is not None:
+        popen_kwargs["cwd"] = cwd
+    if env is not None:
+        popen_kwargs["env"] = env
+    if os.name == "posix":
+        popen_kwargs["start_new_session"] = True
+    else:
+        popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+
+    proc = subprocess.Popen(list(cmd), **popen_kwargs)
+    chunks = []
+    state = {"last": time.monotonic()}
+
+    def _pump():
+        try:
+            for line in proc.stdout:
+                state["last"] = time.monotonic()
+                chunks.append(line)
+                if on_line is not None:
+                    try:
+                        on_line(line)
+                    except Exception:
+                        pass
+        except Exception:
+            pass
+
+    pump = threading.Thread(target=_pump, daemon=True)
+    pump.start()
+
+    started = time.monotonic()
+    kind = None
+    while True:
+        if proc.poll() is not None:
+            break
+        now = time.monotonic()
+        if now - state["last"] > stall_timeout:
+            kind = "stall"
+            break
+        if now - started > total_timeout:
+            kind = "budget"
+            break
+        time.sleep(0.5)
+
+    if kind is None:
+        pump.join(timeout=10)
+        try:
+            proc.stdout.close()
+        except Exception:
+            pass
+        return subprocess.CompletedProcess(list(cmd), proc.returncode, "".join(chunks), "")
+
+    _kill_tree(proc)
+    pump.join(timeout=10)
+    try:
+        proc.stdout.close()
+    except Exception:
+        pass
+    now = time.monotonic()
+    raise TreeTimeout(
+        list(cmd),
+        stall_timeout if kind == "stall" else total_timeout,
+        kind,
+        output="".join(chunks),
+        stderr="",
+        elapsed=now - started,
+        idle=now - state["last"],
+    )

--- a/routers/ingest.py
+++ b/routers/ingest.py
@@ -34,6 +34,7 @@ from pydantic import BaseModel
 import auth
 import config
 import db
+import ingest_budget
 import mediatypes
 import settings as settings_store
 from auth import require_scopes
@@ -145,6 +146,36 @@ def ingest_engines(
     }
 
 
+def _probe_durations(paths, max_probe: int = 500):
+    """Duration per file, in the order given; None where it could not be read.
+
+    Bounded on two axes so a huge or a wedged folder cannot hang the scan:
+    at most `max_probe` files are actually probed (the estimator extrapolates the
+    rest from the median), and each ffprobe gets its own short timeout. A probe
+    that fails yields None rather than 0 — treating "unknown" as "zero seconds"
+    would shrink the budget, and a too-small budget kills healthy imports.
+    """
+    import subprocess
+    from concurrent.futures import ThreadPoolExecutor
+
+    def _one(path):
+        try:
+            r = subprocess.run(
+                ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+                 "-of", "default=nw=1:nk=1", str(path)],
+                capture_output=True, text=True, timeout=15)
+            return float((r.stdout or "").strip())
+        except Exception:
+            return None
+
+    head = paths[:max_probe]
+    if not head:
+        return []
+    with ThreadPoolExecutor(max_workers=16) as ex:
+        out = list(ex.map(_one, head))
+    return out + [None] * (len(paths) - len(head))
+
+
 @router.post("/api/ingest/scan")
 def scan_media(
     body: ScanRequest,
@@ -166,12 +197,65 @@ def scan_media(
             files.append({"name": f.name, "size_mb": round(f.stat().st_size / 1048576, 1), "path": str(f), "already": already})
         elif ext in UNSUPPORTED_STILL_EXTS:
             unsupp[ext] = unsupp.get(ext, 0) + 1
+    # Probe durations so the caller can be told how long this will take BEFORE it
+    # starts, and so the run's budget is derived from the actual material instead
+    # of a fixed number. ffprobe over a NAS measured 0.13s/file serially; a small
+    # pool brings 200 files to ~8s, which is worth it for an honest ETA.
+    pending = [f for f in files if not f["already"]]
+    durations = _probe_durations([f["path"] for f in pending])
+    for f, d in zip(pending, durations):
+        f["duration_s"] = d
+    est = ingest_budget.estimate_seconds(durations, n_files=len(pending))
+    known = [d for d in durations if d]
     return {
         "total": len(files),
-        "new": sum(1 for f in files if not f["already"]),
+        "new": len(pending),
         "manifest": _build_scan_manifest(files, unsupp),
         "files": files,
+        # Advisory only — the UI shows it, nothing is killed on it. What actually
+        # bounds the run is `budget_s` (and the stall watchdog, which this cannot see).
+        "estimate": {
+            "seconds": round(est),
+            "budget_s": round(ingest_budget.budget_seconds(est)),
+            "stall_s": round(ingest_budget.stall_seconds(max(known) if known else 0)),
+            "probed": len(known),
+            "of": len(pending),
+        },
     }
+
+def _ingest_limits(target: Path, limit: int = 0):
+    """(stall_seconds, budget_seconds) for this folder, from its own material.
+
+    Probing is best-effort: a folder we cannot read yields the floors, which are
+    the old behaviour plus a stall watchdog. Never let the estimate step be able
+    to fail the import it is only advising on.
+    """
+    try:
+        paths = []
+        for f in sorted(target.rglob("*")):
+            if f.is_file() and f.suffix.lower() in MEDIA_EXTS:
+                paths.append(str(f))
+        if limit and limit > 0:
+            paths = paths[:limit]
+        durations = _probe_durations(paths)
+        est = ingest_budget.estimate_seconds(durations, n_files=len(paths))
+        known = [d for d in durations if d]
+        return (ingest_budget.stall_seconds(max(known) if known else 0),
+                ingest_budget.budget_seconds(est))
+    except Exception:
+        return (config.INGEST_STALL_FLOOR_SECONDS, config.INGEST_BUDGET_FLOOR_SECONDS)
+
+
+def _timeout_detail(e) -> str:
+    mins = lambda s: int((s or 0) // 60)
+    if getattr(e, "kind", None) == "stall":
+        return ("匯入停滯：已 {0} 分鐘沒有任何進度輸出（門檻 {1} 分鐘），"
+                "研判卡住，已停止整個處理程序。已完成的素材都已寫進素材庫，"
+                "重跑會從中斷處接續。").format(mins(e.idle), mins(e.timeout))
+    return ("匯入超過預估時間的上限（{0} 分鐘）並被停止 —— 它當時仍在輸出進度，"
+            "所以多半只是估值偏低而非卡住。已完成的素材都已寫進素材庫，"
+            "重跑會從中斷處接續。").format(mins(e.timeout))
+
 
 @router.post("/api/ingest")
 def ingest_media(
@@ -191,10 +275,15 @@ def ingest_media(
     if not _acquire_ingest_slot():  # audit H3
         raise HTTPException(409, "已有匯入任務進行中，請稍候")
     try:
-        # run_tree, not subprocess.run: on timeout the whole ingest.py→ffmpeg/whisper
-        # tree is killed, not just the direct child (fable-audit round-5 #2 / #12).
+        # run_tree_watched, not a single wall-clock cap: the old fixed 1800s could
+        # not finish a 200-clip import (measured 94 minutes) yet was still too long
+        # to notice a wedged child. Two limits derived from the material itself —
+        # `stall` catches "hung", `budget` catches "estimate was wrong". Both kill
+        # the whole ingest.py→ffmpeg/whisper tree (fable-audit round-5 #2 / #12).
         import proctree
-        result = proctree.run_tree(cmd, timeout=1800, cwd=str(BASE_DIR))
+        stall_s, budget_s = _ingest_limits(target, body.limit)
+        result = proctree.run_tree_watched(
+            cmd, stall_timeout=stall_s, total_timeout=budget_s, cwd=str(BASE_DIR))
         payload = {
             "ok": result.returncode == 0,
             "stdout": result.stdout[-2000:] if result.stdout else "",
@@ -206,8 +295,12 @@ def ingest_media(
             # status-code monitors see it.
             return JSONResponse(status_code=500, content=payload)
         return payload
+    except proctree.TreeTimeout as e:
+        # The two kinds need different words: "stalled" means go look at the box,
+        # "over budget" means it was probably still working and can be resumed.
+        raise HTTPException(504, _timeout_detail(e))
     except subprocess.TimeoutExpired:
-        raise HTTPException(504, "匯入逾時（>30 分鐘）")  # audit L11: was 200 + ok:false
+        raise HTTPException(504, "匯入逾時")  # audit L11: was 200 + ok:false
     finally:
         _release_ingest_slot()
 
@@ -398,9 +491,16 @@ def _bg_ingest(dir_path: str) -> None:
     while time.time() < deadline:
         if _acquire_ingest_slot():
             try:
-                proctree.run_tree(
+                # Same two limits as the interactive route. This path swallows
+                # its exceptions (it is a background task with nobody to tell),
+                # so without a stall watchdog a wedged upload-ingest would hold
+                # the single-flight slot for the full budget and block every
+                # later import with a 409.
+                stall_s, budget_s = _ingest_limits(Path(dir_path))
+                proctree.run_tree_watched(
                     [sys.executable, str(BASE_DIR / "ingest.py"), "--dir", dir_path],
-                    timeout=1800,
+                    stall_timeout=stall_s,
+                    total_timeout=budget_s,
                     cwd=str(BASE_DIR),
                 )
             except Exception:
@@ -481,6 +581,22 @@ def _on_ingest_ws_done(task: "asyncio.Task") -> None:
         )
 
 
+def _kill_ingest_tree(proc) -> None:
+    """Kill the ingest subprocess AND its descendants (ffmpeg / whisper / ollama
+    client). `proc.kill()` alone leaves them running and holding the GPU."""
+    import signal as _signal
+    if os.name == "posix":
+        try:
+            os.killpg(os.getpgid(proc.pid), _signal.SIGKILL)
+            return
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+    try:
+        proc.kill()
+    except ProcessLookupError:
+        pass
+
+
 async def _run_ingest_with_ws(target: Path, limit: int, opts: Optional[list] = None):
     """Run ingest as a single subprocess, parse stdout for progress."""
     import re, sys
@@ -499,6 +615,11 @@ async def _run_ingest_with_ws(target: Path, limit: int, opts: Optional[list] = N
     proc = await asyncio.create_subprocess_exec(
         *cmd, stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT, cwd=str(BASE_DIR),
+        # Own session so the watchdog below can kill the WHOLE tree. Without it
+        # `proc.kill()` reaps ingest.py and orphans its ffmpeg/whisper children —
+        # the exact bug run_tree exists to prevent (fable-audit round-5 #2 / #12),
+        # which this path never had because it never had a timeout at all.
+        start_new_session=(os.name == "posix"),
         # brick 3: drive the structured per-stage progress protocol (own-line JSON
         # events) instead of parsing the compact inline `>probe` human markers.
         env={**os.environ, "ARKIV_STAGE_EVENTS": "1"},
@@ -506,6 +627,37 @@ async def _run_ingest_with_ws(target: Path, limit: int, opts: Optional[list] = N
         # raises inside the read loop; give pathological log lines 1MB headroom.
         limit=2 ** 20,
     )
+
+    # Two limits derived from the material (see ingest_budget). This path had NO
+    # timeout at all: a wedged child produced no EOF, so the read loop waited
+    # forever, the UI sat on its last event, and the single-flight slot stayed held.
+    stall_s, budget_s = await asyncio.to_thread(_ingest_limits, target, limit)
+    beat = {"at": time.monotonic()}
+    halted = {"reason": None}
+
+    async def _watchdog():
+        started = time.monotonic()
+        while True:
+            await asyncio.sleep(1.0)
+            if proc.returncode is not None:
+                return
+            now = time.monotonic()
+            idle, elapsed = now - beat["at"], now - started
+            if idle > stall_s:
+                halted["reason"] = "stall"
+            elif elapsed > budget_s:
+                halted["reason"] = "budget"
+            else:
+                continue
+            await ingest_ws.broadcast({
+                "type": "halted", "reason": halted["reason"],
+                "idle_s": round(idle), "elapsed_s": round(elapsed),
+                "stall_s": round(stall_s), "budget_s": round(budget_s),
+            })
+            _kill_ingest_tree(proc)
+            return
+
+    watchdog = asyncio.create_task(_watchdog())
 
     ok, skipped, failed = 0, 0, 0
     last_total = limit or 0
@@ -524,6 +676,9 @@ async def _run_ingest_with_ws(target: Path, limit: int, opts: Optional[list] = N
     # concurrent ingest. Always kill the subprocess on the way out.
     try:
         async for line in proc.stdout:
+            # Any byte counts as liveness. ingest.py flushes a marker at every
+            # stage, so silence really is "not progressing", not "buffered".
+            beat["at"] = time.monotonic()
             text = line.decode("utf-8", errors="replace").strip()
             if not text:
                 continue
@@ -604,8 +759,9 @@ async def _run_ingest_with_ws(target: Path, limit: int, opts: Optional[list] = N
 
         await proc.wait()
     finally:
+        watchdog.cancel()
         if proc.returncode is None:  # audit M3: loop exited abnormally — reap child
-            proc.kill()
+            _kill_ingest_tree(proc)
             await proc.wait()
     # Derive failed from the observed total (not `limit`, which is 0 for "all"
     # and overstates when it exceeds the real file count) and surface the exit
@@ -616,7 +772,11 @@ async def _run_ingest_with_ws(target: Path, limit: int, opts: Optional[list] = N
 
     await ingest_ws.broadcast({
         "type": "complete", "ok": ok, "skipped": skipped, "failed": failed,
-        "returncode": rc
+        "returncode": rc,
+        # Carried on `complete` as well as the earlier `halted`: a client that
+        # connected late, or missed the event, must still learn this run was cut
+        # short rather than read a partial result as a finished one.
+        "halted": halted["reason"],
     })
 
 

--- a/tests/test_ingest_budget.py
+++ b/tests/test_ingest_budget.py
@@ -1,0 +1,88 @@
+"""預估與兩道截止線的算法。
+
+2026-09-06 用 200 支現場素材反推出來的係數（單檔秒 ≈ 5.0 + 5.6 × 幀數，
+R² = 0.88），這裡鎖住它的**性質**而不是鎖住那兩個數字 —— 數字會隨機器改，
+性質不會：預估要隨量成長、探不到的檔不可以當成零、下限要擋住小批次被誤殺。
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import config  # noqa: E402
+import ingest_budget as ib  # noqa: E402
+
+
+def test_estimate_tracks_the_real_run():
+    """對照組：那批 200 支實測 94 分鐘，估值要落在同一個量級。"""
+    durations = [11.0] * 100 + [9.0] * 60 + [30.0] * 30 + [90.0] * 10
+    est = ib.estimate_seconds(durations)
+    assert 60 * 60 <= est <= 150 * 60, "%.0f 分" % (est / 60)
+
+
+def test_estimate_grows_with_frames_not_just_files():
+    """同樣的檔案數、更長的素材 → 更多幀 → 更貴。
+
+    這條在防「拿檔案數當唯一自變數」——實測那樣做 R² 只有 0.39。
+    """
+    short = ib.estimate_seconds([5.0] * 50)     # 每支 3 幀
+    long_ = ib.estimate_seconds([120.0] * 50)   # 每支 7 幀
+    assert long_ > short * 1.5
+
+
+def test_unprobed_files_are_not_treated_as_zero():
+    """🔴 探不到 ≠ 零秒。當成零會讓預算偏小，而偏小的預算會殺掉正常的匯入。"""
+    all_known = ib.estimate_seconds([20.0] * 10)
+    half_unknown = ib.estimate_seconds([20.0] * 5 + [None] * 5)
+    assert half_unknown == pytest.approx(all_known, rel=0.15)
+    # 反向：若被當成 0，估值會明顯掉下來
+    assert half_unknown > all_known * 0.7
+
+
+def test_estimate_extrapolates_when_only_a_sample_was_probed():
+    """只探測了前 N 支時，其餘要用中位數補齊，不可以當作不存在。"""
+    sampled = ib.estimate_seconds([20.0] * 10, n_files=100)
+    full = ib.estimate_seconds([20.0] * 100)
+    assert sampled == pytest.approx(full, rel=0.05)
+
+
+def test_estimate_with_nothing_probed_still_scales_with_count():
+    a = ib.estimate_seconds([None] * 10, n_files=10)
+    b = ib.estimate_seconds([None] * 100, n_files=100)
+    assert b == pytest.approx(a * 10, rel=0.01)
+    assert a > 0
+
+
+def test_budget_has_a_floor_so_small_imports_are_not_killed():
+    """暖機一次就 ~100 秒；沒有下限的話最小的匯入反而最容易被誤殺。"""
+    tiny = ib.budget_seconds(ib.estimate_seconds([3.0]))
+    assert tiny >= config.INGEST_BUDGET_FLOOR_SECONDS
+
+
+def test_budget_exceeds_the_estimate_it_is_derived_from():
+    """預算必須明顯大於估值 —— 估值只是建議，等於死線就等於沒有餘裕。"""
+    est = ib.estimate_seconds([30.0] * 300)
+    assert ib.budget_seconds(est) >= est * 1.5
+
+
+def test_stall_threshold_grows_with_the_longest_clip():
+    """whisper 解碼是一支檔一次不透明呼叫 —— 長片會靜默很久，門檻要跟著放大。
+
+    最慢的解碼路徑（faster-whisper large-v3 在 CPU 上）實測 RTF 1.22。
+    """
+    assert ib.stall_seconds(60) == config.INGEST_STALL_FLOOR_SECONDS
+    two_hours = ib.stall_seconds(7200)
+    assert two_hours > 7200, "門檻若小於素材本身時長，長片必被誤殺"
+
+
+def test_stall_threshold_never_drops_below_the_floor():
+    for d in (None, 0, -5, 1.0):
+        assert ib.stall_seconds(d) >= config.INGEST_STALL_FLOOR_SECONDS
+
+
+def test_frame_count_is_borrowed_not_reimplemented():
+    """🔴 幀數必須跟 frames.py 同一份實作，不可以在這裡重抄一份會漂的尺。"""
+    from frames import _adaptive_frame_count
+    for d in (0.5, 1.9, 2.0, 10.0, 10.1, 60.0, 61.0, 200.0):
+        assert ib._frames_for(d) == _adaptive_frame_count(d)

--- a/tests/test_ingest_watchdog_router.py
+++ b/tests/test_ingest_watchdog_router.py
@@ -1,0 +1,76 @@
+"""路由層：兩道截止線怎麼被算出來、以及它們如何回報。
+
+原本 `/api/ingest` 是一個寫死的 `timeout=1800`，而 `/api/ingest/ws`
+（UI 實際走的那條）**完全沒有 timeout** —— 卡住的子行程不會給 EOF，
+讀取迴圈就永遠等下去，單飛槽位也一直被占著。
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import proctree  # noqa: E402
+
+
+def test_scan_reports_an_estimate_and_both_limits(fastapi_client, monkeypatch, tmp_path):
+    monkeypatch.setenv("ARKIV_INGEST_ROOTS", str(tmp_path))
+    (tmp_path / "a.mp4").write_bytes(b"\x00" * 1024)
+    (tmp_path / "b.mp4").write_bytes(b"\x00" * 1024)
+    r = fastapi_client.post("/api/ingest/scan", json={"path": str(tmp_path)})
+    assert r.status_code == 200, r.text
+    est = r.json().get("estimate")
+    assert est, "掃描要能回答『這會跑多久』——否則使用者只能用猜的設參數"
+    for k in ("seconds", "budget_s", "stall_s", "probed", "of"):
+        assert k in est, k
+    # 預算必須嚴格大於估值，否則估值本身就變成死線
+    assert est["budget_s"] > est["seconds"]
+    assert est["of"] == 2
+
+
+def test_estimate_is_reported_even_when_nothing_can_be_probed(fastapi_client, monkeypatch, tmp_path):
+    """探不到時序估不可以整個消失 —— 那會讓 UI 退回沒有資訊的狀態。"""
+    monkeypatch.setenv("ARKIV_INGEST_ROOTS", str(tmp_path))
+    (tmp_path / "broken.mp4").write_bytes(b"not really a video")
+    r = fastapi_client.post("/api/ingest/scan", json={"path": str(tmp_path)})
+    est = r.json()["estimate"]
+    assert est["probed"] == 0
+    assert est["seconds"] > 0, "探不到就回 0 秒，等於宣稱『瞬間完成』"
+
+
+def test_timeout_detail_names_which_limit_fired():
+    """兩種停止要用不同的話講 —— 使用者的下一步不一樣。"""
+    from routers.ingest import _timeout_detail
+    stall = _timeout_detail(proctree.TreeTimeout(
+        ["x"], 600, "stall", elapsed=900, idle=700))
+    budget = _timeout_detail(proctree.TreeTimeout(
+        ["x"], 3600, "budget", elapsed=3700, idle=3))
+    assert "停滯" in stall and "卡住" in stall
+    assert "超過預估" in budget
+    assert stall != budget
+    # 兩者都必須說「已完成的不會丟」，否則使用者會以為要整批重來
+    for msg in (stall, budget):
+        assert "接續" in msg
+
+
+def test_limits_fall_back_to_floors_on_an_unreadable_folder(tmp_path):
+    """估算失敗不可以連累它只是在建議的那個匯入。"""
+    import config
+    from routers.ingest import _ingest_limits
+    stall, budget = _ingest_limits(tmp_path / "does-not-exist")
+    assert stall >= config.INGEST_STALL_FLOOR_SECONDS
+    assert budget >= config.INGEST_BUDGET_FLOOR_SECONDS
+
+
+def test_no_fixed_1800_second_deadline_remains():
+    """回歸鎖：那個寫死的 30 分鐘是本次要移除的東西。
+
+    它同時錯兩個方向 —— 200 支要 94 分鐘（撐不到第 60 支），
+    而對「已經卡死」又太久。
+    """
+    src = Path(__file__).resolve().parents[1] / "routers" / "ingest.py"
+    text = src.read_text(encoding="utf-8")
+    offending = [ln for ln in text.splitlines()
+                 if "timeout=1800" in ln.replace(" ", "")]
+    assert not offending, offending

--- a/tests/test_proctree_watched.py
+++ b/tests/test_proctree_watched.py
@@ -1,0 +1,115 @@
+"""兩道獨立的截止線 —— 而它們必須說得出是哪一道觸發的。
+
+固定 30 分鐘死線同時錯兩個方向：對 200 支的匯入太小（實測要 94 分鐘，
+撐不到第 60 支），對「已經卡死的 ffmpeg」又太大。拆成
+「靜默多久」與「總共多久」之後，兩者才各自能設對。
+
+⚠️ 本檔刻意用秒級門檻跑真的子行程 —— 這條路徑的失效模式（緩衝、
+執行緒沒收、孫行程沒被殺）在 mock 裡全部看不見。
+"""
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import proctree  # noqa: E402
+
+
+def _py(code):
+    return [sys.executable, "-c", code]
+
+
+def test_normal_run_returns_output_and_code():
+    r = proctree.run_tree_watched(
+        _py("import sys; print('hello'); sys.exit(3)"),
+        stall_timeout=10, total_timeout=10)
+    assert r.returncode == 3
+    assert "hello" in r.stdout
+
+
+def test_silent_child_is_killed_as_stall():
+    """沒有輸出 = 停滯。這是 watchdog 的主要用途。"""
+    t0 = time.time()
+    with pytest.raises(proctree.TreeTimeout) as ei:
+        proctree.run_tree_watched(
+            _py("import time; time.sleep(60)"),
+            stall_timeout=1.5, total_timeout=30)
+    assert ei.value.kind == "stall"
+    assert ei.value.idle >= 1.5
+    assert time.time() - t0 < 15, "應該在 stall_timeout 後就殺，不是等到 total"
+
+
+def test_chatty_but_overlong_child_is_killed_as_budget():
+    """一直在講話但超過總預算 —— 這是「估錯了」，不是「卡住了」。
+
+    配對驗：跟上一條的差別只有「有沒有輸出」，而兩者必須回不同的 kind。
+    """
+    with pytest.raises(proctree.TreeTimeout) as ei:
+        proctree.run_tree_watched(
+            _py("import time,sys\n"
+                "for i in range(200):\n"
+                "    print(i, flush=True); time.sleep(0.2)"),
+            stall_timeout=5, total_timeout=1.5)
+    assert ei.value.kind == "budget"
+    assert ei.value.elapsed >= 1.5
+
+
+def test_output_captured_up_to_the_kill():
+    """殺掉時已經產出的東西不可以丟 —— 那是使用者唯一的線索。"""
+    with pytest.raises(proctree.TreeTimeout) as ei:
+        proctree.run_tree_watched(
+            _py("import time,sys\nprint('MARKER', flush=True)\ntime.sleep(60)"),
+            stall_timeout=1.5, total_timeout=30)
+    assert "MARKER" in (ei.value.output or "")
+
+
+def test_on_line_sees_lines_as_they_arrive():
+    seen = []
+    proctree.run_tree_watched(
+        _py("import sys\nfor i in range(3): print('L%d' % i, flush=True)"),
+        stall_timeout=10, total_timeout=10, on_line=seen.append)
+    assert [x.strip() for x in seen] == ["L0", "L1", "L2"]
+
+
+def test_a_broken_on_line_cannot_kill_the_run():
+    """負向：消費端壞掉不可以連累匯入本身。"""
+    def boom(_line):
+        raise ValueError("consumer exploded")
+    r = proctree.run_tree_watched(
+        _py("print('still fine')"), stall_timeout=10, total_timeout=10, on_line=boom)
+    assert r.returncode == 0
+    assert "still fine" in r.stdout
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX 的行程群組語意")
+def test_stall_kill_takes_the_grandchild_too(tmp_path):
+    """整棵樹要一起死 —— 只殺直接子行程會留下 ffmpeg/whisper 孤兒。
+
+    孫行程把自己的 pid 寫進檔案，然後長睡；殺完之後那個 pid 必須不存在。
+    """
+    pidfile = tmp_path / "grandchild.pid"
+    code = (
+        "import subprocess, sys, time\n"
+        "gc = subprocess.Popen([sys.executable, '-c',\n"
+        "  \"import os,time,sys; open(sys.argv[1],'w').write(str(os.getpid())); time.sleep(120)\",\n"
+        "  %r])\n"
+        "time.sleep(120)\n" % str(pidfile)
+    )
+    with pytest.raises(proctree.TreeTimeout):
+        proctree.run_tree_watched(_py(code), stall_timeout=2.5, total_timeout=30)
+    deadline = time.time() + 5
+    pid = None
+    while time.time() < deadline and pid is None:
+        if pidfile.exists() and pidfile.read_text().strip():
+            pid = int(pidfile.read_text().strip())
+        else:
+            time.sleep(0.2)
+    assert pid, "孫行程沒來得及登記 pid，這條測不到東西"
+    time.sleep(0.5)
+    with pytest.raises(OSError):
+        os.kill(pid, 0)   # 還活著的話這裡不會丟例外 → 測試失敗


### PR DESCRIPTION
`routers/ingest.py` 寫死 `timeout=1800`，而 `/api/ingest/ws`（**UI 實際走的那條**）
完全沒有 timeout。兩者都不對：

| | 問題 |
|---|---|
| `/api/ingest` | 2026-09-06 實測 200 支要 **94 分鐘** — 30 分鐘撐不到第 60 支，而它硬殺整棵樹 |
| `/api/ingest/ws` | 卡住時子行程不給 EOF → 讀取迴圈永遠等下去、單飛槽位一直被占著 |

## 兩道獨立的截止線

```
stall    子行程可以沉默多久   → 抓「卡住了」
budget   整批總共可以跑多久   → 抓「估錯了」
```

分開之後兩者才各自設得對，而且**停止時說得出是哪一道** —— 使用者的下一步不同：
停滯要去看機器（ollama 還活著嗎），超預算多半只是估低了、重跑就好。
兩種訊息都明寫「已完成的素材都在庫裡、重跑會接續」。

## 係數是量出來的，不是猜的

拿那次跑掛的 log 逐檔耗時（n=33）迴歸：

| 自變數 | R² |
|---|---|
| 素材時長 | 0.39 |
| **幀數** | **0.88** |

成本由 vision 的**幀數**驅動，不是片長：

```
單檔處理秒 ≈ 5.0 + 5.6 × 幀數     (R² = 0.88, n=33)

  幀數 3 → 中位 21.8s（每幀 7.3s）
  幀數 5 → 中位 32.7s（每幀 6.5s）
```

回推那批 200 支 → **91 分鐘**，實測 **94 分鐘**。
係數走 `config` 常數、可用環境變數覆寫（M2 Max + qwen2.5vl:7b 上量的，換機器會漂），
預算 = 估值 × 2。

⚠️ **停滯門檻不是死的 10 分鐘。** `transcribe.py` 自己的註解寫著 whisper 解碼是
「一支檔一次不透明呼叫」—— 長片在解碼期間完全不出聲。最慢的解碼路徑
（faster-whisper large-v3 在 CPU 上，Mac 沒有 Metal）實測 **RTF 1.22**，
所以門檻隨最長的素材放大：`max(600s, 最長素材 × 1.3)`。

## 幀數不重抄一份

`ingest_budget._frames_for` 直接 import `frames._adaptive_frame_count`。
兩份會漂，而漂掉之後預算會**安靜地**變錯 —— 有一條測試專門鎖這件事。

## 其他

- **scan 回 ETA**：16 執行緒探時長（200 支 8.5 秒），回傳預估、預算、停滯門檻給 UI。
  探不到的檔用中位數代入，**不可以當成 0** —— 那會讓預算偏小而殺掉正常的匯入（有測試）。
- **WS 子行程改用 `start_new_session`**，watchdog 才殺得掉整棵樹。原本 `proc.kill()`
  會留下 ffmpeg/whisper 孤兒占著 GPU —— 正是 `run_tree` 存在的理由，而這條路徑從來沒有，
  因為它根本沒有 timeout。
- **`complete` 事件也帶 `halted` 原因**：晚加入的前端沒看到 `halted` 事件，
  不能把被中斷的結果讀成正常完成。
- **前端**：Ingest 設定頁的 `timing pending · brick 4` 佔位換成真的 ETA；
  Live 頁被停止時跳出告警框，兩種原因用不同的話講。

## 驗證

| | 未修版 | 已修版 |
|---|---|---|
| 22 條新測試 | router 那 5 條**全紅** | 全綠 |

| 檢查 | 結果 |
|---|---|
| `pytest -q` | 2006 → **2028 passed**, 8 skipped |
| `npm run check` | 41 檔 **0 errors 0 warnings** |
| `npm run test` | **24 pass 0 fail** |

`proctree` 的測試**刻意跑真的子行程**（含「孫行程也要一起死」那條）——
緩衝、執行緒沒收、孤兒行程這些失效模式在 mock 裡全部看不見。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4bk97WfFTpK1xQCWuvZPg