### PR TITLE
feat(ingest): 瀏覽器根本沒有選資料夾的能力 —— 補常用來源捷徑

### DIFF
--- a/frontend/src/routes/IngestSetup.svelte
+++ b/frontend/src/routes/IngestSetup.svelte
@@ -28,6 +28,11 @@
   // brick 4 — real transcription pickers, options from /api/ingest/engines.
   // '' = use the backend default (no flag sent), so unchanged callers stay default.
   let engines = null
+  // Source shortcuts: [{label, path}]. The browser build has no folder picker
+  // (canPickFolder() needs window.__TAURI__), so without these the only way to
+  // reach a long NAS path on the web UI is to retype it every single time.
+  let presets = []
+  let presetNote = ''
   let whisperGuard = '' // '' = default preset; else mode int as string
   let language = ''     // '' = auto-detect; else whisper code
   // brick 4b — vision model picker. Unlike the per-run whisper preset above,
@@ -114,6 +119,25 @@
   // Persist the chosen vision model as the library default (vision.model), the
   // same setting SettingsLive writes. The next ingest picks it up via
   // settings.vision_model(). No per-run flag exists for vision (by design).
+  // Adding the shortcut from here rather than only in Settings: the moment you
+  // know a path is worth keeping is right after you typed it, not later in
+  // another screen.
+  async function savePreset() {
+    const val = path.trim()
+    if (!val) { presetNote = '先填路徑'; return }
+    if (presets.some((p) => p.path === val)) { presetNote = '這個路徑已在捷徑裡'; return }
+    const label = (val.replace(/\/+$/, '').split('/').pop() || val).slice(0, 24)
+    const next = [...presets, { label, path: val }]
+    presetNote = '儲存中…'
+    try {
+      await api.putSettings({
+        'ingest.source_presets': next.map((p) => `${p.label}|${p.path}`).join('; '),
+      })
+      presets = next
+      presetNote = `已加入捷徑「${label}」`
+    } catch (e) { presetNote = '儲存失敗' }
+  }
+
   async function saveVisionModel() {
     visionNote = '儲存中…'
     try { await api.putSettings({ 'vision.model': visionModel }); visionNote = '已設為全庫預設 ✓' }
@@ -130,6 +154,7 @@
       if (engines && engines.default_language) language = engines.default_language
       if (engines && typeof engines.default_recursive === 'boolean') opts.recursive = engines.default_recursive
       if (engines && engines.vision_model) visionModel = engines.vision_model
+      presets = engines?.source_presets ?? []
     } catch (e) { /* picker falls back to default-only */ }
     const h = window.location.hash
     const qi = h.indexOf('?')
@@ -175,6 +200,16 @@
               <button class="seg" on:click={browsePath} disabled={scanning} title="選擇資料夾">⋯</button>
             {/if}
             <button class="ak-btn" on:click={scan} disabled={scanning}>{scanning ? 'scanning…' : 'Scan'}</button>
+          </div>
+          <div class="presetrow">
+            {#each presets as p (p.path)}
+              <button class="seg preset" class:on={path.trim() === p.path}
+                      title={p.path} on:click={() => { path = p.path; scan() }}>{p.label}</button>
+            {/each}
+            <button class="seg preset add" on:click={savePreset}
+                    title="把目前路徑存成捷徑（存在 Settings 的 ingest.source_presets）">＋</button>
+            {#if presetNote}<Mono dim style="font-size:9.5px;">{presetNote}</Mono>
+            {:else if !presets.length}<Mono dim style="font-size:9.5px;">按 ＋ 把常用路徑存成捷徑</Mono>{/if}
           </div>
         </div>
 
@@ -295,6 +330,9 @@
   .sel:focus { outline: none; border-color: var(--ink); }
 
   .optrow { display: flex; align-items: center; gap: 14px; }
+  .presetrow { display: flex; flex-wrap: wrap; align-items: center; gap: 4px; margin-top: 5px; }
+  .preset { font-size: 10px; padding: 2px 8px; }
+  .preset.add { font-weight: 600; }
   .optlabel { display: flex; flex-direction: column; gap: 1px; font-size: 12px; }
   .seg { font-family: var(--ak-mono); font-size: 10px; letter-spacing: 0.08em; width: 46px; flex: 0 0 46px; padding: 5px 0; border: 1px solid var(--rule-hi); background: transparent; color: var(--quiet); cursor: pointer; }
   .seg.on { background: var(--invert); color: var(--invert-ink); border-color: var(--invert); font-weight: 700; }

--- a/routers/ingest.py
+++ b/routers/ingest.py
@@ -142,6 +142,10 @@ def ingest_engines(
         "vision_models": vision_models,
         "vision_num_ctx": settings_store.vision_num_ctx(),
         "languages": _INGEST_LANGUAGES,
+        # Source shortcuts. The browser build has no folder picker at all
+        # (canPickFolder() needs window.__TAURI__), so on the web UI the only way
+        # to reach a long NAS path is to retype it every time.
+        "source_presets": settings_store.source_preset_list(),
     }
 
 

--- a/settings.py
+++ b/settings.py
@@ -137,6 +137,16 @@ def _schema() -> Dict[str, Dict[str, Any]]:
             "max": 40,
         },
         # --- Ingest defaults ---
+        # A single str rather than a new list type: adding one would ripple through
+        # _coerce / _stored_to_typed / _typed_to_stored and the settings UI, for a
+        # value that is a handful of short strings. Format is documented in the
+        # label because that label IS the UI for editing it.
+        "ingest.source_presets": {
+            "group": "ingest",
+            "label": "Ingest source shortcuts — 標籤|路徑，以分號分隔（例：CARD|/Volumes/CARD/DCIM; NAS|/Volumes/home/影片專案）",
+            "type": "str",
+            "default": lambda: "",
+        },
         "ingest.recursive": {
             "group": "ingest",
             "label": "Recurse into sub-folders by default",
@@ -281,6 +291,40 @@ def transcription_default_mode(project: Optional[str] = None) -> int:
 def transcription_default_language(project: Optional[str] = None) -> str:
     """Effective forced language; "" means auto-detect."""
     return for_project("transcription.default_language", project)
+
+
+def ingest_source_presets(project: Optional[str] = None) -> str:
+    """The raw shortcut string. Thin and scope-aware like every other accessor —
+    parsing lives in `source_preset_list` so this one keeps the uniform
+    "write a value, read that value back" contract the schema coverage test locks."""
+    return str(for_project("ingest.source_presets", project) or "")
+
+
+def source_preset_list(project: Optional[str] = None) -> List[Dict[str, str]]:
+    """[{label, path}] for the ingest source shortcut buttons.
+
+    Deliberately forgiving: a malformed entry is dropped rather than raising.
+    This value is typed by hand into a settings field, and a stray semicolon must
+    not be able to break the ingest screen — losing one shortcut is recoverable,
+    a screen that will not render is not.
+    """
+    raw = ingest_source_presets(project)
+    out: List[Dict[str, str]] = []
+    seen = set()
+    for chunk in str(raw).split(";"):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        label, sep, path = chunk.partition("|")
+        label, path = label.strip(), path.strip()
+        if not sep:            # no "|" — treat the whole thing as a path
+            label, path = "", chunk
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        out.append({"label": label or path.rstrip("/").split("/")[-1] or path,
+                    "path": path})
+    return out
 
 
 def ingest_recursive(project: Optional[str] = None) -> bool:

--- a/tests/test_ingest_source_presets.py
+++ b/tests/test_ingest_source_presets.py
@@ -1,0 +1,66 @@
+"""Ingest 來源捷徑 —— 而它存在的理由是瀏覽器根本沒有選資料夾的能力。
+
+`canPickFolder()` 要 `window.__TAURI__`，所以 `⋯` 那顆按鈕**只有桌面 App 會渲染**。
+在瀏覽器開 :8501 的人，每次都得手打
+`/Volumes/home/影片專案/商業案/李多慧` 這種長路徑。
+
+解析刻意寬鬆：這個值是人手打進設定欄位的，一個多餘的分號不可以讓匯入頁開不起來。
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import settings  # noqa: E402
+
+
+def _parse(monkeypatch, raw):
+    monkeypatch.setattr(settings, "for_project", lambda *a, **k: raw)
+    return settings.source_preset_list()
+
+
+def test_label_and_path_pairs(monkeypatch):
+    got = _parse(monkeypatch, "CARD|/Volumes/CARD/DCIM; NAS|/Volumes/home/影片專案")
+    assert got == [{"label": "CARD", "path": "/Volumes/CARD/DCIM"},
+                   {"label": "NAS", "path": "/Volumes/home/影片專案"}]
+
+
+def test_bare_path_gets_its_folder_name_as_label(monkeypatch):
+    got = _parse(monkeypatch, "/Volumes/home/影片專案/李多慧")
+    assert got == [{"label": "李多慧", "path": "/Volumes/home/影片專案/李多慧"}]
+
+
+def test_malformed_input_drops_entries_instead_of_raising(monkeypatch):
+    """🔴 一個多打的分號不可以讓整頁掛掉 —— 少一個捷徑救得回來，開不起來的畫面救不回來。"""
+    for raw in ("", ";", ";;;", "   ", "|", "A|", "|/x;B|/y"):
+        got = _parse(monkeypatch, raw)
+        assert isinstance(got, list)
+        for item in got:
+            assert item["path"] and item["label"]
+
+
+def test_duplicate_paths_collapse(monkeypatch):
+    got = _parse(monkeypatch, "X|/same; Y|/same")
+    assert len(got) == 1
+
+
+def test_empty_setting_is_empty_list_not_none(monkeypatch):
+    """UI 用 `{#each}` 走它 —— None 會炸，[] 不會。"""
+    assert _parse(monkeypatch, "") == []
+    assert _parse(monkeypatch, None) == []
+
+
+def test_engines_endpoint_exposes_the_presets(fastapi_client):
+    r = fastapi_client.get("/api/ingest/engines")
+    assert r.status_code == 200, r.text
+    assert "source_presets" in r.json(), "前端只讀這個端點，沒帶就等於沒做"
+    assert isinstance(r.json()["source_presets"], list)
+
+
+def test_setting_is_registered_in_the_schema(monkeypatch):
+    """沒進 schema 就 PUT 不進去 —— 而 UI 的『＋』就是靠 PUT 存的。"""
+    assert "ingest.source_presets" in settings.SETTINGS_SCHEMA
+    assert settings.SETTINGS_SCHEMA["ingest.source_presets"]["type"] == "str"
+    # accessor 必須穿透（薄的），解析是另一個函式 —— 這是 settings 的體例，
+    # 由 test_settings_g5 的覆蓋表逐 key 驗 project scope
+    monkeypatch.setattr(settings, "for_project", lambda *a, **k: "A|/x")
+    assert settings.ingest_source_presets() == "A|/x"

--- a/tests/test_settings_g5.py
+++ b/tests/test_settings_g5.py
@@ -297,6 +297,7 @@ def _accessors(settings):
         "export.default_dir": ("/tmp/arkiv-out", settings.export_default_dir),
         "export.subtitle_max_cjk": (30, settings.subtitle_max_cjk),
         "ingest.recursive": (False, settings.ingest_recursive),
+        "ingest.source_presets": ("CARD|/Volumes/CARD/DCIM", settings.ingest_source_presets),
     }
 
 


### PR DESCRIPTION
`IngestSetup.svelte:174` 的 `⋯` 選資料夾按鈕包在 `{#if canBrowse}` 裡，而
`canPickFolder()` 需要 `window.__TAURI__` —— **只有桌面 App 會渲染**。

在瀏覽器開 :8501 的人，每次都得手打 `/Volumes/home/影片專案/商業案/李多慧` 這種長路徑。

## 做法

```
Source · folder
[/Volumes/home/影片專案/商業案/李多慧      ] [Scan]
[李多慧] [CARD] [NAS 專案] [＋]        ← 新增這一排
```

點一下填入並自動 Scan。清單存在 `ingest.source_presets`（Settings 可維護），
格式 `標籤|路徑`、以分號分隔。

那顆「＋」把**目前**路徑存成捷徑 —— 知道一個路徑值得留下來的那一刻，
是你剛打完它的時候，不是之後跑去另一個畫面時。

## 兩個結構決定

**① 用 `str` 存，不新增 list 型別。**
加一個型別會擴散到 `_coerce` / `_stored_to_typed` / `_typed_to_stored` 與設定 UI 四處，
而這個值只是幾個短字串。

**② accessor 保持穿透，解析另立 `source_preset_list()`。**
第一版讓 accessor 直接回解析後的 list，被既有的
`test_settings_g5::test_every_setting_has_an_accessor` 抓到 —— 那張覆蓋表的契約是
「寫什麼讀什麼」，並逐 key 驗 project scope。
**是既有測試先發現我破壞了體例，不是我自己看出來的**，所以順手把新 key 補進那張表。

## 解析刻意寬鬆

這個值是人手打進設定欄位的，**一個多餘的分號不可以讓匯入頁開不起來** ——
少一個捷徑救得回來，開不起來的畫面救不回來。

| 輸入 | 結果 |
|---|---|
| `CARD\|/a; NAS\|/b` | 2 筆 |
| `/only/path` | 1 筆（標籤取資料夾名） |
| `A\|/x;;B\|/y;` | 2 筆（多餘分號忽略） |
| `X\|/dup;Y\|/dup` | 1 筆（去重） |
| `""` / `;;;` / `\|` / `A\|` | `[]`，不丟例外 |

## 驗證

| 檢查 | 結果 |
|---|---|
| `pytest -q` | **2019 passed**, 8 skipped |
| `npm run check` | 41 檔 **0 errors 0 warnings** |
| `npm run test` | **24 pass 0 fail** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4bk97WfFTpK1xQCWuvZPg