### PR TITLE
fix(settings): Projects 頁沒說「你現在開的是哪個庫」—— 而註冊表看起來像切換器

### DIFF
--- a/frontend/src/routes/SettingsLive.svelte
+++ b/frontend/src/routes/SettingsLive.svelte
@@ -569,14 +569,21 @@
             <div class="fshead">
               <Eyebrow style="margin-bottom:4px;">PROJECT REGISTRY · 專案註冊表</Eyebrow>
               <div class="ak-display fstitle">Projects</div>
-              <div class="fsdesc">跨庫專案登記——加入 / 移除 / 同步索引時間。寫入 <code>~/.arkiv-projects.json</code>。健康狀態來自 <code>/api/projects/health</code>。</div>
+              <div class="fsdesc">跨庫專案登記——加入 / 移除 / 同步索引時間。寫入 <code>~/.arkiv-projects.json</code>。健康狀態來自 <code>/api/projects/health</code>。<br />註冊表的用途是讓跨庫精選集能以名稱指認片段，<strong>不是素材庫的切換器</strong>——一個伺服器行程只服務一個素材庫。</div>
             </div>
+
+            <div class="pactive">
+              <span class="pactlabel">目前開啟</span>
+              <span class="pactname">{stats?.project_registered_name || stats?.project || '—'}</span>
+              {#if stats && !stats.project_registered_name}<span class="pactwarn">未註冊</span>{/if}
+            </div>
+            <div class="pacthint">要看別的素材庫，得用該路徑重新啟動後端（<code>ARKIV_PROJECT_ROOT</code>）；在這張表上新增或移除不會改變上面這一行。</div>
 
             <div class="ptable">
               <div class="phead"><span>NAME</span><span>PATH</span><span>INDEXED</span><span>HEALTH</span><span></span></div>
               {#each projects as p}
-                <div class="prow">
-                  <span class="pname">{p.name}</span>
+                <div class="prow" class:pcurrent={!!stats?.project_registered_name && p.name === stats.project_registered_name}>
+                  <span class="pname">{p.name}{#if !!stats?.project_registered_name && p.name === stats.project_registered_name}<span class="pdot" title="目前開啟中">●</span>{/if}</span>
                   <span class="ppath" title={p.path}>{p.path}</span>
                   <Mono dim style="font-size:10.5px;">{shortDate(p.last_indexed_at)}</Mono>
                   <span class="phealth" class:ok={projHealth[p.name] === 'ok'}>{projHealth[p.name] || '—'}</span>
@@ -715,4 +722,11 @@
   .phealth { font-family: var(--ak-mono); font-size: 10px; letter-spacing: 0.04em; text-transform: uppercase; color: var(--quiet-2); }
   .phealth.ok { color: var(--cyan); }
   .paddrow { display: grid; grid-template-columns: 1.2fr 2fr 1.4fr; gap: 8px; margin-bottom: 12px; }
+  .pactive { display: flex; align-items: baseline; gap: 8px; margin-bottom: 4px; }
+  .pactlabel { font-family: var(--ak-mono); font-size: 9px; letter-spacing: 0.08em; color: var(--quiet-2); text-transform: uppercase; }
+  .pactname { font-size: 13px; color: var(--ink); }
+  .pactwarn { font-family: var(--ak-mono); font-size: 10px; letter-spacing: 0.04em; color: var(--quiet-2); text-transform: uppercase; }
+  .pacthint { font-size: 11px; color: var(--quiet); margin-bottom: 10px; line-height: 1.5; }
+  .prow.pcurrent .pname { color: var(--cyan); }
+  .pdot { color: var(--cyan); font-size: 9px; margin-left: 5px; vertical-align: middle; }
 </style>


### PR DESCRIPTION
## 症狀

在 Projects 註冊一個素材庫 → 它出現在表裡、健康狀態 ok → 使用者以為可以開它 → 看到的還是原本那個庫，而且**沒有任何錯誤訊息**。

實際踩到的經過：先在 UI 註冊了一個新庫、API 回 200、清單也確實多一列，於是判定「App 看得到了」。它確實在清單裡 —— 只是清單不是入口。

## 根因不是「切換壞了」，是「從來就沒有切換」

`settings.py:15` 已經寫明：*one server process serves one library*。資料根在 import 時由 `ARKIV_PROJECT_ROOT` 定死（`config.py:75`），前端也確實沒有任何切換端點（整份 JS 只有 `api/projects`、`/`、`/health`、`/sync`）。

註冊表的用途是讓跨庫精選集以 `(project_name, media_id)` 指認片段（`bins.py:4`）——**這是對的**。壞的是它沒告訴使用者自己不是切換器，而 UI 的形狀（名稱／路徑／健康狀態的表格）讀起來就像一個庫的清單。

同一個形狀在這個 repo 已經出現過：每一層都「成功」了，只有使用者要的那件事沒發生。

## 改法

`/api/stats` **早就**回傳 `project_registered_name`（`routers/analytics.py:87`），前端從來沒用過它。所以不必動後端：

- 表格上方加一行「目前開啟 &lt;名稱&gt;」；當前載入的庫未註冊時標「未註冊」並退回目錄名（`stats.project`）
- 說明文字明講註冊表不是切換器，要換庫得用該路徑重啟後端
- 對應的那一列標 ● 並上色，讓「清單裡的某一個」跟「現在這一個」視覺上分得開

只動 `SettingsLive.svelte`，+17/−3。不新增 API、不動後端。

## 驗證

| 項目 | 結果 |
|---|---|
| `svelte-check --fail-on-warnings` | 41 檔 · 0 error · 0 warning |
| `vite build` | 通過 |
| `node --test` | 24 pass · 0 fail |
| 隔離環境實測 | 以 `ARKIV_PROJECTS_REGISTRY` 起 v1.3.0 伺服器，`/api/stats` 回 `project='庫A'` / `project_registered_name='婚禮案素材庫'`，確認兩者的區別如 `projects.py:466` 註解所述 |
| 送出的 bundle | 含全部新字串與 `project_registered_name&&…` 條件守衛 |

⚠️ **像素層截圖未做** —— 瀏覽器 profile 當時被其他工作佔用。以上是到 HTTP 為止的驗證，最後的視覺呈現請 reviewer 過目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JDgzY5sojuSEqD4epJx4P