### PR TITLE
fix(ingest): 相機的旋轉旗標可能是錯的，而照著轉會毀掉整條下游

### DIFF
--- a/config.py
+++ b/config.py
@@ -371,6 +371,21 @@ def _detect_ffmpeg_tool(tool: str, env_var: str) -> str:
 
 
 FFMPEG_PATH = _detect_ffmpeg_tool("ffmpeg", "ARKIV_FFMPEG_PATH")
+
+# Ignore the container's rotation metadata (display matrix / tags.rotate).
+#
+# Cameras write that flag from an orientation sensor, and the sensor can be
+# wrong — a body on a gimbal, or pointed steeply up/down, can record a 90°
+# flag over footage that is already correctly framed landscape. Honouring it
+# then rotates good footage into a sideways, pillarboxed mess, and because the
+# swap happens at ingest every downstream artifact inherits it: stored
+# width/height, thumbnails, the frames vision reads, and proxies. Nothing
+# errors — the vision descriptions come back plausible-sounding for a sideways
+# image, so the damage is invisible in the data.
+#
+# Off by default: genuinely vertical footage exists and its flag is correct.
+# Turn it on per-ingest for a shoot you have confirmed is mis-flagged.
+IGNORE_ROTATION = os.getenv("ARKIV_IGNORE_ROTATION", "0").lower() in ("1", "true", "yes")
 FFPROBE_PATH = _detect_ffmpeg_tool("ffprobe", "ARKIV_FFPROBE_PATH")
 
 import platform as _plat

--- a/frames.py
+++ b/frames.py
@@ -210,8 +210,11 @@ def _extract_frame_to(video_path: str, t: float, out: Path) -> bool:
     # to be a real photo used to land with no thumbnail and no frames while
     # .png / .webp came through fine. Omit the seek entirely for stills.
     seek = [] if _is_still_raster(video_path) else ["-ss", str(t)]
+    # -noautorotate must precede -i: it is a demuxer option, so after the input
+    # it is silently ignored and the frame still comes out rotated.
+    norot = ["-noautorotate"] if getattr(config, "IGNORE_ROTATION", False) else []
     cmd = (
-        [config.FFMPEG_PATH] + seek + ["-i", video_path]
+        [config.FFMPEG_PATH] + norot + seek + ["-i", video_path]
         + _frame_vf_args(video_path)
         + ["-frames:v", "1", str(tmp), "-y"]
     )

--- a/ingest.py
+++ b/ingest.py
@@ -392,7 +392,15 @@ def probe(path: str) -> Optional[Dict]:
                 if "rotation" in sd:
                     try: rot = abs(int(sd["rotation"]))
                     except (ValueError, TypeError): pass
-        if rot in (90, 270):
+        if rot:
+            # Surfacing, not silence: a rotation flag is the one piece of
+            # geometry we take on trust from the file, and when it is wrong
+            # every artifact below it is wrong too with nothing to show for it.
+            print("  [rotation] {0}: metadata says {1}° — {2}".format(
+                os.path.basename(path), rot,
+                "ignored (ARKIV_IGNORE_ROTATION=1)"
+                if getattr(config, "IGNORE_ROTATION", False) else "applied"))
+        if rot in (90, 270) and not getattr(config, "IGNORE_ROTATION", False):
             w, h = h, w
 
     return {

--- a/tests/test_rotation_override.py
+++ b/tests/test_rotation_override.py
@@ -1,0 +1,98 @@
+"""Container rotation metadata can be wrong, and honouring it corrupts every
+downstream artifact.
+
+A camera writes the rotation flag from an orientation sensor. On a gimbal, or
+pointed steeply up or down, that sensor misreads and the file ends up carrying
+a 90/180° flag over footage that is already framed landscape. Honouring it
+swaps the stored width/height, rotates the thumbnail, rotates the frames vision
+reads, and rotates the proxy — and the vision captions come back reading
+perfectly plausible for a sideways image, so nothing in the data says anything
+is wrong.
+
+Observed on a real shoot: 6 of 200 clips, 4 of them stored as 2160x3840.
+"""
+import importlib
+import json
+import config
+import ingest
+import frames as frm
+
+
+def _reload(monkeypatch, value):
+    monkeypatch.setenv("ARKIV_IGNORE_ROTATION", value)
+    importlib.reload(config)
+    importlib.reload(ingest)
+    importlib.reload(frm)
+    return config
+
+
+def _stub_ffprobe(monkeypatch, mod, rotation):
+    """probe() shells out to ffprobe; stub the subprocess, not a helper."""
+    class _R:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+    def fake_run(cmd, **kw):
+        r = _R(); r.stdout = json.dumps(_probe_payload(rotation)); return r
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+
+def _probe_payload(rotation):
+    return {
+        "streams": [{
+            "codec_type": "video", "width": 3840, "height": 2160,
+            "r_frame_rate": "60000/1001",
+            "side_data_list": [{"rotation": rotation}],
+        }],
+        "format": {"duration": "10.0", "size": "1000000"},
+    }
+
+
+def test_rotation_is_honoured_by_default(monkeypatch, tmp_path):
+    """Genuinely vertical footage exists and its flag is correct — the default
+    must keep trusting it."""
+    cfg = _reload(monkeypatch, "0")
+    assert cfg.IGNORE_ROTATION is False
+    _stub_ffprobe(monkeypatch, ingest, -90)
+    f = tmp_path / "a.mp4"; f.write_bytes(b"x")
+    got = ingest.probe(str(f))
+    assert (got["width"], got["height"]) == (2160, 3840)
+
+
+def test_rotation_can_be_ignored(monkeypatch, tmp_path):
+    cfg = _reload(monkeypatch, "1")
+    assert cfg.IGNORE_ROTATION is True
+    _stub_ffprobe(monkeypatch, ingest, -90)
+    f = tmp_path / "a.mp4"; f.write_bytes(b"x")
+    got = ingest.probe(str(f))
+    assert (got["width"], got["height"]) == (3840, 2160), \
+        "ignoring rotation must leave the stored geometry alone"
+
+
+def test_frame_extraction_passes_noautorotate_when_ignoring(monkeypatch, tmp_path):
+    """-noautorotate is a demuxer option: after -i it is silently ignored and
+    the frame still comes out rotated. It has to precede the input."""
+    _reload(monkeypatch, "1")
+    seen = {}
+    def _cap(cmd, out_path=None, timeout=60):
+        seen["cmd"] = cmd
+        return False        # 讓 _extract_frame_to 走失敗路徑，不去 os.replace
+    monkeypatch.setattr(frm, "_run_ffmpeg", _cap)
+    src = tmp_path / "a.mp4"; src.write_bytes(b"x")
+    frm._extract_frame_to(str(src), 1.0, tmp_path / "o.jpg")
+    cmd = seen.get("cmd", [])
+    assert "-noautorotate" in cmd, cmd
+    assert cmd.index("-noautorotate") < cmd.index("-i"), \
+        "-noautorotate after -i is silently ignored"
+
+
+def test_frame_extraction_omits_noautorotate_by_default(monkeypatch, tmp_path):
+    _reload(monkeypatch, "0")
+    seen = {}
+    def _cap(cmd, out_path=None, timeout=60):
+        seen["cmd"] = cmd
+        return False        # 讓 _extract_frame_to 走失敗路徑，不去 os.replace
+    monkeypatch.setattr(frm, "_run_ffmpeg", _cap)
+    src = tmp_path / "a.mp4"; src.write_bytes(b"x")
+    frm._extract_frame_to(str(src), 1.0, tmp_path / "o.jpg")
+    assert "-noautorotate" not in seen.get("cmd", []), seen.get("cmd")


### PR DESCRIPTION
## 症狀

一場實拍 200 支素材，其中 6 支帶了 `±90` / `±180` 的旋轉 metadata —— 但**素材本身是正常的橫幅**。機身在 RS2 Pro 雲台上，方向感測器誤判。

ingest 無條件相信那個旗標（`ingest.py` 讀到 90/270 就對調 w/h，ffmpeg 也預設 autorotate），於是：

```
DB 的 width/height 被對調      4 支變成 2160×3840
縮圖                          320×569 直式（正常是 320×180）
vision 讀的幀                  側躺的畫面
proxy                         側躺的畫面
```

## 為什麼沒被發現

**vision 對側躺畫面照樣吐出通順的描述**：

> `0064` → 「一群人在室內活動中拍照。」「一位女性在活動上與觀眾互動。」

從資料本身完全看不出異常。真正發現它是因為**成片裡出現了左右兩條大黑邊的直式畫面** —— 已經是下游好幾層之後。

## 修法

新增 `ARKIV_IGNORE_ROTATION`（**預設關**）：

- 開啟時 `probe` 不對調 w/h，`frames` 的 ffmpeg 加 `-noautorotate`
- 預設維持關閉，因為**真正直拍的素材存在且它的旗標是對的**

這不是「旗標一律不可信」，是「這一批確認是錯的」—— 所以做成 per-ingest 的開關，不是行為變更。

同時讓 ingest **把偵測到的旋轉印出來**（原本是靜默套用）：

```
[rotation] A7520260906_0064.MP4: metadata says -90° — ignored (ARKIV_IGNORE_ROTATION=1)
```

旗標是我們唯一完全採信檔案的幾何資訊。它錯的時候底下每一層都跟著錯，而在此之前**沒有任何東西出聲**。

## ⚠️ 一個容易寫錯的細節

`-noautorotate` **必須放在 `-i` 前面** —— 它是 demuxer 選項，放在輸入之後會被**靜默忽略**，畫面照樣是轉過的。測試有釘住這個順序：

```python
assert cmd.index("-noautorotate") < cmd.index("-i"), \
    "-noautorotate after -i is silently ignored"
```

## 驗證

- `tests/test_rotation_override.py` 四支：預設仍尊重旗標 / 開關可忽略 / ffmpeg 參數順序 / 預設不加該參數
- **既有全套 2042 passed, 11 skipped** —— 不受影響
- 實機：6 支以 `ARKIV_IGNORE_ROTATION=1` 重新 ingest 後，DB 尺寸回到 `3840×2160`、縮圖回到 `320×180`、vision 重跑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JDgzY5sojuSEqD4epJx4P