### PR TITLE
fix(ingest): 審計 round 1 —— 六個會殺掉健康匯入、卻不說是誰殺的缺口

### DIFF
--- a/config.py
+++ b/config.py
@@ -630,13 +630,41 @@ if VECTOR_BACKEND == "pg" and not ARKIV_PG_DSN:
 # ── Ingest 的兩道截止線（見 ingest_budget.py 的完整推導）─────────────────────
 # 係數來自 2026-09-06 的 200 支現場實測迴歸（n=33）：單檔秒 ≈ 5.0 + 5.6 × 幀數，
 # R² = 0.88。⚠️ M2 Max + qwen2.5vl:7b 上量的，換機器要重新量 —— 所以可用環境變數覆寫。
-INGEST_PER_FILE_SECONDS = float(os.getenv("ARKIV_INGEST_PER_FILE_SECONDS", "5.0"))
-INGEST_PER_FRAME_SECONDS = float(os.getenv("ARKIV_INGEST_PER_FRAME_SECONDS", "5.6"))
+def _ingest_num(name, default, lo=None):
+    """Read a tuning constant without letting a typo take down the process.
+
+    These are bare `float(os.getenv(...))` at import time, and every module in
+    the codebase imports config — so `ARKIV_INGEST_BUDGET_FLOOR=30m` does not
+    produce a bad budget, it produces an API that will not start, with a
+    ValueError from config.py as the only clue. This file already solves that
+    three other ways (see _read_vision_num_ctx / _read_subtitle_max_cjk / the
+    GPU_MEM_THRESHOLD try-except); this matches them.
+
+    `lo` also guards the values that are nonsense rather than unparseable:
+    a BUDGET_FACTOR below 1.0 makes the budget smaller than the estimate it is
+    supposed to be a safety margin over.
+    """
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        v = float(raw)
+    except (TypeError, ValueError):
+        print("[config] {0}={1!r} is not a number — using {2}".format(name, raw, default))
+        return default
+    if lo is not None and v < lo:
+        print("[config] {0}={1} below the {2} floor — using {2}".format(name, v, lo))
+        return lo
+    return v
+
+
+INGEST_PER_FILE_SECONDS = _ingest_num("ARKIV_INGEST_PER_FILE_SECONDS", 5.0, lo=0.0)
+INGEST_PER_FRAME_SECONDS = _ingest_num("ARKIV_INGEST_PER_FRAME_SECONDS", 5.6, lo=0.0)
 # 預算 = 估值 × 這個係數。估值不是死線，這個乘積才是。
-INGEST_BUDGET_FACTOR = float(os.getenv("ARKIV_INGEST_BUDGET_FACTOR", "2.0"))
+INGEST_BUDGET_FACTOR = _ingest_num("ARKIV_INGEST_BUDGET_FACTOR", 2.0, lo=1.0)
 # 下限：模型暖機一次就 ~100 秒，沒有下限的話最小的匯入反而最容易被誤殺。
-INGEST_BUDGET_FLOOR_SECONDS = float(os.getenv("ARKIV_INGEST_BUDGET_FLOOR", "1800"))
+INGEST_BUDGET_FLOOR_SECONDS = _ingest_num("ARKIV_INGEST_BUDGET_FLOOR", 1800, lo=0.0)
 # 可以沉默多久才算卡住。whisper 解碼期間完全不出聲，而最慢的路徑
 # （faster-whisper large-v3 在 CPU 上）實測 RTF 1.22 —— 門檻要隨最長的素材放大。
-INGEST_STALL_FLOOR_SECONDS = float(os.getenv("ARKIV_INGEST_STALL_FLOOR", "600"))
-INGEST_STALL_RTF = float(os.getenv("ARKIV_INGEST_STALL_RTF", "1.3"))
+INGEST_STALL_FLOOR_SECONDS = _ingest_num("ARKIV_INGEST_STALL_FLOOR", 600, lo=0.0)
+INGEST_STALL_RTF = _ingest_num("ARKIV_INGEST_STALL_RTF", 1.3, lo=0.0)

--- a/ingest_budget.py
+++ b/ingest_budget.py
@@ -63,14 +63,29 @@ def estimate_seconds(durations: Iterable[Optional[float]], n_files: Optional[int
             + total_frames * config.INGEST_PER_FRAME_SECONDS)
 
 
-def budget_seconds(estimate_s: float) -> float:
-    """總預算 —— 估值乘安全係數，並有下限。
+def budget_seconds(estimate_s: float, max_duration_s: Optional[float] = None) -> float:
+    """總預算 —— 估值乘安全係數，並有兩道下限。
 
-    下限存在的理由：小批次的估值可能只有幾十秒，而模型暖機一次就要 ~100 秒。
+    下限一：小批次的估值可能只有幾十秒，而模型暖機一次就要 ~100 秒。
     沒有下限的話，最小的匯入反而最容易被誤殺。
+
+    🔴 下限二（`max_duration_s`）：預算不得低於同一批的 stall 門檻。
+
+    estimate_seconds() 只模型化了 vision 的每幀成本 —— 時長僅透過幀數影響它，
+    轉錄時間完全沒進去。而 stall_seconds() 明白知道轉錄跟片長成正比（它自己
+    的註解引 RTF 1.22）。兩個函式對同一件成本的模型互相矛盾，結果是：
+
+        一支 2 小時的片 → budget 46 分，stall 156 分
+
+    預算比「這一批被允許的沉默」還短 3.4 倍，所以長素材必然在還健康地轉錄時
+    就被判 budget 超時，而 stall 那條路徑對超過 ~23 分鐘的素材是不可達的
+    dead code。傳入 max_duration_s 讓預算至少涵蓋 stall 容許的等待。
     """
-    return max(config.INGEST_BUDGET_FLOOR_SECONDS,
-               estimate_s * config.INGEST_BUDGET_FACTOR)
+    floor = config.INGEST_BUDGET_FLOOR_SECONDS
+    if max_duration_s:
+        # 同一批最長素材的 stall 門檻 + 一趟估值，才是「合理的最壞情況」
+        floor = max(floor, stall_seconds(max_duration_s) + estimate_s)
+    return max(floor, estimate_s * config.INGEST_BUDGET_FACTOR)
 
 
 def stall_seconds(max_duration_s: Optional[float]) -> float:

--- a/proctree.py
+++ b/proctree.py
@@ -136,6 +136,11 @@ def run_tree_watched(
         "stderr": subprocess.STDOUT,   # merged: any output is liveness
         "text": True,
         "bufsize": 1,
+        # run_tree takes encoding/errors; this one did not, so a single
+        # non-UTF-8 byte raised inside the pump thread. Not decoding strictly is
+        # the right default here because the output is a liveness signal, not
+        # data — losing a character beats losing the reader.
+        "errors": "replace",
     }
     if cwd is not None:
         popen_kwargs["cwd"] = cwd
@@ -160,8 +165,16 @@ def run_tree_watched(
                         on_line(line)
                     except Exception:
                         pass
-        except Exception:
-            pass
+        except Exception as e:
+            # A dead pump is worse than a lost line: nobody drains the pipe, the
+            # child blocks on write once the buffer fills, state["last"] stops
+            # advancing, and the watchdog kills a perfectly healthy run while
+            # reporting it as stalled. UnicodeDecodeError is the realistic cause
+            # (ffmpeg/whisper emitting one non-UTF-8 byte, a cp950 progress bar
+            # on the Windows box) — the Popen below now decodes with
+            # errors="replace" so it cannot happen, and this records anything
+            # else instead of vanishing.
+            state["pump_error"] = "{0}: {1}".format(type(e).__name__, e)
 
     pump = threading.Thread(target=_pump, daemon=True)
     pump.start()

--- a/routers/ingest.py
+++ b/routers/ingest.py
@@ -220,12 +220,32 @@ def scan_media(
         # bounds the run is `budget_s` (and the stall watchdog, which this cannot see).
         "estimate": {
             "seconds": round(est),
-            "budget_s": round(ingest_budget.budget_seconds(est)),
+            # 同一個 max_duration 要餵進去，否則 UI 顯示的「上限 X 分」
+            # 跟實際執行時 _ingest_limits 算出來的不是同一個數字。
+            "budget_s": round(ingest_budget.budget_seconds(
+                est, max_duration_s=(max(known) if known else 0))),
             "stall_s": round(ingest_budget.stall_seconds(max(known) if known else 0)),
             "probed": len(known),
             "of": len(pending),
         },
     }
+
+
+def _unprocessed_first(paths):
+    """Order paths so the ones ingest.py will actually touch come first.
+
+    Best-effort: if the DB cannot be read we return the input unchanged, because
+    a wrong order only makes the budget as wrong as it already was, whereas
+    raising here would take down a request that has nothing to do with budgets.
+    """
+    try:
+        import db as _db
+        with _db.get_conn() as conn:
+            done = {r[0] for r in conn.execute("SELECT path FROM media")}
+    except Exception:
+        return paths
+    return [p for p in paths if p not in done] + [p for p in paths if p in done]
+
 
 def _ingest_limits(target: Path, limit: int = 0):
     """(stall_seconds, budget_seconds) for this folder, from its own material.
@@ -240,12 +260,18 @@ def _ingest_limits(target: Path, limit: int = 0):
             if f.is_file() and f.suffix.lower() in MEDIA_EXTS:
                 paths.append(str(f))
         if limit and limit > 0:
-            paths = paths[:limit]
+            # ingest.py --limit N processes the first N *unprocessed* files, so
+            # slicing the full listing budgets for the wrong set: a folder whose
+            # first 400 clips are already indexed 10-second takes and whose last
+            # 100 are 30-minute interviews gets a budget derived from the takes,
+            # then spends it on the interviews and is killed mid-run.
+            paths = _unprocessed_first(paths)[:limit]
         durations = _probe_durations(paths)
         est = ingest_budget.estimate_seconds(durations, n_files=len(paths))
         known = [d for d in durations if d]
-        return (ingest_budget.stall_seconds(max(known) if known else 0),
-                ingest_budget.budget_seconds(est))
+        mx = max(known) if known else 0
+        return (ingest_budget.stall_seconds(mx),
+                ingest_budget.budget_seconds(est, max_duration_s=mx))
     except Exception:
         return (config.INGEST_STALL_FLOOR_SECONDS, config.INGEST_BUDGET_FLOOR_SECONDS)
 
@@ -587,14 +613,21 @@ def _on_ingest_ws_done(task: "asyncio.Task") -> None:
 
 def _kill_ingest_tree(proc) -> None:
     """Kill the ingest subprocess AND its descendants (ffmpeg / whisper / ollama
-    client). `proc.kill()` alone leaves them running and holding the GPU."""
-    import signal as _signal
-    if os.name == "posix":
-        try:
-            os.killpg(os.getpgid(proc.pid), _signal.SIGKILL)
-            return
-        except (ProcessLookupError, PermissionError, OSError):
-            pass
+    client). `proc.kill()` alone leaves them running and holding the GPU.
+
+    Delegates to proctree._kill_tree rather than reimplementing it. This *was* a
+    third hand-rolled copy whose non-POSIX branch fell straight through to
+    proc.kill() — no taskkill /F /T — so on Windows the watchdog reaped ingest.py
+    and orphaned its ffmpeg/whisper grandchildren. proctree's own docstring
+    predicted exactly this ("the Windows branch in particular is easy to fix on
+    one side only"); the drift arrived in the same change that wrote it.
+    """
+    try:
+        import proctree
+        proctree._kill_tree(proc)
+        return
+    except Exception:
+        pass
     try:
         proc.kill()
     except ProcessLookupError:
@@ -653,12 +686,21 @@ async def _run_ingest_with_ws(target: Path, limit: int, opts: Optional[list] = N
                 halted["reason"] = "budget"
             else:
                 continue
+            # Re-check immediately before acting: the broadcast below is an
+            # await, and a run that finishes during it would otherwise be
+            # reported as HALTED *and* have its already-reaped pid passed to
+            # killpg — which on pid reuse signals an unrelated process group.
+            # The final phase (embedding / index rebuild) is silent, so this is
+            # precisely when a healthy run looks stalled.
+            if proc.returncode is not None:
+                halted.pop("reason", None)
+                return
+            _kill_ingest_tree(proc)
             await ingest_ws.broadcast({
                 "type": "halted", "reason": halted["reason"],
                 "idle_s": round(idle), "elapsed_s": round(elapsed),
                 "stall_s": round(stall_s), "budget_s": round(budget_s),
             })
-            _kill_ingest_tree(proc)
             return
 
     watchdog = asyncio.create_task(_watchdog())

--- a/tests/test_ingest_audit_round1.py
+++ b/tests/test_ingest_audit_round1.py
@@ -1,0 +1,87 @@
+"""Round-1 audit of the ingest budget/watchdog work (#436/#437/#438).
+
+Each test pins one finding that was verified against the real code. They share
+a shape: the failure is silent — the run is killed, or reported as halted, or
+never starts — and nothing in the output says which of the two deadlines, or
+which process, or which env var was responsible.
+"""
+import os
+import importlib
+import pytest
+
+import ingest_budget
+import proctree
+
+
+# ── ①② 預算與靜默門檻互相矛盾 ────────────────────────────────
+@pytest.mark.parametrize("dur", [1800.0, 3600.0, 7200.0])
+def test_budget_is_never_shorter_than_the_silence_it_allows(dur):
+    """stall_seconds 說「這麼久的沉默是合法的」，budget 就不能比它短。
+
+    estimate_seconds 只模型化 vision 的每幀成本，轉錄完全沒進去；stall_seconds
+    卻明白知道轉錄跟片長成正比。兩者矛盾時，長素材會在還健康地轉錄時被判
+    budget 超時，而 stall 那條路徑變成不可達的 dead code。
+    """
+    est = ingest_budget.estimate_seconds([dur], n_files=1)
+    stall = ingest_budget.stall_seconds(dur)
+    budget = ingest_budget.budget_seconds(est, max_duration_s=dur)
+    assert budget >= stall, (
+        "budget {0:.0f}s < stall {1:.0f}s — 長素材必然在健康轉錄中被殺，"
+        "而 stall watchdog 永遠碰不到".format(budget, stall))
+
+
+def test_budget_without_duration_keeps_old_behaviour():
+    est = ingest_budget.estimate_seconds([10.0] * 5, n_files=5)
+    assert ingest_budget.budget_seconds(est) >= 0
+
+
+# ── ⑬ 一個打錯的環境變數不該讓整個 API 起不來 ──────────────────
+@pytest.mark.parametrize("bad", ["30m", "", "abc", "1,800"])
+def test_malformed_tuning_env_does_not_break_import(monkeypatch, bad):
+    monkeypatch.setenv("ARKIV_INGEST_BUDGET_FLOOR", bad)
+    import config
+    importlib.reload(config)          # 不該拋
+    assert config.INGEST_BUDGET_FLOOR_SECONDS > 0
+    monkeypatch.delenv("ARKIV_INGEST_BUDGET_FLOOR")
+    importlib.reload(config)
+
+
+def test_budget_factor_below_one_is_clamped(monkeypatch):
+    """係數小於 1 會讓「安全邊際」比它要保護的估值還小。"""
+    monkeypatch.setenv("ARKIV_INGEST_BUDGET_FACTOR", "0.5")
+    import config
+    importlib.reload(config)
+    assert config.INGEST_BUDGET_FACTOR >= 1.0
+    monkeypatch.delenv("ARKIV_INGEST_BUDGET_FACTOR")
+    importlib.reload(config)
+
+
+# ── ⑤ 三份 tree-kill 不可以各修各的 ──────────────────────────
+def test_ingest_kill_delegates_to_proctree(monkeypatch):
+    """proctree._kill_tree 的 docstring 說它被抽出來就是為了避免兩邊漂移，
+    而 routers/ingest.py 曾經是第三份手寫複本、非 POSIX 分支沒有 taskkill。"""
+    from routers import ingest as ring
+    called = {}
+    monkeypatch.setattr(proctree, "_kill_tree", lambda p: called.setdefault("hit", True))
+
+    class _P:
+        pid = 424242
+        def kill(self): called["fallback"] = True
+    ring._kill_ingest_tree(_P())
+    assert called.get("hit"), "應該委派給 proctree._kill_tree"
+
+
+# ── ⑦ pump thread 死掉比掉一行字嚴重得多 ──────────────────────
+def test_watched_run_decodes_leniently():
+    """一個非 UTF-8 byte 曾讓 pump thread 靜默結束 → 沒人排空管線 →
+    子程序卡在寫入 → watchdog 殺掉一個健康的程序並回報「卡住」。"""
+    import inspect
+    src = inspect.getsource(proctree.run_tree_watched)
+    assert '"errors"' in src or "errors=" in src, \
+        "run_tree_watched 的 Popen 必須寬容解碼"
+
+
+def test_pump_failure_is_recorded_not_swallowed():
+    import inspect
+    src = inspect.getsource(proctree.run_tree_watched)
+    assert "pump_error" in src, "pump 的例外要留下痕跡，不能 except: pass"


### PR DESCRIPTION
獨立審計 #436/#437/#438，逐條回到程式碼驗證後修掉六個。它們形狀相同：**匯入被殺、或被回報成卡住、或根本起不來，而輸出不會說是誰造成的。**

## ①② 預算與靜默門檻互相矛盾

`estimate_seconds` 只模型化 vision 的每幀成本 —— **轉錄時間完全沒進去**。而 `stall_seconds` 明白知道轉錄跟片長成正比（它自己的註解引 RTF 1.22）。

一支 **2 小時**的片：

```
budget  46 分   ← 總量上限
stall  156 分   ← 「這麼久的沉默是合法的」
```

**預算比它自己允許的沉默還短 3.4 倍。** 所以長素材必然在還健康地轉錄時被判 budget 超時，而 stall 那條路徑對超過 ~23 分鐘的素材是**不可達的 dead code**。

## ③ 預算算的是錯的那組檔

`_ingest_limits` 對 `rglob` 找到的**全部**檔案做 `paths[:limit]`，但 `ingest.py --limit N` 處理的是前 N 個**未處理**的檔。

前 400 支已索引（10 秒短片）、後 100 支是 30 分鐘訪談的資料夾 → 拿短片算出的預算去跑訪談。

## ⑤ 第三份 tree-kill，而且只修了一邊

`proctree._kill_tree` 的 docstring：

> *Extracted so the timeout path and the watchdog path cannot drift apart —— **the Windows branch in particular is easy to fix on one side only**.*

而 `routers/ingest.py:588` 的 `_kill_ingest_tree` **就是那個只修一邊的複本** —— 非 POSIX 直接掉到 `proc.kill()`，沒有 `taskkill /F /T`。Windows 上 watchdog 只收掉 `ingest.py`，孤兒化它的 ffmpeg/whisper 孫程序。**註解預言的事發生在寫下它的同一個 diff 裡。**

## ⑥ 跑完的匯入被回報成 HALTED

watchdog 先 `await broadcast` 才 kill，中間**沒有重新檢查 returncode**。最後階段（embedding / 索引重建）是靜默的 —— 正是健康的匯入看起來像卡住的時候。它若在那個 await 期間正常結束：

- UI 顯示紅色「匯入已停止 · 研判卡住」，而它其實跑完了
- `killpg` 打在已被回收的 pid 上，**pid 重用時會誤殺無關的行程群**

## ⑦ 一個 byte 讓 pump thread 靜默死亡

`run_tree_watched` 的 Popen 用 `text=True` 但**沒有 `errors=`**（`run_tree` 有這個參數，它沒有）。

```
非 UTF-8 byte → UnicodeDecodeError → except: pass → pump thread 結束
              → 沒人排空管線 → 子程序卡在寫入 → state["last"] 停止推進
              → watchdog 殺掉一個完全健康的匯入，並回報「ollama 沒有回應」
```

## ⑬ 一個打錯的環境變數讓整個 API 起不來

六個 tuning 常數都是 import 期的裸 `float(os.getenv(...))`，而**每個模組都 import config**。`ARKIV_INGEST_BUDGET_FLOOR=30m` 不是產生一個壞預算，是產生一個**不會啟動的 API**。

這個檔案已經有三種安全處理的寫法（`_read_vision_num_ctx` / `_read_subtitle_max_cjk` / `GPU_MEM_THRESHOLD` 的 try-except），改為一致。順帶把 `BUDGET_FACTOR` 夾在 1.0 以上 —— 小於 1 的「安全係數」會讓預算比它要保護的估值還小。

## 驗證

`tests/test_ingest_audit_round1.py` **12 支**（每支對應一個 finding），既有 **2042 passed** 不受影響，合計 **2054 passed / 11 skipped**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JDgzY5sojuSEqD4epJx4P