### PR TITLE
fix(offload/ingest): 審計 round 2 —— 七個「少做了一件事，而接收面看不出來」

### DIFF
--- a/frontend/src/routes/IngestLive.svelte
+++ b/frontend/src/routes/IngestLive.svelte
@@ -48,6 +48,7 @@
   let rebuilding = false
   let err = ''
   let startedAt = 0 // ms — set when the run's 'start' event arrives (for elapsed)
+  let joinedLate = false // true when startedAt was seeded by a mid-run join, not 'start'
   let now = Date.now() // kept fresh by the 1s tick; seeded so countdowns never read 0
   let tick = null
   // edge-state C1 (redesign essay 08) — auto-reconnect with backoff when the ws
@@ -89,6 +90,25 @@
     return api.appendToken(base)
   }
 
+  // A client that connects mid-run never saw 'start', and the server sends no
+  // snapshot on connect. Everything the header shows is seeded there, so a
+  // late join (a reload, the auto-reconnect below, a second tab) rendered
+  // 0 files / 0% / blank elapsed over a live import — and `remaining` went to
+  // 0 because it is total minus the rows we happen to have seen. Every per-file
+  // and per-stage event already carries `total`, so adopt it from the first one
+  // that arrives instead of adding a protocol round-trip. The 'complete'
+  // handler already does this for `halted` — same gap, one field wide.
+  function adoptRunHeader(msg) {
+    if (!total && msg.total) total = msg.total
+    if (!startedAt) {
+      // We do not know when the run began, only when we joined. Showing that
+      // number as ELAPSED would be a wrong figure where there is currently a
+      // blank one, so it is flagged and labelled "+MM:SS (since joined)".
+      startedAt = Date.now()
+      joinedLate = true
+    }
+  }
+
   function pushLog(text, stage = '') {
     const t = new Date().toLocaleTimeString()
     log = [{ t, stage, text }, ...log].slice(0, 60)
@@ -114,8 +134,10 @@
         stageCounts = {}
         complete = null
         startedAt = Date.now()
+        joinedLate = false
         pushLog(`start · ${total} files`)
       } else if (msg.type === 'file') {
+        adoptRunHeader(msg)
         // Preserve any stage already recorded for this file (e.g. a vision event
         // can land after the "done" file event in phase 2 — don't clobber it).
         const prev = files[msg.index] || {}
@@ -123,6 +145,7 @@
         files = files // trigger reactivity
         pushLog(`[${msg.index}/${msg.total}] ${msg.filename} · ${msg.status}`)
       } else if (msg.type === 'stage') {
+        adoptRunHeader(msg)
         // Per-stage event (S1a brick 3): attribute to the in-flight file by index
         // and refresh the aggregate tally the backend keeps for us.
         const prev = files[msg.index] || { filename: msg.filename, status: 'transcribing' }
@@ -215,7 +238,7 @@
     ['TRANSCRIBED', stageCounts.transcribe || 0],
     ['TAGGED', stageCounts.vision || 0],
   ]
-  $: elapsed = startedAt && now ? fmtDur(now - startedAt) : ''
+  $: elapsed = startedAt && now ? (joinedLate ? '+' : '') + fmtDur(now - startedAt) : ''
 
   function fmtDur(ms) {
     const s = Math.floor(ms / 1000)
@@ -283,7 +306,7 @@
       <div class="hero">
         <div class="herohead">
           <Eyebrow>Ingest · live websocket</Eyebrow>
-          <Mono dim style="font-size:10.5px;">{#if startedAt}{elapsed} elapsed · real /ws/ingest{:else}real /ws/ingest stream{/if}</Mono>
+          <Mono dim style="font-size:10.5px;">{#if startedAt}{elapsed} {joinedLate ? 'since joined' : 'elapsed'} · real /ws/ingest{:else}real /ws/ingest stream{/if}</Mono>
         </div>
 
         {#if active}

--- a/frontend/src/routes/IngestSetup.svelte
+++ b/frontend/src/routes/IngestSetup.svelte
@@ -131,10 +131,27 @@
   // Adding the shortcut from here rather than only in Settings: the moment you
   // know a path is worth keeping is right after you typed it, not later in
   // another screen.
+  // `ingest.source_presets` is one flat string: entries split on ';', label and
+  // path split on the first '|'. Neither character is escaped, and both are legal
+  // in a macOS folder name — so a path containing one does not merely lose its
+  // own shortcut. This writer re-serialises the WHOLE list from `presets`, and
+  // `presets` came back through that same lossy parser, so adding any shortcut
+  // rewrites every previously-mangled entry into its mangled form permanently.
+  // The settings docstring's promise that "losing one shortcut is recoverable"
+  // stops being true at exactly that point. Refuse the unrepresentable path
+  // instead, and say which character is the problem.
+  const PRESET_UNSAFE = /[;|]/
   async function savePreset() {
     const val = path.trim()
     if (!val) { presetNote = '先填路徑'; return }
     if (presets.some((p) => p.path === val)) { presetNote = '這個路徑已在捷徑裡'; return }
+    const bad = val.match(PRESET_UNSAFE)
+    if (bad) { presetNote = `路徑含有「${bad[0]}」，捷徑格式存不了這個字元`; return }
+    if (presets.some((p) => PRESET_UNSAFE.test(p.path) || PRESET_UNSAFE.test(p.label))) {
+      // Writing now would persist the damage to the existing entries too.
+      presetNote = '既有捷徑裡有「;」或「|」，請先到 Settings 修好再新增'
+      return
+    }
     const label = (val.replace(/\/+$/, '').split('/').pop() || val).slice(0, 24)
     const next = [...presets, { label, path: val }]
     presetNote = '儲存中…'

--- a/frontend/src/routes/Offload.svelte
+++ b/frontend/src/routes/Offload.svelte
@@ -67,7 +67,9 @@
   // every refusal names its reason.
   $: previewed = phase === 'preview' || (phase === 'done' && stopped)
   $: pct = pTotal ? Math.min(100, Math.round((pDone / pTotal) * 100)) : 0
-  $: anyFailed = summary ? Object.values(summary).some((s) => s.failed_files > 0) || doneCode !== 0 : false
+  $: anyFailed = summary
+    ? Object.values(summary).some((s) => s.failed_files > 0 || s.error) || doneCode !== 0
+    : false
   const base = (p) => String(p).split(/[\\/]/).pop()
 
   function addDst() { dsts = [...dsts, ''] }
@@ -159,13 +161,22 @@
           if (!line) continue
           let ev; try { ev = JSON.parse(line) } catch { continue }
           if (ev.type === 'dst_start') {
+            // stage/stageFiles belong to the destination that just ENDED. With
+            // more than one --dst (card → two drives, the normal DIT setup) the
+            // last event of drive 1 is phase:mhl_verify, so leaving it set makes
+            // drive 2's copy render as "Verifying MHL manifest" until drive 2
+            // emits a phase of its own — a stuck label over live file progress.
             curDst = ev.dst; pTotal = ev.total; pDone = 0; pFailed = 0
+            stage = ''; stageFiles = 0
           } else if (ev.type === 'file') {
             pDone++
             if (ev.status === 'failed') pFailed++
             recent = [{ name: ev.name, status: ev.status }, ...recent].slice(0, 8)
           } else if (ev.type === 'phase') {
+            // mhl_failed is terminal for this destination: keep the row's own
+            // error visible rather than showing a hashing pass that already died.
             stage = ev.phase; stageFiles = ev.files || 0
+            if (ev.phase === 'mhl_failed') pushToast(`MHL 失敗 · ${ev.dst}：${ev.error || ''}`, 'error')
           } else if (ev.type === 'done') {
             stage = ''
             doneCode = ev.code
@@ -350,7 +361,7 @@
               {#each Object.entries(summary) as [dst, s]}
                 <div class="srow" class:fail={s.failed_files > 0}>
                   <Mono style="font-size:10.5px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">{base(dst)}</Mono>
-                  <Mono dim style="font-size:10px;">{s.verified_files} ok{s.failed_files ? ` · ${s.failed_files} fail` : ''}{s.mhl_path ? ' · MHL' : ''}</Mono>
+                  <Mono dim style="font-size:10px;">{s.verified_files} ok{s.failed_files ? ` · ${s.failed_files} fail` : ''}{s.mhl_path ? ' · MHL' : ''}{s.error ? ` · MHL 失敗：${s.error}` : ''}</Mono>
                 </div>
               {/each}
             </div>

--- a/offload.py
+++ b/offload.py
@@ -594,22 +594,44 @@ def run_offload(src, dsts, hash_algo=DEFAULT_HASH, include_heic=False, resume=No
         _save_state(state_path, state)
 
         mhl_path = None
+        mhl_error = None
         if emit_mhl and verified_rel_paths:
             # Two full re-reads of every byte happen below (write, then verify) and
             # neither emits anything on its own. Without these markers the UI sits
             # on "file N/N" for as long as the hashing takes — 35 minutes for 89 GB
             # in the 2026-09-06 field run — and looks hung while it is working.
-            _emit(progress, {"type": "phase", "dst": dst_key, "phase": "mhl_write",
-                             "files": len(verified_rel_paths)})
-            mhl_path = _write_mhl(dst_root, hash_algo, op="offload")
-            dst_state["mhl_path"] = str(mhl_path)
-            _save_state(state_path, state)
-            if verify:
-                _emit(progress, {"type": "phase", "dst": dst_key, "phase": "mhl_verify",
+            #
+            # A manifest failure is scoped to THIS destination. It used to raise
+            # straight out of the `for dst_root` loop, which cost three things at
+            # once: (1) every REMAINING destination was skipped, so a hash mismatch
+            # on drive 1 silently cancelled the drive-2 copy — and the second copy
+            # is the entire point of a two-drive offload; (2) `summary[dst_key]` was
+            # never assigned, so the router synthesised `{"type":"done","summary":{}}`
+            # and the UI showed "exit 1" with no row saying which drive or why —
+            # the RuntimeError text went to the merged stdout, where the ndjson
+            # reader's `JSON.parse` dropped it; (3) `dst_state["status"]` stayed
+            # "running", which is the same state a user-cancelled run leaves behind.
+            # A verify failure IS the chain-of-custody event this tool exists to
+            # report, so it must be the loudest thing in the summary, not the
+            # quietest. Mirrors the `_check_destination_mount` path above.
+            try:
+                _emit(progress, {"type": "phase", "dst": dst_key, "phase": "mhl_write",
                                  "files": len(verified_rel_paths)})
-                verify_result = _verify_emitted_mhl(dst_root, mhl_path)
-                if verify_result is not None and verify_result != 0:
-                    raise RuntimeError("mhl verify failed for {0}: exit code {1}".format(mhl_path, verify_result))
+                mhl_path = _write_mhl(dst_root, hash_algo, op="offload")
+                dst_state["mhl_path"] = str(mhl_path)
+                _save_state(state_path, state)
+                if verify:
+                    _emit(progress, {"type": "phase", "dst": dst_key, "phase": "mhl_verify",
+                                     "files": len(verified_rel_paths)})
+                    verify_result = _verify_emitted_mhl(dst_root, mhl_path)
+                    if verify_result is not None and verify_result != 0:
+                        raise RuntimeError("mhl verify failed for {0}: exit code {1}".format(mhl_path, verify_result))
+            except Exception as exc:
+                mhl_error = "{0}: {1}".format(type(exc).__name__, exc)
+                final_status = "failed"
+                dst_state["error"] = mhl_error
+                _emit(progress, {"type": "phase", "dst": dst_key, "phase": "mhl_failed",
+                                 "files": len(verified_rel_paths), "error": mhl_error})
 
         dst_state["status"] = final_status
         _save_state(state_path, state)
@@ -619,8 +641,14 @@ def run_offload(src, dsts, hash_algo=DEFAULT_HASH, include_heic=False, resume=No
             "failed_files": failed,
             "mhl_path": str(mhl_path) if mhl_path else None,
             "status": dst_state["status"],
+            "error": mhl_error,
         }
-        if failed == 0:
+        # A manifest failure counts as a failed destination even though every byte
+        # copied and verified: without the manifest there is no chain of custody,
+        # and `any_ok` is what decides whether the run exits 1 (partial) or 2 (all
+        # bad). Reporting a manifest-less drive as OK is the failure this whole
+        # branch exists to prevent.
+        if failed == 0 and mhl_error is None:
             any_ok = True
         else:
             all_ok = False

--- a/proctree.py
+++ b/proctree.py
@@ -199,7 +199,14 @@ def run_tree_watched(
             proc.stdout.close()
         except Exception:
             pass
-        return subprocess.CompletedProcess(list(cmd), proc.returncode, "".join(chunks), "")
+        # stderr is merged into stdout above, so this field can never carry the
+        # child's error output — and /api/ingest presents it verbatim as the
+        # diagnostic field. A permanently-empty diagnostic is worse than none:
+        # it reads as "the child said nothing". The one thing that genuinely has
+        # no other channel is a pump crash (round 1 stopped swallowing it, but
+        # nobody read what it recorded), so that is what goes here.
+        return subprocess.CompletedProcess(
+            list(cmd), proc.returncode, "".join(chunks), state.get("pump_error", ""))
 
     _kill_tree(proc)
     pump.join(timeout=10)
@@ -213,7 +220,7 @@ def run_tree_watched(
         stall_timeout if kind == "stall" else total_timeout,
         kind,
         output="".join(chunks),
-        stderr="",
+        stderr=state.get("pump_error", ""),
         elapsed=now - started,
         idle=now - state["last"],
     )

--- a/routers/ingest.py
+++ b/routers/ingest.py
@@ -150,34 +150,75 @@ def ingest_engines(
     }
 
 
+# ffprobe over a NAS measured 0.13s/file; /api/ingest/scan probes the folder to
+# show an ETA and then the run probes THE SAME FILES AGAIN to derive its budget.
+# A clip's duration cannot change without its size or mtime changing, so this
+# memoises on exactly that. Bounded so a long-lived server cannot grow it without
+# limit; the eviction is crude because a wrong eviction only costs one re-probe.
+_PROBE_CACHE: dict = {}
+_PROBE_CACHE_MAX = 20000
+
+
+def _probe_key(path):
+    try:
+        st = os.stat(path)
+    except OSError:
+        return None
+    return (str(path), st.st_size, int(st.st_mtime))
+
+
 def _probe_durations(paths, max_probe: int = 500):
     """Duration per file, in the order given; None where it could not be read.
 
     Bounded on two axes so a huge or a wedged folder cannot hang the scan:
-    at most `max_probe` files are actually probed (the estimator extrapolates the
-    rest from the median), and each ffprobe gets its own short timeout. A probe
-    that fails yields None rather than 0 — treating "unknown" as "zero seconds"
-    would shrink the budget, and a too-small budget kills healthy imports.
+    at most `max_probe` files are actually probed, and each ffprobe gets its own
+    short timeout. A probe that fails yields None rather than 0 — treating
+    "unknown" as "zero seconds" would shrink the budget, and a too-small budget
+    kills healthy imports.
+
+    The `max_probe` sample is taken EVENLY across the list, not off the head.
+    `stall_seconds` scales the silence threshold by `max(known)`, and whisper is
+    silent for the whole decode of a single clip — so the one number that must
+    not be missed is the longest clip. Probing the alphabetical first 500 of a
+    2000-clip folder makes the 40-minute interview at position 1200 invisible,
+    and the stall watchdog then kills a healthy import in the middle of
+    transcribing it. An even stride costs nothing and samples the whole folder.
     """
     import subprocess
     from concurrent.futures import ThreadPoolExecutor
 
     def _one(path):
+        key = _probe_key(path)
+        if key is not None and key in _PROBE_CACHE:
+            return _PROBE_CACHE[key]
         try:
             r = subprocess.run(
                 ["ffprobe", "-v", "error", "-show_entries", "format=duration",
                  "-of", "default=nw=1:nk=1", str(path)],
                 capture_output=True, text=True, timeout=15)
-            return float((r.stdout or "").strip())
+            val = float((r.stdout or "").strip())
         except Exception:
-            return None
+            return None  # not cached: a failure can be transient (NAS asleep)
+        if key is not None:
+            if len(_PROBE_CACHE) >= _PROBE_CACHE_MAX:
+                _PROBE_CACHE.clear()
+            _PROBE_CACHE[key] = val
+        return val
 
-    head = paths[:max_probe]
-    if not head:
+    n = len(paths)
+    if not n:
         return []
+    if n <= max_probe:
+        idxs = list(range(n))
+    else:
+        stride = n / float(max_probe)
+        idxs = sorted({min(n - 1, int(i * stride)) for i in range(max_probe)})
     with ThreadPoolExecutor(max_workers=16) as ex:
-        out = list(ex.map(_one, head))
-    return out + [None] * (len(paths) - len(head))
+        probed = list(ex.map(_one, [paths[i] for i in idxs]))
+    out = [None] * n
+    for i, d in zip(idxs, probed):
+        out[i] = d
+    return out
 
 
 @router.post("/api/ingest/scan")
@@ -231,13 +272,25 @@ def scan_media(
     }
 
 
-def _unprocessed_first(paths):
-    """Order paths so the ones ingest.py will actually touch come first.
+def _unprocessed(paths):
+    """The paths ingest.py will actually touch — already-indexed ones dropped.
 
     Best-effort: if the DB cannot be read we return the input unchanged, because
-    a wrong order only makes the budget as wrong as it already was, whereas
-    raising here would take down a request that has nothing to do with budgets.
+    an over-wide budget is only as wrong as it already was, whereas raising here
+    would take down a request that has nothing to do with budgets.
     """
+    try:
+        import db as _db
+        with _db.get_conn() as conn:
+            done = {r[0] for r in conn.execute("SELECT path FROM media")}
+    except Exception:
+        return list(paths)
+    return [p for p in paths if p not in done]
+
+
+def _unprocessed_first(paths):
+    """Order-preserving variant: unprocessed first, processed after. Kept because
+    a caller that must not lose entries needs the reordering, not the filter."""
     try:
         import db as _db
         with _db.get_conn() as conn:
@@ -259,13 +312,22 @@ def _ingest_limits(target: Path, limit: int = 0):
         for f in sorted(target.rglob("*")):
             if f.is_file() and f.suffix.lower() in MEDIA_EXTS:
                 paths.append(str(f))
+        # ingest.py SKIPs anything already indexed, in both modes. Budgeting the
+        # full listing therefore prices work that will never happen — and it made
+        # /api/ingest/scan's comment ("同一個 max_duration 要餵進去，否則 UI 顯示
+        # 的『上限 X 分』跟實際執行時算出來的不是同一個數字") false for the
+        # limit=0 path the UI actually uses: scan estimates over `pending`, this
+        # estimated over everything. Re-importing into a 5000-clip library showed
+        # an ETA from the 3 new files and ran on a budget from all 5000.
+        pending = _unprocessed(paths)
         if limit and limit > 0:
             # ingest.py --limit N processes the first N *unprocessed* files, so
             # slicing the full listing budgets for the wrong set: a folder whose
             # first 400 clips are already indexed 10-second takes and whose last
             # 100 are 30-minute interviews gets a budget derived from the takes,
             # then spends it on the interviews and is killed mid-run.
-            paths = _unprocessed_first(paths)[:limit]
+            pending = pending[:limit]
+        paths = pending
         durations = _probe_durations(paths)
         est = ingest_budget.estimate_seconds(durations, n_files=len(paths))
         known = [d for d in durations if d]
@@ -292,7 +354,19 @@ def ingest_media(
     body: IngestRequest,
     _tok: dict = Depends(require_scopes("ingest_write")),
 ):
-    """Trigger ingest from the web UI — runs ingest.py as subprocess."""
+    """Trigger ingest — runs ingest.py as a subprocess and blocks until it ends.
+
+    ⚠️ Not the UI's path (the SPA uses POST /api/ingest/ws + the /ws/ingest
+    stream). This one is for MCP/CLI callers, and it is synchronous in three
+    senses at once, for as long as `budget_s` — which is derived from the
+    material and was 94 minutes for the 200-clip field run: it holds one anyio
+    threadpool worker, one HTTP connection, and the single-flight ingest slot.
+    A caller whose own timeout is shorter gets nothing back AND cannot retry
+    (409) until the run it can no longer see finishes. Nothing here can detect
+    that disconnect — a sync route has no equivalent of the offload stream's
+    GeneratorExit. Long imports belong on the WS route; this stays for small,
+    scripted ones.
+    """
     import subprocess, sys
     target = Path(body.path).expanduser().resolve()
     if not target.is_dir():

--- a/tests/test_ingest_audit_round2.py
+++ b/tests/test_ingest_audit_round2.py
@@ -1,0 +1,255 @@
+"""審計 round 2 —— 七個「畫面說沒事、實際上少做了一件事」的缺口。
+
+Round 1 修的是「會殺掉健康匯入、卻不說是誰殺的」。這一輪的形狀不同：
+每一條都是**做少了一件事，而接收面看不出來**。
+
+  ④ MHL 校驗失敗 raise 出整個 dst 迴圈 → 第二顆碟根本沒複製
+  ⑧ run_tree_watched 的 stderr 恆空，而 /api/ingest 拿它當診斷欄
+  ⑨ dst_start 沒清 stage → 第二顆碟複製中卻顯示「正在校驗 MHL」
+  ⑩ 中途加入的 client 沒收過 start → 0 檔 0% 空白 elapsed 蓋在跑著的匯入上
+  ⑪ 捷徑的分隔字元沒跳脫，而寫回是整串重寫 → 新增一筆會固化既有的損壞
+  ⑫ scan 探測過的檔，實際跑的時候整份重探
+  ⑯ max_probe 取前 500 筆 → 最長的那支可能沒被取樣，而 stall 門檻靠它
+"""
+import io
+import inspect
+
+import pytest
+
+
+# ── ④ MHL 失敗要留在這顆碟裡 ────────────────────────────────────────────────
+
+def _card(tmp_path):
+    card = tmp_path / "card"
+    card.mkdir()
+    (card / "C0001.MP4").write_bytes(b"x" * 64)
+    return card
+
+
+def test_mhl_failure_still_copies_the_other_destination(tmp_path, monkeypatch):
+    """第二顆碟是兩碟備份的全部意義 —— 第一顆的 manifest 掛了不該取消它。"""
+    import offload
+    card = _card(tmp_path)
+    d1, d2 = tmp_path / "d1", tmp_path / "d2"
+    d1.mkdir(); d2.mkdir()
+
+    def _boom(dst_root, hash_algo, op="offload"):
+        if str(dst_root) == str(d1):
+            raise RuntimeError("mhl write blew up")
+        return dst_root / "fake.mhl"
+
+    monkeypatch.setattr(offload, "_write_mhl", _boom)
+    monkeypatch.setattr(offload, "_verify_emitted_mhl", lambda *a, **k: 0)
+
+    code, summary, _ = offload.run_offload(
+        str(card), [str(d1), str(d2)], resume=str(tmp_path / "state.json"),
+        progress="none")
+
+    assert (d2 / "C0001.MP4").exists(), "第一顆碟的 manifest 失敗把第二顆碟整個跳過了"
+    assert summary[str(d1)]["status"] == "failed"
+    assert summary[str(d1)]["error"], "失敗要說是什麼失敗，不能只留一個 exit code"
+    assert summary[str(d2)]["status"] == "done"
+    assert code != 0, "有一顆碟沒有 manifest，不可以回 0"
+
+
+def test_mhl_verify_mismatch_is_a_failed_destination(tmp_path, monkeypatch):
+    """每個 byte 都複製並校驗過，但 manifest 對不上 —— 這顆碟仍然是 failed。
+
+    verified_files 會是滿的，所以 failed_files == 0；只看那個數字會把
+    「沒有 chain of custody 的碟」當成成功。
+    """
+    import offload
+    card = _card(tmp_path)
+    d1 = tmp_path / "d1"; d1.mkdir()
+    monkeypatch.setattr(offload, "_write_mhl", lambda *a, **k: d1 / "x.mhl")
+    monkeypatch.setattr(offload, "_verify_emitted_mhl", lambda *a, **k: 3)
+
+    code, summary, _ = offload.run_offload(
+        str(card), [str(d1)], resume=str(tmp_path / "s.json"), progress="none")
+
+    s = summary[str(d1)]
+    assert s["failed_files"] == 0, "前提：複製本身沒失敗"
+    assert s["status"] == "failed"
+    assert "3" in (s["error"] or "")
+    assert code == 2, "唯一的目的地掛了 → all-bad"
+
+
+def test_mhl_failure_emits_a_phase_event(tmp_path, monkeypatch, capsys):
+    """UI 的 ndjson reader 只 JSON.parse；traceback 走 stdout 會被它丟掉，
+    所以失敗必須是一個 event，不能只是一段例外文字。"""
+    import offload, json
+    card = _card(tmp_path)
+    d1 = tmp_path / "d1"; d1.mkdir()
+    monkeypatch.setattr(offload, "_write_mhl", lambda *a, **k: d1 / "x.mhl")
+    monkeypatch.setattr(offload, "_verify_emitted_mhl", lambda *a, **k: 9)
+    offload.run_offload(str(card), [str(d1)], resume=str(tmp_path / "s.json"),
+                        progress="json")
+    events = []
+    for line in capsys.readouterr().out.splitlines():
+        try:
+            events.append(json.loads(line))
+        except ValueError:
+            pass
+    assert any(e.get("phase") == "mhl_failed" for e in events)
+
+
+# ── ⑧ pump_error 不能是死路 ─────────────────────────────────────────────────
+
+def test_watched_run_surfaces_pump_error_not_empty_stderr():
+    """round 1 停止吞掉 pump 例外、改成記下來 —— 但沒有人讀那筆紀錄。
+
+    stderr 因為 merge 進 stdout 而恆為空，偏偏 /api/ingest 把它當診斷欄印出來。
+    唯一沒有別的通道的東西就是 pump 自己的例外，所以那格放它。
+    """
+    import proctree
+    src = inspect.getsource(proctree.run_tree_watched)
+    assert 'stderr=""' not in src, "TreeTimeout 仍寫死空 stderr"
+    assert src.count('state.get("pump_error"') == 2, \
+        "正常結束與逾時兩條路徑都要把 pump_error 交出去"
+
+
+def test_watched_run_normal_path_has_empty_stderr_when_pump_is_healthy(tmp_path):
+    import proctree, sys
+    r = proctree.run_tree_watched(
+        [sys.executable, "-c", "print('hi')"], stall_timeout=10, total_timeout=30)
+    assert r.returncode == 0
+    assert "hi" in r.stdout
+    assert r.stderr == "", "pump 沒出事就不該無中生有一個錯誤"
+
+
+# ── ⑫/⑯ 探測：不重複、而且要取樣到最長的那一支 ──────────────────────────────
+
+def test_probe_durations_caches_on_size_and_mtime(tmp_path, monkeypatch):
+    """scan 探過的檔，實際跑的時候不該再探一次（NAS 上 0.13s/檔 × 200）。"""
+    from routers import ingest as R
+    R._PROBE_CACHE.clear()
+    f = tmp_path / "a.mp4"; f.write_bytes(b"x" * 10)
+    calls = []
+
+    class _R:
+        stdout = "12.5"
+
+    def _fake_run(cmd, **kw):
+        calls.append(cmd)
+        return _R()
+
+    monkeypatch.setattr(R.__dict__["__builtins__"] if False else __import__("subprocess"),
+                        "run", _fake_run)
+    assert R._probe_durations([str(f)]) == [12.5]
+    assert R._probe_durations([str(f)]) == [12.5]
+    assert len(calls) == 1, "同一個未變動的檔被探了兩次"
+
+    f.write_bytes(b"y" * 999)  # size changes → cache must miss
+    R._probe_durations([str(f)])
+    assert len(calls) == 2, "檔案變了卻還吃舊的探測結果"
+
+
+def test_probe_durations_samples_across_the_whole_folder(monkeypatch):
+    """stall 門檻 = max(known) × RTF。取前 N 筆會讓排在後面的長片隱形，
+    而 whisper 解碼那支長片時是完全靜默的 —— 門檻不夠大就會誤殺。"""
+    import subprocess
+    from routers import ingest as R
+    R._PROBE_CACHE.clear()
+    paths = ["/x/{0:04d}.mp4".format(i) for i in range(2000)]
+    seen = []
+
+    class _R:
+        stdout = ""
+
+    def _spy(cmd, **kw):
+        seen.append(cmd[-1])
+        return _R()
+
+    monkeypatch.setattr(subprocess, "run", _spy)
+    out = R._probe_durations(paths, max_probe=50)
+    assert len(out) == 2000, "回傳長度必須對齊輸入，呼叫端是用 zip 對位的"
+    assert len(seen) == 50, "探測數量的上限沒守住"
+    nums = sorted(int(p.split("/")[-1].split(".")[0]) for p in seen)
+    assert nums[-1] >= 1900, "2000 支裡最後段完全沒被取樣到 —— 最長的片會隱形"
+    assert nums[0] <= 100, "取樣也要涵蓋前段"
+
+
+# ── ⑫ 預估與實跑要算同一批檔 ────────────────────────────────────────────────
+
+def test_ingest_limits_budgets_only_unprocessed_files(tmp_path, monkeypatch):
+    """/api/ingest/scan 的註解宣稱 UI 顯示的上限跟實跑算出來的是同一個數字。
+    limit=0（UI 的預設路徑）以前把已匯入的檔也算進去，那句宣稱就是假的。
+    """
+    from routers import ingest as R
+    d = tmp_path / "lib"; d.mkdir()
+    new = d / "new.mp4"; new.write_bytes(b"x")
+    old = d / "old.mp4"; old.write_bytes(b"x")
+    monkeypatch.setattr(R, "_unprocessed", lambda paths: [p for p in paths if p.endswith("new.mp4")])
+    seen = {}
+
+    def _probe(paths, max_probe=500):
+        seen["paths"] = list(paths)
+        return [60.0] * len(paths)
+
+    monkeypatch.setattr(R, "_probe_durations", _probe)
+    R._ingest_limits(d)
+    assert seen["paths"] == [str(new)], "已匯入的檔還被算進預算"
+
+
+def test_unprocessed_drops_indexed_and_survives_a_dead_db(monkeypatch):
+    from routers import ingest as R
+    import db as _db
+
+    class _Conn:
+        def execute(self, q):
+            return [("/x/done.mp4",)]
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    monkeypatch.setattr(_db, "get_conn", lambda: _Conn())
+    assert R._unprocessed(["/x/done.mp4", "/x/new.mp4"]) == ["/x/new.mp4"]
+
+    def _boom():
+        raise RuntimeError("db gone")
+
+    monkeypatch.setattr(_db, "get_conn", _boom)
+    assert R._unprocessed(["/x/a.mp4"]) == ["/x/a.mp4"], \
+        "DB 讀不到時要退回原樣，不能把預算算成 0 檔"
+
+
+# ── ⑨/⑩/⑪ 前端：三個「少做一件事」的接收面 ─────────────────────────────────
+
+def _svelte(name):
+    return io.open("frontend/src/routes/" + name, encoding="utf-8").read()
+
+
+def test_offload_ui_clears_stage_on_next_destination():
+    """只看 dst_start 那一支，不能讓後面 done 分支裡的 stage = '' 混進來充數。"""
+    src = _svelte("Offload.svelte")
+    i = src.index("ev.type === 'dst_start'")
+    j = src.index("ev.type === 'file'", i)   # 下一個 else-if = 這支的結尾
+    branch = src[i:j]
+    assert "stage = ''" in branch, \
+        "換到下一顆碟時沒清 stage，第二顆碟複製中會顯示上一顆的『正在校驗 MHL』"
+    assert "stageFiles = 0" in branch
+
+
+def test_offload_ui_counts_a_manifest_failure_as_failed():
+    src = _svelte("Offload.svelte")
+    i = src.index("$: anyFailed")
+    assert "s.error" in src[i:i + 200], \
+        "manifest 失敗時 failed_files 是 0，只看它會把沒有 manifest 的碟當成功"
+    assert "s.error ?" in src, "summary 那列要看得到失敗原因"
+
+
+def test_ingest_live_adopts_total_when_joining_mid_run():
+    src = _svelte("IngestLive.svelte")
+    assert "adoptRunHeader" in src
+    i = src.index("function adoptRunHeader")
+    body = src[i:i + 500]
+    assert "msg.total" in body, "中途加入時沒有從既有事件補回 total → 進度條恆 0%"
+    assert "joinedLate" in body, "補上的 elapsed 是『加入後』，要標記不能當成 elapsed"
+
+
+def test_ingest_setup_refuses_unrepresentable_preset_paths():
+    src = _svelte("IngestSetup.svelte")
+    assert "PRESET_UNSAFE" in src
+    i = src.index("async function savePreset")
+    body = src[i:i + 1200]
+    assert "PRESET_UNSAFE.test(p.path)" in body, \
+        "寫回是整串重寫 —— 既有的損壞會被固化，所以寫之前要先擋"

--- a/tests/test_offload_mhl_phase.py
+++ b/tests/test_offload_mhl_phase.py
@@ -99,6 +99,11 @@ def test_status_is_not_done_when_mhl_write_fails(scratch, monkeypatch):
     """🔴 本檔的核心：MHL 沒寫成，state 就不可以說 done。
 
     這是「取消在那 35 分鐘裡」的可測代理 —— 兩者都是「拷完了但 manifest 沒有」。
+
+    ⚠️ 2026-09-08 審計 round 2：原本這裡是 `pytest.raises(RuntimeError)` ——
+    失敗會 raise 出整個 dst 迴圈。那讓本檔的核心成立了，但代價是**剩下的目的地
+    一顆都不會拷**，而第二顆碟正是兩碟備份的全部意義。現在失敗收斂在這顆碟裡，
+    所以核心命題從「不是 done」升級成更強的「明確是 failed，而且說得出原因」。
     """
     offload = _bootstrap_mhl(scratch, monkeypatch)
     monkeypatch.chdir(scratch)
@@ -107,14 +112,19 @@ def test_status_is_not_done_when_mhl_write_fails(scratch, monkeypatch):
         raise RuntimeError("simulated: interrupted during manifest write")
     monkeypatch.setattr(offload, "_write_mhl", _boom)
 
-    with pytest.raises(RuntimeError):
-        offload.run_offload(_src(scratch), [scratch / "dst"], verify=True,
-                            emit_mhl=True, resume=str(scratch / "st.json"))
+    code, summary, _sp = offload.run_offload(
+        _src(scratch), [scratch / "dst"], verify=True,
+        emit_mhl=True, resume=str(scratch / "st.json"))
 
     st = json.loads((scratch / "st.json").read_text(encoding="utf-8"))
-    dst_state = st["destinations"][str((scratch / "dst").resolve())]
+    key = str((scratch / "dst").resolve())
+    dst_state = st["destinations"][key]
     assert dst_state["status"] != "done", "檔案拷完不等於過卡完成 —— manifest 才是交付物"
+    assert dst_state["status"] == "failed", "「running」跟使用者中途取消同形，分不出來"
+    assert "interrupted during manifest write" in (dst_state.get("error") or "")
     assert not dst_state.get("mhl_path")
+    assert summary[key]["error"], "summary 是 UI 唯一讀得到的東西"
+    assert code != 0, "沒有 manifest 不可以回 0"
 
 
 def test_status_done_always_carries_an_mhl_path(scratch, monkeypatch):


### PR DESCRIPTION
Round 1（#446）修的是**會殺掉健康匯入、卻不說是誰殺的**缺口。這一輪形狀不同：每一條都是**做少了一件事，而畫面上看不出來**。

## ④ MHL 失敗 raise 出整個 dst 迴圈 —— 第二顆碟根本沒被拷 🔴

`offload.py` 的 manifest 校驗失敗直接 `raise` 穿出 `for dst_root`，同時輸掉三件事：

1. **剩下的目的地全部跳過。** 第一顆碟 hash 對不上 → 第二顆碟一個 byte 都不會拷。而第二顆碟正是兩碟備份的全部意義。
2. **`summary[dst_key]` 沒被賦值** → router 補一個 `{"type":"done","summary":{}}` → UI 顯示「✗ 轉存有失敗 (exit 1)」而**沒有任何一列說是哪顆碟、為什麼**。RuntimeError 的文字走 merge 過的 stdout，被 ndjson reader 的 `JSON.parse` catch 靜靜丟掉。
3. **`dst_state["status"]` 停在 `"running"`** —— 那正是使用者中途取消會留下的狀態。round 1 特地把「拷完 ≠ done」修對了，卻讓校驗失敗掉進取消那一格。

校驗失敗正是這個工具存在的理由，不該是 summary 裡最安靜的東西。現在收斂成 per-destination `failed` + `error`，形狀對齊上面既有的 `_check_destination_mount` 路徑。

⚠️ 連帶：**「每個 byte 都驗過但 manifest 沒有」算成失敗的目的地**。那種情況 `failed_files == 0`，只看那個數字會把沒有保管鏈的碟當成功。

## ⑧ `run_tree_watched` 的 stderr 恆空，而 `/api/ingest` 拿它當診斷欄

`stderr=subprocess.STDOUT`（merge 進 stdout 當存活訊號），所以 `result.stderr` 永遠是 `""`，而 `/api/ingest` 把它原樣當診斷欄回給呼叫端 —— 讀起來像「子行程什麼都沒說」。唯一沒有別的通道的東西是 pump 自己的例外：round 1 停止吞掉它、改成記進 `state["pump_error"]`，但**沒有人讀那筆紀錄**。正常結束與逾時兩條路徑現在都把它交出來。

## ⑨ `Offload.svelte`：`dst_start` 沒清 `stage`

多目的地時，第一顆碟的最後一個事件是 `phase: mhl_verify`。不清掉 → 第二顆碟**正在複製檔案**的畫面頂著「Verifying MHL manifest — hashing N files again」，直到第二顆碟自己發出 phase 為止。順帶：`anyFailed` 要把 `s.error` 算進去，否則 manifest 失敗會顯示成完成。

## ⑩ `IngestLive.svelte`：中途加入的 client 全是 0

server 在 connect 時不送 snapshot，而 header 的每個數字都只在 `start` 事件裡種下。重新整理／自動重連／第二個分頁 → **0 檔、0%、空白 elapsed 蓋在一個正在跑的匯入上**（`remaining` 也是 0，因為它是 total 減掉我們碰巧看到的列數）。

每個 `file`／`stage` 事件本來就帶 `total`，從第一個收到的補回來即可，不必加協定往返。`complete` 的 handler 早就為 `halted` 做了同一件事 —— 同一個缺口，只補了一格寬。

elapsed 標成 `+MM:SS since joined`：把加入時間當成起跑時間，會是「用一個錯的數字換掉一個空白」。

## ⑪ `IngestSetup.svelte`：捷徑分隔字元沒跳脫，而寫回是整串重寫

entry 以 `;` 分、label/path 以第一個 `|` 分，兩個字元都沒跳脫、都是合法的 macOS 檔名字元。

真正的傷害不是「這筆捷徑存壞」：`savePreset` 用整個 `presets` 陣列重新序列化，而 `presets` 本身是那個有損 parser 吐出來的 —— **新增任何一筆，都會把既有被解錯的項目永久寫成解錯的樣子**。`settings.py` 那句「losing one shortcut is recoverable」正好在此不成立。

## ⑫ scan 探測過的檔，實跑時整份重探

`/api/ingest/scan` 探完 200 支只為了顯示 ETA，接著 `_ingest_limits` 再探一次同一批。時長不可能在 size/mtime 不變的情況下改變 → 就地記憶化。

同時修掉 **limit=0（UI 的預設路徑）把已匯入的檔也算進預算**：scan 只估 `pending`，實跑估全部 —— 而 scan 那段註解白紙黑字宣稱兩者是同一個數字。

## ⑯（round 2 新發現）`max_probe` 取前 500 筆，而 stall 門檻靠 `max(known)`

2000 支的資料夾只探字母序前 500 支，排在第 1200 支的 40 分鐘訪談就隱形了 —— 而 whisper 解碼那支的整段時間**完全靜默**，門檻不夠大就會在它健康轉錄時判它卡死。改成等距取樣，成本不變。

## 已驗證但未改行為：`/api/ingest` 是同步路由（⑭）

它會佔住一個 anyio threadpool worker、一條 HTTP 連線、和 single-flight 名額長達整個 `budget_s`（實測 94 分）。呼叫端自己的 timeout 較短時，拿不到結果**而且在它看不見的那次跑完之前都會 409**。SPA 不走它（走 `/api/ingest/ws`），而同步路由沒有 offload stream 那個 `GeneratorExit` 可以偵測斷線。已在 docstring 寫明射程，未改行為。

---

## 驗證

新增 13 支測試（`tests/test_ingest_audit_round2.py`）。**在修正前的 main 上跑：12 支紅** —— 唯一綠的那支是「pump 沒出事時 stderr 要是空的」迴歸護欄，本來就該兩邊都綠。

第一版有兩支是假綠（`dst_start` 那支的 700 字元視窗吃到了後面 `done` 分支裡的 `stage = ''`），已收窄成只看該分支。

- `pytest -q` → **2070 passed / 8 skipped**
- `npm run build` 綠、`npm test` → 24 passed

`test_offload_mhl_phase.py` 的核心測試同輪更新：它原本靠 `pytest.raises(RuntimeError)` 成立，而那個 raise 正是 ④ 的病灶。命題升級成更強的「明確是 `failed`，而且說得出原因」，並在 docstring 寫下為什麼放棄傳播。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JDgzY5sojuSEqD4epJx4P