### PR TITLE
feat(health): 補上「跑起來了不等於畫面是新的」那道缺口

### DIFF
--- a/health.py
+++ b/health.py
@@ -14,6 +14,7 @@ import platform
 import shutil
 import subprocess
 import sys
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
 
@@ -88,6 +89,44 @@ def _check_opencc():
     else:
         check("opencc", False, "(not installed — needed only for Chinese transcripts)",
               required=False)
+
+
+def spa_freshness(root: Path):
+    """(status, detail) for the built SPA under `root`.
+
+    status: "ok" | "missing" | "stale" | "unmeasurable"
+
+    Compares `frontend/dist/index.html`'s mtime against the last COMMIT that
+    touched `frontend/src` — not against the source files' mtimes. A fresh clone
+    stamps every file with checkout time, so an mtime-vs-mtime comparison calls
+    `dist` stale on every new machine, and a check that cries wolf gets ignored.
+
+    "unmeasurable" is deliberately its own state rather than folded into "ok":
+    a packaged install with no git history cannot date its own source, and
+    "I can't tell" must not render as "fresh".
+    """
+    src = root / "frontend" / "src"
+    dist = root / "frontend" / "dist" / "index.html"
+    if not src.is_dir():
+        return "unmeasurable", "no frontend/src — packaged install"
+    if not dist.exists():
+        return "missing", "run `npm run build` in frontend/"
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(root), "log", "-1", "--format=%ct", "--", "frontend/src"],
+            capture_output=True, text=True, timeout=15)
+        src_commit = int(r.stdout.strip()) if r.returncode == 0 and r.stdout.strip() else None
+    except Exception:
+        src_commit = None
+    if src_commit is None:
+        return "unmeasurable", "no git history for frontend/src"
+    built = dist.stat().st_mtime
+    if built >= src_commit:
+        return "ok", "built {0}".format(datetime.fromtimestamp(built).strftime("%Y-%m-%d"))
+    return "stale", "dist built {0}, src changed {1} — {2:.0f} days stale; run `npm run build`".format(
+        datetime.fromtimestamp(built).strftime("%Y-%m-%d"),
+        datetime.fromtimestamp(src_commit).strftime("%Y-%m-%d"),
+        (src_commit - built) / 86400.0)
 
 
 def detect_platform() -> str:
@@ -470,6 +509,26 @@ def main():
         check("uvicorn", True)
     except ImportError:
         check("uvicorn", False, "(pip install uvicorn)")
+
+    # ── Built SPA freshness ─────────────────────────────────────────────
+    # 2026-09-08: the deployed install at ~/.arkiv was serving a `frontend/dist`
+    # built on 7/16 — every UI change in v1.2.0 and v1.3.0 was invisible for
+    # ~2 months. `dist/` is gitignored, so nothing in the repo, the installer or
+    # the upgrade path notices when it falls behind `frontend/src`.
+    #
+    # This is the third face of a shape the fleet already guards twice: DEPLOY
+    # catches "committed but not shipped", CLAUDE.md #8 catches "pulled but not
+    # running". Neither can see "running, but the screen is from July".
+    print("\n-- Built SPA --")
+    _status, _detail = spa_freshness(Path(__file__).resolve().parent)
+    if _status == "ok":
+        check("frontend/dist newer than frontend/src", True, "({0})".format(_detail))
+    elif _status == "unmeasurable":
+        check("frontend/dist freshness", False, "({0})".format(_detail), required=False)
+    elif _status == "missing":
+        check("frontend/dist built", False, "(missing — {0})".format(_detail))
+    else:
+        check("frontend/dist newer than frontend/src", False, "({0})".format(_detail))
 
     # ── Summary ─────────────────────────────────────────────────────────
     total = PASS + FAIL + SKIP

--- a/tests/test_spa_freshness.py
+++ b/tests/test_spa_freshness.py
@@ -1,0 +1,107 @@
+"""前端 build 有沒有跟上原始碼 —— 而這個缺口在 fleet 已有的兩道守衛之間。
+
+2026-09-08 實犯：部署在 `~/.arkiv` 的 `frontend/dist` 是 **7 月 16 日**建的，
+於是 :8501 有兩個月 serve 的是七月的前端 —— v1.2.0 與 v1.3.0 的 UI 改動
+從來沒出現在畫面上。`dist/` 是 gitignored，所以 repo、安裝器、升級路徑
+沒有任何一環會發現它落後了。
+
+既有的兩道守衛各自防的是：
+    DEPLOY gate      「commit 了不等於上線」
+    CLAUDE.md #8     「pull 了不等於在跑」
+缺的是第三面：「**跑起來了不等於畫面是新的**」。
+"""
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from health import spa_freshness  # noqa: E402
+
+
+def _repo(tmp_path, src_mtime_offset=0):
+    """建一個最小的 git repo，frontend/src 有一顆 commit。"""
+    r = tmp_path / "repo"
+    (r / "frontend" / "src").mkdir(parents=True)
+    (r / "frontend" / "src" / "App.svelte").write_text("x", encoding="utf-8")
+    env = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+           "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    import os
+    env = dict(os.environ, **env)
+    subprocess.run(["git", "init", "-q"], cwd=r, check=True, env=env)
+    subprocess.run(["git", "add", "-A"], cwd=r, check=True, env=env)
+    subprocess.run(["git", "commit", "-qm", "src"], cwd=r, check=True, env=env)
+    return r
+
+
+def _build(repo, mtime):
+    d = repo / "frontend" / "dist"
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / "index.html"
+    f.write_text("<html>", encoding="utf-8")
+    import os
+    os.utime(f, (mtime, mtime))
+    return f
+
+
+def test_dist_newer_than_last_src_commit_is_ok(tmp_path):
+    r = _repo(tmp_path)
+    _build(r, time.time() + 60)
+    status, _ = spa_freshness(r)
+    assert status == "ok"
+
+
+def test_dist_older_than_last_src_commit_is_stale(tmp_path):
+    """🔴 本檔的核心：這正是 2026-09-08 那個兩個月沒人發現的狀態。"""
+    r = _repo(tmp_path)
+    _build(r, time.time() - 86400 * 60)      # 60 天前建的
+    status, detail = spa_freshness(r)
+    assert status == "stale"
+    assert "npm run build" in detail, detail
+    assert "days stale" in detail
+
+
+def test_missing_dist_is_not_ok(tmp_path):
+    """沒 build 過不可以被讀成通過 —— UI 會退回舊頁或 404。"""
+    r = _repo(tmp_path)
+    status, detail = spa_freshness(r)
+    assert status == "missing"
+    assert "npm run build" in detail
+
+
+def test_no_git_history_is_unmeasurable_not_ok(tmp_path):
+    """🔴 量不到必須是自己一種狀態，不可以折進『新鮮』。
+
+    打包安裝沒有 git 歷史 ⇒ 無法為原始碼定日期。把它當成 ok，
+    等於讓「我不知道」長得跟「沒問題」一樣 —— 那正是本 repo 反覆踩的形狀。
+    """
+    r = tmp_path / "nogit"
+    (r / "frontend" / "src").mkdir(parents=True)
+    _build(r, time.time())
+    status, detail = spa_freshness(r)
+    assert status == "unmeasurable"
+    assert "git" in detail.lower()
+
+
+def test_packaged_install_without_src_is_unmeasurable(tmp_path):
+    r = tmp_path / "packaged"
+    (r / "frontend").mkdir(parents=True)
+    status, _ = spa_freshness(r)
+    assert status == "unmeasurable"
+
+
+def test_fresh_clone_does_not_report_stale(tmp_path):
+    """負向：整棵樹同一個 mtime（fresh clone 的樣子）不可以被判 stale。
+
+    這是刻意不拿 src 的 mtime 去比的理由 —— 那樣每台新機器都會誤報，
+    而一個常誤報的守衛會被忽略，等於沒有。
+    """
+    r = _repo(tmp_path)
+    now = time.time()
+    import os
+    for p in (r / "frontend" / "src").rglob("*"):
+        os.utime(p, (now, now))
+    _build(r, now)
+    assert spa_freshness(r)[0] == "ok"


### PR DESCRIPTION
2026-09-08 升級 `~/.arkiv` 時發現 `frontend/dist/index.html` 是 **7 月 16 日**建的 ——
:8501 有兩個月 serve 的是七月的前端，**v1.2.0 與 v1.3.0 的 UI 改動從來沒出現在畫面上**。

`dist/` 是 gitignored，所以 repo、安裝器、升級路徑**沒有任何一環**會發現它落後了。

## 這是同一個形狀的第三面

| 守衛 | 防的是 |
|---|---|
| DEPLOY gate | commit 了不等於上線 |
| CLAUDE.md #8 | pull 了不等於在跑 |
| **本次** | **跑起來了不等於畫面是新的** |

## 判準刻意不用 mtime 比 mtime

拿 `frontend/src` 的檔案 mtime 去比 `dist`，在 fresh clone 上**每台新機器都會誤報**
（checkout 把整棵樹蓋成同一個時間）。**一個常誤報的守衛會被忽略，等於沒有。**

改成比「最後一次動到 `frontend/src` 的 **commit 時間**」—— 那個值跨機器穩定。

## 四種狀態，而「量不到」是獨立的一種

```
ok            dist 比最後一次 src commit 新
stale         dist 較舊 → FAIL，訊息帶兩個日期與落後天數
missing       沒 build 過 → FAIL
unmeasurable  沒有 frontend/src（打包安裝）或沒有 git 歷史 → SKIP
```

🔴 `unmeasurable` **不折進 `ok`**：打包安裝無法為自己的原始碼定日期，而
「我不知道」長得跟「沒問題」一樣 —— 那正是本 repo 反覆踩到的形狀。

## 驗證

新測試 **6 條**，其中兩條是負向：

- `fresh clone 不可誤報 stale`（整棵樹同一 mtime）
- `沒有 git 歷史必須是 unmeasurable 而非 ok`

把 `health.py` 還原成 main 版之後，該測試檔**連 collection 都過不了**
（`ImportError: spa_freshness`）—— 證明它確實依賴新程式碼。

| 檢查 | 結果 |
|---|---|
| `pytest -q` | **2076 passed**, 8 skipped |
| `health.py` 三分支實跑 | missing ✓ ／ stale（正確算出 420 天）✓ ／ ok ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)